### PR TITLE
Worker Interface uses LocalPosition class

### DIFF
--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/BoundedObject.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/BoundedObject.java
@@ -7,8 +7,15 @@
 
 package org.mars_sim.msp.core;
 
-public class BoundedObject implements LocalBoundedObject{
+import java.io.Serializable;
 
+public class BoundedObject implements LocalBoundedObject, Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+	
 	double w;
 	double l;
 	double f;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/LocalAreaUtil.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/LocalAreaUtil.java
@@ -155,17 +155,6 @@ public class LocalAreaUtil {
 	 * Gets a random location inside a local bounded object.
 	 *
 	 * @param boundedObject the local bounded object.
-	 * @return random X/Y location relative to the center of the bounded object.
-	 * @deprecated
-	 */
-	public static Point2D.Double getRandomInteriorLocation(LocalBoundedObject boundedObject) {
-		return getRandomInteriorPosition(boundedObject, true).toPoint();
-	}
-
-	/**
-	 * Gets a random location inside a local bounded object.
-	 *
-	 * @param boundedObject the local bounded object.
 	 * @param useBoundary   true if inner boundary distance should be used.
 	 * @return random X/Y location relative to the center of the bounded object.
 	 */
@@ -198,49 +187,50 @@ public class LocalAreaUtil {
 
 	
 	/**
-	 * Gets a random location outside a local bounded object at a given distance
+	 * Gets a random position outside a local bounded object at a given distance
 	 * away.
 	 *
 	 * @param boundedObject the local bounded object.
 	 * @param distance      the distance away from the object.
 	 * @return random X/Y location relative to the center of the bounded object.
 	 */
-	public static Point2D.Double getRandomExteriorLocation(LocalBoundedObject boundedObject, double distance) {
-
-		Point2D.Double result = new Point2D.Double(0D, 0D);
+	public static LocalPosition getRandomExteriorPosition(LocalBoundedObject boundedObject, double distance) {
 
 		int side = RandomUtil.getRandomInt(3);
 
+		double x = 0;
+		double y = 0;
 		switch (side) {
 		// Front side.
 		case 0:
-			result.x = RandomUtil.getRandomDouble(boundedObject.getWidth() + (distance * 2D))
+			x = RandomUtil.getRandomDouble(boundedObject.getWidth() + (distance * 2D))
 					- ((boundedObject.getWidth() / 2D) + distance);
-			result.y = (boundedObject.getLength() / 2D) + distance;
+			y = (boundedObject.getLength() / 2D) + distance;
 			break;
 
 		// Back side.
 		case 1:
-			result.x = RandomUtil.getRandomDouble(boundedObject.getWidth() + (distance * 2D))
+			x = RandomUtil.getRandomDouble(boundedObject.getWidth() + (distance * 2D))
 					- (boundedObject.getWidth() + distance);
-			result.y = (boundedObject.getLength() / -2D) - distance;
+			y = (boundedObject.getLength() / -2D) - distance;
 			break;
 
 		// Left side.
 		case 2:
-			result.x = (boundedObject.getWidth() / 2D) + distance;
-			result.y = RandomUtil.getRandomDouble(boundedObject.getLength() + (distance * 2D))
+			x = (boundedObject.getWidth() / 2D) + distance;
+			y = RandomUtil.getRandomDouble(boundedObject.getLength() + (distance * 2D))
 					- ((boundedObject.getLength() / 2D) + distance);
 			break;
 
 		// Right side.
 		case 3:
-			result.x = (boundedObject.getWidth() / -2D) - distance;
-			result.y = RandomUtil.getRandomDouble(boundedObject.getLength() + (distance * 2D))
+			x = (boundedObject.getWidth() / -2D) - distance;
+			y = RandomUtil.getRandomDouble(boundedObject.getLength() + (distance * 2D))
 					- ((boundedObject.getLength() / 2D) + distance);
+			break;
 		}
 
-		return result;
+		return new LocalPosition(x, y);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/LocalAreaUtil.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/LocalAreaUtil.java
@@ -77,8 +77,8 @@ public class LocalAreaUtil {
 		double rotateX = (xLoc * Math.cos(radianRotation)) - (yLoc * Math.sin(radianRotation));
 		double rotateY = (xLoc * Math.sin(radianRotation)) + (yLoc * Math.cos(radianRotation));
 
-		double translateX = rotateX + boundedObject.getXLocation();
-		double translateY = rotateY + boundedObject.getYLocation();
+		double translateX = rotateX + boundedObject.getPosition().getX();
+		double translateY = rotateY + boundedObject.getPosition().getY();
 
 		return new LocalPosition(translateX, translateY);
 	}
@@ -130,8 +130,8 @@ public class LocalAreaUtil {
 	 * @return Point containing the X and Y locations relative to the object.
 	 */
 	public static LocalPosition getObjectRelativePosition(LocalPosition position, LocalBoundedObject boundedObject) {
-		double translateX = position.getX() - boundedObject.getXLocation();
-		double translateY = position.getY() - boundedObject.getYLocation();
+		double translateX = position.getX() - boundedObject.getPosition().getX();
+		double translateY = position.getY() - boundedObject.getPosition().getY();
 
 		double radianRotation = (Math.PI * 2D) - Math.toRadians(boundedObject.getFacing());
 		double rotateX = (translateX * Math.cos(radianRotation)) - (translateY * Math.sin(radianRotation));
@@ -148,18 +148,7 @@ public class LocalAreaUtil {
 	 */
 	public static LocalPosition getRandomLocalRelativePosition(LocalBoundedObject boundedObject) {
 		LocalPosition randomInternal = getRandomInteriorPosition(boundedObject, true);
-		return LocalAreaUtil.getLocalRelativePosition(randomInternal, boundedObject);
-	}
-
-	
-	/**
-	 * Gets a random position inside a local bounded object.
-	 *
-	 * @param boundedObject the local bounded object.
-	 * @return random X/Y location relative to the center of the bounded object.
-	 */
-	public static LocalPosition getRandomInteriorPosition(LocalBoundedObject boundedObject) {
-		return getRandomInteriorPosition(boundedObject, true);
+		return getLocalRelativePosition(randomInternal, boundedObject);
 	}
 
 	/**
@@ -171,18 +160,6 @@ public class LocalAreaUtil {
 	 */
 	public static Point2D.Double getRandomInteriorLocation(LocalBoundedObject boundedObject) {
 		return getRandomInteriorPosition(boundedObject, true).toPoint();
-	}
-
-	/**
-	 * Gets a random location inside a local bounded object.
-	 *
-	 * @param boundedObject the local bounded object.
-	 * @param useBoundary   true if inner boundary distance should be used.
-	 * @return random X/Y location relative to the center of the bounded object.
-	 * @deprecated
-	 */
-	public static Point2D.Double getRandomInteriorLocation(LocalBoundedObject boundedObject, boolean useBoundary) {
-		return getRandomInteriorPosition(boundedObject, useBoundary).toPoint();
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/LocalAreaUtil.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/LocalAreaUtil.java
@@ -116,22 +116,42 @@ public class LocalAreaUtil {
 	 * @param yLoc          the Y location relative to the local area.
 	 * @param boundedObject the local bounded object.
 	 * @return Point containing the X and Y locations relative to the object.
+	 * @deprecated
 	 */
 	public static Point2D.Double getObjectRelativeLocation(double xLoc, double yLoc, LocalBoundedObject boundedObject) {
-		Point2D.Double result = new Point2D.Double();
-
-		double translateX = xLoc - boundedObject.getXLocation();
-		double translateY = yLoc - boundedObject.getYLocation();
+		return getObjectRelativePosition(new LocalPosition(xLoc, yLoc), boundedObject).toPoint();
+	}
+	
+	/**
+	 * Gets a object relative location for a given location and an object.
+	 *
+	 * @param position          the position relative to the local area.
+	 * @param boundedObject the local bounded object.
+	 * @return Point containing the X and Y locations relative to the object.
+	 */
+	public static LocalPosition getObjectRelativePosition(LocalPosition position, LocalBoundedObject boundedObject) {
+		double translateX = position.getX() - boundedObject.getXLocation();
+		double translateY = position.getY() - boundedObject.getYLocation();
 
 		double radianRotation = (Math.PI * 2D) - Math.toRadians(boundedObject.getFacing());
 		double rotateX = (translateX * Math.cos(radianRotation)) - (translateY * Math.sin(radianRotation));
 		double rotateY = (translateX * Math.sin(radianRotation)) + (translateY * Math.cos(radianRotation));
 
-		result.setLocation(rotateX, rotateY);
-
-		return result;
+		return new LocalPosition(rotateX, rotateY);
 	}
 
+	/**
+	 * Gets a random position inside relative to the bounded Object
+	 *
+	 * @param boundedObject the local bounded object.
+	 * @return random X/Y location relative to the center of the bounded object.
+	 */
+	public static LocalPosition getRandomLocalRelativePosition(LocalBoundedObject boundedObject) {
+		LocalPosition randomInternal = getRandomInteriorPosition(boundedObject, true);
+		return LocalAreaUtil.getLocalRelativePosition(randomInternal, boundedObject);
+	}
+
+	
 	/**
 	 * Gets a random position inside a local bounded object.
 	 *

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/LocalBoundedObject.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/LocalBoundedObject.java
@@ -17,6 +17,7 @@ public interface LocalBoundedObject {
 	 * 
 	 * @return X location (meters from local center point - West: positive, East:
 	 *         negative).
+	 * @deprecated
 	 */
 	public double getXLocation();
 
@@ -25,8 +26,14 @@ public interface LocalBoundedObject {
 	 * 
 	 * @return Y location (meters from local center point - North: positive, South:
 	 *         negative).
+	 * @deprecated
 	 */
 	public double getYLocation();
+
+	/**
+	 * Get the position of this object relative to the local area's center point
+	 */
+	public LocalPosition getPosition();
 	
 	/**
 	 * Gets the object's width.

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/LocalPosition.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/LocalPosition.java
@@ -118,6 +118,16 @@ public class LocalPosition implements Serializable {
 	public boolean isClose(LocalPosition other) {
 		return getDistanceTo(other) < VERY_SMALL_DISTANCE;
 	}
+
+	/**
+	 * Is this position within the boundaries of an X & Y
+	 * @param maxX
+	 * @param maxY
+	 * @return
+	 */
+	public boolean isWithin(double maxX, double maxY) {
+		return (Math.abs(x) < maxX && Math.abs(y) < maxY);
+	}
 	
 	@Override
 	public int hashCode() {
@@ -160,4 +170,5 @@ public class LocalPosition implements Serializable {
 	public java.awt.geom.Point2D.Double toPoint() {
 		return new java.awt.geom.Point2D.Double(x, y);
 	}
+
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/LocalPosition.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/LocalPosition.java
@@ -18,8 +18,18 @@ public class LocalPosition implements Serializable {
 	 *
 	 */
 	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Default position of the center
+	 */
+    public static final LocalPosition DEFAULT_POSITION = new LocalPosition(0D, 0D);
+
+	/** A very small distance (meters) for measuring how close two positions are. */
+	private static final double VERY_SMALL_DISTANCE = .00001D;
+	
 	private double x;
 	private double y;
+
 
 	public LocalPosition(double x, double y) {
 		super();
@@ -69,7 +79,46 @@ public class LocalPosition implements Serializable {
         return new LocalPosition((x + other.x) / 2D,
         						 (y + other.y) / 2D);
 	}
+	/**
+	 * Get the rotation direction to another Position.
+	 * @param other
+	 * @return
+	 */
+	public double getDirectionTo(LocalPosition other) {
+    	double result = Math.atan2(x - other.x,
+                				   other.y - y);
 
+		while (result > (Math.PI * 2D)) {
+		    result -= (Math.PI * 2D);
+		}
+		
+		while (result < 0D) {
+		    result += (Math.PI * 2D);
+		}
+		return result;
+	}
+	
+	/**
+	 * Get the Position a distacne and rotatino direction from this one.
+	 * @param distance
+	 * @param direction
+	 * @return New position
+	 */
+	public LocalPosition getPosition(double distance, double direction) {
+		double newXLoc = (-1D * Math.sin(direction) * distance) + x;
+		double newYLoc = (Math.cos(direction) * distance) + y;
+        return new LocalPosition(newXLoc, newYLoc);
+	}
+	
+	/**
+	 * Is another position close to this one?
+	 * @param other
+	 * @return
+	 */
+	public boolean isClose(LocalPosition other) {
+		return getDistanceTo(other) < VERY_SMALL_DISTANCE;
+	}
+	
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -103,4 +152,12 @@ public class LocalPosition implements Serializable {
 		return "[x=" + x + ", y=" + y + "]";
 	}
 
+	/**
+	 * Bridging method for transition
+	 * @deprecated
+	 * @return
+	 */
+	public java.awt.geom.Point2D.Double toPoint() {
+		return new java.awt.geom.Point2D.Double(x, y);
+	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/Person.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/Person.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.mars_sim.msp.core.CollectionUtils;
 import org.mars_sim.msp.core.Coordinates;
 import org.mars_sim.msp.core.LifeSupportInterface;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.SimulationConfig;
 import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.UnitEventType;
@@ -146,10 +147,8 @@ public class Person extends Unit implements MissionMember, Serializable, Tempora
 	private double height;
 	/** The height of the person (in kg). */
 	private double weight;
-	/** Settlement X location (meters) from settlement center. */
-	private double xLoc;
-	/** Settlement Y location (meters) from settlement center. */
-	private double yLoc;
+	/** Settlement position (meters) from settlement center. */
+	private LocalPosition position;
 	/** Settlement Z location (meters) from settlement center. */
 	private double zLoc;
 
@@ -235,8 +234,7 @@ public class Person extends Unit implements MissionMember, Serializable, Tempora
 	 */
 	public Person(Settlement settlement) {
 		super("Mock Person", settlement.getCoordinates());
-		this.xLoc = 0D;
-		this.yLoc = 0D;
+		this.position = LocalPosition.DEFAULT_POSITION;
 		this.associatedSettlementID = settlement.getIdentifier();
 		super.setDescription(EARTHLING);
 
@@ -249,7 +247,6 @@ public class Person extends Unit implements MissionMember, Serializable, Tempora
 		BuildingManager.addToRandomBuilding(this, associatedSettlementID);
 		// Create PersonAttributeManager instance
 		attributes = new PersonAttributeManager();
-
 	}
 
 	/**
@@ -265,8 +262,7 @@ public class Person extends Unit implements MissionMember, Serializable, Tempora
 		super.setDescription(EARTHLING);
 
 		// Initialize data members
-		this.xLoc = 0D;
-		this.yLoc = 0D;
+		this.position = LocalPosition.DEFAULT_POSITION;
 		this.associatedSettlementID = settlement.getIdentifier();
 
 		// create a prior training profile
@@ -702,39 +698,23 @@ public class Person extends Unit implements MissionMember, Serializable, Tempora
 	}
 
 	/**
-	 * Gets the person's X location at a settlement.
+	 * Gets the person's position at a settlement.
 	 *
-	 * @return X distance (meters) from the settlement's center.
+	 * @return distance (meters) from the settlement's center.
 	 */
-	public double getXLocation() {
-		return xLoc;
+	@Override
+	public LocalPosition getPosition() {
+		return position;
 	}
 
 	/**
-	 * Sets the person's X location at a settlement.
+	 * Sets the person's position at a settlement.
 	 *
-	 * @param xLocation the X distance (meters) from the settlement's center.
+	 * @param position
 	 */
-	public void setXLocation(double xLocation) {
-		this.xLoc = xLocation;
-	}
-
-	/**
-	 * Gets the person's Y location at a settlement.
-	 *
-	 * @return Y distance (meters) from the settlement's center.
-	 */
-	public double getYLocation() {
-		return yLoc;
-	}
-
-	/**
-	 * Sets the person's Y location at a settlement.
-	 *
-	 * @param yLocation
-	 */
-	public void setYLocation(double yLocation) {
-		this.yLoc = yLocation;
+	@Override
+	public void setPosition(LocalPosition position) {
+		this.position = position;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingSalvageMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingSalvageMission.java
@@ -564,8 +564,7 @@ public class BuildingSalvageMission extends Mission implements Serializable {
 					luvTemp.setReservedForMission(true);
 
 					// Place light utility vehicles at random location in construction site.
-					LocalPosition relativeLocSite = LocalAreaUtil.getRandomInteriorPosition(constructionSite);
-					LocalPosition settlementLocSite = LocalAreaUtil.getLocalRelativePosition(relativeLocSite, constructionSite);
+					LocalPosition settlementLocSite = LocalAreaUtil.getRandomLocalRelativePosition(constructionSite);
 					luvTemp.setParkedLocation(settlementLocSite, RandomUtil.getRandomDouble(360D));
 
 					if (!settlement.removeParkedVehicle(luvTemp)) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingSalvageMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingSalvageMission.java
@@ -6,7 +6,6 @@
  */
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.awt.geom.Point2D;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -19,6 +18,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.mars_sim.msp.core.LocalAreaUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.UnitEventType;
 import org.mars_sim.msp.core.equipment.EVASuit;
@@ -564,11 +564,9 @@ public class BuildingSalvageMission extends Mission implements Serializable {
 					luvTemp.setReservedForMission(true);
 
 					// Place light utility vehicles at random location in construction site.
-					Point2D.Double relativeLocSite = LocalAreaUtil.getRandomInteriorLocation(constructionSite);
-					Point2D.Double settlementLocSite = LocalAreaUtil.getLocalRelativeLocation(relativeLocSite.getX(),
-							relativeLocSite.getY(), constructionSite);
-					luvTemp.setParkedLocation(settlementLocSite.getX(), settlementLocSite.getY(),
-							RandomUtil.getRandomDouble(360D));
+					LocalPosition relativeLocSite = LocalAreaUtil.getRandomInteriorPosition(constructionSite);
+					LocalPosition settlementLocSite = LocalAreaUtil.getLocalRelativePosition(relativeLocSite, constructionSite);
+					luvTemp.setParkedLocation(settlementLocSite, RandomUtil.getRandomDouble(360D));
 
 					if (!settlement.removeParkedVehicle(luvTemp)) {
 						logger.severe(Msg.getString("BuildingSalvageMission.log.cantRetrieve" //$NON-NLS-1$

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/EmergencySupply.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/EmergencySupply.java
@@ -6,7 +6,6 @@
  */
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.awt.geom.Point2D;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
@@ -16,6 +15,7 @@ import java.util.Map;
 import org.mars_sim.msp.core.Coordinates;
 import org.mars_sim.msp.core.InventoryUtil;
 import org.mars_sim.msp.core.LocalAreaUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.equipment.ContainerUtil;
 import org.mars_sim.msp.core.equipment.EVASuit;
@@ -337,9 +337,7 @@ public class EmergencySupply extends RoverMission implements Serializable {
 			// Get random inhabitable building at emergency settlement.
 			Building destinationBuilding = emergencySettlement.getBuildingManager().getRandomAirlockBuilding();
 			if (destinationBuilding != null) {
-				Point2D destinationLoc = LocalAreaUtil.getRandomInteriorLocation(destinationBuilding);
-				Point2D adjustedLoc = LocalAreaUtil.getLocalRelativeLocation(destinationLoc.getX(),
-						destinationLoc.getY(), destinationBuilding);
+				LocalPosition adjustedLoc = LocalAreaUtil.getRandomLocalRelativePosition(destinationBuilding);
 
 				if (member instanceof Person) {
 					Person person = (Person) member;
@@ -454,9 +452,7 @@ public class EmergencySupply extends RoverMission implements Serializable {
 		if (member.isInVehicle()) {
 
 			// Move person to random location within rover.
-			Point2D.Double vehicleLoc = LocalAreaUtil.getRandomInteriorLocation(getVehicle());
-			Point2D.Double adjustedLoc = LocalAreaUtil.getLocalRelativeLocation(vehicleLoc.getX(), vehicleLoc.getY(),
-					getVehicle());
+			LocalPosition adjustedLoc = LocalAreaUtil.getRandomLocalRelativePosition(getVehicle());
 			// TODO Refactor
 			if (member instanceof Person) {
 				Person person = (Person) member;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RoverMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RoverMission.java
@@ -6,7 +6,6 @@
  */
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.awt.geom.Point2D;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -16,6 +15,7 @@ import java.util.Set;
 
 import org.mars_sim.msp.core.InventoryUtil;
 import org.mars_sim.msp.core.LocalAreaUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.equipment.EVASuit;
 import org.mars_sim.msp.core.equipment.Equipment;
@@ -341,9 +341,7 @@ public abstract class RoverMission extends VehicleMission {
 		else {
 
 			// Gets a random location within rover.
-			Point2D.Double vehicleLoc = LocalAreaUtil.getRandomInteriorLocation(v);
-			Point2D.Double adjustedLoc = LocalAreaUtil.getLocalRelativeLocation(vehicleLoc.getX(),
-					vehicleLoc.getY(), v);
+			LocalPosition adjustedLoc = LocalAreaUtil.getRandomLocalRelativePosition(v);
 
 			if (member instanceof Person) {
 				Person person = (Person) member;
@@ -674,9 +672,7 @@ public abstract class RoverMission extends VehicleMission {
 			Building destinationBuilding = disembarkSettlement.getBuildingManager().getRandomAirlockBuilding();
 
 			if (destinationBuilding != null) {
-				Point2D destinationLoc = LocalAreaUtil.getRandomInteriorLocation(destinationBuilding);
-				Point2D adjustedLoc = LocalAreaUtil.getLocalRelativeLocation(destinationLoc.getX(),
-						destinationLoc.getY(), destinationBuilding);
+				LocalPosition adjustedLoc = LocalAreaUtil.getRandomLocalRelativePosition(destinationBuilding);
 
 				boolean hasStrength = p.getPhysicalCondition().isFitByLevel(1500, 90, 1500);
 
@@ -697,8 +693,7 @@ public abstract class RoverMission extends VehicleMission {
 					rescueOperation(rover, p, disembarkSettlement);
 
 					logger.info(p, "Transported to ("
-							+ Math.round(p.getXLocation()*10.0)/10.0 + ", "
-							+ Math.round(p.getYLocation()*10.0)/10.0 + ") in "
+							+ p.getPosition() + ") in "
 							+ p.getBuildingLocation().getNickName()); //$NON-NLS-1$
 
 					// Note: how to force the person to receive some form of medical treatment ?

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Trade.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Trade.java
@@ -6,7 +6,6 @@
  */
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.awt.geom.Point2D;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
@@ -17,6 +16,7 @@ import java.util.logging.Level;
 import org.mars_sim.msp.core.Coordinates;
 import org.mars_sim.msp.core.InventoryUtil;
 import org.mars_sim.msp.core.LocalAreaUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.equipment.EVASuit;
 import org.mars_sim.msp.core.equipment.EquipmentType;
@@ -299,9 +299,7 @@ public class Trade extends RoverMission implements Serializable {
 			// Get random inhabitable building at trading settlement.
 			Building destinationBuilding = tradingSettlement.getBuildingManager().getRandomAirlockBuilding();
 			if (destinationBuilding != null) {
-				Point2D destinationLoc = LocalAreaUtil.getRandomInteriorLocation(destinationBuilding);
-				Point2D adjustedLoc = LocalAreaUtil.getLocalRelativeLocation(destinationLoc.getX(),
-						destinationLoc.getY(), destinationBuilding);
+				LocalPosition adjustedLoc = LocalAreaUtil.getRandomLocalRelativePosition(destinationBuilding);
 				if (member instanceof Person) {
 					Person person = (Person) member;
 					if (Walk.canWalkAllSteps(person, adjustedLoc.getX(), adjustedLoc.getY(), 0, destinationBuilding)) {
@@ -465,9 +463,7 @@ public class Trade extends RoverMission implements Serializable {
 		if (!isDone() && !member.isInVehicle()) {
 
 			// Move person to random location within rover.
-			Point2D.Double vehicleLoc = LocalAreaUtil.getRandomInteriorLocation(getVehicle());
-			Point2D.Double adjustedLoc = LocalAreaUtil.getLocalRelativeLocation(vehicleLoc.getX(), vehicleLoc.getY(),
-					getVehicle());
+			LocalPosition adjustedLoc = LocalAreaUtil.getRandomLocalRelativePosition(getVehicle());
 
 			// Elect a new mission lead if the previous one was dead
 			if (member instanceof Person) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/VehicleMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/VehicleMission.java
@@ -1703,8 +1703,9 @@ public abstract class VehicleMission extends TravelMission implements UnitListen
 	 * Start the disembarking phase
 	 */
 	protected void startDisembarkingPhase() {
-		setPhase(DISEMBARKING,
-				getCurrentNavpoint().getDescription());
+		NavPoint np = getCurrentNavpoint();
+	
+		setPhase(DISEMBARKING, (np != null ? np.getDescription() : "Unknown"));
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ConstructBuilding.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ConstructBuilding.java
@@ -6,7 +6,6 @@
  */
 package org.mars_sim.msp.core.person.ai.task;
 
-import java.awt.geom.Point2D;
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
@@ -88,7 +87,7 @@ public class ConstructBuilding extends EVAOperation implements Serializable {
 			this.vehicles = mission.getConstructionVehicles();
 
 			// Determine location for construction site.
-			Point2D constructionSiteLoc = determineConstructionLocation();
+			LocalPosition constructionSiteLoc = determineConstructionLocation();
 			setOutsideSiteLocation(constructionSiteLoc.getX(), constructionSiteLoc.getY());
 
 			// Add task phase
@@ -127,7 +126,7 @@ public class ConstructBuilding extends EVAOperation implements Serializable {
 		}
 
 		// Determine location for construction site.
-		Point2D constructionSiteLoc = determineConstructionLocation();
+		LocalPosition constructionSiteLoc = determineConstructionLocation();
 		setOutsideSiteLocation(constructionSiteLoc.getX(), constructionSiteLoc.getY());
 
 		// Add task phase
@@ -213,13 +212,8 @@ public class ConstructBuilding extends EVAOperation implements Serializable {
 	 *
 	 * @return location.
 	 */
-	private Point2D determineConstructionLocation() {
-
-		Point2D.Double relativeLocSite = LocalAreaUtil.getRandomInteriorLocation(site, false);
-		Point2D.Double settlementLocSite = LocalAreaUtil.getLocalRelativeLocation(relativeLocSite.getX(),
-				relativeLocSite.getY(), site);
-
-		return settlementLocSite;
+	private LocalPosition determineConstructionLocation() {
+		return LocalAreaUtil.getRandomLocalRelativePosition(site);
 	}
 
 	@Override
@@ -352,9 +346,7 @@ public class ConstructBuilding extends EVAOperation implements Serializable {
 						operatingLUV = true;
 
 						// Place light utility vehicles at random location in construction site.
-						LocalPosition relativeLocSite = LocalAreaUtil.getRandomInteriorPosition(site);
-						LocalPosition settlementLocSite = LocalAreaUtil
-								.getLocalRelativePosition(relativeLocSite, site);
+						LocalPosition settlementLocSite = LocalAreaUtil.getRandomLocalRelativePosition(site);
 						luv.setParkedLocation(settlementLocSite, RandomUtil.getRandomDouble(360D));
 
 						break;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ConstructBuilding.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ConstructBuilding.java
@@ -14,6 +14,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Logger;
 
 import org.mars_sim.msp.core.LocalAreaUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.NaturalAttributeType;
@@ -351,11 +352,10 @@ public class ConstructBuilding extends EVAOperation implements Serializable {
 						operatingLUV = true;
 
 						// Place light utility vehicles at random location in construction site.
-						Point2D.Double relativeLocSite = LocalAreaUtil.getRandomInteriorLocation(site);
-						Point2D.Double settlementLocSite = LocalAreaUtil
-								.getLocalRelativeLocation(relativeLocSite.getX(), relativeLocSite.getY(), site);
-						luv.setParkedLocation(settlementLocSite.getX(), settlementLocSite.getY(),
-								RandomUtil.getRandomDouble(360D));
+						LocalPosition relativeLocSite = LocalAreaUtil.getRandomInteriorPosition(site);
+						LocalPosition settlementLocSite = LocalAreaUtil
+								.getLocalRelativePosition(relativeLocSite, site);
+						luv.setParkedLocation(settlementLocSite, RandomUtil.getRandomDouble(360D));
 
 						break;
 					}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/EnterAirlock.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/EnterAirlock.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.logging.Level;
 
 import org.mars_sim.msp.core.LocalAreaUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.equipment.EVASuit;
@@ -237,11 +238,7 @@ public class EnterAirlock extends Task implements Serializable {
 		}
 
 		else {
-//			addSubTask(new WalkSettlementInterior(person, (Building)airlock.getEntity(),
-//					newPos.getX(),
-//					newPos.getY(), 0));
-			person.setXLocation(newPos.getX());
-			person.setYLocation(newPos.getY());
+			person.setPosition(new LocalPosition(newPos));
 		}
 
 		logger.log(person, Level.FINE, 4000, "Arrived at ("
@@ -575,7 +572,7 @@ public class EnterAirlock extends Task implements Serializable {
 
 				// Walk to interior airlock position.
 				addSubTask(new WalkRoverInterior(person, airlockRover,
-						insideAirlockPos.getX(), insideAirlockPos.getY()));
+										new LocalPosition(insideAirlockPos)));
 			}
 		}
 
@@ -841,7 +838,7 @@ public class EnterAirlock extends Task implements Serializable {
 				logger.log(person, Level.FINE, 4_000,
 						"Attempted to step closer to " + airlockRover.getNickName() + "'s inner door.");
 
-				addSubTask(new WalkRoverInterior(person, airlockRover, interiorDoorPos.getX(), interiorDoorPos.getY()));
+				addSubTask(new WalkRoverInterior(person, airlockRover, new LocalPosition(interiorDoorPos)));
 			}
 		}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ExitAirlock.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ExitAirlock.java
@@ -15,6 +15,7 @@ import java.util.logging.Level;
 
 import org.mars_sim.msp.core.CollectionUtils;
 import org.mars_sim.msp.core.InventoryUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.equipment.EVASuit;
 import org.mars_sim.msp.core.equipment.EquipmentOwner;
@@ -264,11 +265,8 @@ public class ExitAirlock extends Task implements Serializable {
 		}
 
 		else {
-//			addSubTask(new WalkSettlementInterior(person, (Building)airlock.getEntity(),
-//					newPos.getX(),
-//					newPos.getY(), 0));
-			person.setXLocation(newPos.getX());
-			person.setYLocation(newPos.getY());
+
+			person.setPosition(new LocalPosition(newPos));
 		}
 
 		logger.log(person, Level.FINER, 4_000,

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MineSite.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MineSite.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import org.mars_sim.msp.core.Coordinates;
 import org.mars_sim.msp.core.LocalAreaUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.person.Person;
@@ -198,12 +199,11 @@ public class MineSite extends EVAOperation implements Serializable {
 
 			if (luv.addPerson(person)) {
 				
-				Point2D.Double vehicleLoc = LocalAreaUtil.getRandomInteriorLocation(luv);
-				Point2D.Double settlementLoc = LocalAreaUtil.getLocalRelativeLocation(vehicleLoc.getX(),
-						vehicleLoc.getY(), luv);
+				LocalPosition vehicleLoc = LocalAreaUtil.getRandomInteriorPosition(luv);
+				LocalPosition settlementLoc = LocalAreaUtil.getLocalRelativePosition(vehicleLoc,
+														luv);
 
-				person.setXLocation(settlementLoc.getX());
-				person.setYLocation(settlementLoc.getY());
+				person.setPosition(settlementLoc);
 				luv.setOperator(person);
 
 				operatingLUV = true;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MineSite.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MineSite.java
@@ -199,9 +199,7 @@ public class MineSite extends EVAOperation implements Serializable {
 
 			if (luv.addPerson(person)) {
 				
-				LocalPosition vehicleLoc = LocalAreaUtil.getRandomInteriorPosition(luv);
-				LocalPosition settlementLoc = LocalAreaUtil.getLocalRelativePosition(vehicleLoc,
-														luv);
+				LocalPosition settlementLoc = LocalAreaUtil.getRandomLocalRelativePosition(luv);
 
 				person.setPosition(settlementLoc);
 				luv.setOperator(person);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/OperateVehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/OperateVehicle.java
@@ -13,6 +13,7 @@ import java.util.logging.Level;
 import org.mars_sim.msp.core.CollectionUtils;
 import org.mars_sim.msp.core.Coordinates;
 import org.mars_sim.msp.core.Direction;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.Simulation;
 import org.mars_sim.msp.core.logging.SimLogger;
@@ -530,14 +531,12 @@ public abstract class OperateVehicle extends Task implements Serializable {
 	 * Determine the vehicle's initial parked location while traveling to settlement.
 	 */
 	private void determineInitialSettlementParkedLocation() {
-	    
-	    Direction oppDir = new Direction(vehicle.getDirection().getDirection() + Math.PI);
-	    double distance = 200D;
-	    double xLoc = 0D - (distance * oppDir.getSinDirection());
-        double yLoc = distance * oppDir.getCosDirection();
+	   
+        // Park 200 meters from the new settlement in teh irection of travel
+        LocalPosition parkingPlace = LocalPosition.DEFAULT_POSITION.getPosition(200D, vehicle.getDirection().getDirection() + Math.PI);
         double degDir = vehicle.getDirection().getDirection() * 180D / Math.PI;
 	    
-        vehicle.setParkedLocation(xLoc, yLoc, degDir);
+        vehicle.setParkedLocation(parkingPlace, degDir);
 	}
 	
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/SalvageBuilding.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/SalvageBuilding.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import org.mars_sim.msp.core.LocalAreaUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.Simulation;
 import org.mars_sim.msp.core.person.Person;
@@ -93,7 +94,7 @@ implements Serializable {
             this.vehicles = mission.getConstructionVehicles();
 
             // Determine location for salvage site.
-            Point2D salvageSiteLoc = determineSalvageLocation();
+            LocalPosition salvageSiteLoc = determineSalvageLocation();
             setOutsideSiteLocation(salvageSiteLoc.getX(), salvageSiteLoc.getY());
 
             // Add task phase
@@ -130,7 +131,7 @@ implements Serializable {
 	public void init() {
 
         // Determine location for salvage site.
-        Point2D salvageSiteLoc = determineSalvageLocation();
+        LocalPosition salvageSiteLoc = determineSalvageLocation();
         setOutsideSiteLocation(salvageSiteLoc.getX(), salvageSiteLoc.getY());
 
         // Add task phase
@@ -206,13 +207,8 @@ implements Serializable {
      * Determine location to go to at salvage site.
      * @return location.
      */
-    private Point2D determineSalvageLocation() {
-
-        Point2D.Double relativeLocSite = LocalAreaUtil.getRandomInteriorLocation(site, false);
-        Point2D.Double settlementLocSite = LocalAreaUtil.getLocalRelativeLocation(relativeLocSite.getX(),
-                relativeLocSite.getY(), site);
-
-        return settlementLocSite;
+    private LocalPosition determineSalvageLocation() {
+    	return LocalAreaUtil.getRandomLocalRelativePosition(site);
     }
 
     @Override
@@ -380,11 +376,8 @@ implements Serializable {
                         operatingLUV = true;
 
                         // Place light utility vehicles at random location in construction site.
-                        Point2D.Double relativeLocSite = LocalAreaUtil.getRandomInteriorLocation(site);
-                        Point2D.Double settlementLocSite = LocalAreaUtil.getLocalRelativeLocation(
-                                relativeLocSite.getX(), relativeLocSite.getY(), site);
-                        luv.setParkedLocation(settlementLocSite.getX(), settlementLocSite.getY(),
-                                RandomUtil.getRandomDouble(360D));
+                        LocalPosition settlementLocSite = LocalAreaUtil.getRandomLocalRelativePosition(site);
+                        luv.setParkedLocation(settlementLocSite, RandomUtil.getRandomDouble(360D));
 
                         break;
                     }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ToggleFuelPowerSource.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ToggleFuelPowerSource.java
@@ -6,7 +6,6 @@
  */
 package org.mars_sim.msp.core.person.ai.task;
 
-import java.awt.geom.Point2D;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -14,6 +13,7 @@ import java.util.List;
 import java.util.logging.Level;
 
 import org.mars_sim.msp.core.LocalAreaUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.Simulation;
 import org.mars_sim.msp.core.logging.SimLogger;
@@ -200,9 +200,7 @@ implements Serializable {
 
         // Determine location within power source building.
         // Note: Use action point rather than random internal location.
-        Point2D.Double buildingLoc = LocalAreaUtil.getRandomInteriorLocation(powerBuilding);
-        Point2D.Double settlementLoc = LocalAreaUtil.getLocalRelativeLocation(buildingLoc.getX(),
-                buildingLoc.getY(), powerBuilding);
+        LocalPosition settlementLoc = LocalAreaUtil.getRandomLocalRelativePosition(powerBuilding);
 
         if (Walk.canWalkAllSteps(person, settlementLoc.getX(), settlementLoc.getY(), 0,
                 powerBuilding)) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/Walk.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/Walk.java
@@ -101,9 +101,7 @@ public class Walk extends Task implements Serializable {
 			if (buildingList.size() > 0) {
 				int buildingIndex = RandomUtil.getRandomInt(buildingList.size() - 1);
 				Building destinationBuilding = buildingList.get(buildingIndex);
-				Point2D interiorPos = LocalAreaUtil.getRandomInteriorLocation(destinationBuilding);
-				Point2D adjustedInteriorPos = LocalAreaUtil.getLocalRelativeLocation(interiorPos.getX(),
-						interiorPos.getY(), destinationBuilding);
+				LocalPosition adjustedInteriorPos = LocalAreaUtil.getRandomLocalRelativePosition(destinationBuilding);
 				walkingSteps = new WalkingSteps(person, adjustedInteriorPos.getX(), adjustedInteriorPos.getY(), 0,
 						destinationBuilding);
 			}
@@ -122,10 +120,7 @@ public class Walk extends Task implements Serializable {
 				// person.isInVehicleInGarage()
 				Building garageBuilding = BuildingManager.getBuilding(vehicle);
 				if (garageBuilding != null) {
-
-					Point2D interiorPos = LocalAreaUtil.getRandomInteriorLocation(garageBuilding);
-					Point2D adjustedInteriorPos = LocalAreaUtil.getLocalRelativeLocation(interiorPos.getX(),
-							interiorPos.getY(), garageBuilding);
+					LocalPosition adjustedInteriorPos = LocalAreaUtil.getRandomLocalRelativePosition(garageBuilding);
 					walkingSteps = new WalkingSteps(person, adjustedInteriorPos.getX(), adjustedInteriorPos.getY(), 0,
 							garageBuilding);
 					walkToSettlement = true;
@@ -145,9 +140,7 @@ public class Walk extends Task implements Serializable {
 						Airlock airlock = settlement.getClosestAvailableAirlock(person);
 						if (airlock != null) {
 							LocalBoundedObject entity = (LocalBoundedObject) airlock.getEntity();
-							Point2D interiorPos = LocalAreaUtil.getRandomInteriorLocation(entity);
-							Point2D adjustedInteriorPos = LocalAreaUtil.getLocalRelativeLocation(interiorPos.getX(),
-									interiorPos.getY(), entity);
+							LocalPosition adjustedInteriorPos = LocalAreaUtil.getRandomLocalRelativePosition(entity);
 							walkingSteps = new WalkingSteps(person, adjustedInteriorPos.getX(),
 									adjustedInteriorPos.getY(), 0, entity);
 							walkToSettlement = true;
@@ -170,9 +163,7 @@ public class Walk extends Task implements Serializable {
 				// Walk to random location within rover.
 				if (vehicle instanceof Rover) {
 					Rover rover = (Rover) person.getVehicle();
-					Point2D interiorPos = LocalAreaUtil.getRandomInteriorLocation(rover);
-					Point2D adjustedInteriorPos = LocalAreaUtil.getLocalRelativeLocation(interiorPos.getX(),
-							interiorPos.getY(), rover);
+					LocalPosition adjustedInteriorPos = LocalAreaUtil.getRandomLocalRelativePosition(rover);
 					walkingSteps = new WalkingSteps(person, adjustedInteriorPos.getX(), adjustedInteriorPos.getY(), 0,
 							rover);
 				}
@@ -185,9 +176,7 @@ public class Walk extends Task implements Serializable {
 			Airlock airlock = findEmergencyAirlock(person);
 			if (airlock != null) {
 				LocalBoundedObject entity = (LocalBoundedObject) airlock.getEntity();
-				Point2D interiorPos = LocalAreaUtil.getRandomInteriorLocation(entity);
-				Point2D adjustedInteriorPos = LocalAreaUtil.getLocalRelativeLocation(interiorPos.getX(),
-						interiorPos.getY(), entity);
+				LocalPosition adjustedInteriorPos = LocalAreaUtil.getRandomLocalRelativePosition(entity);
 				walkingSteps = new WalkingSteps(person, adjustedInteriorPos.getX(), adjustedInteriorPos.getY(), 0, entity);
 			}
 		}
@@ -242,9 +231,7 @@ public class Walk extends Task implements Serializable {
 			if (buildingList.size() > 0) {
 				int buildingIndex = RandomUtil.getRandomInt(buildingList.size() - 1);
 				Building destinationBuilding = buildingList.get(buildingIndex);
-				Point2D interiorPos = LocalAreaUtil.getRandomInteriorLocation(destinationBuilding);
-				Point2D adjustedInteriorPos = LocalAreaUtil.getLocalRelativeLocation(interiorPos.getX(),
-						interiorPos.getY(), destinationBuilding);
+				LocalPosition adjustedInteriorPos = LocalAreaUtil.getRandomLocalRelativePosition(destinationBuilding);
 				walkingSteps = new WalkingSteps(robot, adjustedInteriorPos.getX(), adjustedInteriorPos.getY(), 0,
 						destinationBuilding);
 			}
@@ -790,10 +777,7 @@ public class Walk extends Task implements Serializable {
 				// longer within rover.
 				if (!LocalAreaUtil.isLocationWithinLocalBoundedObject(step.xLoc, step.yLoc, rover)) {
 					// Determine new destination location within rover.
-					// TODO: Determine location based on activity spot?
-					Point2D newRoverLoc = LocalAreaUtil.getRandomInteriorLocation(rover);
-					Point2D relativeRoverLoc = LocalAreaUtil.getLocalRelativeLocation(newRoverLoc.getX(),
-							newRoverLoc.getY(), rover);
+					LocalPosition relativeRoverLoc = LocalAreaUtil.getRandomLocalRelativePosition(rover);
 					step.xLoc = relativeRoverLoc.getX();
 					step.yLoc = relativeRoverLoc.getY();
 				}
@@ -846,9 +830,7 @@ public class Walk extends Task implements Serializable {
 			if (!LocalAreaUtil.isLocationWithinLocalBoundedObject(step.xLoc, step.yLoc, rover)) {
 				// Determine new destination location within rover.
 				// TODO: Determine location based on activity spot?
-				Point2D newRoverLoc = LocalAreaUtil.getRandomInteriorLocation(rover);
-				Point2D relativeRoverLoc = LocalAreaUtil.getLocalRelativeLocation(newRoverLoc.getX(),
-						newRoverLoc.getY(), rover);
+				LocalPosition relativeRoverLoc = LocalAreaUtil.getRandomLocalRelativePosition(rover);
 				step.xLoc = relativeRoverLoc.getX();
 				step.yLoc = relativeRoverLoc.getY();
 			}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/WalkOutside.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/WalkOutside.java
@@ -22,6 +22,7 @@ import java.util.logging.Level;
 import org.mars_sim.msp.core.Coordinates;
 import org.mars_sim.msp.core.LocalAreaUtil;
 import org.mars_sim.msp.core.LocalBoundedObject;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.equipment.EVASuit;
 import org.mars_sim.msp.core.logging.SimLogger;
@@ -628,15 +629,12 @@ public class WalkOutside extends Task implements Serializable {
 
 		while (coveredMeters > VERY_SMALL_DISTANCE) {
 			// Walk to next path location.
-			Point2D location = walkingPath.get(walkingPathIndex);
-			double distanceToLocation = Point2D.distance(worker.getXLocation(), worker.getYLocation(), 
-						location.getX(), location.getY());
-
+			LocalPosition location = new LocalPosition(walkingPath.get(walkingPathIndex));
+			double distanceToLocation = worker.getPosition().getDistanceTo(location); 
 			if (coveredMeters >= distanceToLocation) {
 
 				// Set person at next path location.
-				worker.setXLocation(location.getX());
-				worker.setYLocation(location.getY());
+				worker.setPosition(location);
 
 				coveredMeters -= distanceToLocation;
 				if (walkingPath.size() > (walkingPathIndex + 1)) {
@@ -654,8 +652,7 @@ public class WalkOutside extends Task implements Serializable {
 				walkInDirection(direction, coveredMeters);
 
 				// Set person at next path location.
-				worker.setXLocation(location.getX());
-				worker.setYLocation(location.getY());
+				worker.setPosition(location);
 				
 				coveredMeters = 0D;
 			}
@@ -667,8 +664,7 @@ public class WalkOutside extends Task implements Serializable {
 			logger.log(worker, Level.FINER, 5000, "Finished walking to new location outside.");
 			Point2D finalLocation = walkingPath.get(walkingPath.size() - 1);
 			
-			worker.setXLocation(finalLocation.getX());
-			worker.setYLocation(finalLocation.getY());
+			worker.setPosition(new LocalPosition(finalLocation));
 
 			endTask();
 		}
@@ -737,11 +733,7 @@ public class WalkOutside extends Task implements Serializable {
 	 * @param distance  the distance (meters) to travel.
 	 */
 	private void walkInDirection(double direction, double distance) {
-		double newXLoc = (-1D * Math.sin(direction) * distance) + worker.getXLocation();
-		double newYLoc = (Math.cos(direction) * distance) + worker.getYLocation();
-
-		worker.setXLocation(newXLoc);
-		worker.setYLocation(newYLoc);
+		worker.setPosition(worker.getPosition().getPosition(distance, direction) );
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/WalkSettlementInterior.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/WalkSettlementInterior.java
@@ -245,7 +245,7 @@ public class WalkSettlementInterior extends Task implements Serializable {
 		while (coveredMeters > VERY_SMALL_DISTANCE) {
 			// Walk to next path location.
 			InsidePathLocation location = walkingPath.getNextPathLocation();
-			double distanceToLocation = worker.getPosition().getDirectionTo(location.getPosition());
+			double distanceToLocation = worker.getPosition().getDistanceTo(location.getPosition());
 
 			if (coveredMeters >= distanceToLocation) {
 
@@ -363,7 +363,7 @@ public class WalkSettlementInterior extends Task implements Serializable {
 		Iterator<InsidePathLocation> i = walkingPath.getRemainingPathLocations().iterator();
 		while (i.hasNext()) {
 			InsidePathLocation nextLoc = i.next();
-			nextLoc.getPosition().getDirectionTo(prevPosition);
+			result += nextLoc.getPosition().getDistanceTo(prevPosition);
 			prevPosition = nextLoc.getPosition();
 		}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/WalkSettlementInterior.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/WalkSettlementInterior.java
@@ -6,12 +6,12 @@
  */
 package org.mars_sim.msp.core.person.ai.task;
 
-import java.awt.geom.Point2D;
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.logging.Level;
 
 import org.mars_sim.msp.core.LocalAreaUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.person.Person;
@@ -51,17 +51,14 @@ public class WalkSettlementInterior extends Task implements Serializable {
 	private static final double PERSON_WALKING_SPEED = Walk.PERSON_WALKING_SPEED; // [km per hr].
 	private static final double ROBOT_WALKING_SPEED = Walk.ROBOT_WALKING_SPEED; // [km per hr].
 
-//	private static final double VERY_SMALL = .00001D;
 	private static final double VERY_SMALL_DISTANCE = .00001D;
 	private static final double STRESS_MODIFIER = -.2D;
 
 	// Data members
-	private double destXLoc;
-	private double destYLoc;
+	private LocalPosition destPosition;
 	private double destZLoc;
 	
 	private Settlement settlement;
-	// private Building startBuilding;
 	private Building destBuilding;
 	private InsideBuildingPath walkingPath;
 
@@ -71,11 +68,11 @@ public class WalkSettlementInterior extends Task implements Serializable {
 	 * @param person               the person performing the task.
 	 * @param destinationBuilding  the building that is walked to. (Can be same as
 	 *                             current building).
-	 * @param destinationXLocation the destination X location at the settlement.
-	 * @param destinationYLocation the destination Y location at the settlement.
+	 * @param destinationPosition the destination position at the settlement.
+	 * @param destinationYLocation the destination Z location at the settlement.
 	 */
-	public WalkSettlementInterior(Person person, Building destinationBuilding, double destinationXLocation,
-			double destinationYLocation, double destinationZLocation) {
+	public WalkSettlementInterior(Person person, Building destinationBuilding, LocalPosition destinationPosition,
+								  double destinationZLocation) {
 		super(NAME, person, false, false, STRESS_MODIFIER, null, 100D);
 
 		// Check that the person is currently inside the settlement.
@@ -88,12 +85,11 @@ public class WalkSettlementInterior extends Task implements Serializable {
 		// Initialize data members.
 		this.settlement = person.getSettlement();
 		this.destBuilding = destinationBuilding;
-		this.destXLoc = destinationXLocation;
-		this.destYLoc = destinationYLocation;
+		this.destPosition = destinationPosition;
 		this.destZLoc = destinationZLocation;
 		
 		// Check if (destXLoc, destYLoc) is within destination building.
-		if (!LocalAreaUtil.isLocationWithinLocalBoundedObject(destXLoc, destYLoc, destBuilding)) {
+		if (!LocalAreaUtil.isPositionWithinLocalBoundedObject(destPosition, destBuilding)) {
 			logger.warning(person, "Was unable to walk to the destination in " + destBuilding);
 			person.getMind().getTaskManager().clearAllTasks("Destination not reachable");
 			return;
@@ -111,8 +107,7 @@ public class WalkSettlementInterior extends Task implements Serializable {
 			// Determine the walking path to the destination.
 			if (settlement != null)
 				walkingPath = settlement.getBuildingConnectorManager().determineShortestPath(startBuilding,
-					person.getXLocation(), person.getYLocation(), destinationBuilding, destinationXLocation,
-					destinationYLocation);
+					person.getPosition(), destinationBuilding, destPosition);
 	
 			// If no valid walking path is found, end task.
 			if (walkingPath == null) {
@@ -144,8 +139,7 @@ public class WalkSettlementInterior extends Task implements Serializable {
 	 * @param destinationXLocation
 	 * @param destinationYLocation
 	 */
-	public WalkSettlementInterior(Robot robot, Building destinationBuilding, double destinationXLocation,
-			double destinationYLocation) {
+	public WalkSettlementInterior(Robot robot, Building destinationBuilding, LocalPosition destinationPosition) {
 		super("Walking Settlement Interior", robot, false, false, STRESS_MODIFIER, null, 100D);
 
 		// Check that the robot is currently inside the settlement.
@@ -156,11 +150,10 @@ public class WalkSettlementInterior extends Task implements Serializable {
 		// Initialize data members.
 		this.settlement = robot.getSettlement();
 		this.destBuilding = destinationBuilding;
-		this.destXLoc = destinationXLocation;
-		this.destYLoc = destinationYLocation;
+		this.destPosition = destinationPosition;
 		
 		// Check that destination location is within destination building.
-		if (!LocalAreaUtil.isLocationWithinLocalBoundedObject(destXLoc, destYLoc, destBuilding)) {
+		if (!LocalAreaUtil.isPositionWithinLocalBoundedObject(destPosition, destBuilding)) {
 			logger.warning(robot, "Was unable to walk to the destination in " + robot.getBuildingLocation());
 			// "Given destination walking location not within destination building.");
 			endTask();
@@ -177,8 +170,7 @@ public class WalkSettlementInterior extends Task implements Serializable {
 
 		// Determine the walking path to the destination.
 		walkingPath = settlement.getBuildingConnectorManager().determineShortestPath(startBuilding,
-				robot.getXLocation(), robot.getYLocation(), destinationBuilding, destinationXLocation,
-				destinationYLocation);
+				robot.getPosition(), destinationBuilding, destPosition);
 
 		// If no valid walking path is found, end task.
 		if (walkingPath == null) {
@@ -253,14 +245,12 @@ public class WalkSettlementInterior extends Task implements Serializable {
 		while (coveredMeters > VERY_SMALL_DISTANCE) {
 			// Walk to next path location.
 			InsidePathLocation location = walkingPath.getNextPathLocation();
-			double distanceToLocation = Point2D.distance(worker.getXLocation(), worker.getYLocation(),
-						location.getXLocation(), location.getYLocation());
+			double distanceToLocation = worker.getPosition().getDirectionTo(location.getPosition());
 
 			if (coveredMeters >= distanceToLocation) {
 
 				// Set person at next path location, changing buildings if necessary.
-				worker.setXLocation(location.getXLocation());
-				worker.setYLocation(location.getYLocation());
+				worker.setPosition(location.getPosition());
 
 				coveredMeters -= distanceToLocation;
 				
@@ -280,14 +270,14 @@ public class WalkSettlementInterior extends Task implements Serializable {
 				// Walk in direction of next path location.
 				
 				// Determine direction
-				double direction = determineDirection(location.getXLocation(), location.getYLocation());
+				double direction = worker.getPosition().getDirectionTo(location.getPosition());
 				
 				// Determine person's new location at distance and direction.
 				walkInDirection(direction, coveredMeters);
 
 				// Set person at next path location, changing buildings if necessary.
-				worker.setXLocation(location.getXLocation());
-				worker.setYLocation(location.getYLocation());
+				// TODO Is this right becausw the walk in direiiton also updates 
+				worker.setPosition(location.getPosition());
 
 				coveredMeters = 0D;
 			}
@@ -298,38 +288,14 @@ public class WalkSettlementInterior extends Task implements Serializable {
 			InsidePathLocation location = walkingPath.getNextPathLocation();
 
 			logger.log(worker, Level.FINEST, 0, "Close enough to final destination ("
-					+ location.getXLocation() + ", "
-					+ location.getYLocation());
+					+ location.getPosition());
 			
-			worker.setXLocation(location.getXLocation());
-			worker.setYLocation(location.getYLocation());
+			worker.setPosition(location.getPosition());
 
 			endTask();
 		}
 		
 		return timeLeft;
-	}
-
-	/**
-	 * Determine the direction of travel to a location.
-	 * 
-	 * @param destinationXLocation the destination X location.
-	 * @param destinationYLocation the destination Y location.
-	 * @return direction (radians).
-	 */
-	double determineDirection(double destinationXLocation, double destinationYLocation) {
-		double result = Math.atan2(worker.getXLocation() - destinationXLocation,
-					destinationYLocation - worker.getYLocation());
-
-		while (result > (Math.PI * 2D)) {
-			result -= (Math.PI * 2D);
-		}
-
-		while (result < 0D) {
-			result += (Math.PI * 2D);
-		}
-
-		return result;
 	}
 
 	/**
@@ -339,12 +305,7 @@ public class WalkSettlementInterior extends Task implements Serializable {
 	 * @param distance  the distance (meters) to travel.
 	 */
 	void walkInDirection(double direction, double distance) {
-
-		double newXLoc = (-1D * Math.sin(direction) * distance) + worker.getXLocation();
-		double newYLoc = (Math.cos(direction) * distance) + worker.getYLocation();
-
-		worker.setXLocation(newXLoc);
-		worker.setYLocation(newYLoc);
+		worker.setPosition(worker.getPosition().getPosition(distance, direction));
 	}
 
 	/**
@@ -397,15 +358,13 @@ public class WalkSettlementInterior extends Task implements Serializable {
 	private double getRemainingPathDistance() {
 
 		double result = 0D;
-		double prevXLoc = worker.getXLocation();
-		double prevYLoc = worker.getYLocation();
+		LocalPosition prevPosition = worker.getPosition();
 
 		Iterator<InsidePathLocation> i = walkingPath.getRemainingPathLocations().iterator();
 		while (i.hasNext()) {
 			InsidePathLocation nextLoc = i.next();
-			result += Point2D.Double.distance(prevXLoc, prevYLoc, nextLoc.getXLocation(), nextLoc.getYLocation());
-			prevXLoc = nextLoc.getXLocation();
-			prevYLoc = nextLoc.getYLocation();
+			nextLoc.getPosition().getDirectionTo(prevPosition);
+			prevPosition = nextLoc.getPosition();
 		}
 
 		return result;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/utils/Task.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/utils/Task.java
@@ -18,6 +18,7 @@ import java.util.logging.Level;
 
 import org.mars_sim.msp.core.LocalAreaUtil;
 import org.mars_sim.msp.core.LocalBoundedObject;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.SimulationConfig;
 import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.UnitEventType;
@@ -1127,12 +1128,10 @@ public abstract class Task implements Serializable, Comparable<Task> {
 	 */
 	protected void walkToRandomLocInBuilding(Building building, boolean allowFail) {
 
-		Point2D interiorPos = LocalAreaUtil.getRandomInteriorLocation(building);
-		Point2D adjustedInteriorPos = LocalAreaUtil.getLocalRelativeLocation(interiorPos.getX(), interiorPos.getY(),
-				building);
+		LocalPosition adjustedInteriorPos = LocalAreaUtil.getRandomLocalRelativePosition(building);
 
 		// Create subtask for walking to destination.
-		createWalkingSubtask(building, adjustedInteriorPos, allowFail);
+		createWalkingSubtask(building, adjustedInteriorPos.toPoint(), allowFail);
 	}
 
 	/**
@@ -1269,12 +1268,10 @@ public abstract class Task implements Serializable, Comparable<Task> {
 	 */
 	protected void walkToRandomLocInRover(Rover rover, boolean allowFail) {
 
-		Point2D interiorPos = LocalAreaUtil.getRandomInteriorLocation(rover);
-		Point2D adjustedInteriorPos = LocalAreaUtil.getLocalRelativeLocation(interiorPos.getX(), interiorPos.getY(),
-				rover);
+		LocalPosition adjustedInteriorPos = LocalAreaUtil.getRandomLocalRelativePosition(rover);
 
 		// Create subtask for walking to destination.
-		createWalkingSubtask(rover, adjustedInteriorPos, allowFail);
+		createWalkingSubtask(rover, adjustedInteriorPos.toPoint(), allowFail);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/utils/Worker.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/utils/Worker.java
@@ -10,6 +10,7 @@ package org.mars_sim.msp.core.person.ai.task.utils;
 import java.io.Serializable;
 
 import org.mars_sim.msp.core.Coordinates;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.UnitListener;
 import org.mars_sim.msp.core.UnitType;
@@ -145,39 +146,38 @@ public interface Worker extends Loggable, Serializable, EquipmentOwner {
 	 */
 	public void setMission(Mission newMission);
 
-
-	// These methods below should be moved to separate Walker interface
-	// Also should be converted into a single LocalCoordinate class
-	// instead of 2DPoint which is a UI AWT class
-
-
 	/**
 	 * Gets the worker X location at a settlement.
 	 *
 	 * @return X distance (meters) from the settlement's center.
+	 * @deprecated
 	 */
-	public double getXLocation();
-
-	/**
-	 * Sets the worker's X location at a settlement.
-	 *
-	 * @param xLocation the X distance (meters) from the settlement's center.
-	 */
-	public void setXLocation(double xLocation);
+	default double getXLocation() {
+		return getPosition().getX();
+	}
 
 	/**
 	 * Gets the worker's Y location at a settlement.
 	 *
 	 * @return Y distance (meters) from the settlement's center.
+	 * @deprecated
 	 */
-	public double getYLocation();
+	default double getYLocation() {
+		return getPosition().getY();
+	}
 
 	/**
-	 * Sets the worker's Y location at a settlement.
-	 *
-	 * @param yLocation
+	 * Get the Worker's position within the Settlement/Vehicle
+	 * @return
 	 */
-	public void setYLocation(double yLocation);
+	public LocalPosition getPosition();
+	
+	/**
+	 * Sets the worker's position at a settlement.
+	 *
+	 * @param position
+	 */
+	public void setPosition(LocalPosition position);
 
 	/**
 	 * Gets the manager of the Worker's Tasks

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/robot/Robot.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/robot/Robot.java
@@ -18,6 +18,7 @@ import java.util.logging.Logger;
 
 import org.mars_sim.msp.core.CollectionUtils;
 import org.mars_sim.msp.core.Coordinates;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.UnitEventType;
 import org.mars_sim.msp.core.UnitType;
@@ -115,10 +116,8 @@ public class Robot extends Unit implements Salvagable, Temporal, Malfunctionable
 	/** The carrying capacity of the robot. */
 	private int carryingCapacity;
 
-	/** Settlement X location (meters) from settlement center. */
-	private double xLoc;
-	/** Settlement Y location (meters) from settlement center. */
-	private double yLoc;
+	/** Settlement position (meters) from settlement center. */
+	private LocalPosition position;
 
 	/** The birthplace of the robot. */
 	private String birthplace;
@@ -157,9 +156,7 @@ public class Robot extends Unit implements Salvagable, Temporal, Malfunctionable
 		this.nickName = name;
 		this.associatedSettlementID = (Integer) settlement.getIdentifier();
 		this.robotType = robotType;
-
-		xLoc = 0D;
-		yLoc = 0D;
+		this.position = LocalPosition.DEFAULT_POSITION;
 
 		isSalvaged = false;
 		salvageInfo = null;
@@ -299,39 +296,23 @@ public class Robot extends Unit implements Salvagable, Temporal, Malfunctionable
     }
 
 	/**
-	 * Gets the robot's X location at a settlement.
+	 * Gets the robot's position at a settlement.
 	 *
-	 * @return X distance (meters) from the settlement's center.
+	 * @return distance (meters) from the settlement's center.
 	 */
-	public double getXLocation() {
-		return xLoc;
+	@Override
+	public LocalPosition getPosition() {
+		return position;
 	}
 
 	/**
-	 * Sets the robot's X location at a settlement.
+	 * Sets the robot's position at a settlement.
 	 *
-	 * @param xLocation the X distance (meters) from the settlement's center.
+	 * @param position the distance (meters) from the settlement's center.
 	 */
-	public void setXLocation(double xLocation) {
-		this.xLoc = xLocation;
-	}
-
-	/**
-	 * Gets the robot's Y location at a settlement.
-	 *
-	 * @return Y distance (meters) from the settlement's center.
-	 */
-	public double getYLocation() {
-		return yLoc;
-	}
-
-	/**
-	 * Sets the robot's Y location at a settlement.
-	 *
-	 * @param yLocation
-	 */
-	public void setYLocation(double yLocation) {
-		this.yLoc = yLocation;
+	@Override
+	public void setPosition(LocalPosition position) {
+		this.position = position;
 	}
 
 	/**
@@ -807,11 +788,6 @@ public class Robot extends Unit implements Salvagable, Temporal, Malfunctionable
 	 */
 	public void setSponsor(String sponsor) {
 		this.sponsor = sponsor;
-	}
-
-	//@Override
-	public void setVehicle(Vehicle vehicle) {
-		// this.vehicle = vehicle;
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/BuildingTemplate.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/BuildingTemplate.java
@@ -151,7 +151,7 @@ public class BuildingTemplate implements Serializable, Comparable<BuildingTempla
 			return id;
 		}
 
-		public LocalPosition getLocation() {
+		public LocalPosition getPosition() {
 			return location;
 		}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/Building.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/Building.java
@@ -848,26 +848,25 @@ public class Building extends Structure implements Malfunctionable, Indoor, // C
 		return floorArea * HEIGHT * 1000; // 1 Cubic Meter = 1,000 Liters
 	}
 
-
-	public LocalPosition getPosition() {
-		return loc;
-	}
-	
 	@Override
 	public double getXLocation() {
 		return loc.getX();
 	}
-
+	
 	@Override
 	public double getYLocation() {
 		return loc.getY();
 	}
 	
 	@Override
+	public LocalPosition getPosition() {
+		return loc;
+	}
+
+	@Override
 	public double getFacing() {
 		return facing;
 	}
-
 
 	public boolean getInTransport() {
 		return inTransportMode;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/BuildingManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/BuildingManager.java
@@ -1674,8 +1674,7 @@ public class BuildingManager implements Serializable {
 		if (building != null) {
 			try {
 				// Add person to random location within building.
-				LocalPosition buildingLoc = LocalAreaUtil.getRandomInteriorPosition(building);
-				LocalPosition settlementLoc = LocalAreaUtil.getLocalRelativePosition(buildingLoc, building);
+				LocalPosition settlementLoc = LocalAreaUtil.getRandomLocalRelativePosition(building);
 
 				if (unit instanceof Person) {
 					Person person = (Person) unit;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/BuildingManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/BuildingManager.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import org.mars_sim.msp.core.BoundedObject;
 import org.mars_sim.msp.core.LocalAreaUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Simulation;
 import org.mars_sim.msp.core.SimulationConfig;
 import org.mars_sim.msp.core.Unit;
@@ -1368,26 +1369,6 @@ public class BuildingManager implements Serializable {
 	}
 
 	/**
-	 * Check what building a given local settlement position is within.
-	 *
-	 * @param xLoc the local X position.
-	 * @param yLoc the local Y position.
-	 * @return building the position is within, or null if the position is not
-	 *         within any building.
-	 */
-	public Building getBuildingAtPosition(double xLoc, double yLoc) {
-        Iterator<Building> i = buildings.iterator();
-        while (i.hasNext()) {
-            Building building = i.next();
-            if (LocalAreaUtil.isLocationWithinLocalBoundedObject(xLoc, yLoc, building)) {
-                return building;
-            }
-        }
-
-        return null;
-	}
-
-	/**
 	 * Gets a list of uncrowded buildings from a given list of buildings with life
 	 * support.
 	 *
@@ -1635,13 +1616,14 @@ public class BuildingManager implements Serializable {
 	 *
 	 * @param person   the person to add.
 	 * @param building the building to add the person to.
+	 * @param posotion Position within the Building
 	 */
-	public static void addPersonOrRobotToBuilding(Unit unit, Building building, double xLocation, double yLocation) {
+	public static void addPersonOrRobotToBuilding(Unit unit, Building building, LocalPosition position) {
 		if (building != null) {
 
-			if (!LocalAreaUtil.isLocationWithinLocalBoundedObject(xLocation, yLocation, building)) {
+			if (!LocalAreaUtil.isPositionWithinLocalBoundedObject(position, building)) {
 				throw new IllegalArgumentException(
-						building.getNickName() + " does not contain location x: " + xLocation + ", y: " + yLocation);
+						building.getNickName() + " does not contain location " + position);
 			}
 
 			try {
@@ -1652,8 +1634,7 @@ public class BuildingManager implements Serializable {
 					if (!lifeSupport.containsOccupant(person)) {
 						lifeSupport.addPerson(person);
 
-						person.setXLocation(xLocation);
-						person.setYLocation(yLocation);
+						person.setPosition(position);
 						person.setCurrentBuilding(building);
 					}
 				}
@@ -1665,8 +1646,7 @@ public class BuildingManager implements Serializable {
 					if (roboticStation.containsRobotOccupant(robot)) {
 						roboticStation.addRobot(robot);
 
-						robot.setXLocation(xLocation);
-						robot.setYLocation(yLocation);
+						robot.setPosition(position);
 						robot.setCurrentBuilding(building);
 					}
 				}
@@ -1689,10 +1669,8 @@ public class BuildingManager implements Serializable {
 		if (building != null) {
 			try {
 				// Add person to random location within building.
-				// TODO: Modify this when implementing active locations in buildings.
-				Point2D.Double buildingLoc = LocalAreaUtil.getRandomInteriorLocation(building);
-				Point2D.Double settlementLoc = LocalAreaUtil.getLocalRelativeLocation(buildingLoc.getX(),
-						buildingLoc.getY(), building);
+				LocalPosition buildingLoc = LocalAreaUtil.getRandomInteriorPosition(building);
+				LocalPosition settlementLoc = LocalAreaUtil.getLocalRelativePosition(buildingLoc, building);
 
 				if (unit instanceof Person) {
 					Person person = (Person) unit;
@@ -1701,10 +1679,8 @@ public class BuildingManager implements Serializable {
 					if (!lifeSupport.containsOccupant(person)) {
 						lifeSupport.addPerson(person);
 
-						person.setXLocation(settlementLoc.getX());
-						person.setYLocation(settlementLoc.getY());
+						person.setPosition(settlementLoc);
 						person.setCurrentBuilding(building);
-//						logger.config(person + " was being randomly added to " + building.getNickName());
 					}
 				}
 
@@ -1715,8 +1691,7 @@ public class BuildingManager implements Serializable {
 					if (!roboticStation.containsRobotOccupant(robot)) {
 						roboticStation.addRobot(robot);
 
-						robot.setXLocation(settlementLoc.getX());
-						robot.setYLocation(settlementLoc.getY());
+						robot.setPosition(settlementLoc);
 						robot.setCurrentBuilding(building);
 					}
 				}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/BuildingSpec.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/BuildingSpec.java
@@ -9,11 +9,13 @@ package org.mars_sim.msp.core.structure.building;
 
 import java.awt.geom.Point2D;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.science.ScienceType;
 import org.mars_sim.msp.core.structure.building.function.FunctionType;
 
@@ -92,7 +94,7 @@ public class BuildingSpec {
 	private List<ResourceProcessSpec> resourceProcess = EMPTY_RESOURCE;
 
 	private List<Point2D> beds;
-	private List<Point2D> parking;
+	private List<LocalPosition> parking;
 
 	private List<ScienceType> wasteSpecialties;
 	
@@ -254,16 +256,16 @@ public class BuildingSpec {
 		return beds;
 	}
 
-	public void setBeds(List<Point2D> beds) {
+	void setBeds(List<Point2D> beds) {
 		this.beds = beds;
 	}
 	
-	public List<Point2D> getParking() {
+	public List<LocalPosition> getParking() {
 		return parking;
 	}
 
-	public void setParking(List<Point2D> parking) {
-		this.parking = parking;
+	void setParking(List<LocalPosition> parking) {
+		this.parking = Collections.unmodifiableList(parking);
 	}
 
 	public List<ScienceType> getWasteSpecialties() {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/connection/BuildingConnectorManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/connection/BuildingConnectorManager.java
@@ -121,8 +121,8 @@ public class BuildingConnectorManager implements Serializable {
 							+ " does not exist for settlement " + settlement.getName());
 				}
 
-				double connectionXLoc = connectionTemplate.getLocation().getX();
-				double connectionYLoc = connectionTemplate.getLocation().getY();
+				double connectionXLoc = connectionTemplate.getPosition().getX();
+				double connectionYLoc = connectionTemplate.getPosition().getY();
 				Point2D.Double connectionSettlementLoc = LocalAreaUtil.getLocalRelativeLocation(connectionXLoc,
 						connectionYLoc, building);
 
@@ -351,35 +351,29 @@ public class BuildingConnectorManager implements Serializable {
 	/**
 	 * Determines the shortest building path between two locations in buildings.
 	 * 
-	 * @param building1     the first building.
-	 * @param building1XLoc the starting X location in the first building.
-	 * @param building1YLoc the starting Y location in the first building.
-	 * @param building2     the second building.
-	 * @param building2XLoc the ending X location in the second building.
-	 * @param building2YLoc the ending Y location in the second building.
+	 * @param startBuilding     the first building.
+	 * @param startPositionc the starting position in the first building.
+	 * @param endBuilding     the second building.
+	 * @param endPosition the ending position in the second building.
 	 * @return shortest path or null if no path found.
 	 */
-	public InsideBuildingPath determineShortestPath(Building building1, double building1XLoc, double building1YLoc,
-			Building building2, double building2XLoc, double building2YLoc) {
+	public InsideBuildingPath determineShortestPath(Building startBuilding, LocalPosition startPosition,
+			Building endBuilding, LocalPosition endPosition) {
 
-//		if ((building1 == null) || (building2 == null)) {
-//			throw new IllegalArgumentException("Building arguments cannot be null");
-//		}
 
-		BuildingLocation startingLocation = new BuildingLocation(building1, building1XLoc, building1YLoc);
-		BuildingLocation endingLocation = new BuildingLocation(building2, building2XLoc, building2YLoc);
+		BuildingLocation start = new BuildingLocation(startBuilding, startPosition);
+		BuildingLocation end = new BuildingLocation(endBuilding, endPosition);
 
 		InsideBuildingPath startingPath = new InsideBuildingPath();
-		startingPath.addPathLocation(startingLocation);
+		startingPath.addPathLocation(start);
 
 		InsideBuildingPath finalPath = null;
-		if (!building1.equals(building2)) {
+		if (!startBuilding.equals(endBuilding)) {
 			// Check shortest path to target building from this building.
-//			logger.config(building1.getNickName() + " " + building2.getNickName());
-			finalPath = determineShortestPath(startingPath, building1, building2, endingLocation);
+			finalPath = determineShortestPath(startingPath, startBuilding, endBuilding, end);
 		} else {
 			finalPath = startingPath;
-			finalPath.addPathLocation(endingLocation);
+			finalPath.addPathLocation(end);
 		}
 
 		// Iterate path index.
@@ -388,6 +382,25 @@ public class BuildingConnectorManager implements Serializable {
 		}
 
 		return finalPath;
+	}
+	
+	/**
+	 * Determines the shortest building path between two locations in buildings.
+	 * 
+	 * @param building1     the first building.
+	 * @param building1XLoc the starting X location in the first building.
+	 * @param building1YLoc the starting Y location in the first building.
+	 * @param building2     the second building.
+	 * @param building2XLoc the ending X location in the second building.
+	 * @param building2YLoc the ending Y location in the second building.
+	 * @return shortest path or null if no path found.
+	 * @deprecated
+	 */
+	public InsideBuildingPath determineShortestPath(Building building1, double building1XLoc, double building1YLoc,
+			Building building2, double building2XLoc, double building2YLoc) {
+
+		return determineShortestPath(building1, new LocalPosition(building1XLoc, building1YLoc),
+									 building2, new LocalPosition(building2XLoc, building2YLoc));
 	}
 
 	/**
@@ -849,4 +862,5 @@ public class BuildingConnectorManager implements Serializable {
 			this.connectToBuilding = connectToBuilding;
 		}
 	}
+
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/connection/BuildingConnectorManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/connection/BuildingConnectorManager.java
@@ -94,7 +94,7 @@ public class BuildingConnectorManager implements Serializable {
 		BuildingManager buildingManager = settlement.getBuildingManager();
 
 		// Create partial building connector list from building connection templates.
-		List<PartialBuildingConnector> partialBuildingConnectorList = new CopyOnWriteArrayList<PartialBuildingConnector>();
+		List<PartialBuildingConnector> partialBuildingConnectorList = new CopyOnWriteArrayList<>();
 		Iterator<BuildingTemplate> i = buildingTemplates.iterator();
 		while (i.hasNext()) {
 			BuildingTemplate buildingTemplate = i.next();
@@ -123,8 +123,7 @@ public class BuildingConnectorManager implements Serializable {
 
 				double connectionXLoc = connectionTemplate.getPosition().getX();
 				double connectionYLoc = connectionTemplate.getPosition().getY();
-				Point2D.Double connectionSettlementLoc = LocalAreaUtil.getLocalRelativeLocation(connectionXLoc,
-						connectionYLoc, building);
+				LocalPosition connectionSettlementLoc = LocalAreaUtil.getLocalRelativePosition(connectionTemplate.getPosition(), building);
 
 				double connectionFacing = 0D;
 				if (connectionXLoc == (building.getWidth() / 2D)) {
@@ -146,8 +145,7 @@ public class BuildingConnectorManager implements Serializable {
 				}
 
 				PartialBuildingConnector partialConnector = new PartialBuildingConnector(building,
-						new LocalPosition(connectionSettlementLoc), connectionFacing,
-						connectionBuilding);
+						connectionSettlementLoc, connectionFacing, connectionBuilding);
 				partialBuildingConnectorList.add(partialConnector);
 			}
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/function/GroundVehicleMaintenance.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/function/GroundVehicleMaintenance.java
@@ -6,12 +6,12 @@
  */
 package org.mars_sim.msp.core.structure.building.function;
 
-import org.mars_sim.msp.core.structure.Settlement;
-import org.mars_sim.msp.core.structure.building.Building;
-
-import java.awt.geom.Point2D;
 import java.io.Serializable;
 import java.util.Iterator;
+
+import org.mars_sim.msp.core.LocalPosition;
+import org.mars_sim.msp.core.structure.Settlement;
+import org.mars_sim.msp.core.structure.building.Building;
 
 /**
  * The GroundVehicleMaintenance class is a building function for a building
@@ -35,10 +35,8 @@ implements Serializable {
 		vehicleCapacity = buildingConfig.getFunctionCapacity(building.getBuildingType(),
 															 FunctionType.GROUND_VEHICLE_MAINTENANCE);
 
-		int parkingLocationNum = buildingConfig.getParkingLocationNumber(building.getBuildingType());
-		for (int x = 0; x < parkingLocationNum; x++) {
-			Point2D parkingLocationPoint = buildingConfig.getParkingLocation(building.getBuildingType(), x);
-			addParkingLocation(parkingLocationPoint.getX(), parkingLocationPoint.getY());
+		for (LocalPosition parkingLocationPoint : buildingConfig.getParkingLocations(building.getBuildingType())) {
+			addParkingLocation(parkingLocationPoint);
 		}
 	}
 
@@ -49,14 +47,14 @@ implements Serializable {
 	 * @param parkingLocations the parking locations.
 	 */
 	public GroundVehicleMaintenance(Building building, int vehicleCapacity, 
-			Point2D[] parkingLocations) {
+			LocalPosition[] parkingLocations) {
 		// Call VehicleMaintenance constructor.
 		super(FunctionType.GROUND_VEHICLE_MAINTENANCE, building);
 
 		this.vehicleCapacity = vehicleCapacity;
 		
-		for (int x = 0; x < parkingLocations.length; x++) {
-			addParkingLocation(parkingLocations[x].getX(), parkingLocations[x].getY());
+		for (LocalPosition parkingLocation : parkingLocations) {
+			addParkingLocation(parkingLocation);
 		}
 	}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/function/VehicleMaintenance.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/function/VehicleMaintenance.java
@@ -6,7 +6,6 @@
  */
 package org.mars_sim.msp.core.structure.building.function;
 
-import java.awt.geom.Point2D;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -17,6 +16,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Level;
 
 import org.mars_sim.msp.core.LocalAreaUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.location.LocationStateType;
 import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.person.Person;
@@ -125,22 +125,17 @@ public abstract class VehicleMaintenance extends Function implements Serializabl
 		
 			// Put vehicle in assigned parking location within building.
 			ParkingLocation location = getEmptyParkingLocation();
-			double newXLoc = 0D;
-			double newYLoc = 0D;
+			LocalPosition newLoc;
 			if (location != null) {
-				Point2D.Double settlementLoc = LocalAreaUtil.getLocalRelativeLocation(location.getXLocation(),
-						location.getYLocation(), getBuilding());
-				newXLoc = settlementLoc.getX();
-				newYLoc = settlementLoc.getY();
+				newLoc = LocalAreaUtil.getLocalRelativePosition(location.getPosition(), getBuilding());
 				location.parkVehicle(vehicle);
 			} else {
 				// Park vehicle in center point of building.
-				newXLoc = getBuilding().getXLocation();
-				newYLoc = getBuilding().getYLocation();
+				newLoc = getBuilding().getPosition();
 			}
 	
 			double newFacing = getBuilding().getFacing();
-			vehicle.setParkedLocation(newXLoc, newYLoc, newFacing);
+			vehicle.setParkedLocation(newLoc, newFacing);
 	
 			logger.fine(vehicle, "Added to " + building.getNickName() + " in " + building.getSettlement());
 			
@@ -250,11 +245,10 @@ public abstract class VehicleMaintenance extends Function implements Serializabl
 	/**
 	 * Add a new parking location in the building.
 	 * 
-	 * @param xLocation the relative X location of the parking spot.
-	 * @param yLocation the relative Y location of the parking spot.
+	 * @param position the relative position of the parking spot.
 	 */
-	protected void addParkingLocation(double xLocation, double yLocation) {
-		parkingLocations.add(new ParkingLocation(xLocation, yLocation));
+	protected void addParkingLocation(LocalPosition position) {
+		parkingLocations.add(new ParkingLocation(position));
 	}
 
 	/**
@@ -327,22 +321,16 @@ public abstract class VehicleMaintenance extends Function implements Serializabl
 		private static final long serialVersionUID = 1L;
 		
 		// Data members
-		private double xLocation;
-		private double yLocation;
+		private LocalPosition pos;
 		private Vehicle parkedVehicle;
 
-		protected ParkingLocation(double xLocation, double yLocation) {
-			this.xLocation = xLocation;
-			this.yLocation = yLocation;
+		protected ParkingLocation(LocalPosition pos) {
+			this.pos = pos;
 			parkedVehicle = null;
 		}
 
-		public double getXLocation() {
-			return xLocation;
-		}
-
-		public double getYLocation() {
-			return yLocation;
+		public LocalPosition getPosition() {
+			return pos;
 		}
 
 		public Vehicle getParkedVehicle() {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/construction/ConstructionManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/construction/ConstructionManager.java
@@ -260,8 +260,7 @@ implements Serializable {
 
 		// Add construction site.
 		ConstructionSite site = createNewConstructionSite();
-		site.setXLocation(salvagedBuilding.getXLocation());
-		site.setYLocation(salvagedBuilding.getYLocation());
+		site.setPosition(salvagedBuilding.getPosition());
 		site.setFacing(salvagedBuilding.getFacing());
 		ConstructionStageInfo buildingStageInfo = ConstructionUtil.getConstructionStageInfo(salvagedBuilding.getBuildingType());
 		if (buildingStageInfo != null) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/construction/ConstructionSite.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/construction/ConstructionSite.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.mars_sim.msp.core.BoundedObject;
 import org.mars_sim.msp.core.LocalBoundedObject;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Simulation;
 import org.mars_sim.msp.core.UnitType;
 import org.mars_sim.msp.core.person.ai.mission.MissionMember;
@@ -53,8 +54,7 @@ implements Serializable, LocalBoundedObject {
 
     private double width;
     private double length;
-    private double xLocation;
-    private double yLocation;
+    private LocalPosition position;
     private double facing;
 
     private boolean undergoingConstruction;
@@ -86,8 +86,7 @@ implements Serializable, LocalBoundedObject {
 
     	width = 0D;
         length = 0D;
-        xLocation = 0D;
-        yLocation = 0D;
+        position = LocalPosition.DEFAULT_POSITION;
         facing = 0D;
         foundationStage = null;
         frameStage = null;
@@ -125,30 +124,23 @@ implements Serializable, LocalBoundedObject {
 
     @Override
     public double getXLocation() {
-        return xLocation;
-    }
-
-    /**
-     * Sets the X location of the construction site.
-     * @param xLocation x location in meters from center of settlement (West: positive, East: negative).
-     */
-    public void setXLocation(double xLocation) {
-        this.xLocation = xLocation;
+        return position.getX();
     }
 
     @Override
     public double getYLocation() {
-        return yLocation;
+        return position.getY();
     }
 
-    /**
-     * Sets the Y location of the construction site.
-     * @param yLocation y location in meters from center of settlement (North: positive, South: negative).
-     */
-    public void setYLocation(double yLocation) {
-        this.yLocation = yLocation;
+    @Override
+    public LocalPosition getPosition() {
+    	return position;
     }
-
+    
+	public void setPosition(LocalPosition position2) {
+		this.position = position2;
+	}
+	
     @Override
     public double getFacing() {
         return facing;
@@ -363,7 +355,7 @@ implements Serializable, LocalBoundedObject {
         String uniqueName = manager.getBuildingNickName(buildingType);
 
         Building newBuilding = new Building(id, buildingType, uniqueName,
-        		new BoundedObject(xLocation, yLocation, width, length, facing),
+        		new BoundedObject(position, width, length, facing),
                 settlement.getBuildingManager());
         manager.addBuilding(newBuilding, true);
 
@@ -569,4 +561,5 @@ implements Serializable, LocalBoundedObject {
 	public boolean isInSettlement() {
 		return false;
 	}
+
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Flyer.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Flyer.java
@@ -12,6 +12,7 @@ import java.util.logging.Level;
 
 import org.mars_sim.msp.core.Direction;
 import org.mars_sim.msp.core.LocalAreaUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.structure.building.Building;
@@ -150,10 +151,8 @@ public abstract class Flyer extends Vehicle implements Serializable {
 		}
 
 		else {
+			LocalPosition centerLoc = LocalPosition.DEFAULT_POSITION;
 			
-			double centerXLoc = 0D;
-			double centerYLoc = 0D;
-
 			// Place the vehicle starting from the settlement center (0,0).
 
 			int oX = 15;
@@ -185,11 +184,9 @@ public abstract class Flyer extends Vehicle implements Serializable {
 					}
 
 					if (hab != null) {
-						centerXLoc = (int) hab.getXLocation();
-						centerYLoc = (int) hab.getYLocation();
+						centerLoc = hab.getPosition();
 					} else if (hub != null) {
-						centerXLoc = (int) hub.getXLocation();
-						centerYLoc = (int) hub.getYLocation();
+						centerLoc = hub.getPosition();
 					}
 				}
 
@@ -197,16 +194,12 @@ public abstract class Flyer extends Vehicle implements Serializable {
 					// Try parking near a garage
 					
 					Building garage = BuildingManager.getAGarage(getSettlement());
-					centerXLoc = (int) garage.getXLocation();
-					centerYLoc = (int) garage.getYLocation();
+					centerLoc = garage.getPosition();
 				}
 			}
 
-			double newXLoc = 0D;
-			double newYLoc = 0D;
-
 			double newFacing = 0D;
-
+			LocalPosition newLoc = null;
 			double step = 10D;
 			boolean foundGoodLocation = false;
 
@@ -216,14 +209,14 @@ public abstract class Flyer extends Vehicle implements Serializable {
 				for (int y = oY; (y < step) && !foundGoodLocation; y++) {
 					double distance = RandomUtil.getRandomDouble(step) + x;
 					double radianDirection = RandomUtil.getRandomDouble(Math.PI * 2D);
-					newXLoc = centerXLoc - (distance * Math.sin(radianDirection));
-					newYLoc = centerYLoc + (distance * Math.cos(radianDirection));
+					
+					newLoc = centerLoc.getPosition(distance, radianDirection);
 					newFacing = RandomUtil.getRandomDouble(360D);
 
 					// Check if new vehicle location collides with anything.
-					foundGoodLocation = //LocalAreaUtil.isGoodLocation(this, newXLoc, newYLoc, newFacing, getCoordinates());
-							LocalAreaUtil.isObjectCollisionFree(this, this.getWidth() * 1.3, this.getLength() * 1.3, newXLoc,
-							newYLoc, newFacing, getCoordinates());
+					foundGoodLocation = 
+							LocalAreaUtil.isObjectCollisionFree(this, this.getWidth() * 1.3, this.getLength() * 1.3, newLoc.getX(),
+							newLoc.getY(), newFacing, getCoordinates());
 					// Note: Enlarge the collision surface of a vehicle to avoid getting trapped within those enclosed space 
 					// surrounded by buildings or hallways.
 					// This is just a temporary solution to stop the vehicle from acquiring a parking between buildings.
@@ -231,8 +224,7 @@ public abstract class Flyer extends Vehicle implements Serializable {
 				}
 			}
 
-			setParkedLocation(newXLoc, newYLoc, newFacing);
-
+			setParkedLocation(newLoc, newFacing);
 		}
 	}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Rover.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Rover.java
@@ -17,6 +17,7 @@ import java.util.logging.Level;
 import org.mars_sim.msp.core.Coordinates;
 import org.mars_sim.msp.core.LifeSupportInterface;
 import org.mars_sim.msp.core.LocalAreaUtil;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.SimulationConfig;
 import org.mars_sim.msp.core.data.UnitSet;
@@ -982,8 +983,8 @@ public class Rover extends GroundVehicle implements Crewable, LifeSupportInterfa
 	}
 
 	@Override
-	public void setParkedLocation(double xLocation, double yLocation, double facing) {
-		super.setParkedLocation(xLocation, yLocation, facing);
+	public void setParkedLocation(LocalPosition position, double facing) {
+		super.setParkedLocation(position, facing);
 
 		// Update towed vehicle locations.
 		updatedTowedVehicleSettlementLocation();
@@ -999,18 +1000,16 @@ public class Rover extends GroundVehicle implements Crewable, LifeSupportInterfa
 			if (towedVehicle instanceof Rover) {
 				// Towed rovers should be located behind this rover with same facing.
 				double distance = (getLength() + towedVehicle.getLength()) / 2D;
-				double towedX = 0D;
-				double towedY = 0D - distance;
-				Point2D.Double towedLoc = LocalAreaUtil.getLocalRelativeLocation(towedX, towedY, this);
-				towedVehicle.setParkedLocation(towedLoc.getX(), towedLoc.getY(), getFacing());
+				LocalPosition towingPosition = new LocalPosition(0D, - distance);
+				LocalPosition towedLoc = LocalAreaUtil.getLocalRelativePosition(towingPosition, this);
+				towedVehicle.setParkedLocation(towedLoc, getFacing());
 			} else if (towedVehicle instanceof LightUtilityVehicle) {
 				// Towed light utility vehicles should be attached to back of the rover
 				// sideways and facing to the right.
 				double distance = (getLength() + towedVehicle.getWidth()) / 2D;
-				double towedX = 0D;
-				double towedY = 0D - distance;
-				Point2D.Double towedLoc = LocalAreaUtil.getLocalRelativeLocation(towedX, towedY, this);
-				towedVehicle.setParkedLocation(towedLoc.getX(), towedLoc.getY(), getFacing() + 90D);
+				LocalPosition towingPosition = new LocalPosition(0D, - distance);
+				LocalPosition towedLoc = LocalAreaUtil.getLocalRelativePosition(towingPosition, this);
+				towedVehicle.setParkedLocation(towedLoc, getFacing() + 90D);
 			}
 		}
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Vehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Vehicle.java
@@ -25,6 +25,7 @@ import org.mars_sim.msp.core.Coordinates;
 import org.mars_sim.msp.core.Direction;
 import org.mars_sim.msp.core.LocalAreaUtil;
 import org.mars_sim.msp.core.LocalBoundedObject;
+import org.mars_sim.msp.core.LocalPosition;
 import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.UnitEventType;
 import org.mars_sim.msp.core.UnitType;
@@ -612,10 +613,9 @@ public abstract class Vehicle extends Unit
 				Person crewmember = i.next();
 
 				Point2D currentCrewPos = currentCrewPositions.get(crewmember);
-				Point2D.Double settlementLoc = LocalAreaUtil.getLocalRelativeLocation(currentCrewPos.getX(),
-						currentCrewPos.getY(), this);
-				crewmember.setXLocation(settlementLoc.getX());
-				crewmember.setYLocation(settlementLoc.getY());
+				LocalPosition settlementLoc = LocalAreaUtil.getLocalRelativePosition(new LocalPosition(currentCrewPos),
+																		this);
+				crewmember.setPosition(settlementLoc);
 			}
 		}
 	}
@@ -633,10 +633,9 @@ public abstract class Vehicle extends Unit
 				Robot robotCrewmember = i.next();
 
 				Point2D currentCrewPos = currentRobotCrewPositions.get(robotCrewmember);
-				Point2D.Double settlementLoc = LocalAreaUtil.getLocalRelativeLocation(currentCrewPos.getX(),
-						currentCrewPos.getY(), this);
-				robotCrewmember.setXLocation(settlementLoc.getX());
-				robotCrewmember.setYLocation(settlementLoc.getY());
+				LocalPosition settlementLoc = LocalAreaUtil.getLocalRelativePosition(new LocalPosition(currentCrewPos),
+														this);
+				robotCrewmember.setPosition(settlementLoc);
 			}
 		}
 	}

--- a/mars-sim-core/src/test/java/org/mars_sim/msp/core/person/ai/task/WalkingStepsTest.java
+++ b/mars-sim-core/src/test/java/org/mars_sim/msp/core/person/ai/task/WalkingStepsTest.java
@@ -1,6 +1,5 @@
 package org.mars_sim.msp.core.person.ai.task;
 
-import java.awt.geom.Point2D;
 import java.util.Iterator;
 
 import org.junit.Before;
@@ -722,9 +721,9 @@ public class WalkingStepsTest extends TestCase {
         BuildingAirlock airlock0 = new BuildingAirlock(building0, 1, 0D, 0D, 0D, 0D, 0D, 0D);
         building0.addFunction(new EVA(building0, airlock0));
 
-        Point2D parkingLocation = new Point2D.Double(0D, 0D);
+        LocalPosition parkingLocation = LocalPosition.DEFAULT_POSITION;
         GroundVehicleMaintenance garage = new GroundVehicleMaintenance(building0, 1,
-                new Point2D[] { parkingLocation });
+                new LocalPosition[] { parkingLocation });
         building0.addFunction(garage);
 //        garage.addVehicle(rover);
 
@@ -789,9 +788,9 @@ public class WalkingStepsTest extends TestCase {
         BuildingAirlock airlock0 = new BuildingAirlock(building0, 1, 0D, 0D, 0D, 0D, 0D, 0D);
         building0.addFunction(new EVA(building0, airlock0));
 
-        Point2D parkingLocation = new Point2D.Double(0D, 0D);
+        LocalPosition parkingLocation = LocalPosition.DEFAULT_POSITION;
         GroundVehicleMaintenance garage = new GroundVehicleMaintenance(building0, 1,
-                new Point2D[] { parkingLocation });
+                new LocalPosition[] { parkingLocation });
         building0.addFunction(garage);
 //        garage.addVehicle(rover);
 


### PR DESCRIPTION
The Worker interface and implementing classes are using the```LocalPosition``` class instead of separate X & Y.

The ```Vehicle``` class now holds the parked location as a singe attribute.. This allows further removal of excessive method parameters.