### PR TITLE
Change Loggable to use getName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .idea
 .prefs
 /mars-sim.iml
+.vscode

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/AirlockCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/AirlockCommand.java
@@ -44,8 +44,8 @@ public class AirlockCommand extends AbstractSettlementCommand {
 		else {
 			// Display details
 			for(Building b : bm.getBuildings(FunctionType.EVA)) {
-				if (b.getNickName().contains(input)) {
-					CommandHelper.outputAirlockDetailed(response, b.getNickName(),
+				if (b.getName().contains(input)) {
+					CommandHelper.outputAirlockDetailed(response, b.getName(),
 														b.getEVA().getAirlock());
 					response.appendBlankLine();
 				}

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/BuildingCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/BuildingCommand.java
@@ -36,7 +36,7 @@ public class BuildingCommand extends AbstractSettlementCommand {
 		response.appendTableHeading("Building", CommandHelper.BUILIDNG_WIDTH, "Power", 10, "Demand (kwh)", "Heat %",
 									"Temp.", "People");
 		for (Building building : i) {
-			response.appendTableRow(building.getNickName(), building.getPowerMode().getName(),
+			response.appendTableRow(building.getName(), building.getPowerMode().getName(),
 									building.getFullPowerRequired(),
 									building.getHeatMode().getPercentage(), building.getCurrentTemperature(),
 									building.getNumPeople());

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/CropCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/CropCommand.java
@@ -46,7 +46,7 @@ public class CropCommand extends AbstractSettlementCommand {
 									.collect(Collectors.toList());
 		// Display each farm seperately
 		for (Farming farm : farms) {			
-			response.append(farm.getBuilding().getNickName());
+			response.append(farm.getBuilding().getName());
 			response.appendBlankLine();
 			if (farm.getNumCrops2Plant() > 0) {
 				response.appendLabelledDigit("Available Crop Spaces", farm.getNumCrops2Plant());

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/ManufactureCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/ManufactureCommand.java
@@ -41,7 +41,7 @@ public class ManufactureCommand extends AbstractSettlementCommand {
 		StructuredResponse response = new StructuredResponse();
 		for (Building building : workshops) {
 			Manufacture workshop = building.getManufacture();
-			response.appendHeading(building.getNickName());
+			response.appendHeading(building.getName());
 			response.appendLabelledDigit("Printers In Use", workshop.getNumPrintersInUse());
 			response.appendLabeledString("Processes Active", workshop.getCurrentProcesses() + "/" + workshop.getMaxProcesses());
 			List<ManufactureProcess> processes = workshop.getProcesses();

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/MealCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/MealCommand.java
@@ -41,7 +41,7 @@ public class MealCommand extends AbstractSettlementCommand {
 		StructuredResponse response = new StructuredResponse();
 		for (Building building : kitchens) {
 			Cooking kitchen = building.getCooking();
-			response.appendHeading(building.getNickName());
+			response.appendHeading(building.getName());
 			List<CookedMeal> meals = kitchen.getCookedMealList();
 			if (meals.isEmpty()) {
 				response.append("No meals available");

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/PeopleCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/PeopleCommand.java
@@ -67,7 +67,7 @@ public class PeopleCommand extends AbstractSettlementCommand {
 		for (Person person : everyone) {
 			response.appendTableRow(person.getName(),
 									citizens.contains(person),
-									(indoorP.contains(person) ? person.getBuildingLocation().getNickName() : "No"),
+									(indoorP.contains(person) ? person.getBuildingLocation().getName() : "No"),
 									onMission.contains(person),
 									eva.contains(person),
 									(buriedP.contains(person) ? "Buried"

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/ProcessCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/ProcessCommand.java
@@ -44,7 +44,7 @@ public class ProcessCommand extends AbstractSettlementCommand {
 		
 		// Loop building that do processing
 		for(Building building : settlement.getBuildingManager().getBuildings(FunctionType.RESOURCE_PROCESSING)) {
-			String bName = building.getNickName();
+			String bName = building.getName();
 			ResourceProcessing processor = building.getResourceProcessing();
 		
 			for(ResourceProcess p : processor.getProcesses()) {

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/unit/UnitLocationCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/unit/UnitLocationCommand.java
@@ -47,7 +47,7 @@ public class UnitLocationCommand extends AbstractUnitCommand {
 			Building building = source.getBuildingLocation();
 			message.append("In ");
 			if (building != null) {
-				message.append(building.getNickName()).append(" @ ");
+				message.append(building.getName()).append(" @ ");
 			}
 
 			message.append(base.getName());				

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/Unit.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/Unit.java
@@ -258,8 +258,6 @@ public abstract class Unit implements Serializable, Loggable, UnitIdentifer, Com
 	 * @param newName new name
 	 */
 	public final void changeName(String newName) {
-//		String oldName = this.name;
-
 		// Create an event here ?
 		setName(newName);
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/equipment/Equipment.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/equipment/Equipment.java
@@ -652,10 +652,9 @@ public abstract class Equipment extends Unit implements Indoor, Salvagable {
 	 */
 	@Override
 	public int hashCode() {
-		int hashCode = getNickName().hashCode();
-		hashCode *= getEquipmentType().hashCode() ;
+		int hashCode = getEquipmentType().hashCode() ;
 		hashCode *= getIdentifier();
-		return hashCode;
+		return hashCode % 64;
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/logging/Loggable.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/logging/Loggable.java
@@ -33,7 +33,7 @@ public interface Loggable {
 	 * 
 	 * @return
 	 */
-	String getNickName();
+	String getName();
 
 	/**
 	 * Physical location the surface

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/logging/SimLogger.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/logging/SimLogger.java
@@ -15,7 +15,6 @@ import java.util.logging.Logger;
 
 import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.structure.Settlement;
-import org.mars_sim.msp.core.structure.building.Building;
 import org.mars_sim.msp.core.structure.construction.ConstructionSite;
 
 /**
@@ -211,10 +210,10 @@ public class SimLogger {
 		}
 		else if (actor instanceof Settlement) {
 			// Actor in bracket; it's top level
-			outputMessage.append(actor.getNickName()).append(CLOSED_BRACKET_SPACE);
+			outputMessage.append(actor.getName()).append(CLOSED_BRACKET_SPACE);
 		}
 		else if (actor instanceof ConstructionSite) {
-			outputMessage.append(actor.getNickName()).append(CLOSED_BRACKET_SPACE);
+			outputMessage.append(actor.getName()).append(CLOSED_BRACKET_SPACE);
 		}
 		else {
 			// Need container hierarchy in brackets
@@ -224,7 +223,7 @@ public class SimLogger {
 			else {
 				outputMessage.append(LocationFormat.getLocationDescription(actor, location));
 			}
-			outputMessage.append(CLOSED_BRACKET_SPACE).append(actor.getNickName()).append(DASH);
+			outputMessage.append(CLOSED_BRACKET_SPACE).append(actor.getName()).append(DASH);
 		}
 
 		outputMessage.append(message);
@@ -241,29 +240,6 @@ public class SimLogger {
 	}
 
 	/**
-	 * THhis method will be moved into Unit as part of Issue #296
-	 * @param location
-	 * @param outputMessage
-	 */
-	private static void locationDescription(Unit location, StringBuilder outputMessage) {
-		Unit next = null;
-		if (location instanceof Building) {
-			next = location.getAssociatedSettlement();
-		}
-		else {
-			next = location.getContainerUnit();
-		}
-
-		// Go up the chain if not surface
-		if (next != null && (next.getIdentifier() != Unit.MARS_SURFACE_UNIT_ID)) {
-			locationDescription(next, outputMessage);
-			outputMessage.append(" - ");
-		}
-		outputMessage.append(location.getNickName());
-	}
-
-
-	/**
 	 * Returns the line
 	 *
 	 * @return
@@ -271,7 +247,7 @@ public class SimLogger {
 	private static String getUniqueIdentifer(Loggable actor) {
 		StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
 		String loggerClass = SimLogger.class.getName();
-		String nickName = (actor != null ? actor.getNickName() : "unknown");
+		String nickName = (actor != null ? actor.getName() : "unknown");
 
 		// Skip the first frame as it is the "getStackTrace" call
 		for (int idx = 1; idx < stackTrace.length; idx++) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/Building.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/Building.java
@@ -164,8 +164,6 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 
 	/** Type of building. */
 	protected String buildingType;
-	/** Nick name for this building. */
-	private String nickName;
 	/** Description for this building. */
 	private String description;
 
@@ -242,17 +240,16 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 	 *
 	 * @param id           the building's unique ID number.
 	 * @param buildingType the building Type.
-	 * @param nickName     the building's nick name.
+	 * @param name         the building's name.
 	 * @param bounds       the physical position of this Building
 	 * @param manager      the building's building manager.
 	 * @throws BuildingException if building can not be created.
 	 */
-	public Building(int id, String buildingType, String nickName, BoundedObject bounds, BuildingManager manager) {
-		super(nickName, manager.getSettlement().getCoordinates());
+	public Building(int id, String buildingType, String name, BoundedObject bounds, BuildingManager manager) {
+		super(name, manager.getSettlement().getCoordinates());
 
 		this.templateID = id;
 		this.buildingType = buildingType;
-		this.nickName = nickName;
 
 		this.settlement = manager.getSettlement();
 		this.settlementID = settlement.getIdentifier();
@@ -351,15 +348,6 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 	 */
 	public String getDescription() {
 		return description;
-	}
-
-	/**
-	 * Sets building nickname
-	 *
-	 * @param nick name
-	 */
-	public void setBuildingNickName(String name) {
-		this.nickName = name;
 	}
 
 	/**
@@ -796,38 +784,6 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 	}
 
 	/**
-	 * Sets the building's nickName
-	 *
-	 * @return none
-	 */
-	// Called by TabPanelBuilding.java for building nickname change
-	public void setNickName(String nickName) {
-		this.nickName = nickName;
-		changeName(nickName);
-	}
-
-	/**
-	 * Gets the building's nickName
-	 *
-	 * @return building's nickName as a String
-	 */
-	// Called by TabPanelBuilding.java for building nickname change
-	public String getNickName() {
-		if (nickName == null || nickName.equalsIgnoreCase(""))
-			nickName = getName();
-		return nickName;
-	}
-
-	/**
-	 * Gets the building type, not building's nickname
-	 *
-	 * @return building type as a String.
-	 */
-	public String getName() {
-		return buildingType;
-	}
-
-	/**
 	 * Gets the building type.
 	 *
 	 * @return building type as a String. TODO internationalize building names for
@@ -1120,16 +1076,6 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 		}
 
 		return people;
-	}
-
-
-	/**
-	 * String representation of this building.
-	 *
-	 * @return building's nickName.
-	 */
-	public String toString() {
-		return nickName;
 	}
 
 	/**
@@ -1531,13 +1477,7 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj) return true;
-		if (obj == null) return false;
-		if (this.getClass() != obj.getClass()) return false;
-		Building b = (Building) obj;
-		return this.getIdentifier() == b.getIdentifier()
-			&& this.buildingType.equals(b.getBuildingType());
-//			&& this.nickName.equals(b.getNickName());
+		return super.equals(obj);
 	}
 
 	/**
@@ -1545,11 +1485,9 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 	 *
 	 * @return hash code.
 	 */
+	@Override
 	public int hashCode() {
-		int hashCode = nickName.hashCode();
-		hashCode *= getIdentifier();
-		hashCode *= buildingType.hashCode();
-		return hashCode;
+		return super.hashCode();
 	}
 
 	/**
@@ -1565,7 +1503,6 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 		buildingType = null;
 		powerModeCache = null;
 		heatModeCache = null;
-//		malfunctionManager.destroy();
 		malfunctionManager = null;
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/function/BuildingAirlock.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/function/BuildingAirlock.java
@@ -213,7 +213,7 @@ public class BuildingAirlock extends Airlock {
 
     @Override
     public String getEntityName() {
-        return building.getNickName();
+        return building.getName();
     }
 
     @Override

--- a/mars-sim-core/src/test/java/org/mars_sim/msp/core/structure/building/MockBuilding.java
+++ b/mars-sim-core/src/test/java/org/mars_sim/msp/core/structure/building/MockBuilding.java
@@ -21,8 +21,6 @@ public class MockBuilding extends Building {
     public MockBuilding(BuildingManager manager, String name)  {
 		super(manager, name);
 		buildingType = "EVA Airlock";
-		setNickName(name);
-		changeName(name);
 
 		if (manager == null) {
 			throw new IllegalArgumentException("Bulding manager can not be null");
@@ -30,20 +28,19 @@ public class MockBuilding extends Building {
 		manager.addMockBuilding(this);
 
 		malfunctionManager = new MalfunctionManager(this, 0D, 0D);
-		functions = new ArrayList<Function>();
+		functions = new ArrayList<>();
 		functions.add(new LifeSupport(this, 10, 1));
 	}
     
 	public MockBuilding(BuildingTemplate template, BuildingManager manager)  {
 		super(template, manager);
 		buildingType = "Mock Type";
-		setNickName("Mock Building");
 		changeName("Mock Building");
 		
 		unitManager.addUnit(this);
 
 		malfunctionManager = new MalfunctionManager(this, 0D, 0D);
-		functions = new ArrayList<Function>();
+		functions = new ArrayList<>();
 		functions.add(new LifeSupport(this, 10, 1));
 	}
 
@@ -79,11 +76,6 @@ public class MockBuilding extends Building {
 	    functions.add(function);
 	}
 	
-	@Override
-	public String toString() {
-		return super.getNickName();
-	}
-
 	public void setLocation(double x, double y) {
 		loc = new LocalPosition(x, y);	
 	}

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/MonitorWindow.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/MonitorWindow.java
@@ -412,7 +412,7 @@ public class MonitorWindow extends ToolWindow implements TableModelListener, Act
     	Collection<Settlement> list = unitManager.getSettlements();
     	int max = 12;
     	for (Settlement s: list) {
-    		int size = s.getNickName().length();
+    		int size = s.getName().length();
     		if (max < size)
     			max = size;
     	}

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/UnitWindow.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/UnitWindow.java
@@ -105,7 +105,7 @@ public abstract class UnitWindow extends ModalInternalFrame implements ChangeLis
 	 */
 	public UnitWindow(MainDesktopPane desktop, Unit unit, boolean hasDescription) {
 		// Use JInternalFrame constructor
-		super(unit.getNickName(), false, true, false, true);
+		super(unit.getName(), false, true, false, true);
 
 		// Initialize data members
 		this.desktop = desktop;
@@ -435,7 +435,7 @@ public abstract class UnitWindow extends ModalInternalFrame implements ChangeLis
 	@Override
     public String getName() {
 		if (unit != null && unit.getName() != null)
-			return unit.getNickName() +"'s unit window";
+			return unit.getName() +"'s unit window";
 		return null;
     }
 


### PR DESCRIPTION
Goal is to standardise to a singel name to support upcoming RestAPI. A RestAPI will need a single name for all Units.

Changes
- Loggable interface now use the getName method instead of getNickname
- Building no longer maintains a seperate nickname