### PR TITLE
Primary Vehicle Status & Airlock problem

### DIFF
--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/VehicleCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/VehicleCommand.java
@@ -50,7 +50,7 @@ public class VehicleCommand extends AbstractSettlementCommand {
 				.collect(Collectors.toList());
 
 		response.appendTableHeading("Name", CommandHelper.PERSON_WIDTH, "Type", 15, 
-									"Parked", "Home", "Garage", "Reserved", "Mission", 25);
+									"Status", "Home", "Reserved", "Mission", 25);
 
 		BuildingManager bm = settlement.getBuildingManager();
 		var missionMgr = context.getSim().getMissionManager();
@@ -71,11 +71,9 @@ public class VehicleCommand extends AbstractSettlementCommand {
 			}
 			
 			// Dropped Parked once fix problem
-			boolean isParked = parked.contains(v);
 			boolean isHome = settlement.equals(v.getSettlement());
-			boolean isGaraged = bm.isInGarage(v);
-			response.appendTableRow(v.getName(), vTypeStr, isParked,
-						isHome, isGaraged, v.isReserved(), missionName);
+			response.appendTableRow(v.getName(), vTypeStr, v.getPrimaryStatus().getName(),
+						isHome, v.isReserved(), missionName);
 		}
 		
 		context.println(response.getOutput());

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/Simulation.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/Simulation.java
@@ -351,6 +351,9 @@ public class Simulation implements ClockListener, Serializable {
 		MarsClock marsClock = masterClock.getMarsClock();
 		EarthClock earthClock = masterClock.getEarthClock();
 
+		// Set log data
+		DataLogger.changeTime(marsClock);
+
 		// Set instances for logging
 		SimuLoggingFormatter.initializeInstances(masterClock);
 
@@ -611,9 +614,10 @@ public class Simulation implements ClockListener, Serializable {
 	 */
 	private void reinitializeInstances() {
 		SimuLoggingFormatter.initializeInstances(masterClock);
-
+		
 		// Re-initialize the utility class for getting lists of meta tasks.
 		MetaTaskUtil.initializeMetaTasks();
+
 
 		// Re-initialize the resources for the saved sim
 		ResourceUtil.getInstance().initializeInstances();

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/data/DataLogger.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/data/DataLogger.java
@@ -27,7 +27,7 @@ public abstract class DataLogger<T> implements Serializable {
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
 
-	private static int currentSol = 0;
+	private static int currentSol = 1;
 	protected static int currentMsol = 0;
 	
 	private int maxSols = 7;
@@ -38,7 +38,6 @@ public abstract class DataLogger<T> implements Serializable {
 	public DataLogger(int maxSols) {
 		super();
 		this.maxSols = maxSols;
-		newSol(1);
 	}
 	
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingConstructionMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingConstructionMission.java
@@ -829,7 +829,7 @@ public class BuildingConstructionMission extends Mission implements Serializable
 
 			if (vehicle.getVehicleType() == VehicleType.LUV) {
 				LightUtilityVehicle luvTemp = (LightUtilityVehicle) vehicle;
-				if ((luvTemp.haveStatusType(StatusType.PARKED) || luvTemp.haveStatusType(StatusType.GARAGED))
+				if (((luvTemp.getPrimaryStatus() == StatusType.PARKED) || (luvTemp.getPrimaryStatus() == StatusType.GARAGED))
 						&& !luvTemp.isReserved() && (luvTemp.getCrewNum() == 0) && (luvTemp.getRobotCrewNum() == 0)) {
 					result = luvTemp;
 					luvTemp.setReservedForMission(true);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingSalvageMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingSalvageMission.java
@@ -557,7 +557,8 @@ public class BuildingSalvageMission extends Mission implements Serializable {
 
 			if (vehicle instanceof LightUtilityVehicle) {
 				LightUtilityVehicle luvTemp = (LightUtilityVehicle) vehicle;
-				if ((luvTemp.haveStatusType(StatusType.PARKED) || luvTemp.haveStatusType(StatusType.GARAGED))
+				StatusType primStatus = luvTemp.getPrimaryStatus();
+				if (((primStatus == StatusType.PARKED) || (primStatus == StatusType.GARAGED))
 						&& !luvTemp.isReserved() && (luvTemp.getCrewNum() == 0) && (luvTemp.getRobotCrewNum() == 0)) {
 					result = luvTemp;
 					luvTemp.setReservedForMission(true);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mining.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mining.java
@@ -693,7 +693,7 @@ public class Mining extends RoverMission
 			Vehicle vehicle = i.next();
 			if (vehicle.getVehicleType() == VehicleType.LUV) {
 				LightUtilityVehicle luvTemp = (LightUtilityVehicle) vehicle;
-				if ((luvTemp.haveStatusType(StatusType.PARKED) || luvTemp.haveStatusType(StatusType.GARAGED))
+				if (((luvTemp.getPrimaryStatus() == StatusType.PARKED) || (luvTemp.getPrimaryStatus() == StatusType.GARAGED))
 						&& !luvTemp.isReserved() && (luvTemp.getCrewNum() == 0) && (luvTemp.getRobotCrewNum() == 0)) {
 					result = luvTemp;
 					luvTemp.setReservedForMission(true);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RescueSalvageVehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RescueSalvageVehicle.java
@@ -198,7 +198,7 @@ public class RescueSalvageVehicle extends RoverMission implements Serializable {
 		super.setVehicle(newVehicle);
 		if (newVehicle.isReservedForMaintenance()) {
 			newVehicle.setReservedForMaintenance(false);
-			newVehicle.removeStatus(StatusType.MAINTENANCE);
+			newVehicle.removeSecondaryStatus(StatusType.MAINTENANCE);
 		}
 	}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/LoadVehicleEVA.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/LoadVehicleEVA.java
@@ -6,10 +6,6 @@
  */
 package org.mars_sim.msp.core.person.ai.task;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
 
 import org.mars_sim.msp.core.CollectionUtils;
 import org.mars_sim.msp.core.Msg;
@@ -17,17 +13,15 @@ import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.mission.VehicleMission;
 import org.mars_sim.msp.core.person.ai.task.utils.TaskPhase;
-import org.mars_sim.msp.core.resource.ResourceUtil;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.tool.RandomUtil;
-import org.mars_sim.msp.core.vehicle.Rover;
 import org.mars_sim.msp.core.vehicle.Vehicle;
 
 /**
  * The LoadVehicleEVA class is a task for loading a vehicle with fuel and
  * supplies when the vehicle is outside.
  */
-public class LoadVehicleEVA extends EVAOperation implements Serializable {
+public class LoadVehicleEVA extends EVAOperation {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
@@ -41,12 +35,6 @@ public class LoadVehicleEVA extends EVAOperation implements Serializable {
 	/** Task phases. */
 	private static final TaskPhase LOADING = new TaskPhase(Msg.getString("Task.phase.loading")); //$NON-NLS-1$
 
-	/**
-	 * The amount of resources (kg) one person of average strength can load per
-	 * millisol.
-	 */
-	private static final double WATER_NEED = 10D;
-	private static final double OXYGEN_NEED = 10D;
 
 	// Data members
 	/** The vehicle that needs to be loaded. */
@@ -238,49 +226,14 @@ public class LoadVehicleEVA extends EVAOperation implements Serializable {
 	 */
 	private static boolean anyVehiclesNeedEVA(Settlement settlement) {
 
-		Iterator<Vehicle> i = settlement.getParkedVehicles().iterator();
-		while (i.hasNext()) {
-			Vehicle vehicle = i.next();
-			if (vehicle.isReservedForMission()) { 
-				if (!settlement.getBuildingManager().isInGarage(vehicle)) {
-					return true;
-				}
+		for(Vehicle vehicle : settlement.getParkedVehicles()) {
+			if (vehicle.isReservedForMission()
+					&& !settlement.getBuildingManager().isInGarage(vehicle)) {
+				return true;
 			}
 		}
 		return false;
 	}
-	
-	/**
-	 * Gets a list of rovers with crew who are missing EVA suits.
-	 * 
-	 * @param settlement the settlement.
-	 * @return list of rovers.
-	 */
-	public static List<Rover> getRoversNeedingEVASuits(Settlement settlement) {
-
-		List<Rover> result = new ArrayList<>();
-
-		for(Vehicle vehicle : settlement.getParkedVehicles()) {
-			if (vehicle instanceof Rover) {
-				Rover rover = (Rover) vehicle;
-				if (!settlement.getBuildingManager().addToGarage(vehicle)) {
-					int peopleOnboard = rover.getCrewNum();
-					if ((peopleOnboard > 0)) {
-						int numSuits = rover.findNumEVASuits();
-						double water = rover.getAmountResourceStored(ResourceUtil.waterID);
-						double oxygen = rover.getAmountResourceStored(ResourceUtil.oxygenID);
-						if ((numSuits == 0) || (water < WATER_NEED) || (oxygen < OXYGEN_NEED)) {
-							result.add(rover);
-						}
-					}
-				}
-			}
-		}
-
-		return result;
-	}
-
-
 
 	/**
 	 * Gets the vehicle being loaded.

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/LoadVehicleGarage.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/LoadVehicleGarage.java
@@ -28,6 +28,7 @@ import org.mars_sim.msp.core.resource.ResourceUtil;
 import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.structure.building.Building;
+import org.mars_sim.msp.core.structure.building.BuildingManager;
 import org.mars_sim.msp.core.structure.building.function.FunctionType;
 import org.mars_sim.msp.core.structure.building.function.cooking.PreparingDessert;
 import org.mars_sim.msp.core.tool.RandomUtil;
@@ -100,15 +101,18 @@ public class LoadVehicleGarage extends Task implements Serializable {
 			return;
 		}
 		else {
-			// Add the rover to a garage if possible
-			Building garage = settlement.getBuildingManager().addToGarageBuilding(vehicle);
+			// Rover may already be in the Garage
+			Building garage = vehicle.getGarage();
 			
-//			System.out.println("garage is " + garage);
-			
-			// End task if vehicle or garage not available
 			if (garage == null) {
-				endTask();
-				return;
+				// Add the rover to a garage if possible
+				garage = settlement.getBuildingManager().addToGarageBuilding(vehicle);
+			
+				// End task if vehicle or garage not available
+				if (garage == null) {
+					endTask();
+					return;
+				}
 			}
 			
 			// Walk to garage.

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/LoadingController.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/LoadingController.java
@@ -24,6 +24,7 @@ import org.mars_sim.msp.core.resource.ItemResourceUtil;
 import org.mars_sim.msp.core.resource.Part;
 import org.mars_sim.msp.core.resource.ResourceUtil;
 import org.mars_sim.msp.core.structure.Settlement;
+import org.mars_sim.msp.core.vehicle.StatusType;
 import org.mars_sim.msp.core.vehicle.Vehicle;
 
 /**
@@ -176,7 +177,6 @@ public class LoadingController implements Serializable {
 
 		// Temporarily remove rover from settlement so that inventory doesn't get mixed
 		// in.
-//		Inventory sInv = settlement.getInventory();
 		boolean vehicleInSettlement = false;
 		if (settlement.containsParkedVehicle(vehicle)) {
 			vehicleInSettlement = true;
@@ -212,6 +212,8 @@ public class LoadingController implements Serializable {
 		// use load amount (that means load couldn't complete it
 		boolean completed = isCompleted();
 		if (completed) {
+			// Can remove assume fuel is reloaded
+			vehicle.removeSecondaryStatus(StatusType.OUT_OF_FUEL);
 			logger.fine(vehicle, "Loading completed by " + worker.getName());
 		}
 		return (amountLoading > 0D) || completed;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MaintainGroundVehicleEVA.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MaintainGroundVehicleEVA.java
@@ -95,7 +95,7 @@ implements Serializable {
 			}
 			
             vehicle.setReservedForMaintenance(true);
-            vehicle.addStatus(StatusType.MAINTENANCE);
+            vehicle.addSecondaryStatus(StatusType.MAINTENANCE);
             // Determine location for maintenance.
             setOutsideLocation(vehicle);
             
@@ -244,7 +244,7 @@ implements Serializable {
 	protected void clearDown() {
         if (vehicle != null) {
         	vehicle.setReservedForMaintenance(false);
-            vehicle.removeStatus(StatusType.MAINTENANCE);
+            vehicle.removeSecondaryStatus(StatusType.MAINTENANCE);
         }
 		super.clearDown();
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MaintainGroundVehicleGarage.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MaintainGroundVehicleGarage.java
@@ -118,7 +118,7 @@ public class MaintainGroundVehicleGarage extends Task implements Serializable {
 					try {
 						Building garageBuilding = j.next();
 						VehicleMaintenance garageTemp = garageBuilding.getVehicleMaintenance();
-						if (garageTemp.getCurrentVehicleNumber() < garageTemp.getVehicleCapacity()) {
+						if (garageTemp.getAvailableCapacity() > 0) {
 							garage = garageTemp;
 							garage.addVehicle(vehicle);
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MaintainGroundVehicleGarage.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MaintainGroundVehicleGarage.java
@@ -78,7 +78,7 @@ public class MaintainGroundVehicleGarage extends Task implements Serializable {
 			vehicle = getNeedyGroundVehicle(lperson);
 			if (vehicle != null) {
 				vehicle.setReservedForMaintenance(true);
-	            vehicle.addStatus(StatusType.MAINTENANCE);
+	            vehicle.addSecondaryStatus(StatusType.MAINTENANCE);
 			}
 			else
 				endTask();
@@ -91,7 +91,7 @@ public class MaintainGroundVehicleGarage extends Task implements Serializable {
 			vehicle = getNeedyGroundVehicle(lrobot);
 			if (vehicle != null) {
 				vehicle.setReservedForMaintenance(true);
-	            vehicle.addStatus(StatusType.MAINTENANCE);
+	            vehicle.addSecondaryStatus(StatusType.MAINTENANCE);
 			}
 			else
 				endTask();
@@ -244,7 +244,7 @@ public class MaintainGroundVehicleGarage extends Task implements Serializable {
 	protected void clearDown() {
 		if (vehicle != null) {
 			vehicle.setReservedForMaintenance(false);
-	        vehicle.removeStatus(StatusType.MAINTENANCE);
+	        vehicle.removeSecondaryStatus(StatusType.MAINTENANCE);
 	        
 			if (vehicle instanceof Crewable) {
 				Crewable crewableVehicle = (Crewable) vehicle;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/OperateVehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/OperateVehicle.java
@@ -344,11 +344,9 @@ public abstract class OperateVehicle extends Task implements Serializable {
         return time - timeUsed;
 	}
 	
-	private void turnOnBeacon() {
+	private void turnOnBeaconOutOfFuel() {
 		vehicle.setSpeed(0D);
-		vehicle.addStatus(StatusType.OUT_OF_FUEL);
-		vehicle.removeStatus(StatusType.MOVING);
-        vehicle.addStatus(StatusType.PARKED);
+		vehicle.setPrimaryStatus(StatusType.PARKED, StatusType.OUT_OF_FUEL);
         
     	if (!vehicle.isBeaconOn()) {
     		Mission m = vehicle.getMission();
@@ -402,7 +400,7 @@ public abstract class OperateVehicle extends Task implements Serializable {
         		logger.log(vehicle, Level.SEVERE, 20_000, 
     					"Out of fuel. Cannot drive.");
         		// Turn on emergency beacon
-    	    	turnOnBeacon();
+    	    	turnOnBeaconOutOfFuel();
             	
             	endTask();
             	return time;
@@ -412,7 +410,7 @@ public abstract class OperateVehicle extends Task implements Serializable {
         		logger.log(vehicle, Level.SEVERE, 20_000, 
     					"Out of fuel oxidizer. Cannot drive.");
         		// Turn on emergency beacon
-    	    	turnOnBeacon();
+    	    	turnOnBeaconOutOfFuel();
             	
             	endTask();
             	return time;
@@ -465,13 +463,8 @@ public abstract class OperateVehicle extends Task implements Serializable {
             fuelUsed = calculateFuelUsed(distanceTraveled, hrsTime);
 		    
             // Update vehicle status
-        	if (!vehicle.haveStatusType(StatusType.MOVING))
-        		vehicle.addStatus(StatusType.MOVING);
-        	if (vehicle.haveStatusType(StatusType.OUT_OF_FUEL))
-        		vehicle.removeStatus(StatusType.OUT_OF_FUEL);
-            if (vehicle.haveStatusType(StatusType.PARKED))
-            	vehicle.removeStatus(StatusType.PARKED);
-            
+        	vehicle.setPrimaryStatus(StatusType.MOVING);
+
             // Determine new position.
             vehicle.setCoordinates(vehicle.getCoordinates().getNewLocation(vehicle.getDirection(), distanceTraveled));
             // Use up all of the available time
@@ -497,8 +490,7 @@ public abstract class OperateVehicle extends Task implements Serializable {
             // Determine new position.
             vehicle.setCoordinates(vehicle.getCoordinates().getNewLocation(vehicle.getDirection(), distanceTraveled));
   
-        	if (!vehicle.haveStatusType(StatusType.MOVING))
-        		vehicle.addStatus(StatusType.MOVING);
+        	vehicle.setPrimaryStatus(StatusType.MOVING);
         	
         	result = time - distanceTraveled / v / MarsClock.MILLISOLS_PER_HOUR;
         }
@@ -530,12 +522,7 @@ public abstract class OperateVehicle extends Task implements Serializable {
 		vehicle.setOperator(null);
 	   
 		// Update vehicle status
-		if (!vehicle.haveStatusType(StatusType.PARKED))
-			vehicle.addStatus(StatusType.PARKED);
-		if (vehicle.haveStatusType(StatusType.MOVING))
-			vehicle.removeStatus(StatusType.MOVING);
-		if (vehicle.haveStatusType(StatusType.OUT_OF_FUEL))
-			vehicle.removeStatus(StatusType.OUT_OF_FUEL);
+		vehicle.setPrimaryStatus(StatusType.PARKED);
 
 		updateVehicleElevationAltitude();
 	}	

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/Walk.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/Walk.java
@@ -808,6 +808,8 @@ public class Walk extends Task implements Serializable {
 				logger.log(person, Level.FINER, 4_000,
 								"Ended the walk task. Could not enter the airlock in "
 	      						+ airlock.getEntityName() + ".");
+				// Consume all of the time waiting to enter; prevents repeated tries
+				timeLeft = 0D;
 				endTask();
 			}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/MaintainGroundVehicleEVAMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/MaintainGroundVehicleEVAMeta.java
@@ -91,7 +91,7 @@ public class MaintainGroundVehicleEVAMeta extends MetaTask {
 					Building building = j.next();
 					VehicleMaintenance garage = building.getGroundVehicleMaintenance();
 					totalCap += garage.getVehicleCapacity();
-					available += (garage.getVehicleCapacity() - garage.getCurrentVehicleNumber());
+					available += garage.getAvailableCapacity();
 				} catch (Exception e) {
 				}
 			}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/MaintainGroundVehicleGarageMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/MaintainGroundVehicleGarageMeta.java
@@ -136,9 +136,7 @@ public class MaintainGroundVehicleGarageMeta extends MetaTask {
 		while (j.hasNext() && !garageSpace) {
 			Building building = j.next();
 			VehicleMaintenance garage = building.getGroundVehicleMaintenance();
-			if (garage.getCurrentVehicleNumber() < garage.getVehicleCapacity()) {
-				garageSpace = true;
-			}
+			garageSpace = (garage.getAvailableCapacity() > 0);
 
 			Iterator<Vehicle> i = garage.getVehicles().iterator();
 			while (i.hasNext()) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/BuildingManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/BuildingManager.java
@@ -1017,11 +1017,8 @@ public class BuildingManager implements Serializable {
 				return null;
 		}
 
-		List<Building> garages = getGarages();
-
 		if (garages.isEmpty()) {
-			// This settlement has no garages at all.
-			// SHould this code ever be active ?
+			// The vehicle may already be PARKED ?
 			vehicle.setPrimaryStatus(StatusType.PARKED);
 			return null;
 		}
@@ -1029,16 +1026,15 @@ public class BuildingManager implements Serializable {
 		for (Building garageBuilding : garages) {
 			VehicleMaintenance garage = garageBuilding.getVehicleMaintenance();
 
-			if (garage != null && garage.containsVehicle(vehicle)) {
+			if (garage != null) {
+				if (garage.containsVehicle(vehicle)) {
+					logger.log(settlement, vehicle, Level.INFO, 60_000,
+							"Already inside " + garage.getBuilding().getNickName() + ".");
 
-				logger.log(settlement, vehicle, Level.INFO, 60_000,
-						   "Already inside " + garage.getBuilding().getNickName() + ".");
-
-				return garageBuilding;
-			}
-			else {
-				if (garage.getCurrentVehicleNumber() < garage.getVehicleCapacity()
-					&& garage.addVehicle(vehicle)) {
+					return garageBuilding;
+				}
+				else if ((garage.getAvailableCapacity() > 0)
+							&& garage.addVehicle(vehicle)) {
 
 					logger.log(settlement, vehicle, Level.INFO, 60_000,
  							   "Just stowed inside " + garage.getBuilding().getNickName() + ".");
@@ -1077,22 +1073,6 @@ public class BuildingManager implements Serializable {
 	 * @return true if it's already in the garage or added to a garage
 	 */
 	public boolean addToGarage(Vehicle vehicle) {
-		if (vehicle.isBeingTowed())
-			return false;
-
-		if (VehicleType.isRover(vehicle.getVehicleType())) {
-			if (((Rover)vehicle).isTowingAVehicle())
-				return false;
-		}
-
-		List<Building> garages = getGarages();
-
-		if (garages.isEmpty()) {
-			// This settlement has no garages at all
-			vehicle.setPrimaryStatus(StatusType.PARKED);
-			return false;
-		}
-
 		if (isInGarage(vehicle)) {
 			// Vehicle already on Garage
 			vehicle.setPrimaryStatus(StatusType.GARAGED);
@@ -1100,26 +1080,7 @@ public class BuildingManager implements Serializable {
 			return true;
 		}
 
-		else {
-			// Checks if this settlement have open garage space
-			for (Building garageBuilding : garages) {
-				VehicleMaintenance garage = garageBuilding.getVehicleMaintenance();
-				if (garage.getCurrentVehicleNumber() < garage.getVehicleCapacity()
-					&& garage.addVehicle(vehicle)) {
-
-					// Update the vehicle's location state type
-					vehicle.updateLocationStateType(LocationStateType.INSIDE_SETTLEMENT);
-
-					logger.log(settlement, vehicle, Level.INFO, 60_000,
- 							   "Stowed inside " + garage.getBuilding().getNickName() + ".");
-					vehicle.setPrimaryStatus(StatusType.GARAGED);
-
-					return true;
-				}
-			}
-		}
-
-		return false;
+		return (addToGarageBuilding(vehicle) != null);
 	}
 
 
@@ -1160,49 +1121,19 @@ public class BuildingManager implements Serializable {
 	 * Gets the vehicle maintenance building a given vehicle is in.
 	 *
 	 * @return building or null if none.
+	 * @deprecated Should use {@link Vehicle#getGarage()}
 	 */
 	public static Building getBuilding(Vehicle vehicle) {
 		if (vehicle == null)
 			throw new IllegalArgumentException("vehicle is null");
-		Building result = null;
+
 		Settlement settlement = vehicle.getSettlement();
 		if (settlement != null) {
-			List<Building> list = settlement.getBuildingManager().getBuildings(FunctionType.GROUND_VEHICLE_MAINTENANCE);
+			List<Building> list = settlement.getBuildingManager().getGarages();
 			for (Building garageBuilding : list) {
-				try {
-					VehicleMaintenance garage = garageBuilding.getVehicleMaintenance();
-					if (garage != null && garage.containsVehicle(vehicle)) {
-						return garageBuilding;
-					}
-				} catch (Exception e) {
-					logger.log(settlement, vehicle, Level.SEVERE, 2000,
-							   "is not in a building.", e);
-				}
-			}
-		}
-		return result;
-	}
-
-	/**
-	 * Gets the vehicle maintenance building a given vehicle is in.
-	 *
-	 * @return building or null if none.
-	 */
-	public static Building getBuilding(Vehicle vehicle, Settlement settlement) {
-		if (vehicle == null)
-			throw new IllegalArgumentException("vehicle is null");
-		if (settlement != null) {
-			List<Building> list = settlement.getBuildingManager().getBuildings(FunctionType.GROUND_VEHICLE_MAINTENANCE);
-			for (Building garageBuilding : list) {
-				try {
-					VehicleMaintenance garage = garageBuilding.getVehicleMaintenance();
-					if (garage != null && garage.containsVehicle(vehicle)) {
-						return garageBuilding;
-					}
-				} catch (Exception e) {
-//					logger.log(Level.SEVERE, "Calling getBuilding(vehicle, settlement) : " + e.getMessage());
-					logger.log(settlement, vehicle, Level.SEVERE, 2000,
-							   "is not in a building.", e);
+				VehicleMaintenance garage = garageBuilding.getVehicleMaintenance();
+				if (garage != null && garage.containsVehicle(vehicle)) {
+					return garageBuilding;
 				}
 			}
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/BuildingManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/BuildingManager.java
@@ -1020,8 +1020,9 @@ public class BuildingManager implements Serializable {
 		List<Building> garages = getGarages();
 
 		if (garages.isEmpty()) {
-			// This settlement has no garages at all
-			vehicle.removeStatus(StatusType.GARAGED);
+			// This settlement has no garages at all.
+			// SHould this code ever be active ?
+			vehicle.setPrimaryStatus(StatusType.PARKED);
 			return null;
 		}
 
@@ -1088,12 +1089,13 @@ public class BuildingManager implements Serializable {
 
 		if (garages.isEmpty()) {
 			// This settlement has no garages at all
-			vehicle.removeStatus(StatusType.GARAGED);
+			vehicle.setPrimaryStatus(StatusType.PARKED);
 			return false;
 		}
 
 		if (isInGarage(vehicle)) {
-			vehicle.addStatus(StatusType.GARAGED);
+			// Vehicle already on Garage
+			vehicle.setPrimaryStatus(StatusType.GARAGED);
 
 			return true;
 		}
@@ -1110,6 +1112,8 @@ public class BuildingManager implements Serializable {
 
 					logger.log(settlement, vehicle, Level.INFO, 60_000,
  							   "Stowed inside " + garage.getBuilding().getNickName() + ".");
+					vehicle.setPrimaryStatus(StatusType.GARAGED);
+
 					return true;
 				}
 			}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/function/VehicleMaintenance.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/function/VehicleMaintenance.java
@@ -116,9 +116,7 @@ public abstract class VehicleMaintenance extends Function implements Serializabl
 				}
 			}		
 		
-			vehicle.removeStatus(StatusType.MOVING);
-			vehicle.removeStatus(StatusType.PARKED);
-			vehicle.addStatus(StatusType.GARAGED);
+			vehicle.setPrimaryStatus(StatusType.GARAGED);
 		
 			// Update the vehicle's location state type
 			vehicle.updateLocationStateType(LocationStateType.INSIDE_SETTLEMENT);
@@ -179,8 +177,7 @@ public abstract class VehicleMaintenance extends Function implements Serializabl
 					parkedLoc.clearParking();
 				}
 	
-				vehicle.removeStatus(StatusType.GARAGED);
-				vehicle.addStatus(StatusType.PARKED);
+				vehicle.setPrimaryStatus(StatusType.PARKED);
 				
 				// Update the vehicle's location state type
 				vehicle.updateLocationStateType(LocationStateType.WITHIN_SETTLEMENT_VICINITY);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/function/VehicleMaintenance.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/function/VehicleMaintenance.java
@@ -56,8 +56,8 @@ public abstract class VehicleMaintenance extends Function implements Serializabl
 		// Use Function constructor.
 		super(function, building);
 
-		vehicles = new ConcurrentLinkedQueue<Vehicle>();
-		parkingLocations = new ArrayList<ParkingLocation>();
+		vehicles = new ConcurrentLinkedQueue<>();
+		parkingLocations = new ArrayList<>();
 	}
 
 	/**
@@ -76,6 +76,14 @@ public abstract class VehicleMaintenance extends Function implements Serializabl
 	 */
 	public int getCurrentVehicleNumber() {
 		return vehicles.size();
+	}
+
+	/**
+	 * How many available locations unoccupied does the Garage have?
+	 * @param Available parking locations.
+	 */
+	public int getAvailableCapacity() {
+		return vehicleCapacity - vehicles.size();
 	}
 
 	/**
@@ -276,7 +284,7 @@ public abstract class VehicleMaintenance extends Function implements Serializabl
 		ParkingLocation result = null;
 
 		// Get list of empty parking locations.
-		List<ParkingLocation> emptyLocations = new ArrayList<ParkingLocation>(parkingLocations.size());
+		List<ParkingLocation> emptyLocations = new ArrayList<>(parkingLocations.size());
 		Iterator<ParkingLocation> i = parkingLocations.iterator();
 		while (i.hasNext()) {
 			ParkingLocation parkingLocation = i.next();

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Drone.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Drone.java
@@ -93,11 +93,6 @@ public class Drone extends Flyer implements Serializable {
 					}
 				}
 			}
-
-			if (getAmountResourceStored(getFuelType()) > Flyer.LEAST_AMOUNT) {
-				if (super.haveStatusType(StatusType.OUT_OF_FUEL))
-					super.removeStatus(StatusType.OUT_OF_FUEL);
-			}
 		}
 
 
@@ -120,6 +115,7 @@ public class Drone extends Flyer implements Serializable {
 	 * @return the range of the vehicle (in km)
 	 * @throws Exception if error getting range.
 	 */
+	@Override
 	public double getRange(MissionType missionType) {
 		// Note: multiply by 0.9 would account for the extra distance travelled in between sites
 		double fuelRange = super.getRange(missionType) * FUEL_RANGE_FACTOR;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Flyer.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Flyer.java
@@ -63,7 +63,7 @@ public abstract class Flyer extends Vehicle implements Serializable {
 	 * @param settlement          settlement the airborne vehicle is parked at
 	 * @param maintenanceWorkTime the work time required for maintenance (millisols)
 	 */
-	public Flyer(String name, String description, Settlement settlement, double maintenanceWorkTime) {
+	protected Flyer(String name, String description, Settlement settlement, double maintenanceWorkTime) {
 		// use Vehicle constructor
 		super(name, description, settlement, maintenanceWorkTime);
 	}
@@ -234,6 +234,7 @@ public abstract class Flyer extends Vehicle implements Serializable {
 	 * @param fuelConsumed
 	 * @return true if it has enough fuel
 	 */
+/* 
 	protected boolean hasEnoughFuel(double fuelConsumed) {
 		Vehicle v = getVehicle();
         int fuelType = v.getFuelType();
@@ -242,7 +243,7 @@ public abstract class Flyer extends Vehicle implements Serializable {
     		double remainingFuel = v.getAmountResourceStored(fuelType);
 //	
     		if (remainingFuel < LEAST_AMOUNT) {
-    			v.addStatus(StatusType.OUT_OF_FUEL);
+    			v.addSecondaryStatus(StatusType.OUT_OF_FUEL);
     			return false;
     		}
     			
@@ -259,10 +260,5 @@ public abstract class Flyer extends Vehicle implements Serializable {
 	    	return false;
 	    }
 	}
-	
-	/**
-	 * Prepare object for garbage collection.
-	 */
-	public void destroy() {
-	}
+	*/
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/GroundVehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/GroundVehicle.java
@@ -6,8 +6,6 @@
  */
 package org.mars_sim.msp.core.vehicle;
 
-import java.io.Serializable;
-import java.util.logging.Level;
 
 import org.mars_sim.msp.core.Direction;
 import org.mars_sim.msp.core.LocalAreaUtil;
@@ -23,7 +21,7 @@ import org.mars_sim.msp.core.tool.RandomUtil;
  * The GroundVehicle class represents a ground-type vehicle. It is abstract and
  * should be extended to a particular type of ground vehicle.
  */
-public abstract class GroundVehicle extends Vehicle implements Serializable {
+public abstract class GroundVehicle extends Vehicle {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
@@ -148,7 +146,7 @@ public abstract class GroundVehicle extends Vehicle implements Serializable {
 	public void setStuck(boolean stuck) {
 		isStuck = stuck;
 		if (isStuck) {
-			addStatus(StatusType.STUCK);
+			setPrimaryStatus(StatusType.PARKED, StatusType.STUCK);
 			setSpeed(0D);
 			setParkedLocation(LocalPosition.DEFAULT_POSITION, getDirection().getDirection());
 		}
@@ -258,6 +256,7 @@ public abstract class GroundVehicle extends Vehicle implements Serializable {
 	 * @param fuelConsumed
 	 * @return
 	 */
+	/* 
 	protected boolean hasEnoughFuel(double fuelConsumed) {
 		Vehicle v = getVehicle();
         int fuelType = v.getFuelType();
@@ -266,7 +265,7 @@ public abstract class GroundVehicle extends Vehicle implements Serializable {
     		double remainingFuel = v.getAmountResourceStored(fuelType);
 	
     		if (remainingFuel < LEAST_AMOUNT) {
-    			v.addStatus(StatusType.OUT_OF_FUEL);
+    			v.setPrimaryStatus(StatusType.PARKED, StatusType.OUT_OF_FUEL);
     			return false;
     		}
     			
@@ -283,12 +282,5 @@ public abstract class GroundVehicle extends Vehicle implements Serializable {
 	    	return false;
 	    }
 	}
-	
-	/**
-	 * Prepare object for garbage collection.
-	 */
-	public void destroy() {
-//		surface = null;
-//		terrain = null;
-	}
+	*/
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Rover.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Rover.java
@@ -210,10 +210,10 @@ public class Rover extends GroundVehicle implements Crewable, LifeSupportInterfa
 
 		if (towedVehicle != null) {
 			// if towedVehicle is not null, it means this rover has just hooked up for towing the towedVehicle
-			addStatus(StatusType.TOWING);
+			addSecondaryStatus(StatusType.TOWING);
 		}
 		else {
-			removeStatus(StatusType.TOWING);
+			removeSecondaryStatus(StatusType.TOWING);
 		}
 
 		this.towedVehicle = towedVehicle;
@@ -780,16 +780,6 @@ public class Rover extends GroundVehicle implements Crewable, LifeSupportInterfa
 					plugInAirPressure(pulse.getElapsed());
 				}
 			}
-
-			if (getAmountResourceStored(getFuelType()) > GroundVehicle.LEAST_AMOUNT)
-				if (super.haveStatusType(StatusType.OUT_OF_FUEL))
-					super.removeStatus(StatusType.OUT_OF_FUEL);
-
-//			String s = this + " is plugged in.  " +  + airPressure + " kPa  " + temperature + " C";
-//			if (!sCache.equals(s)) {
-//				sCache = s;
-//				logger.info(sCache);
-//			}
 		}
 
 		else if (crewCapacity <= 0) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Rover.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Rover.java
@@ -494,7 +494,7 @@ public class Rover extends GroundVehicle implements Crewable, LifeSupportInterfa
 		if (isInSettlement())
 			return true;
 
-		if (haveStatusType(StatusType.GARAGED))
+		if (getPrimaryStatus() == StatusType.GARAGED)
 			return true;
 
         return haveStatusType(StatusType.TOWED);
@@ -639,7 +639,7 @@ public class Rover extends GroundVehicle implements Crewable, LifeSupportInterfa
 				// TODO: need to model the power usage
 
 				double p = 0;
-				if (haveStatusType(StatusType.GARAGED))
+				if (getPrimaryStatus() == StatusType.GARAGED)
 					p = getGarage().getCurrentTemperature();
 				else
 					p = getSettlement().getTemperature();// * (malfunctionManager.getTemperatureModifier() / 100D);
@@ -687,10 +687,10 @@ public class Rover extends GroundVehicle implements Crewable, LifeSupportInterfa
 				// TODO: need to model the power usage
 
 				double p = 0;
-				if (haveStatusType(StatusType.GARAGED))
+				if (getPrimaryStatus() == StatusType.GARAGED)
 					p = getGarage().getCurrentAirPressure();
 				else
-					p = getSettlement().getAirPressure();// * (malfunctionManager.getAirPressureModifier() / 100D);
+					p = getSettlement().getAirPressure();
 
 				double delta = airPressure - p;
 				if (delta > 5)

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/StatusType.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/StatusType.java
@@ -9,32 +9,40 @@ package org.mars_sim.msp.core.vehicle;
 
 import org.mars_sim.msp.core.Msg;
 
+/**
+ * Vehicle status types. They can be either primary or secondary.
+ * Primary status type are mutually exclusive on a Vehicle.
+ */
 public enum StatusType {
 	
-	GARAGED 			(Msg.getString("StatusType.garaged")), //$NON-NLS-1$
-	MAINTENANCE 		(Msg.getString("StatusType.maintenance")), //$NON-NLS-1$
-	MALFUNCTION 		(Msg.getString("StatusType.malfunction")), //$NON-NLS-1$
-	MOVING 				(Msg.getString("StatusType.moving")), //$NON-NLS-1$
-	PARKED 				(Msg.getString("StatusType.parked")), //$NON-NLS-1$
-	STUCK				(Msg.getString("StatusType.stuck")), //$NON-NLS-1$
-	TOWED 				(Msg.getString("StatusType.towed")), //$NON-NLS-1$	
-	TOWING 				(Msg.getString("StatusType.towing")), //$NON-NLS-1$	
-	OUT_OF_FUEL 		(Msg.getString("StatusType.outOfFuel")) //$NON-NLS-1$
+	GARAGED 			(Msg.getString("StatusType.garaged"), true), //$NON-NLS-1$
+	MAINTENANCE 		(Msg.getString("StatusType.maintenance"), false), //$NON-NLS-1$
+	MALFUNCTION 		(Msg.getString("StatusType.malfunction"), false), //$NON-NLS-1$
+	MOVING 				(Msg.getString("StatusType.moving"), true), //$NON-NLS-1$
+	PARKED 				(Msg.getString("StatusType.parked"), true), //$NON-NLS-1$
+	STUCK				(Msg.getString("StatusType.stuck"), false), //$NON-NLS-1$
+	TOWED 				(Msg.getString("StatusType.towed"), false), //$NON-NLS-1$	
+	TOWING 				(Msg.getString("StatusType.towing"), false), //$NON-NLS-1$	
+	OUT_OF_FUEL 		(Msg.getString("StatusType.outOfFuel"),false) //$NON-NLS-1$
 	;
 	
 	private String name;
+	private boolean primary;
 
-	private StatusType(String name) {
+	private StatusType(String name, boolean primary) {
 		this.name = name;
+		this.primary = primary;
 	}
 
 	public String getName() {
-		// TODO change all names to i18n-keys for accessing messages.properties
 		return this.name;
 	}
 	
 	public String toString() {
-		// TODO change all names to i18n-keys for accessing messages.properties
 		return this.name;
+	}
+
+	public boolean isPrimary() {
+		return primary;
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Vehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Vehicle.java
@@ -1219,7 +1219,7 @@ public abstract class Vehicle extends Unit
 	 * @return {@link Vehicle}
 	 */
 	public Building getGarage() {
-		return BuildingManager.getBuilding(this, getSettlement());
+		return BuildingManager.getBuilding(this);
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/ConstructionVehiclePanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/ConstructionVehiclePanel.java
@@ -282,7 +282,7 @@ class ConstructionVehiclePanel extends WizardPanel {
             LightUtilityVehicle vehicle = (LightUtilityVehicle) getUnit(row);
             
             if (column == 1) {
-				if (!vehicle.haveStatusType(StatusType.PARKED) && !vehicle.haveStatusType(StatusType.GARAGED))
+				if ((vehicle.getPrimaryStatus() != StatusType.PARKED) && (vehicle.getPrimaryStatus() != StatusType.GARAGED))
                 	result = true;
             }
             else if (column == 2) {

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/FlyerPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/FlyerPanel.java
@@ -289,7 +289,7 @@ class FlyerPanel extends WizardPanel {
 				if (vehicle.getStoredMass() > 0D)
 					result = true;
 			} else if (column == 8) {
-				if (!vehicle.haveStatusType(StatusType.PARKED) && !vehicle.haveStatusType(StatusType.GARAGED))
+				if ((vehicle.getPrimaryStatus() != StatusType.PARKED) && (vehicle.getPrimaryStatus() != StatusType.GARAGED))
 					result = true;
 
 				// Allow rescue/salvage mission to use vehicle undergoing maintenance.

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/LightUtilityVehiclePanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/LightUtilityVehiclePanel.java
@@ -235,7 +235,7 @@ extends WizardPanel {
 			LightUtilityVehicle vehicle = (LightUtilityVehicle) getUnit(row);
 
 			if (column == 1) {
-				if (!vehicle.haveStatusType(StatusType.PARKED) && !vehicle.haveStatusType(StatusType.GARAGED))
+				if ((vehicle.getPrimaryStatus() != StatusType.PARKED) && (vehicle.getPrimaryStatus() != StatusType.GARAGED))
 					result = true;
 			}
 			else if (column == 2) {

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/SalvageVehiclePanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/SalvageVehiclePanel.java
@@ -283,7 +283,7 @@ public class SalvageVehiclePanel extends WizardPanel {
             LightUtilityVehicle vehicle = (LightUtilityVehicle) getUnit(row);
             
             if (column == 1) {
-				if (!vehicle.haveStatusType(StatusType.PARKED) && !vehicle.haveStatusType(StatusType.GARAGED))
+				if ((vehicle.getPrimaryStatus() != StatusType.PARKED) && (vehicle.getPrimaryStatus() != StatusType.GARAGED))
                 	result = true;
             }
             else if (column == 2) {

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/VehiclePanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/VehiclePanel.java
@@ -297,7 +297,7 @@ class VehiclePanel extends WizardPanel {
 				if (vehicle.getStoredMass() > 0D)
 					result = true;
 			} else if (column == 8) {
-				if (!vehicle.haveStatusType(StatusType.PARKED) && !vehicle.haveStatusType(StatusType.GARAGED))
+				if ((vehicle.getPrimaryStatus() != StatusType.PARKED) && (vehicle.getPrimaryStatus() != StatusType.GARAGED))
 					result = true;
 
 				// Allow rescue/salvage mission to use vehicle undergoing maintenance.

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_display_info/DroneDisplayInfoBean.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_display_info/DroneDisplayInfoBean.java
@@ -52,7 +52,7 @@ public class DroneDisplayInfoBean extends VehicleDisplayInfoBean {
 		Drone drone = (Drone) unit;
     	if (drone.haveStatusType(StatusType.MAINTENANCE)) return SoundConstants.SND_ROVER_MAINTENANCE;
     	else if (drone.haveStatusType(StatusType.MALFUNCTION)) return SoundConstants.SND_ROVER_MALFUNCTION;
-    	else if (drone.haveStatusType(StatusType.GARAGED) || drone.haveStatusType(StatusType.PARKED)) return SoundConstants.SND_ROVER_PARKED;
+    	else if ((drone.getPrimaryStatus() == StatusType.GARAGED) || (drone.getPrimaryStatus() == StatusType.PARKED)) return SoundConstants.SND_ROVER_PARKED;
     	else if (drone.getSpeed() > 0) return SoundConstants.SND_ROVER_MOVING;
     	else return "";
 	}

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_display_info/LUVDisplayInfoBean.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_display_info/LUVDisplayInfoBean.java
@@ -54,7 +54,7 @@ public class LUVDisplayInfoBean extends VehicleDisplayInfoBean {
 		LightUtilityVehicle luv = (LightUtilityVehicle) unit;
     	if (luv.haveStatusType(StatusType.MAINTENANCE)) return SoundConstants.SND_ROVER_MAINTENANCE;
     	else if (luv.haveStatusType(StatusType.MALFUNCTION)) return SoundConstants.SND_ROVER_MALFUNCTION;
-    	else if (luv.haveStatusType(StatusType.GARAGED) || luv.haveStatusType(StatusType.PARKED)) return SoundConstants.SND_ROVER_PARKED;
+    	else if ((luv.getPrimaryStatus() == StatusType.GARAGED) || (luv.getPrimaryStatus() == StatusType.PARKED)) return SoundConstants.SND_ROVER_PARKED;
     	else if (luv.getCrewNum() > 0 || luv.getRobotCrewNum() > 0) return SoundConstants.SND_ROVER_MOVING;
     	else return "";
 	}

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_display_info/RoverDisplayInfoBean.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_display_info/RoverDisplayInfoBean.java
@@ -58,10 +58,11 @@ public class RoverDisplayInfoBean extends VehicleDisplayInfoBean {
 	 */
 	public String getSound(Unit unit) {
 		Vehicle rover = (Vehicle) unit;
-    	if (rover.haveStatusType(StatusType.MOVING)) return SoundConstants.SND_ROVER_MOVING;
+		StatusType primStatus = rover.getPrimaryStatus();
+    	if (primStatus == StatusType.MOVING) return SoundConstants.SND_ROVER_MOVING;
     	else if (rover.haveStatusType(StatusType.MAINTENANCE)) return SoundConstants.SND_ROVER_MAINTENANCE;
     	else if (rover.haveStatusType(StatusType.MALFUNCTION)) return SoundConstants.SND_ROVER_MALFUNCTION;
-    	else if (rover.haveStatusType(StatusType.GARAGED) || rover.haveStatusType(StatusType.PARKED)) return SoundConstants.SND_ROVER_PARKED;
+    	else if ((primStatus == StatusType.GARAGED) || (primStatus == StatusType.PARKED)) return SoundConstants.SND_ROVER_PARKED;
     	else return "";
 	}
 }

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/vehicle/DirectionDisplayPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/vehicle/DirectionDisplayPanel.java
@@ -116,7 +116,7 @@ public class DirectionDisplayPanel extends JPanel {
 		g.drawString("E", centerX + letterRadius - (eWidth / 2), centerY + (fontHeight / 2));
 
 		// Draw direction line if necessary
-		if (vehicle.haveStatusType(StatusType.MOVING) || (vehicle.haveStatusType(StatusType.STUCK) && vehicle.getSpeed() > 0D)) {
+		if (vehicle.getPrimaryStatus() == StatusType.MOVING) {
 			Direction direction = vehicle.getDirection();
 			double hyp = (double) (CIRCLE_RADIUS);
 			int newX = (int) Math.round(hyp * direction.getSinDirection());

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/vehicle/TerrainDisplayPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/vehicle/TerrainDisplayPanel.java
@@ -94,7 +94,7 @@ public class TerrainDisplayPanel extends JPanel {
 
 		// Find terrain grade.
 		double terrainGrade = 0D;
-		if (vehicle.haveStatusType(StatusType.MOVING))
+		if (vehicle.getPrimaryStatus() == StatusType.MOVING)
 			terrainGrade = vehicle.getTerrainGrade();
 
 		// Determine y difference


### PR DESCRIPTION
PR contain 2 sets of changes:

#595 To solve the Status log problem and improve the logic added a Primary Status to Vehicle. This represent the physical situation of a Vehicle, e.g Moving, Parked or Garaged. The remaining Statuses are now classified as Secondary.
#597 - fixed a problem with a stuck simulation going into an infinite loop when a Vehicle airlock is full. Now simulate the Person waiting.