### PR TITLE
Support for multiple Scenarios

### DIFF
--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/SimulationBuilder.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/SimulationBuilder.java
@@ -16,6 +16,8 @@ import java.util.logging.Logger;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.mars_sim.msp.core.configuration.Scenario;
+import org.mars_sim.msp.core.configuration.ScenarioConfig;
 import org.mars_sim.msp.core.logging.DiagnosticsManager;
 import org.mars_sim.msp.core.person.CrewConfig;
 import org.mars_sim.msp.core.reportingAuthority.ReportingAuthority;
@@ -259,7 +261,10 @@ public class SimulationBuilder {
 				builder.createFullSettlement(spec);
 			}
 			else {
-				builder.createInitialSettlements();
+				// TODO workaround for now until Editor working
+				ScenarioConfig config = new ScenarioConfig();
+				Scenario bootstrap = config.getItem(ScenarioConfig.DEFAULT);
+				builder.createInitialSettlements(bootstrap);
 			}
 		}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/SimulationBuilder.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/SimulationBuilder.java
@@ -18,7 +18,9 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.mars_sim.msp.core.configuration.Scenario;
 import org.mars_sim.msp.core.configuration.ScenarioConfig;
+import org.mars_sim.msp.core.configuration.UserConfigurableConfig;
 import org.mars_sim.msp.core.logging.DiagnosticsManager;
+import org.mars_sim.msp.core.person.Crew;
 import org.mars_sim.msp.core.person.CrewConfig;
 import org.mars_sim.msp.core.reportingAuthority.ReportingAuthority;
 import org.mars_sim.msp.core.reportingAuthority.ReportingAuthorityFactory;
@@ -56,7 +58,8 @@ public class SimulationBuilder {
 	private String latitude = null;
 	private String longitude = null;
 	private boolean useCrews = true;
-	private CrewConfig crewConfig;
+	private UserConfigurableConfig<Crew> crewConfig;
+	private Scenario bootstrap;
 
 	public SimulationBuilder(SimulationConfig simulationConfig) {
 		super();
@@ -257,13 +260,18 @@ public class SimulationBuilder {
 				crewConfig = new CrewConfig();
 			}
 			builder.setCrew(crewConfig);
+			
+			// Is the a specific template requested?
 			if (spec !=  null) {
 				builder.createFullSettlement(spec);
 			}
 			else {
-				// TODO workaround for now until Editor working
-				ScenarioConfig config = new ScenarioConfig();
-				Scenario bootstrap = config.getItem(ScenarioConfig.DEFAULT);
+				if (bootstrap == null) {
+					String defaultName = ScenarioConfig.PREDEFINED_SCENARIOS[0];
+					ScenarioConfig config = new ScenarioConfig();
+					bootstrap = config.getItem(defaultName);
+				}
+				logger.config("Using Scenario '" + bootstrap.getName() + "'");
 				builder.createInitialSettlements(bootstrap);
 			}
 		}
@@ -331,7 +339,11 @@ public class SimulationBuilder {
 									 new Coordinates(latitude, longitude), null);
 	}
 
