### PR TITLE
Fixed problem with NPE in quickstart mode

### DIFF
--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/SimulationBuilder.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/SimulationBuilder.java
@@ -242,8 +242,9 @@ public class SimulationBuilder {
 
 	/**
 	 * Uses the previously defines options and start the required Simulation
+	 * @return The new simulation started
 	 */
-	public void start() {
+	public Simulation start() {
 		Version version = java.lang.Runtime.version();
 		logger.config("-----------------------------------------------------------");
 		logger.config("    Java Version Full String = "+version);
@@ -305,6 +306,8 @@ public class SimulationBuilder {
 		}
 
 		sim.startClock(false);
+		
+		return sim;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/SimulationConfig.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/SimulationConfig.java
@@ -128,6 +128,7 @@ public class SimulationConfig implements Serializable {
 	private int autosaveInterval = 0;
 	private int averageTransitTime = 0;
 	private int unusedCores = 0;	
+	private transient boolean loaded = false;
 	
 	/*
 	 * -----------------------------------------------------------------------------
@@ -210,7 +211,12 @@ public class SimulationConfig implements Serializable {
 	 * @throws Exception if error loading or parsing configuration files.
 	 */
 	public void loadConfig() {
-
+		if (loaded) {
+			logger.warning("Loadconfig called more than once. Ignored");
+			return;
+		}
+		loaded = true;
+		
 		// Load simulation document
 		Document simulationDoc = parseXMLFileAsJDOMDocument(SIMULATION_FILE, true);
 		obtainMarsStartDateTime(simulationDoc);

--- a/mars-sim-libgdx/MarsProject No args.launch
+++ b/mars-sim-libgdx/MarsProject No args.launch
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/mars-sim-main/src/main/java/org/mars_sim/main/MarsProject.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.mars_sim.main.MarsProject"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="mars-sim-main"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="mars-sim-main"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx1536m"/>
+</launchConfiguration>

--- a/mars-sim-main/MarsProject -noaudio -scenario Single Settlement.launch
+++ b/mars-sim-main/MarsProject -noaudio -scenario Single Settlement.launch
@@ -11,7 +11,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.mars_sim.main.MarsProject"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="mars-sim-main"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-new -noaudio -scenario &quot;Single Settlement&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-new -noaudio -cleanui -scenario &quot;Single Settlement&quot;"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="mars-sim-main"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx1536m"/>

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/MainDesktopPane.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/MainDesktopPane.java
@@ -116,18 +116,18 @@ public class MainDesktopPane extends JDesktopPane
 	private MainWindow mainWindow;
 	private EventTableModel eventTableModel;
 
-	private static Simulation sim = Simulation.instance();
-	private static UnitManager unitManager = sim.getUnitManager();
+	private Simulation sim;
 
 	/**
 	 * Constructor 1.
 	 *
 	 * @param mainWindow the main outer window
 	 */
-	public MainDesktopPane(MainWindow mainWindow) {
+	public MainDesktopPane(MainWindow mainWindow, Simulation sim) {
 		super();
 
 		this.mainWindow = mainWindow;
+		this.sim = sim;
 
 		// Initialize data members
 		soundPlayer = new AudioPlayer(this);
@@ -283,7 +283,7 @@ public class MainDesktopPane extends JDesktopPane
 	 */
 	public void prepareListeners() {
 		// Attach UnitManagerListener to desktop
-		unitManager = sim.getUnitManager();
+		UnitManager unitManager = sim.getUnitManager();
 		unitManager.addUnitManagerListener(this);
 
 		// Add addUnitListener()
@@ -977,6 +977,7 @@ public class MainDesktopPane extends JDesktopPane
 	 * Caches the creation of settlements for speeding up loading time
 	 */
 	public void cacheSettlementUnitWindow() {
+		UnitManager unitManager = sim.getUnitManager();
 		if (mode == GameMode.COMMAND)
 			openUnitWindow(unitManager.getCommanderSettlement(), true, false);
 		else {

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/sound/AudioPlayer.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/sound/AudioPlayer.java
@@ -66,7 +66,7 @@ public class AudioPlayer implements ClockListener {
 	public AudioPlayer(MainDesktopPane desktop) {
 
 		// Add AudioPlayer to MasterClock's clock listener
-		masterClock.addClockListener(this);
+		desktop.getSimulation().getMasterClock().addClockListener(this);
 	
 		if (!isVolumeDisabled) {
 			loadMusicTracks();


### PR DESCRIPTION
Root cause is UI classes are hold invalid static references to
Simulation. Generally status references should not be initialised as
part of class loading unless the references instances themselves are
static and unchanged.

Changes:
- MainWindow & MainWindowPane hold instance reference to Simulation not
static. Simulation instance passed in constructor
- SimulationBuilder start method returns the created Simulation
- MarsProject passes the newly created Simulation to the UI as part of
the start-up
- SimulationConfig is being double loaded again; added the loaded flag
back to Config class
- Added '-cleanui' method that will force the UI to be clean and ignore
the saved UI configuration
- Having the '-new' will now bypass the user questions in the console
- AudioPlayer gets the Simulation from the MainDesktopPane (parent)
instead of holding a static reference
- Added a new Eclipse Configuration that is a vanilla start taking no
arguments