### PR TITLE
Docker multistage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*/target/*
+.idea/*
+.settings/*
+.github/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@
 .idea/*
 .settings/*
 .github/*
+# Needed for Docker image
+!mars-sim-headless/target/mars-sim-headless.jar

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,13 +34,6 @@ jobs:
       - name: Build with Maven
         run: mvn -B package -DskipTests=true --file pom.xml 
         
-      - name: Copy JAR
-        run: |
-          # Find the project version off the MVN pom
-          MARS_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)
-          cp mars-sim-headless/target/mars-sim-headless-$MARS_VERSION-jar-with-dependencies.jar mars-sim-headless.jar
-          docker build . --file Dockerfile --tag $IMAGE_NAME
-        
       - name: Build imagewith Package Docker
         run: |
           docker build . --file Dockerfile.package --tag $IMAGE_NAME

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,34 +18,9 @@ env:
   IMAGE_NAME: mars-sim
 
 jobs:
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
-  test:    
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-          
-      - name: Build with Maven
-        run: mvn -B package -DskipTests --file pom.xml 
-        
-      - name: Run tests
-        run: |
-          # Find the project version off the MVN pom
-          MARS_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)
-          docker build . --file Dockerfile --build-arg mars_version=$MARS_VERSION
-
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:
-    # Ensure test job passes before pushing image.
-    needs: test
-
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 
@@ -57,13 +32,19 @@ jobs:
           java-version: 11
           
       - name: Build with Maven
-        run: mvn -B package -DskipTests --file pom.xml 
+        run: mvn -B package -DskipTests=true --file pom.xml 
         
-      - name: Build image
+      - name: Copy JAR
         run: |
           # Find the project version off the MVN pom
           MARS_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)
-          docker build . --file Dockerfile --tag $IMAGE_NAME --build-arg mars_version=$MARS_VERSION
+          cp mars-sim-headless/target/mars-sim-headless-$MARS_VERSION-jar-with-dependencies.jar mars-sim-headless.jar
+          docker build . --file Dockerfile --tag $IMAGE_NAME
+        
+      - name: Build imagewith Package Docker
+        run: |
+          docker build . --file Dockerfile.package --tag $IMAGE_NAME
+
           
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ COPY pom.xml .
 COPY mars-sim-core mars-sim-core/
 COPY mars-sim-console mars-sim-console/
 COPY mars-sim-headless mars-sim-headless/
-COPY mars-sim-javafx mars-sim-javafx/
 COPY mars-sim-main mars-sim-main/
 COPY mars-sim-mapdata mars-sim-mapdata/
 COPY mars-sim-ui mars-sim-ui/
@@ -19,8 +18,7 @@ RUN mvn -DskipTests=true package
 FROM openjdk:11.0.9.1-jre
 WORKDIR /app
 # Override when building
-ARG mars_version=3.1.2
-COPY --from=build /app/src/mars-sim-headless/target/mars-sim-headless-${mars_version}-jar-with-dependencies.jar mars-sim-headless.jar
+COPY --from=build /app/src/mars-sim-headless/target/mars-sim-headless.jar mars-sim-headless.jar
 
 # The folder /app/data/mars-sim build be a bind volume if the simulation state is persistent
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,26 @@
+# Build stage
+# the Maven project
+FROM maven:3.6.3-openjdk-11-slim AS build
+WORKDIR /app/src
+
+# Ideally the source code shouo dbe under a src subdirectory in GitHub repo
+COPY pom.xml .
+COPY mars-sim-core mars-sim-core/
+COPY mars-sim-console mars-sim-console/
+COPY mars-sim-headless mars-sim-headless/
+COPY mars-sim-javafx mars-sim-javafx/
+COPY mars-sim-main mars-sim-main/
+COPY mars-sim-mapdata mars-sim-mapdata/
+COPY mars-sim-ui mars-sim-ui/
+
+RUN mvn -DskipTests=true package
+
+# Package stage
 FROM openjdk:11.0.9.1-jre
 WORKDIR /app
 # Override when building
 ARG mars_version=3.1.2
-COPY mars-sim-headless/target/mars-sim-headless-${mars_version}-jar-with-dependencies.jar mars-sim-headless.jar
+COPY --from=build /app/src/mars-sim-headless/target/mars-sim-headless-${mars_version}-jar-with-dependencies.jar mars-sim-headless.jar
 
 # The folder /app/data/mars-sim build be a bind volume if the simulation state is persistent
 

--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -3,9 +3,8 @@
 FROM openjdk:11.0.9.1-jre
 WORKDIR /app
 
-# Override when building. Jar must be prebuild and not in target folder
-ARG mars_version=3.1.2
-COPY mars-sim-headless.jar mars-sim-headless.jar
+# Jar must be prebuild and not in target folder
+COPY mars-sim-headless/target/mars-sim-headless.jar mars-sim-headless.jar
 
 # The folder /app/data/mars-sim build be a bind volume if the simulation state is persistent
 

--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -1,0 +1,16 @@
+# Only a packing stage. JAR must be available
+# Package stage
+FROM openjdk:11.0.9.1-jre
+WORKDIR /app
+
+# Override when building. Jar must be prebuild and not in target folder
+ARG mars_version=3.1.2
+COPY mars-sim-headless.jar mars-sim-headless.jar
+
+# The folder /app/data/mars-sim build be a bind volume if the simulation state is persistent
+
+# Cannot pass coommandline argument when using the JAR launcher
+# Attempt to load if saved simulation is present or new if not. Use a different data directory that is mapped to a 
+# Docker volume
+ENTRYPOINT [ "java", "-cp", "/app/mars-sim-headless.jar", "org.mars_sim.headless.MarsProjectHeadless", "-load", "-new", "-timeratio", "1024", "-remote", "18080", "-datadir", "/app/data/mars-sim" ]
+EXPOSE 18080

--- a/mars-sim-console/pom.xml
+++ b/mars-sim-console/pom.xml
@@ -4,7 +4,7 @@ xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.github</groupId>
+    <groupId>com.github.mars-sim</groupId>
     <artifactId>mars-sim</artifactId>
     <version>3.1.2</version>
   </parent>

--- a/mars-sim-console/src/main/java/org/mars/sim/console/InteractiveTerm.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/InteractiveTerm.java
@@ -611,7 +611,7 @@ public class InteractiveTerm {
 
 		UserChannel channel = new TextIOChannel(textIO);
 		// Console is always an admin
-        Conversation conversation = new Conversation(channel, new TopLevel(true), sim);
+        Conversation conversation = new Conversation(channel, new TopLevel(true), true, sim);
 
         conversation.interact();
 		logger.info("Conversation ended");

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/ConsoleApp.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/ConsoleApp.java
@@ -18,7 +18,7 @@ public class ConsoleApp {
 			channel = new StreamChannel(System.in, System.out);
 		}
 		
-        Conversation conversation = new Conversation(channel, new TopLevel(true), null);
+        Conversation conversation = new Conversation(channel, new TopLevel(true), true, null);
         conversation.interact();
         
     }

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/Conversation.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/Conversation.java
@@ -38,6 +38,7 @@ public class Conversation implements UserOutbound {
 	private Object optionsPartial;
 
 	private Simulation sim;
+	private boolean admin;
 	
 	/**
 	 * Start a conversation with the user using a Comms Channel starting with a certain command.
@@ -45,10 +46,11 @@ public class Conversation implements UserOutbound {
 	 * @param out
 	 * @param initial
 	 */