-	public void setCrewConfig(CrewConfig crewConfig) {
+	public void setCrewConfig(UserConfigurableConfig<Crew> crewConfig) {
 		this.crewConfig  = crewConfig;
+	}
+
+	public void setScenario(Scenario scenario) {
+		this.bootstrap = scenario;
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/configuration/Scenario.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/configuration/Scenario.java
@@ -1,0 +1,54 @@
+package org.mars_sim.msp.core.configuration;
+
+import java.util.List;
+
+import org.mars_sim.msp.core.structure.InitialSettlement;
+
+/**
+ * This represents a certain scenario that is used to bootstrap a new Simulation.
+
+ */
+public class Scenario implements UserConfigurable {
+
+	private String description;
+	private boolean bundled;
+	private String name;
+	private List<InitialSettlement> settlements;
+
+	public Scenario(String name, String description, List<InitialSettlement> settlements,
+			boolean bundled) {
+		super();
+		this.name = name;
+		this.description = description;
+		this.bundled = bundled;
+		this.settlements = settlements;
+	}
+
+	@Override
+	public String getDescription() {
+		return description;
+	}
+
+	@Override
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public boolean isBundled() {
+		return bundled;
+	}
+
+	/**
+	 * The initial settlements associated with this scenario.
+	 * @return
+	 */
+	public List<InitialSettlement> getSettlements() {
+		return settlements;
+	}
+}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/configuration/Scenario.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/configuration/Scenario.java
@@ -1,3 +1,9 @@
+/**
+ * Mars Simulation Project
+ * Scenario.java
+ * @version 3.3.0 2021-08-20
+ * @author Barry Evans
+ */
 package org.mars_sim.msp.core.configuration;
 
 import java.util.List;
@@ -6,7 +12,6 @@ import org.mars_sim.msp.core.structure.InitialSettlement;
 
 /**
  * This represents a certain scenario that is used to bootstrap a new Simulation.
-
  */
 public class Scenario implements UserConfigurable {
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/configuration/ScenarioConfig.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/configuration/ScenarioConfig.java
@@ -1,0 +1,114 @@
+package org.mars_sim.msp.core.configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.mars_sim.msp.core.Coordinates;
+import org.mars_sim.msp.core.Msg;
+import org.mars_sim.msp.core.structure.InitialSettlement;
+
+public class ScenarioConfig extends UserConfigurableConfig<Scenario> {
+	
+	private static final String PREFIX = "scenario_";
+	private static final String INITIAL_SETTLEMENT_LIST = "initial-settlement-list";
+	private static final String SETTLEMENT_EL = "settlement";
+	private static final String CREW_ATTR = "crew";
+	private static final String NAME_ATTR = "name";
+	private static final String DESCRIPTION_ATTR = "description";
+	private static final String TEMPLATE_ATTR = "template";
+	private static final String LOCATION_EL = "location";
+	private static final String LONGITUDE_ATTR = "longitude";
+	private static final String LATITUDE_ATTR = "latitude";
+	private static final String POPULATION_EL = "population";
+	private static final String NUMBER_ATTR = "number";
+	private static final String ROBOTS_EL = "robots";
+	private static final String SPONSOR_EL = "sponsor";
+	
+	// Default scenario
+	public static final String DEFAULT = "Default";
+	
+	public ScenarioConfig() {
+		super(PREFIX);
+		
+		// One scenario is bundled
+		loadItem(getItemFilename(DEFAULT), true);
+	}
+
+	@Override
+	protected Document createItemDoc(Scenario item) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	protected Scenario parseItemXML(Document doc, boolean predefined) {
+		Element root = doc.getRootElement();
+		String name = root.getAttributeValue(NAME_ATTR);
+		String description = root.getAttributeValue(DESCRIPTION_ATTR);
+		List<InitialSettlement> is = loadInitialSettlements(root);
+		
+		return new Scenario(name, description, is, predefined);
+	}
+	
+	/**
+	 * Load initial settlements.
+	 * 
+	 * @param settlementDoc DOM document with settlement configuration.
+	 * @throws Exception if XML error.
+	 */
+	private List<InitialSettlement> loadInitialSettlements(Element scenarioElement) {
+		Element initialSettlementList = scenarioElement.getChild(INITIAL_SETTLEMENT_LIST);
+		List<Element> settlementNodes = initialSettlementList.getChildren(SETTLEMENT_EL);
+		List<InitialSettlement> initialSettlements = new ArrayList<>();
+		
+		for (Element settlementElement : settlementNodes) {
+
+			String settlementName = settlementElement.getAttributeValue(NAME_ATTR);
+			String template = settlementElement.getAttributeValue(TEMPLATE_ATTR);
+
+			Coordinates location = null;
+			List<Element> locationNodes = settlementElement.getChildren(LOCATION_EL);
+			if (locationNodes.size() > 0) {
+				Element locationElement = locationNodes.get(0);
+
+				String longitudeString = locationElement.getAttributeValue(LONGITUDE_ATTR);
+				String latitudeString = locationElement.getAttributeValue(LATITUDE_ATTR);
+
+				// take care to internationalize the coordinates
+				longitudeString = longitudeString.replace("E", Msg.getString("direction.eastShort")); //$NON-NLS-1$ //$NON-NLS-2$
+				longitudeString = longitudeString.replace("W", Msg.getString("direction.westShort")); //$NON-NLS-1$ //$NON-NLS-2$
+
+				// take care to internationalize the coordinates
+				latitudeString = latitudeString.replace("N", Msg.getString("direction.northShort")); //$NON-NLS-1$ //$NON-NLS-2$
+				latitudeString = latitudeString.replace("S", Msg.getString("direction.southShort")); //$NON-NLS-1$ //$NON-NLS-2$
+
+				location = new Coordinates(latitudeString, longitudeString);
+			}
+
+			Element populationElement = settlementElement.getChild(POPULATION_EL);
+			String numberStr = populationElement.getAttributeValue(NUMBER_ATTR);
+			int popNumber = Integer.parseInt(numberStr);
+			if (popNumber < 0) {
+				throw new IllegalStateException("populationNumber cannot be less than zero: " + popNumber);
+			}
+
+			Element numOfRobotsElement = settlementElement.getChild(ROBOTS_EL);
+			String numOfRobotsStr = numOfRobotsElement.getAttributeValue(NUMBER_ATTR);
+			int numOfRobots = Integer.parseInt(numOfRobotsStr);
+			if (numOfRobots < 0) {
+				throw new IllegalStateException("The number of robots cannot be less than zero: " + numOfRobots);
+			}
+
+			Element sponsorElement = settlementElement.getChild(SPONSOR_EL);
+			String sponsor = sponsorElement.getAttributeValue(NAME_ATTR);
+			String crew = settlementElement.getAttributeValue(CREW_ATTR);
+			
+			initialSettlements .add(new InitialSettlement(settlementName, sponsor, template, popNumber, numOfRobots,
+										location, crew));
+		}
+		
+		return initialSettlements;
+	}
+}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/configuration/UserConfigurable.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/configuration/UserConfigurable.java
@@ -1,0 +1,37 @@
+/**
+ * Mars Simulation Project
+ * UserConfigurable.java
+ * @author Barry Evans
+ */
+package org.mars_sim.msp.core.configuration;
+
+/**
+ * This represents a configuration ites that can be configured by the user.
+ */
+public interface UserConfigurable {
+
+	/**
+	 * Get the description.
+	 * @return
+	 */
+	String getDescription();
+
+	/**
+	 * Update the description.
+	 * @param description
+	 */
+	void setDescription(String description);
+
+	/**
+	 * Get the unique name of this configurable item.
+	 * @return
+	 */
+	String getName();
+
+	/**
+	 * Is this crew bundled with the code base
+	 * @return
+	 */
+	boolean isBundled();
+
+}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/configuration/UserConfigurableConfig.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/configuration/UserConfigurableConfig.java
@@ -95,7 +95,7 @@ public abstract class UserConfigurableConfig<T extends UserConfigurable> {
 	 * @param crewName
 	 * @return
 	 */
-	private String getItemFilename(String name) {
+	protected String getItemFilename(String name) {
 		// Replace spaces 
 		return itemPrefix + name.toLowerCase().replace(' ', '_');
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/configuration/UserConfigurableConfig.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/configuration/UserConfigurableConfig.java
@@ -1,0 +1,248 @@
+package org.mars_sim.msp.core.configuration;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.xml.XMLConstants;
+
+import org.apache.commons.io.FileUtils;
+import org.jdom2.Document;
+import org.jdom2.JDOMException;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import org.mars_sim.msp.core.SimulationConfig;
+import org.mars_sim.msp.core.SimulationFiles;
+
+/**
+ * This is a manager class of a catagory of UserConfigurable class.
+ * It provides a means to manage a static collection of them and read/write
+ * to file system
+ */
+public abstract class UserConfigurableConfig<T extends UserConfigurable> {
+
+	private static final Logger logger = Logger.getLogger(UserConfigurableConfig.class.getName());
+	private static final String BACKUP = ".bak";
+	
+	private String itemPrefix;
+	private Map<String,T> knownItems = new HashMap<>();
+
+	protected UserConfigurableConfig(String itemPrefix) {
+		this.itemPrefix = itemPrefix;
+		
+		// Scan saved items folder
+		File savedDir = new File(SimulationFiles.getSaveDir());
+	    String[] list = savedDir.list();
+	    for (String userFile : list) {
+	    	if (userFile.startsWith(itemPrefix)
+	    			&& userFile.endsWith(SimulationConfig.XML_EXTENSION)) {
+	    		loadItem(userFile, false);
+	    	}
+		}
+	}
+
+	/**
+	 * Load a create from external or bundled XML.
+	 * @param name
+	 * @return
+	 */
+	protected void loadItem(String file, boolean predefined) {
+		
+		Document doc = parseXMLFileAsJDOMDocument(file, predefined);
+		if (doc == null) {
+			throw new IllegalStateException("Can not find " + file);
+		}
+		
+		T result = parseItemXML(doc, predefined);
+		knownItems.put(result.getName(), result);
+	}
+	
+	/**
+	 * Get a item by it's name
+	 * @param name
+	 * @return
+	 */
+	public T getItem(String name) {
+		return knownItems.get(name);
+	}
+	
+	/**
+	 * Delete the item.
+	 * @param name
+	 */
+	public void deleteItem(String name) {
+		knownItems.remove(name);
+
+		String filename = getItemFilename(name);
+		File oldFile = new File(SimulationFiles.getSaveDir(), filename + SimulationConfig.XML_EXTENSION);
+		logger.info("Deleting file " + oldFile.getAbsolutePath());
+		oldFile.delete();
+	}
+	
+
+	/**
+	 * Gte teh filename for an item based on it's name
+	 * @param crewName
+	 * @return
+	 */
+	private String getItemFilename(String name) {
+		// Replace spaces 
+		return itemPrefix + name.toLowerCase().replace(' ', '_');
+	}
+	
+	/**
+	 * Parses an XML file into a DOM document.
+	 * 
+	 * @param filename the path of the file.
+	 * @param useDTD   true if the XML DTD should be used.
+	 * @return DOM document
+	 * @throws IOException
+	 * @throws JDOMException
+	 * @throws Exception     if XML could not be parsed or file could not be found.
+	 */
+	private Document parseXMLFileAsJDOMDocument(String filename, boolean useDTD) {
+		SAXBuilder builder = null;
+		String path = "";
+		
+		if (useDTD) { // for alpha crew
+			builder = new SAXBuilder();
+		    builder.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		    builder.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			path = SimulationFiles.getXMLDir();
+			
+			// Alpha is a bundled XML so needs to be copied out
+			SimulationConfig.instance().getBundledXML(filename);
+			filename += SimulationConfig.XML_EXTENSION;
+		}
+		else { // for beta crew
+			builder = new SAXBuilder();
+		    builder.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		    builder.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			path = SimulationFiles.getSaveDir();
+		}
+
+	    Document document = null;
+	    
+		File f = new File(path, filename);
+		if (!f.exists()) {
+			return null;
+		}
+		
+		if (f.exists() && f.canRead()) {
+	        
+	        try {
+		        document = builder.build(f);
+		    }
+		    catch (JDOMException | IOException e)
+		    {
+		        e.printStackTrace();
+		    }
+		}
+		
+	    return document;
+	}
+
+	
+	/**
+	 * Save the XML document for this item.
+	 * 
+	 * @param item The details to save
+	 */
+	public void saveItem(T item) {
+
+		String filename = getItemFilename(item.getName());
+		File itemFile = new File(SimulationFiles.getSaveDir(), filename + SimulationConfig.XML_EXTENSION);
+		
+		// Create save directory if it doesn't exist.
+		if (!itemFile.getParentFile().exists()) {
+			itemFile.getParentFile().mkdirs();
+			logger.config(itemFile.getParentFile().getAbsolutePath() + " created successfully."); 
+		}
+		
+		if (itemFile.exists()) {
+			File itemBackup = new File(SimulationFiles.getSaveDir(), filename + BACKUP);
+			try {
+				if (Files.deleteIfExists(itemBackup.toPath())) {
+					// Delete the beta_crew.bak
+				    logger.config("Old " + itemBackup.getName() + " deleted."); 
+				} 
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			
+			
+			try {
+				// Back up the previous version of beta_crew.xml as beta_crew.bak
+				FileUtils.moveFile(itemFile, itemBackup);
+			    logger.config(itemFile.getName() + " --> " + itemBackup.getName()); 
+			} catch (IOException e1) {
+				// TODO Auto-generated catch block
+				e1.printStackTrace();
+			}
+			
+			try {
+				if (Files.deleteIfExists(itemFile.toPath())) {
+				    logger.config("Old " + itemFile.getName() + " deleted."); 
+				} 
+
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+		
+		if (!itemFile.exists()) {
+			Document outputDoc = createItemDoc(item);
+			XMLOutputter fmt = new XMLOutputter();
+			fmt.setFormat(Format.getPrettyFormat());
+				
+			try (FileOutputStream stream = new FileOutputStream(itemFile);
+				 OutputStreamWriter writer = new OutputStreamWriter(stream, "UTF-8")) {						 
+				fmt.output(outputDoc, writer);
+			    logger.config("New " + itemFile.getName() + " created and saved."); 
+			    stream.close();
+			} catch (Exception e) {
+				logger.log(Level.SEVERE, e.getMessage());
+			}
+		}
+		
+		// Update or register new crew
+		knownItems.put(item.getName(), item);
+	}
+	
+	/**
+	 * Get the names of the known items.
+	 * @return Alphabetically sorted names.
+	 */
+	public List<String> getItemNames() {
+		List<String> names = new ArrayList<>(knownItems.keySet());
+		Collections.sort(names);
+		return names;
+	}
+	
+	/**
+	 * Convert an Item into am XML representation
+	 * @param item Item to parse.
+	 * @see #parseXML(Document, boolean)
+	 * @return
+	 */
+	protected abstract Document createItemDoc(T item);
+
+	/**
+	 * Parse an XML document to create an item instance.
+	 * @param doc Document of details
+	 * @param predefined Is this item predefined or user defined.
+	 * @see #createItemDoc(UserConfigurable)
+	 * @return
+	 */
+	abstract protected T parseItemXML(Document doc, boolean predefined);
+}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/Crew.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/Crew.java
@@ -9,7 +9,13 @@ package org.mars_sim.msp.core.person;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Crew {
+import org.mars_sim.msp.core.configuration.UserConfigurable;
+
+
+/**
+ * This class represents a pre-defiend Crew of people who can be assigned to Settlments.
+ */
+public class Crew implements UserConfigurable {
 
 	private String name;
 	private String description = "";
@@ -23,10 +29,12 @@ public class Crew {
 		this.bundled = bundled;
 	}
 
+	@Override
 	public void setDescription(String description) {
 		this.description = description;
 	}
 	
+	@Override
 	public String getDescription() {
 		return description;
 	}
@@ -39,6 +47,7 @@ public class Crew {
 		return team;
 	}
 
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -63,6 +72,7 @@ public class Crew {
 	 * Is this crew bundled with the code base
 	 * @return
 	 */
+	@Override
 	public boolean isBundled() {
 		return bundled;
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/CrewConfig.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/CrewConfig.java
@@ -63,18 +63,14 @@ public class CrewConfig extends UserConfigurableConfig<Crew> {
 	/** 
 	 * Crew files preloaded in the code
 	 */
-	private String [] PREDEFINED_CREWS = {"crew_alpha"};
+	private static final String [] PREDEFINED_CREWS = {"Alpha", "Founders"};
 	private Map<String, Integer> bigFiveMap = new HashMap<>();
 	
 	/**
 	 * Constructor
 	 */
 	public CrewConfig() {
-		super(CREW_PREFIX);
-		
-		for (String name : PREDEFINED_CREWS) {
-			loadItem(name, true);
-		}
+		super(CREW_PREFIX, PREDEFINED_CREWS);
 	}
 
 	/**
@@ -181,18 +177,6 @@ public class CrewConfig extends UserConfigurableConfig<Crew> {
 		doc.getRootElement().addContent(crewList);
 	        
         return doc;
-	}
-
-	/**
-	 * Save an attribute to a Element if it is defined
-	 * @param personElement
-	 * @param activity2
-	 * @param activity3
-	 */
-	private static void saveOptionalAttribute(Element node, String attrName, String value) {
-		if (value != null) {
-			node.setAttribute(new Attribute(attrName, value));
-		}
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/CrewConfig.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/CrewConfig.java
@@ -6,42 +6,25 @@
  */
 package org.mars_sim.msp.core.person;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.xml.XMLConstants;
-
-import org.apache.commons.io.FileUtils;
 import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
-import org.jdom2.JDOMException;
-import org.jdom2.input.SAXBuilder;
-import org.jdom2.output.Format;
-import org.jdom2.output.XMLOutputter;
-import org.mars_sim.msp.core.SimulationConfig;
-import org.mars_sim.msp.core.SimulationFiles;
+import org.mars_sim.msp.core.configuration.UserConfigurableConfig;
 
 /**
  * Provides configuration information about the crew.
  */
-public class CrewConfig {
+public class CrewConfig extends UserConfigurableConfig<Crew> {
 
 	private static final Logger logger = Logger.getLogger(CrewConfig.class.getName());
 
 	private static final String CREW_PREFIX = "crew_";
-	private static final String CREW_BACKUP = ".bak";
 	
 	// Element or attribute names
 	private static final String CREW_COFIG = "crew-configuration";
@@ -82,66 +65,31 @@ public class CrewConfig {
 	 */
 	private String [] PREDEFINED_CREWS = {"crew_alpha"};
 	private Map<String, Integer> bigFiveMap = new HashMap<>();
-
-	private Map<String,Crew> knownCrews = new TreeMap<>();
 	
 	/**
 	 * Constructor
 	 */
 	public CrewConfig() {
+		super(CREW_PREFIX);
+		
 		for (String name : PREDEFINED_CREWS) {
-			loadCrew(name, true);
-		}
-		
-		// Scan save crews
-		File savedDir = new File(SimulationFiles.getSaveDir());
-	    String[] list = savedDir.list();
-	    for (String userFile : list) {
-	    	if (userFile.startsWith(CREW_PREFIX)
-	    			&& userFile.endsWith(SimulationConfig.XML_EXTENSION)) {
-	    		loadCrew(userFile, false);
-	    	}
+			loadItem(name, true);
 		}
 	}
-	
-	/**
-	 * Get a crew by it's name
-	 * @param name
-	 * @return
-	 */
-	public Crew getCrew(String name) {
-		return knownCrews.get(name);
-	}
-	
-	/**
-	 * Delete the crew
-	 * @param name
-	 */
-	public void deleteCrew(String name) {
-		knownCrews.remove(name);
 
-		String filename = getCrewFilename(name);
-		File crewFile = new File(SimulationFiles.getSaveDir(), filename + SimulationConfig.XML_EXTENSION);
-		logger.info("Deleting crew file " + crewFile.getAbsolutePath());
-		crewFile.delete();
-	}
-	
 	/**
-	 * Load a create from external or bundled XML.
-	 * @param name
+	 * Parse an XML document to create an Crew instance.
+	 * @param doc
+	 * @param predefined
 	 * @return
 	 */
-	private void loadCrew(String file, boolean predefined) {
-		
-		Document doc = parseXMLFileAsJDOMDocument(file, predefined);
-		if (doc == null) {
-			throw new IllegalStateException("Can not find " + file);
-		}
+	@Override
+	protected Crew parseItemXML(Document doc, boolean predefined) {
 		Element crewEl = doc.getRootElement();
 		String name = crewEl.getAttributeValue(NAME_ATTR);
 		if (name == null) {
-			name = file.substring(CREW_PREFIX.length(),
-						file.length() - SimulationConfig.XML_EXTENSION.length());
+			logger.warning("Crew has no name");
+			name = "Unknown";
 		}
 		String desc = crewEl.getAttributeValue(DESC_ATTR);
 		if (desc == null) {
@@ -176,69 +124,19 @@ public class CrewConfig {
 			m.setRelationshipMap(parseRelationshipMap(personElement));
 		}
 		
-		logger.config("Loaded Crew " + name + " from " + file);
-		knownCrews.put(name, roster);
+		logger.config("Loaded Crew " + name);
+		return roster;
 	}
 	
-	/**
-	 * Parses an XML file into a DOM document.
-	 * 
-	 * @param filename the path of the file.
-	 * @param useDTD   true if the XML DTD should be used.
-	 * @return DOM document
-	 * @throws IOException
-	 * @throws JDOMException
-	 * @throws Exception     if XML could not be parsed or file could not be found.
-	 */
-	private Document parseXMLFileAsJDOMDocument(String filename, boolean useDTD) {
-		SAXBuilder builder = null;
-		String path = "";
-		
-		if (useDTD) { // for alpha crew
-			builder = new SAXBuilder();
-		    builder.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		    builder.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-			path = SimulationFiles.getXMLDir();
-			
-			// Alpha is a bundled XML so needs to be copied out
-			SimulationConfig.instance().getBundledXML(filename);
-			filename += SimulationConfig.XML_EXTENSION;
-		}
-		else { // for beta crew
-			builder = new SAXBuilder();
-		    builder.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		    builder.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-			path = SimulationFiles.getSaveDir();
-		}
 
-	    Document document = null;
-	    
-		File f = new File(path, filename);
-		if (!f.exists()) {
-			return null;
-		}
-		
-		if (f.exists() && f.canRead()) {
-	        
-	        try {
-		        document = builder.build(f);
-		    }
-		    catch (JDOMException | IOException e)
-		    {
-		        e.printStackTrace();
-		    }
-		}
-		
-	    return document;
-	}
-	
 
 	/**
 	 * Creates an XML document for this crew.
 	 * 
 	 * @return
 	 */
-	private Document createCrewDoc(Crew roster) {
+	@Override
+	protected Document createItemDoc(Crew roster) {
 
 		Element root = new Element(CREW_COFIG);
 		Document doc = new Document(root);
@@ -296,80 +194,6 @@ public class CrewConfig {
 			node.setAttribute(new Attribute(attrName, value));
 		}
 	}
-
-	private static String getCrewFilename(String crewName) {
-		// Replace spaces 
-		return CREW_PREFIX + crewName.toLowerCase().replace(' ', '_');
-	}
-	
-	/**
-	 * Save the XML document for this crew.
-	 * 
-	 * @param roster the crew manifest
-	 */
-	public void save(Crew crew) {
-
-		String filename = getCrewFilename(crew.getName());
-		File crewFile = new File(SimulationFiles.getSaveDir(), filename + SimulationConfig.XML_EXTENSION);
-		File crewBackup = new File(SimulationFiles.getSaveDir(), filename + CREW_BACKUP);
-		
-		// Create save directory if it doesn't exist.
-		if (!crewFile.getParentFile().exists()) {
-			crewFile.getParentFile().mkdirs();
-			logger.config(crewFile.getParentFile().getAbsolutePath() + " created successfully."); 
-		}
-		
-		if (crewFile.exists()) {
-			
-			try {
-				if (Files.deleteIfExists(crewBackup.toPath())) {
-					// Delete the beta_crew.bak
-				    logger.config("Old " + crewBackup.getName() + " deleted."); 
-				} 
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-			
-			
-			try {
-				// Back up the previous version of beta_crew.xml as beta_crew.bak
-				FileUtils.moveFile(crewFile, crewBackup);
-			    logger.config("beta_crew.xml --> beta_crew.bak"); 
-			} catch (IOException e1) {
-				// TODO Auto-generated catch block
-				e1.printStackTrace();
-			}
-			
-			try {
-				if (Files.deleteIfExists(crewFile.toPath())) {
-					// Delete the beta_crew.xml
-				    logger.config("Old " + crewFile.getName() + " deleted."); 
-				} 
-
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
-		
-		if (!crewFile.exists()) {
-			Document outputDoc = createCrewDoc(crew);
-			XMLOutputter fmt = new XMLOutputter();
-			fmt.setFormat(Format.getPrettyFormat());
-				
-			try (FileOutputStream stream = new FileOutputStream(crewFile);
-				 OutputStreamWriter writer = new OutputStreamWriter(stream, "UTF-8")) {						 
-				fmt.output(outputDoc, writer);
-			    logger.config("New " + crewFile.getName() + " created and saved."); 
-			    stream.close();
-			} catch (Exception e) {
-				logger.log(Level.SEVERE, e.getMessage());
-			}
-		}
-		
-		// Update or register new crew
-		knownCrews.put(crew.getName(), crew);
-	}
-	
 
 	/**
 	 * Gets a map of the configured person's natural attributes.
@@ -469,11 +293,5 @@ public class CrewConfig {
 			}
 		}
 		return result;
-	}
-
-	public List<String> getKnownCrewNames() {
-		List<String> names = new ArrayList<>(knownCrews.keySet());
-		Collections.sort(names);
-		return names;
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/SettlementBuilder.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/SettlementBuilder.java
@@ -21,11 +21,11 @@ import org.mars_sim.msp.core.Simulation;
 import org.mars_sim.msp.core.SimulationConfig;
 import org.mars_sim.msp.core.UnitManager;
 import org.mars_sim.msp.core.configuration.Scenario;
+import org.mars_sim.msp.core.configuration.UserConfigurableConfig;
 import org.mars_sim.msp.core.equipment.Equipment;
 import org.mars_sim.msp.core.equipment.EquipmentFactory;
 import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.person.Crew;
-import org.mars_sim.msp.core.person.CrewConfig;
 import org.mars_sim.msp.core.person.Favorite;
 import org.mars_sim.msp.core.person.GenderType;
 import org.mars_sim.msp.core.person.Member;
@@ -71,7 +71,7 @@ public final class SettlementBuilder {
 	private SettlementConfig settlementConfig;
 	private PersonConfig personConfig;
 	private RobotConfig robotConfig;
-	private CrewConfig crewConfig;
+	private UserConfigurableConfig<Crew> crewConfig;
 
 	public SettlementBuilder(Simulation sim, SimulationConfig simConfig) {
 		super();
@@ -588,7 +588,7 @@ public final class SettlementBuilder {
 	/**
 	 * Enable the use of a predefined crews
 	 */
-	public void setCrew(CrewConfig crewConfig) {
+	public void setCrew(UserConfigurableConfig<Crew> crewConfig) {
 		this.crewConfig = crewConfig;
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/SettlementBuilder.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/SettlementBuilder.java
@@ -382,7 +382,7 @@ public final class SettlementBuilder {
 	 */
 	private void createPreconfiguredPeople(Settlement settlement, String crewName) {
 
-		Crew crew = crewConfig.getCrew(crewName);
+		Crew crew = crewConfig.getItem(crewName);
 		if (crew == null) {
 			throw new IllegalArgumentException("No crew defined called " + crewName);
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/SettlementBuilder.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/SettlementBuilder.java
@@ -20,6 +20,7 @@ import org.mars_sim.msp.core.Inventory;
 import org.mars_sim.msp.core.Simulation;
 import org.mars_sim.msp.core.SimulationConfig;
 import org.mars_sim.msp.core.UnitManager;
+import org.mars_sim.msp.core.configuration.Scenario;
 import org.mars_sim.msp.core.equipment.Equipment;
 import org.mars_sim.msp.core.equipment.EquipmentFactory;
 import org.mars_sim.msp.core.logging.SimLogger;
@@ -85,8 +86,9 @@ public final class SettlementBuilder {
 	/**
 	 * Create all the initial Settlements
 	 */
-	public void createInitialSettlements() {
-		for (InitialSettlement spec : settlementConfig.getInitialSettlements()) {
+	public void createInitialSettlements(Scenario bootstrap) {
+		logger.config("Scenario " + bootstrap.getName() + " loading");
+		for (InitialSettlement spec : bootstrap.getSettlements()) {
 			createFullSettlement(spec);
 		}
 		

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/SettlementConfig.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/SettlementConfig.java
@@ -27,7 +27,7 @@ import org.mars_sim.msp.core.resource.ResourceUtil;
 import org.mars_sim.msp.core.structure.BuildingTemplate.BuildingConnectionTemplate;
 
 /**
- * Provides configuration information about settlements. Uses a DOM document to
+ * Provides configuration information about settlements templates. Uses a DOM document to
  * get the information.
  */
 public class SettlementConfig implements Serializable {

--- a/mars-sim-core/src/main/resources/xml/crew_founders.xml
+++ b/mars-sim-core/src/main/resources/xml/crew_founders.xml
@@ -40,36 +40,13 @@
 ]>
 
 
-<crew-configuration name="Alpha" description="Preloaded Alpha crew">
+<crew-configuration name="Founders" description="Project contributors">
 
 	<!-- List of preconfigured crew  -->
 	<crew-list>
-
-		<!--    Configure a crew member   -->
-		<!--    Note that it must include at least a member -->
-		<!--                                                -->
-		<!--             name : the person's name (required) -->
-		<!--           gender : the person's gender, "male" or "female" (required)-->
-		<!--              age : the person's age (optional) -->		
-		<!-- personality-type : the person's MBTI personality type. (optional) -->
-		<!--          country : the nationality of this person (optional. "USA" by default)  	-->
-		<!--              job : the person's permanent job. (optional) -->
-		<!--          sponsor : the person's Sponsor; if not defined then the 
-		                        Settlement sponsor is used. (optional) -->
-			
-		<!-- favorite-main-dish : the person's favorite main dish. (optional)	-->
-		<!-- favorite-side-dish : the person's favorite side dish. (optional)	-->
-		<!--   favorite-dessert : the person's favorite dessert. (optional)		-->
-		<!--  favorite-activity : the person's favorite hobby.					-->
-		
-		<!--    See a list of meal names in meals.xml -->
-		<!--    See a list of favorite activities in FavoriteType class 		-->
-		<!-- 																	-->
-		<!--  Available dessert are soymilk, sugarcane juice, strawberry, granola bar, blueberry muffin, and cranberry juice -->
 	
-		<person name="Karen Andersen" 
-			gender="female" 
-			age="37"
+		<person name="Manny Kung" 
+			gender="male" 
 			personality-type="ISTJ"
 			country="USA"
 			job="Botanist"
@@ -77,20 +54,6 @@
 			favorite-side-dish="Roasted Carrot Soup"
 			favorite-dessert="strawberry"
 			favorite-activity="Field Work">
-
-			<!-- A list of predefined personality traits (optional)
-
-		 	Personality Trait Model / Big Five Model:
-
-//          Openness - The willingness to make a shift of standards in new situations and appreciation for a variety of experience.
-// Conscientiousness - Planning ahead rather than being spontaneous.
-//      Extraversion - The willingness to communicate and socialize with people. Being energetic with people.
-//     Agreeableness - The adaptiveness to other people. Adopt goals in favor of others.
-//       Neuroticism - The extent to which one's emotion are sensitive to his environment; 
-//                     The degree of worrying or feeling vulnerable;
-//	                   The emotional sensitivity and sense of security to the situation.
-
-			See https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/personality-insights/models.shtml -->
 
 			<personality-trait-list>
 				<!-- the personality trait for a person using The Big Five Personality Traits, aka the Five Factor Model (FFM) -->
@@ -132,22 +95,12 @@
 				<skill name="Medicine" level="1"/>
 				<skill name="Cooking" level="1"/>
 			</skill-list>
-
-			<!-- List of configured relationships. (optional) -->
-			<relationship-list>
-				<!-- A relationship with another configured person. -->
-				<!-- person-name : the name of the relationship person. (required) -->
-				<!--   Note that other person must be configured on this list. -->
-				<!--     opinion : this person's opinion of the relationship person. -->
-				<!--                values from 0 (hate) to 100 (close friend) (required) -->
-				<relationship person-name="Rik Declercq" opinion="100"/> 
-			</relationship-list>
 		</person>
 
-		<person name="Rik Declercq" 
+		<person name="Lars Christensen" 
 			gender="male" 
 			personality-type="ESTP"
-			country="USA"
+			country="Denmark"
 			job="Areologist"
 			favorite-main-dish="Salsa Potato Salad" 
 			favorite-side-dish="Sesame Miso Soup" 
@@ -170,10 +123,9 @@
             </skill-list>
        </person>
 
-        <person name="Leonardo DaVinci" 
+        <person name="Scott Davis" 
         	gender="male" 
         	personality-type="INFJ"
-        	sponsor="MS"
 			country="USA"
         	job="Engineer"
 			favorite-main-dish="Steamed Brown Rice" 
@@ -197,11 +149,10 @@
             </skill-list>
         </person>
 
-        <person name="Lena LaGranda" 
-        	gender="female" 
+        <person name="Dennis Krenz" 
+        	gender="male" 
         	personality-type="ENFJ"
-        	sponsor="MS"
-			country="USA"
+			country="Germany"
         	job="Technician"
 			favorite-main-dish="Kidney Bean Fried Rice" 
 			favorite-side-dish="Garlic Bread" 
@@ -224,12 +175,10 @@
             </skill-list>
         </person>
 
-       <person name="Ray Bradbury" 
+       <person name="Barry Evans" 
        		gender="male" 
-       		age="50"
        		personality-type="INTP"
-        	sponsor="MS"
-			country="USA"
+			country="UK"
         	job="Doctor"
 			favorite-main-dish="Veggie Sandwich" 
 			favorite-side-dish="Taro Soup"

--- a/mars-sim-core/src/main/resources/xml/scenario_default.xml
+++ b/mars-sim-core/src/main/resources/xml/scenario_default.xml
@@ -1,0 +1,84 @@
+<?xml version = "1.0" encoding = "UTF-8" standalone = "yes" ?>
+<!DOCTYPE scenario-configuration [
+	<!ELEMENT scenario-configuration (initial-settlement-list)>
+	<!ATTLIST scenario-configuration name CDATA #REQUIRED>
+	<!ATTLIST scenario-configuration description CDATA #REQUIRED>
+
+	<!ELEMENT initial-settlement-list (settlement*)>
+	<!ELEMENT settlement (location, population, robots, sponsor)>
+	<!ATTLIST settlement name CDATA #REQUIRED>
+	<!ATTLIST settlement template CDATA #REQUIRED>
+	<!ATTLIST settlement crew CDATA #IMPLIED>
+	<!ELEMENT location EMPTY>
+	<!ATTLIST location longitude CDATA #REQUIRED>
+	<!ATTLIST location latitude CDATA #REQUIRED>
+	<!ELEMENT population EMPTY>
+	<!ATTLIST population number CDATA #REQUIRED>
+	<!ELEMENT robots EMPTY>
+	<!ATTLIST robots number CDATA #REQUIRED>
+	<!ELEMENT sponsor EMPTY>
+	<!ATTLIST sponsor name CDATA #REQUIRED>
+
+]>
+
+<scenario-configuration name="Default" description="Default provided Scenario">
+	<initial-settlement-list>
+	<!-- List of initial settlements in the simulation -->
+		<settlement name="New Plymouth" template="Phase 2-U">
+			<location longitude="29.75 W" latitude="10.63 N" />
+			<population number="8" />
+			<robots number="4" />
+			<sponsor name="NASA"/>
+		</settlement>
+		
+		<settlement name="Europa" template="Phase 2-E">
+			<location longitude="50.0 W" latitude="20.0 N" />
+			<population number="8" />
+			<robots number="4" />
+			<sponsor name="ESA"/>
+		</settlement>
+		
+		<settlement name="Tian Cheng" template="Phase 2-C">
+			<location longitude="134.67 E" latitude="22.67 N" />
+			<population number="8" />
+			<robots number="4" />
+			<sponsor name="CNSA"/>
+		</settlement>
+		
+		<settlement name="New Pompeii" template="Phase 2-I">
+			<location longitude="82.9 W" latitude="22.0 N" />
+			<population number="8" />
+			<robots number="4" />
+			<sponsor name="ISRO"/>
+		</settlement>
+	
+		<settlement name="Kyocera" template="Phase 2-J">
+			<location longitude="150.0 W" latitude="35.0 N" />
+			<population number="8" />
+			<robots number="4" />
+			<sponsor name="JAXA"/>
+		</settlement>
+			
+		<settlement name="Starcity" template="Phase 3-X">
+			<location longitude="165.32 E" latitude="41.01 N" />
+			<population number="12" />
+			<robots number="8" />
+			<sponsor name="SPACEX"/>
+		</settlement>
+					
+		<settlement name="Zvezda" template="Phase 3-R">
+			<location longitude="76.37 E" latitude="25.94 N" />
+			<population number="12" />
+			<robots number="8" />
+			<sponsor name="RKA"/>
+		</settlement>
+					
+		<settlement name="Schiaparelli Point" template="Alpha Base" crew="Alpha">
+			<location longitude="0.0 W" latitude="0.0 N" />
+			<population number="24" />
+			<robots number="12" />
+			<sponsor name="MS"/>
+		</settlement>
+		
+	</initial-settlement-list>
+</scenario-configuration>

--- a/mars-sim-core/src/main/resources/xml/scenario_default.xml
+++ b/mars-sim-core/src/main/resources/xml/scenario_default.xml
@@ -5,79 +5,53 @@
 	<!ATTLIST scenario-configuration description CDATA #REQUIRED>
 
 	<!ELEMENT initial-settlement-list (settlement*)>
-	<!ELEMENT settlement (location, population, robots, sponsor)>
+	<!ELEMENT settlement (location)>
 	<!ATTLIST settlement name CDATA #REQUIRED>
 	<!ATTLIST settlement template CDATA #REQUIRED>
 	<!ATTLIST settlement crew CDATA #IMPLIED>
+	<!ATTLIST settlement persons CDATA #REQUIRED>
+	<!ATTLIST settlement robots CDATA #REQUIRED>
+	<!ATTLIST settlement sponsor CDATA #REQUIRED>
 	<!ELEMENT location EMPTY>
 	<!ATTLIST location longitude CDATA #REQUIRED>
 	<!ATTLIST location latitude CDATA #REQUIRED>
-	<!ELEMENT population EMPTY>
-	<!ATTLIST population number CDATA #REQUIRED>
-	<!ELEMENT robots EMPTY>
-	<!ATTLIST robots number CDATA #REQUIRED>
-	<!ELEMENT sponsor EMPTY>
-	<!ATTLIST sponsor name CDATA #REQUIRED>
+
 
 ]>
 
 <scenario-configuration name="Default" description="Default provided Scenario">
 	<initial-settlement-list>
 	<!-- List of initial settlements in the simulation -->
-		<settlement name="New Plymouth" template="Phase 2-U">
+		<settlement name="New Plymouth" template="Phase 2-U" persons="8" robots="4" sponsor="NASA">
 			<location longitude="29.75 W" latitude="10.63 N" />
-			<population number="8" />
-			<robots number="4" />
-			<sponsor name="NASA"/>
 		</settlement>
 		
-		<settlement name="Europa" template="Phase 2-E">
+		<settlement name="Europa" template="Phase 2-E" persons="8" robots="4" sponsor="ESA">
 			<location longitude="50.0 W" latitude="20.0 N" />
-			<population number="8" />
-			<robots number="4" />
-			<sponsor name="ESA"/>
 		</settlement>
 		
-		<settlement name="Tian Cheng" template="Phase 2-C">
+		<settlement name="Tian Cheng" template="Phase 2-C" persons="8" robots="4" sponsor="CNSA">
 			<location longitude="134.67 E" latitude="22.67 N" />
-			<population number="8" />
-			<robots number="4" />
-			<sponsor name="CNSA"/>
 		</settlement>
 		
-		<settlement name="New Pompeii" template="Phase 2-I">
+		<settlement name="New Pompeii" template="Phase 2-I" persons="8" robots="4" sponsor="ISRO">
 			<location longitude="82.9 W" latitude="22.0 N" />
-			<population number="8" />
-			<robots number="4" />
-			<sponsor name="ISRO"/>
 		</settlement>
 	
-		<settlement name="Kyocera" template="Phase 2-J">
+		<settlement name="Kyocera" template="Phase 2-J" persons="8" robots="4" sponsor="JAXA">
 			<location longitude="150.0 W" latitude="35.0 N" />
-			<population number="8" />
-			<robots number="4" />
-			<sponsor name="JAXA"/>
 		</settlement>
 			
-		<settlement name="Starcity" template="Phase 3-X">
+		<settlement name="Starcity" template="Phase 3-X" persons="12" robots="8" sponsor="SPACEX">
 			<location longitude="165.32 E" latitude="41.01 N" />
-			<population number="12" />
-			<robots number="8" />
-			<sponsor name="SPACEX"/>
 		</settlement>
 					
-		<settlement name="Zvezda" template="Phase 3-R">
+		<settlement name="Zvezda" template="Phase 3-R" persons="12" robots="8" sponsor="RKA">
 			<location longitude="76.37 E" latitude="25.94 N" />
-			<population number="12" />
-			<robots number="8" />
-			<sponsor name="RKA"/>
 		</settlement>
 					
-		<settlement name="Schiaparelli Point" template="Alpha Base" crew="Alpha">
+		<settlement name="Schiaparelli Point" template="Alpha Base" crew="Alpha" persons="24" robots="12" sponsor="MS">
 			<location longitude="0.0 W" latitude="0.0 N" />
-			<population number="24" />
-			<robots number="12" />
-			<sponsor name="MS"/>
 		</settlement>
 		
 	</initial-settlement-list>

--- a/mars-sim-core/src/main/resources/xml/settlements.xml
+++ b/mars-sim-core/src/main/resources/xml/settlements.xml
@@ -1,7 +1,7 @@
 <?xml version = "1.0" encoding = "UTF-8" standalone = "yes" ?>
 <!DOCTYPE settlement-configuration [
 	<!ELEMENT settlement-configuration (mission-control, life-support-requirements, settlement-template-list,
-	initial-settlement-list, new-arriving-settlement-list, settlement-name-list)>
+	new-arriving-settlement-list, settlement-name-list)>
 	
 	<!ELEMENT mission-control (rover-life-support-range-error-margin, rover-fuel-range-error-margin)>
 	<!ELEMENT rover-life-support-range-error-margin EMPTY>
@@ -71,14 +71,7 @@
 	<!ELEMENT resupply (resupply-mission*)>
 	<!ELEMENT resupply-mission EMPTY>
 	<!ATTLIST resupply-mission name CDATA #REQUIRED>
-	<!ATTLIST resupply-mission arrival-time CDATA #REQUIRED>
-	
-	<!ELEMENT initial-settlement-list (settlement*)>
-	<!ELEMENT settlement (location, population, number-of-robots, sponsor)>
-	<!ATTLIST settlement name CDATA #REQUIRED>
-	<!ATTLIST settlement template CDATA #REQUIRED>
-	<!ATTLIST settlement crew CDATA #IMPLIED>
-	
+	<!ATTLIST resupply-mission arrival-time CDATA #REQUIRED>	
 	
 	<!ELEMENT new-arriving-settlement-list (arriving-settlement*)>
 	<!ELEMENT arriving-settlement (location, population, number-of-robots, sponsor)>
@@ -4760,104 +4753,6 @@
 
 	</settlement-template-list>
 
-	<!-- List of initial settlements in the simulation -->
-	<initial-settlement-list>
-	<!-- For each settlement, use one of the single letter designation as follows for each sponsor : 
-		U - National Aeronautics and Space Administration (NASA)
-		C - China National Space Administration (CNSA)
-		I - Indian Space Research Organisation (ISRO)
-		R - Roscosmos (RKA)		
-		A - Canadian Space Agency (CSA)
-		E - European Space Agency (ESA)
-		J - Japan Aerospace Exploration Agency (JAXA)
-		M - Mars Society (MS)
-		X - Space Exploration Technologies (SpaceX)
-	
-		e.g. "Phase 1-U" means a NASA Phase 1 settlement
-	 -->
-	 
-		<settlement name="New Plymouth" template="Phase 2-U">
-			<location longitude="29.75 W" latitude="10.63 N" />
-			<population number="8" />
-			<number-of-robots number="4" />
-			<sponsor name="NASA"/>
-		</settlement>
-		
-		<settlement name="Europa" template="Phase 2-E">
-			<location longitude="50.0 W" latitude="20.0 N" />
-			<population number="8" />
-			<number-of-robots number="4" />
-			<sponsor name="ESA"/>
-		</settlement>
-		
-		<settlement name="Tian Cheng" template="Phase 2-C">
-			<location longitude="134.67 E" latitude="22.67 N" />
-			<population number="8" />
-			<number-of-robots number="4" />
-			<sponsor name="CNSA"/>
-		</settlement>
-		
-		<settlement name="New Pompeii" template="Phase 2-I">
-			<location longitude="82.9 W" latitude="22.0 N" />
-			<population number="8" />
-			<number-of-robots number="4" />
-			<sponsor name="ISRO"/>
-		</settlement>
-	
-		<settlement name="Kyocera" template="Phase 2-J">
-			<location longitude="150.0 W" latitude="35.0 N" />
-			<population number="8" />
-			<number-of-robots number="4" />
-			<sponsor name="JAXA"/>
-		</settlement>
-			
-		<settlement name="Starcity" template="Phase 3-X">
-			<location longitude="165.32 E" latitude="41.01 N" />
-			<population number="12" />
-			<number-of-robots number="8" />
-			<sponsor name="SPACEX"/>
-		</settlement>
-					
-		<settlement name="Zvezda" template="Phase 3-R">
-			<location longitude="76.37 E" latitude="25.94 N" />
-			<population number="12" />
-			<number-of-robots number="8" />
-			<sponsor name="RKA"/>
-		</settlement>
-					
-		<settlement name="Schiaparelli Point" template="Alpha Base" crew="Alpha">
-			<location longitude="0.0 W" latitude="0.0 N" />
-			<population number="24" />
-			<number-of-robots number="12" />
-			<sponsor name="MS"/>
-		</settlement>
-					
-		<!-- SpaceX's proposed landing sites
-		
-			 https://www.humanmars.net/2019/09/candidate-sites-for-spacex-starship.html?m=1
-		     https://behindtheblack.com/behind-the-black/essays-and-commentaries/spacex-begins-hunt-for-starship-landing-sites-on-mars/ 
-		     
-			 All the candidate landing sites (except #6 in Phlegra Montes) are located 
-		     on the border between Amazonis Planitia and Arcadia Planitia.
-		     
-		     There's a nearby lobate debris apron glacier and is strong evidence that 
-		     this location holds buried glaciers called lobate debris aprons. 
-		   		     
-		<settlement name="Elon One" template="Phase 1">
-			<location longitude="171.0 W" latitude="39.0 N" />
-			<population number="4" />
-			<number-of-robots number="4" />
-			<sponsor name="Space Exploration Technologies (SpaceX)"/>
-		</settlement>
-		<settlement name="Elon Two" template="Phase 1">
-			<location longitude="156.0 W" latitude="40.0 N" />
-			<population number="4" />
-			<number-of-robots number="4" />
-			<sponsor name="Space Exploration Technologies (SpaceX)"/>
-		</settlement>
-		-->
-		
-	</initial-settlement-list>
 
 	<!--  List of settlements that will arrive on Mars at a later time -->
 	<new-arriving-settlement-list>

--- a/mars-sim-main/src/main/java/org/mars_sim/main/MarsProject.java
+++ b/mars-sim-main/src/main/java/org/mars_sim/main/MarsProject.java
@@ -53,8 +53,6 @@ public class MarsProject {
 	private static final String NOGUI = "nogui";
 	private static final String DISPLAYHELP = "help";
 	private static final String GENERATEHELP = "html";
-	
-	private static String[] args;
 
 	/** true if displaying graphic user interface. */
 	private boolean useGUI = true;
@@ -67,19 +65,18 @@ public class MarsProject {
 
 
 	/**
-	 * Constructor 1.
-	 * 
-	 * @param args command line arguments.
+	 * Constructor 
 	 */
-	public MarsProject(String args[]) {
+	public MarsProject() {
 		logger.config("Starting " + Simulation.title);
-		
-		parseArgs(args);
-	}
-
-
-	private void parseArgs(String[] args2) {
-		logger.config("List of input args : " + Arrays.toString(args2));
+	};
+	
+	/**
+	 * Parse the argument and start the simulation.
+	 * @param args
+	 */
+	public void parseArgs(String[] args) {
+		logger.config("List of input args : " + Arrays.toString(args));
 		
 		SimulationBuilder builder = new SimulationBuilder(SimulationConfig.instance());
 		
@@ -138,7 +135,7 @@ public class MarsProject {
 			SimulationConfig.instance().loadConfig();
 			
 			// Get user choices if there is no template defined or a preload
-			if ((builder.getTemplate() == null) && (builder.getSimFile() == null)) {
+			if (!builder.isFullyDefined()) {
 				logger.config("Please go to the mars-sim console's Main Menu to choose an option.");
 				
 				int type = interactiveTerm.startConsoleMainMenu();
@@ -312,8 +309,6 @@ public class MarsProject {
 
 		Logger.getLogger("").setLevel(Level.FINE);
 
-		MarsProject.args = args;
-
 		/*
 		 * [landrus, 27.11.09]: Read the logging configuration from the classloader, so
 		 * that this gets webstart compatible. Also create the logs dir in user.home
@@ -336,7 +331,9 @@ public class MarsProject {
 		System.setProperty("awt.useSystemAAFontSettings", "lcd"); // for newer VMs
 
 		// starting the simulation
-		new MarsProject(args);
+		MarsProject project = new MarsProject();
+		project.parseArgs(args);
+		logger.config("Simulation running");
 	}
 
 }

--- a/mars-sim-main/src/main/java/org/mars_sim/main/MarsProject.java
+++ b/mars-sim-main/src/main/java/org/mars_sim/main/MarsProject.java
@@ -32,7 +32,9 @@ import org.mars_sim.msp.core.Simulation;
 import org.mars_sim.msp.core.SimulationBuilder;
 import org.mars_sim.msp.core.SimulationConfig;
 import org.mars_sim.msp.core.SimulationFiles;
-import org.mars_sim.msp.core.person.CrewConfig;
+import org.mars_sim.msp.core.configuration.Scenario;
+import org.mars_sim.msp.core.configuration.UserConfigurableConfig;
+import org.mars_sim.msp.core.person.Crew;
 import org.mars_sim.msp.ui.helpGenerator.HelpGenerator;
 import org.mars_sim.msp.ui.swing.MainWindow;
 import org.mars_sim.msp.ui.swing.configeditor.SimulationConfigEditor;
@@ -146,10 +148,15 @@ public class MarsProject {
 					logger.config("Running the site editor...");
 					editor.waitForCompletion();
 					
-					CrewConfig crew = editor.getCrewConfig();
+					UserConfigurableConfig<Crew> crew = editor.getCrewConfig();
 					if (crew != null) {
 						// Set the actual CrewConfig as it has editted entries
 						builder.setCrewConfig(crew);
+					}
+					
+					Scenario scenario = editor.getScenario();
+					if (scenario != null) {
+						builder.setScenario(scenario);
 					}
 				}
 			

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/configeditor/CrewEditor.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/configeditor/CrewEditor.java
@@ -37,8 +37,8 @@ import javax.swing.JTextField;
 import javax.swing.WindowConstants;
 import javax.swing.event.DocumentEvent;
 
+import org.mars_sim.msp.core.configuration.UserConfigurableConfig;
 import org.mars_sim.msp.core.person.Crew;
-import org.mars_sim.msp.core.person.CrewConfig;
 import org.mars_sim.msp.core.person.GenderType;
 import org.mars_sim.msp.core.person.Member;
 import org.mars_sim.msp.core.person.ai.job.JobType;
@@ -405,7 +405,7 @@ public class CrewEditor implements ActionListener {
 	 * @param simulationConfigEditor
 	 *            SimulationConfigEditor
 	 */
-	public CrewEditor(SimulationConfigEditor simulationConfigEditor, CrewConfig config) {
+	public CrewEditor(SimulationConfigEditor simulationConfigEditor, UserConfigurableConfig<Crew> config) {
 		
 		this.simulationConfigEditor = simulationConfigEditor;
 		
@@ -441,7 +441,7 @@ public class CrewEditor implements ActionListener {
 	/**
 	 * Creates the GUI
 	 */
-	private void createGUI(CrewConfig crewConfig) {
+	private void createGUI(UserConfigurableConfig<Crew> crewConfig) {
 	
 		f = new WebDialog(simulationConfigEditor.getFrame(), TITLE + " - Alpha Crew On-board", true); //new JFrame(TITLE + " - Alpha Crew On-board");
 		f.setIconImage(MainWindow.getIconImage());

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/configeditor/SimulationConfigEditor.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/configeditor/SimulationConfigEditor.java
@@ -106,12 +106,12 @@ public class SimulationConfigEditor {
 
 		@Override
 		public int getSize() {
-			return crewConfig.getKnownCrewNames().size();
+			return crewConfig.getItemNames().size();
 		}
 
 		@Override
 		public String getElementAt(int index) {
-			return crewConfig.getKnownCrewNames().get(index);
+			return crewConfig.getItemNames().get(index);
 		}
 
 		@Override

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/configeditor/SimulationConfigEditor.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/configeditor/SimulationConfigEditor.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 
+import javax.swing.BorderFactory;
 import javax.swing.ComboBoxModel;
 import javax.swing.DefaultCellEditor;
 import javax.swing.JButton;
@@ -879,12 +880,13 @@ public class SimulationConfigEditor {
 				return finalizeSettlementConfig(newName);
 			}
 		};
-		bottomPanel.add(control.getPane(), BorderLayout.CENTER);
+		bottomPanel.add(control.getPane(), BorderLayout.WEST);
 
 		
 		// Create the bottom button panel.
 		JPanel bottomButtonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
-		bottomPanel.add(bottomButtonPanel, BorderLayout.SOUTH);
+		bottomButtonPanel.setBorder(BorderFactory.createTitledBorder("Simulation"));
+		bottomPanel.add(bottomButtonPanel, BorderLayout.EAST);
 
 		if (mode == GameMode.COMMAND) {
 			// Create the sponsor note label
@@ -944,9 +946,9 @@ public class SimulationConfigEditor {
 
 		bottomButtonPanel.add(cb);
 		bottomButtonPanel.add(crewButton);
-
-		// Load it
-		//settlementTableModel.loadDefaultSettlements(selectedScenario);
+		
+		// Force a load of the default Scenario
+		control.setSelectedItem(ScenarioConfig.PREDEFINED_SCENARIOS[0]);
 		
 		// Set the location of the dialog at the center of the screen.
 		Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/configeditor/UserConfigurableControl.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/configeditor/UserConfigurableControl.java
@@ -11,6 +11,7 @@ import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+import javax.swing.BorderFactory;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -56,9 +57,10 @@ public abstract class UserConfigurableControl<T extends UserConfigurable> implem
 		this.parent = parent;
 
 		this.buttonPane = new JPanel(new FlowLayout(FlowLayout.CENTER));
+		this.buttonPane.setBorder(BorderFactory.createTitledBorder(itemType));
 		
 		// Crew name selection
-		buttonPane.add(new WebLabel(itemType + " Loaded :"));
+		buttonPane.add(new WebLabel("Loaded :"));
 		itemCB = new DefaultComboBoxModel<>();
 		itemCB.addAll(0, config.getItemNames());
 		JComboBox<String> crewSelector = new JComboBox<>(itemCB) ;
@@ -198,6 +200,7 @@ public abstract class UserConfigurableControl<T extends UserConfigurable> implem
 			if ((newName != null) && (newName.length() > 0)) {
 				T newSelected = createItem(newName);
 				if (newSelected != null) {
+					newSelected.setDescription(descriptionTF.getText());
 					config.saveItem(newSelected); 
 
 					itemCB.addElement(newName);
@@ -221,5 +224,17 @@ public abstract class UserConfigurableControl<T extends UserConfigurable> implem
 
 	public JPanel getPane() {
 		return buttonPane;
+	}
+
+	/**
+	 * Set the select item that is displayed
+	 * @param newSelection
+	 */
+	public void setSelectedItem(String newSelection) {
+		// Refresh display with item
+		selectItem(newSelection);
+		
+		// Set the CB after the internal item to stop the dialog popping up
+		itemCB.setSelectedItem(newSelection);
 	}
 }

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/configeditor/UserConfigurableControl.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/configeditor/UserConfigurableControl.java
@@ -1,0 +1,213 @@
+package org.mars_sim.msp.ui.swing.configeditor;
+
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+
+import org.mars_sim.msp.core.configuration.UserConfigurable;
+import org.mars_sim.msp.core.configuration.UserConfigurableConfig;
+
+import com.alee.laf.label.WebLabel;
+import com.alee.laf.text.WebTextField;
+
+/**
+ * This is a UI Control panel that manages the UserConfigurable items of an existing
+ * repository. It provides common CRUD functionality for the items.
+ *
+ * @param <T> The UserConfigurable item that is managed.
+ */
+public abstract class UserConfigurableControl<T extends UserConfigurable> implements ActionListener {
+
+	private static final String LOAD = "load";
+	private static final String SAVE_NEW = "new";
+	private static final String SAVE = "save";
+	private static final String DELETE = "delete";
+	
+	private JButton saveButton;
+	private JButton delButton;
+	
+	private DefaultComboBoxModel<String> crewCB;
+
+	private WebTextField descriptionTF;
+	private UserConfigurableConfig<T> config;
+	private JPanel buttonPane;
+	private T selected;
+	private String itemType;
+	private Component parent;
+
+
+	public UserConfigurableControl(Component parent, String itemType, UserConfigurableConfig<T> config) {
+		this.config = config;
+		this.itemType = itemType;
+		this.parent = parent;
+
+		this.buttonPane = new JPanel(new FlowLayout(FlowLayout.CENTER));
+		
+		// Crew name selection
+		buttonPane.add(new WebLabel("Crew Loaded :"));
+		crewCB = new DefaultComboBoxModel<>();
+		crewCB.addAll(0, config.getItemNames());
+		JComboBox<String> crewSelector = new JComboBox<>(crewCB) ;
+		crewSelector.addActionListener(this);
+		crewSelector.setActionCommand(LOAD);
+		buttonPane.add(crewSelector);
+		
+		// Description field
+		buttonPane.add(new WebLabel("   Description : "));
+		descriptionTF = new WebTextField(15);
+		buttonPane.add(descriptionTF);
+		
+		// Create save crew button.
+		saveButton = new JButton("Save");
+		saveButton.addActionListener(this);
+		saveButton.setActionCommand(SAVE);
+		buttonPane.add(saveButton);		
+
+		// Create save new crew button.
+		JButton newButton = new JButton("Save as New");
+		newButton.setActionCommand(SAVE_NEW);
+		newButton.addActionListener(this);
+		buttonPane.add(newButton);
+
+		// Create save new crew button.
+		delButton = new JButton("Delete");
+		delButton.setActionCommand(DELETE);
+		delButton.addActionListener(this);
+		buttonPane.add(delButton);
+
+		String initialChoice = config.getItemNames().get(0);
+		selectItem(initialChoice);
+	}
+
+	/**
+	 * Change the selected to a new item.
+	 * @param newSelection
+	 */
+	private void selectItem(String newName) {
+		T newSelection = config.getItem(newName);
+		if ((selected== null) || !newSelection.getName().equals(selected.getName())) {
+			selected = newSelection;
+		
+			displayItem(selected);
+			
+			saveButton.setEnabled(!selected.isBundled());
+			delButton.setEnabled(!selected.isBundled());
+			crewCB.setSelectedItem(selected.getName());
+			descriptionTF.setText(selected.getDescription());	
+		}
+	}
+
+
+	/**
+	 * Displayed this new item which is now selected
+	 * @param newDisplay
+	 */
+	protected abstract void displayItem(T newDisplay);
+
+	/**
+	 * Create a new item on the values from teh associaetd editor panel.
+	 * @param newName
+	 * @return
+	 */
+	protected abstract T createItem(String newName);
+
+	/**
+	 * Takes the actions from the button being clicked on
+	 */
+	public void actionPerformed(ActionEvent evt) {
+
+		String cmd = (String) evt.getActionCommand();
+		switch (cmd) {
+		case LOAD: 
+			String loadItem = (String) crewCB.getSelectedItem();
+			if (!selected.getName().equalsIgnoreCase(loadItem)) {
+				JDialog.setDefaultLookAndFeelDecorated(true);
+				int result = JOptionPane.showConfirmDialog(parent, 
+								"Are you sure you want to reload the " + itemType + " '" + loadItem + "' ? " + System.lineSeparator()
+								+ "All the changes made will be lost.",
+								"Confirm Reloading " + itemType,
+								JOptionPane.YES_NO_CANCEL_OPTION);
+				
+				if (result == JOptionPane.YES_OPTION) {
+					selectItem(loadItem);
+				}
+			}
+			break;
+			
+		case DELETE:
+			JDialog.setDefaultLookAndFeelDecorated(true);
+			int result = JOptionPane.showConfirmDialog(parent, 
+							"Are you sure you want to delete the " + itemType + " '" + selected.getName() + "' ? " + System.lineSeparator()
+							+ "All the changes made will be lost.",
+							"Confirm Delete " + itemType,
+							JOptionPane.YES_NO_CANCEL_OPTION);
+			
+			if (result == JOptionPane.YES_OPTION) {
+				String oldItem = selected.getName();
+				config.deleteItem(oldItem);
+				
+				String nextItem = config.getItemNames().get(0);
+				selectItem(nextItem);
+				crewCB.removeElement(oldItem);
+			}
+			break;
+			
+		case SAVE:
+			JDialog.setDefaultLookAndFeelDecorated(true);
+			int result2 = JOptionPane.showConfirmDialog(parent,
+					"Are you sure you want to save the changes for " + selected.getName() + " ? " 
+					+ System.lineSeparator() + System.lineSeparator()
+					+ "Note : If you only want the changes to apply to " + System.lineSeparator()
+					+ "the simulation you are setting up, choose " + System.lineSeparator()
+					+ "'Commit Change' instead." + System.lineSeparator(),
+					"Confirm Saving " + itemType,
+					JOptionPane.YES_NO_CANCEL_OPTION);
+			
+			if (result2 == JOptionPane.YES_OPTION) {
+				T newSelected = createItem(selected.getName());
+
+				if (newSelected != null) {
+					newSelected.setDescription(descriptionTF.getText());
+
+					selected = newSelected;
+					config.saveItem(selected);
+				}
+			}
+			break;
+
+		case SAVE_NEW:
+			JDialog.setDefaultLookAndFeelDecorated(true);
+			String newName = (String)JOptionPane.showInputDialog(
+                   parent, "Enter the name of the new " + itemType);
+
+			// Create new Crew
+			if ((newName != null) && (newName.length() > 0)) {
+				T newSelected = createItem(newName);
+				if (newSelected != null) {
+					config.saveItem(newSelected); 
+
+					crewCB.addElement(newName);
+					selectItem(newName);
+				}
+			}
+			break;
+				
+		default:
+			break;
+		}
+	}
+
+
+
+	public JPanel getPane() {
+		return buttonPane;
+	}
+}

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/configeditor/UserConfigurableControl.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/configeditor/UserConfigurableControl.java
@@ -1,3 +1,9 @@
+/**
+ * Mars Simulation Project
+ * UserConfigurableControl.java
+ * @version 3.3.0 2021-08-20
+ * @author Barry Evans
+ */
 package org.mars_sim.msp.ui.swing.configeditor;
 
 import java.awt.Component;
@@ -34,7 +40,7 @@ public abstract class UserConfigurableControl<T extends UserConfigurable> implem
 	private JButton saveButton;
 	private JButton delButton;
 	
-	private DefaultComboBoxModel<String> crewCB;
+	private DefaultComboBoxModel<String> itemCB;
 
 	private WebTextField descriptionTF;
 	private UserConfigurableConfig<T> config;
@@ -52,10 +58,10 @@ public abstract class UserConfigurableControl<T extends UserConfigurable> implem
 		this.buttonPane = new JPanel(new FlowLayout(FlowLayout.CENTER));
 		
 		// Crew name selection
-		buttonPane.add(new WebLabel("Crew Loaded :"));
-		crewCB = new DefaultComboBoxModel<>();
-		crewCB.addAll(0, config.getItemNames());
-		JComboBox<String> crewSelector = new JComboBox<>(crewCB) ;
+		buttonPane.add(new WebLabel(itemType + " Loaded :"));
+		itemCB = new DefaultComboBoxModel<>();
+		itemCB.addAll(0, config.getItemNames());
+		JComboBox<String> crewSelector = new JComboBox<>(itemCB) ;
 		crewSelector.addActionListener(this);
 		crewSelector.setActionCommand(LOAD);
 		buttonPane.add(crewSelector);
@@ -100,7 +106,7 @@ public abstract class UserConfigurableControl<T extends UserConfigurable> implem
 			
 			saveButton.setEnabled(!selected.isBundled());
 			delButton.setEnabled(!selected.isBundled());
-			crewCB.setSelectedItem(selected.getName());
+			itemCB.setSelectedItem(selected.getName());
 			descriptionTF.setText(selected.getDescription());	
 		}
 	}
@@ -127,7 +133,7 @@ public abstract class UserConfigurableControl<T extends UserConfigurable> implem
 		String cmd = (String) evt.getActionCommand();
 		switch (cmd) {
 		case LOAD: 
-			String loadItem = (String) crewCB.getSelectedItem();
+			String loadItem = (String) itemCB.getSelectedItem();
 			if (!selected.getName().equalsIgnoreCase(loadItem)) {
 				JDialog.setDefaultLookAndFeelDecorated(true);
 				int result = JOptionPane.showConfirmDialog(parent, 
@@ -156,7 +162,7 @@ public abstract class UserConfigurableControl<T extends UserConfigurable> implem
 				
 				String nextItem = config.getItemNames().get(0);
 				selectItem(nextItem);
-				crewCB.removeElement(oldItem);
+				itemCB.removeElement(oldItem);
 			}
 			break;
 			
@@ -194,7 +200,7 @@ public abstract class UserConfigurableControl<T extends UserConfigurable> implem
 				if (newSelected != null) {
 					config.saveItem(newSelected); 
 
-					crewCB.addElement(newName);
+					itemCB.addElement(newName);
 					selectItem(newName);
 				}
 			}
@@ -205,7 +211,13 @@ public abstract class UserConfigurableControl<T extends UserConfigurable> implem
 		}
 	}
 
-
+	/**
+	 * Get the select item name.
+	 * @return
+	 */
+	public String getSelectItemName() {
+		return (String) itemCB.getSelectedItem();
+	}
 
 	public JPanel getPane() {
 		return buttonPane;


### PR DESCRIPTION
The Simulation Config Editor can now saved and reload different Scenarios. The controls are the same as the CrewEditor as they have been consolidated around the concept of a `UserConfigurable` item. Eventually Reporting Authority shoudl also use this interface with an new associated editor.

Scenarios can be create or copy from the default one and saved. These are held as XML files on disk.

There is also a new Founders crew pre-defined that contains contributors to the GitHub project.
close #411