-	public Conversation(UserChannel comms, InteractiveChatCommand initial, Simulation sim) {
+	public Conversation(UserChannel comms, InteractiveChatCommand initial, boolean admin, Simulation sim) {
 		this.current = initial;
         this.active = true;
         this.comms = comms;
+        this.admin = admin;
         this.previous = new Stack<>();
         this.inputHistory = new ArrayList<>();
         
@@ -246,6 +248,10 @@ public class Conversation implements UserOutbound {
 		}
 	}
 
+	public boolean isAdmin() {
+		return admin;
+	}
+	
 	public Simulation getSim() {
 		return sim;
 	}

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/service/SSHConversation.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/service/SSHConversation.java
@@ -9,7 +9,7 @@ public class SSHConversation extends Conversation {
 	private RemoteChatService parent;
 
 	public SSHConversation(RemoteChatService parent, SSHChannel sshChannel, String username, boolean admin, Simulation sim) {
-		super(sshChannel, new RemoteTopLevel(username, admin), sim);
+		super(sshChannel, new RemoteTopLevel(username, admin), admin, sim);
 		this.username = username;
 		this.parent = parent;
 	}

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/DateCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/DateCommand.java
@@ -36,6 +36,14 @@ public class DateCommand extends ChatCommand {
 		responseText.appendLabeledString("Earth Time", earthClock.getTimeStringF0());
 		responseText.appendLabeledString("Uptime",clock.getUpTimer().getUptime());
 
+		if (context.isAdmin()) {
+			// For Admin user display details about the simulation engine
+			responseText.appendBlankLine();
+			responseText.appendLabelledDigit("Last Pulse execution (msec)", (int) clock.getExecutionTime());
+			responseText.appendLabelledDigit("Last sleep time (msec)", (int) clock.getSleepTime());
+			responseText.appendLabelledDigit("Pulse count", (int) clock.getTotalPulses());
+		}
+		
 		context.println(responseText.getOutput());
 		
 		return true;

--- a/mars-sim-core/pom.xml
+++ b/mars-sim-core/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>mars-sim</artifactId>
-		<groupId>com.github</groupId>
+		<groupId>com.github.mars-sim</groupId>
 		<version>3.1.2</version>
 	</parent>
 	<groupId>com.github.mars-sim</groupId>

--- a/mars-sim-headless/pom.xml
+++ b/mars-sim-headless/pom.xml
@@ -162,6 +162,25 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- Copy the headless JAR to a fixed name without a version number -->
+			<plugin>
+				<groupId>com.coderplus.maven.plugins</groupId>
+				<artifactId>copy-rename-maven-plugin</artifactId>
+				<version>1.0</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<configuration>
+							<sourceFile>${project.build.directory}/${project.build.finalName}-jar-with-dependencies.jar</sourceFile>
+							<!-- The destination file must be an exclude in the dockerignore to be accessable in the Docker build -->
+							<destinationFile>${project.build.directory}/${project.name}.jar</destinationFile>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	<dependencies>

--- a/mars-sim-headless/pom.xml
+++ b/mars-sim-headless/pom.xml
@@ -4,7 +4,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.github</groupId>
+		<groupId>com.github.mars-sim</groupId>
 		<artifactId>mars-sim</artifactId>
 		<version>3.1.2</version>
 	</parent>
@@ -13,7 +13,7 @@
 	<name>mars-sim-headless</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>	
-		<domainNameMainClass>org.mars_sim.headless.MarsProjectHeadlessStarter</domainNameMainClass>			
+		<domainNameMainClass>org.mars_sim.headless.MarsProjectHeadlessStarter</domainNameMainClass>		
 	</properties>
 	<build>
 		<plugins>

--- a/mars-sim-main/pom.xml
+++ b/mars-sim-main/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>mars-sim</artifactId>
-		<groupId>com.github</groupId>
+		<groupId>com.github.mars-sim</groupId>
 		<version>3.1.2</version>
 	</parent>
 	<groupId>com.github.mars-sim</groupId>

--- a/mars-sim-mapdata/pom.xml
+++ b/mars-sim-mapdata/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>mars-sim</artifactId>
-		<groupId>com.github</groupId>
+		<groupId>com.github.mars-sim</groupId>
 		<version>3.1.2</version>
 	</parent>
 	<groupId>com.github.mars-sim</groupId>

--- a/mars-sim-ui/pom.xml
+++ b/mars-sim-ui/pom.xml
@@ -5,7 +5,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.github</groupId>
+		<groupId>com.github.mars-sim</groupId>
 		<artifactId>mars-sim</artifactId>
 		<version>3.1.2</version>
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<!-- * General Section * -->
 	<!-- ************************************************************************************************* -->
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.github</groupId>
+	<groupId>com.github.mars-sim</groupId>
 	<artifactId>mars-sim</artifactId>
 	<packaging>pom</packaging>
 	<version>3.1.2</version>


### PR DESCRIPTION
Changed the Dockerfile to support any value in the Maven project version. Dockerfile will now build via a DockerHub build action separately from GitHub Actions. This provides a route to make the Docker image readily available. 
Also there was a mismatch between the groupId between the parent pom and some of the module.  This prevented the build inside Docker running as it uses a totally clean local Maven repository.