### PR TITLE
Consolidate EVA logic in Mission

### DIFF
--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/SpeedCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/SpeedCommand.java
@@ -17,8 +17,8 @@ public class SpeedCommand extends ChatCommand {
 	private static final int MAX_RATE = 2048;
 
 	public SpeedCommand() {
-		super(TopLevel.SIMULATION_GROUP, "sp", "speed", "Change the simulation speed");
-		setInteractive(true);
+		super(TopLevel.SIMULATION_GROUP, "sp", "speed",
+					"Simulation speed; optional argument of new speed");
 		addRequiredRole(ConversationRole.ADMIN);
 	}
 
@@ -32,18 +32,26 @@ public class SpeedCommand extends ChatCommand {
         context.println("The target simulation ratio is x" + desiredRatio);
         context.println("The actual simualtion ratio achieved is x" + currentRatio);
         
-		String change = context.getInput("Change (Y/N)?");
-
-        if ("Y".equalsIgnoreCase(change)) {
-            int newRate = context.getIntInput("Enter the new simulation rate 1.." + MAX_RATE);
-            if ((1 <= newRate) && (newRate <= MAX_RATE)) {
-            	clock.setDesiredTR(newRate);
-            	context.println("New desired ratio is x" + newRate);
-            }
-        }
-        else {
-        	context.println("Invalid input. Try again.");
-        	return false;
+		if (input != null) {
+			boolean failed = false;
+			try {
+				int newRate = Integer.parseInt(input);
+				if ((1 <= newRate) && (newRate <= MAX_RATE)) {
+					clock.setDesiredTR(newRate);
+					context.println("New desired ratio is x" + newRate);
+				}
+				else {
+					failed = true;
+				}
+			}
+			catch (NumberFormatException nfe) {
+				failed = true;
+			}
+			
+			if (failed) {
+        		context.println("Invalid input. Must be an integer between 1 & " + MAX_RATE);
+        		return false;
+			}
         }
 
         return true;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/Person.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/Person.java
@@ -769,7 +769,8 @@ public class Person extends Unit implements MissionMember, Serializable, Tempora
 			return ((Vehicle)c).getSettlement();
 		}
 
-		if (c.getUnitType() == UnitType.PERSON || c.getUnitType() == UnitType.ROBOT) {
+		if (c.getUnitType() == UnitType.BUILDING || c.getUnitType() == UnitType.PERSON
+				|| c.getUnitType() == UnitType.ROBOT) {
 			return c.getSettlement();
 		}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectResourcesMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectResourcesMission.java
@@ -363,22 +363,6 @@ public abstract class CollectResourcesMission extends EVAMission
 		return true;
 	}
 
-		/**
-	 * Gets the range of a trip based on its time limit and collection sites.
-	 *
-	 * @param tripTimeLimit time (millisols) limit of trip.
-	 * @param numSites      the number of collection sites.
-	 * @param useBuffer     Use time buffer in estimations if true.
-	 * @return range (km) limit.
-	 */
-	protected double getTripTimeRange(double tripTimeLimit, int numSites, boolean useBuffer) {
-		double timeAtSites = getEstimatedTimeAtEVASite(useBuffer) * numSites;
-		double tripTimeTravellingLimit = tripTimeLimit - timeAtSites;
-		double averageSpeed = getAverageVehicleSpeedForOperators();
-		double averageSpeedMillisol = averageSpeed / MarsClock.MILLISOLS_PER_HOUR;
-		return tripTimeTravellingLimit * averageSpeedMillisol;
-	}
-
 	/**
 	 * Calculate the collection for for a worker.
 	 * @param worker

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectResourcesMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectResourcesMission.java
@@ -6,11 +6,9 @@
  */
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -36,8 +34,8 @@ import org.mars_sim.msp.core.vehicle.Rover;
  * several random locations around a settlement and collect resources of a given
  * type.
  */
-public abstract class CollectResourcesMission extends RoverMission
-	implements Serializable, SiteMission {
+public abstract class CollectResourcesMission extends EVAMission
+	implements  SiteMission {
 
 
 	/** default serial id. */
@@ -66,10 +64,6 @@ public abstract class CollectResourcesMission extends RoverMission
 	private static final int MAX_PEOPLE = 6;
 
 	// Data members
-	/** External flag for ending collection at the current site. */
-	private boolean endCollectingSite;
-	/** The number of containers needed for the mission. */
-	private int containerNum;
 	/** The type of resource to collect. */
 	protected int resourceID;
 	/** The total site score of this prospective resource collection mission. */
@@ -109,7 +103,7 @@ public abstract class CollectResourcesMission extends RoverMission
 			double resourceCollectionRate, EquipmentType containerID, int containerNum, int numSites) {
 
 		// Use RoverMission constructor
-		super(missionName, missionType, startingPerson);
+		super(missionName, missionType, startingPerson, null, COLLECT_RESOURCES);
 
 		// Problem starting mission
 		if (isDone()) {
@@ -126,9 +120,9 @@ public abstract class CollectResourcesMission extends RoverMission
 		if (s != null) {
 			setResourceID(resourceID);
 			this.resourceCollectionRate = resourceCollectionRate;
-			this.containerID = containerID;
-			this.containerNum = containerNum;
 			this.collected = new HashMap<>();
+
+			setEVAEquipment(containerID, containerNum);
 
 			// Recruit additional members to mission.
 			if (!recruitMembersForMission(startingPerson, MIN_PEOPLE))
@@ -175,7 +169,7 @@ public abstract class CollectResourcesMission extends RoverMission
 				}
 
 				// Reorder sites for shortest distance and load
-				List<Coordinates> orderSites = Exploration.getMinimalPath(startingLocation, unorderedSites);
+				List<Coordinates> orderSites = getMinimalPath(startingLocation, unorderedSites);
 				addNavpoints(orderSites, (i -> PROPSPECTING_SITE + (i+1)));
 
 				double containerCap = ContainerUtil.getContainerCapacity(containerID);
@@ -200,7 +194,6 @@ public abstract class CollectResourcesMission extends RoverMission
 		}
 	}
 
-
 	/**
 	 * Constructor with explicit data
 	 *
@@ -222,15 +215,15 @@ public abstract class CollectResourcesMission extends RoverMission
 			int containerNum, Rover rover, List<Coordinates> collectionSites) {
 
 		// Use RoverMission constructor
-		super(missionName, missionType, (MissionMember) members.toArray()[0], rover);
+		super(missionName, missionType, (MissionMember) members.toArray()[0], rover, COLLECT_RESOURCES);
 
 		this.resourceID = resourceID;
 
 		double containerCap = ContainerUtil.getContainerCapacity(containerID);
 		this.siteResourceGoal = 2 * containerCap * containerNum / collectionSites.size();
 		this.resourceCollectionRate = resourceCollectionRate;
-		this.containerID = containerID;
-		this.containerNum = containerNum;
+
+		setEVAEquipment(containerID, containerNum);
 
 		// Set collection navpoints.
 		addNavpoints(collectionSites, (i -> PROPSPECTING_SITE + (i+1)));
@@ -273,67 +266,6 @@ public abstract class CollectResourcesMission extends RoverMission
 		return collected;
 	}
 
-	/**
-	 * Determines a new phase for the mission when the current phase has ended.
-	 *
-	 * @throws MissionException if problem setting a new phase.
-	 */
-	@Override
-	protected boolean determineNewPhase() {
-		boolean handled = true;
-		if (!super.determineNewPhase()) {
-			if (TRAVELLING.equals(getPhase())) {
-
-				if (getCurrentNavpoint() == null)
-					// go back home
-					returnHome();
-				else if (isCurrentNavpointSettlement()) {
-					startDisembarkingPhase();
-				}
-
-				else if (canStartEVA()) {
-					setPhase(COLLECT_RESOURCES,
-							getCurrentNavpointDescription());
-				}
-			}
-			else if (WAIT_SUNLIGHT.equals(getPhase())) {
-				setPhase(COLLECT_RESOURCES,
-						getCurrentNavpointDescription());
-			}
-			else if (COLLECT_RESOURCES.equals(getPhase())) {
-				// Update the resource collected
-				updateResources(getVehicle());
-				startTravellingPhase();
-			}
-			else {
-				handled  = false;
-			}
-		}
-		return handled;
-	}
-
-	@Override
-	protected void performPhase(MissionMember member) {
-		super.performPhase(member);
-		if (COLLECT_RESOURCES.equals(getPhase())) {
-			collectingPhase(member);
-		}
-	}
-
-	/**
-	 * If collecting phase then stop all EVA
-	 */
-	@Override
-	public void abortPhase() {
-		if (COLLECT_RESOURCES.equals(getPhase())) {
-
-			endCollectingSite = true;
-
-			endAllEVA();
-		}
-		else 
-			super.abortPhase();
-	}
 
 	/**
 	 * Updates the resources collected
@@ -373,112 +305,78 @@ public abstract class CollectResourcesMission extends RoverMission
 	 */
 	public abstract int [] getCollectibleResources();
 
-	/**
-	 * Performs the collecting phase of the mission.
-	 *
-	 * @param member the mission member currently performing the mission
-	 */
-	private void collectingPhase(MissionMember member) {
+	@Override
+	protected boolean performEVA(Person person) {
 
 		Rover rover = getRover();
 		double roverRemainingCap = rover.getCargoCapacity() - rover.getStoredMass();
 
-		double weight = ((Person)member).getMass();
-
+		double weight = person.getMass();
 		if (roverRemainingCap < weight + 5) {
-			endCollectingSite = false;
-			setPhaseEnded(true);
-		}
-
-		double resourcesCapacity = updateResources(rover);
-
-		// Check if end collecting flag is set.
-		if (endCollectingSite) {
-			endCollectingSite = false;
-			setPhaseEnded(true);
+			return false;
 		}
 
 		// If collected resources are sufficient for this site, end the collecting
 		// phase.
 		if (siteCollectedResources >= siteResourceGoal) {
-			setPhaseEnded(true);
+			return false;
 		}
 
-		if (isEveryoneInRover()) {
+			// // Determine if no one can start the collect resources task.
+			// boolean nobodyCollect = true;
+			// Iterator<MissionMember> j = getMembers().iterator();
+			// while (j.hasNext() && nobodyCollect) {
+			// 	MissionMember m = j.next();
+			// 	for (Integer type : getCollectibleResources()) {
+			// 		if (CollectResources.canCollectResources(m, getRover(), containerID, type)) {
+			// 			nobodyCollect = false;
+			// 		}
+			// 	}
+			// }
 
-			// Determine if no one can start the collect resources task.
-			boolean nobodyCollect = true;
-			Iterator<MissionMember> j = getMembers().iterator();
-			while (j.hasNext() && nobodyCollect) {
-				MissionMember m = j.next();
-				for (Integer type : getCollectibleResources()) {
-					if (CollectResources.canCollectResources(m, getRover(), containerID, type)) {
-						nobodyCollect = false;
-					}
-				}
-			}
+		// Do the EVA task
+		double rate = calculateRate(person);
 
-			if (nobodyCollect || !isEnoughSunlightForEVA()) {
-				logger.info(member, "Too dark for " + getPhaseDescription() + " of " + getTypeID()
-									+ ", moving to next site");
-				setPhaseEnded(true);
-			}
+		// Randomize the rate of collection upon arrival
+		rate = rate
+				* (1 + RandomUtil.getRandomDouble(-.2, .2));
 
-			// Anyone in the crew or a single person at the home settlement has a dangerous
-			// illness, end phase.
-			if (hasEmergency()) {
-				setPhaseEnded(true);
-			}
+		// Note: Add how areologists and some scientific study may come up with better technique
+		// to obtain better estimation of the collection rate. Go to a prospective site, rather
+		// than going to a site coordinate in the blind.
 
-			// Check if enough resources for remaining trip. false = not using margin.
-			if (!hasEnoughResourcesForRemainingMission(false)) {
-				// If not, determine an emergency destination.
-				determineEmergencyDestination(member);
-				setPhaseEnded(true);
-			}
+		if (rate > 20)
+			resourceCollectionRate = rate;
+
+		// If person can collect resources, start him/her on that task.
+		if (CollectResources.canCollectResources(person, getRover(), containerID, resourceID)) {
+			EVAOperation collectResources = new CollectResources("Collecting Resources", person,
+					getRover(), resourceID, resourceCollectionRate,
+					siteResourceGoal - siteCollectedResources, rover.getAmountResourceStored(resourceID),
+					containerID);
+			assignTask(person, collectResources);
 		}
-
-		if (!getPhaseEnded()
-				&& (siteCollectedResources < siteResourceGoal)
-				&& !endCollectingSite
-				&& member instanceof Person) {
-
-			Person person = (Person) member;
-
-			double rate = calculateRate(person);
-
-			// Randomize the rate of collection upon arrival
-			rate = rate
-					* (1 + RandomUtil.getRandomDouble(-.2, .2));
-
-			// Note: Add how areologists and some scientific study may come up with better technique
-			// to obtain better estimation of the collection rate. Go to a prospective site, rather
-			// than going to a site coordinate in the blind.
-
-			if (rate > 20)
-				resourceCollectionRate = rate;
-
-			// If person can collect resources, start him/her on that task.
-			if (CollectResources.canCollectResources(person, getRover(), containerID, resourceID)) {
-				EVAOperation collectResources = new CollectResources("Collecting Resources", person,
-						getRover(), resourceID, resourceCollectionRate,
-						siteResourceGoal - siteCollectedResources, rover.getAmountResourceStored(resourceID),
-						containerID);
-				assignTask(person, collectResources);
-			}
-		}
-
-		else {
-			// If the rover is full of resources, head home.
-			if (siteCollectedResources >= resourcesCapacity) {
-				setNextNavpointIndex(getNumberOfNavpoints() - 2);
-				updateTravelDestination();
-				siteCollectedResources = 0D;
-			}
-		}
-
+	
 		// This will update the siteCollectedResources and totalResourceCollected after the last on-site collection activity
 		updateResources(rover);
+
+		return true;
+	}
+
+		/**
+	 * Gets the range of a trip based on its time limit and collection sites.
+	 *
+	 * @param tripTimeLimit time (millisols) limit of trip.
+	 * @param numSites      the number of collection sites.
+	 * @param useBuffer     Use time buffer in estimations if true.
+	 * @return range (km) limit.
+	 */
+	protected double getTripTimeRange(double tripTimeLimit, int numSites, boolean useBuffer) {
+		double timeAtSites = getEstimatedTimeAtEVASite(useBuffer) * numSites;
+		double tripTimeTravellingLimit = tripTimeLimit - timeAtSites;
+		double averageSpeed = getAverageVehicleSpeedForOperators();
+		double averageSpeedMillisol = averageSpeed / MarsClock.MILLISOLS_PER_HOUR;
+		return tripTimeTravellingLimit * averageSpeedMillisol;
 	}
 
 	/**
@@ -582,146 +480,17 @@ public abstract class CollectResourcesMission extends RoverMission
 	protected abstract double scoreLocation(Coordinates newLocation);
 
 	/**
-	 * Gets the range of a trip based on its time limit and collection sites.
-	 *
-	 * @param tripTimeLimit time (millisols) limit of trip.
-	 * @param numSites      the number of collection sites.
-	 * @param useBuffer     Use time buffer in estimations if true.
-	 * @return range (km) limit.
-	 */
-	protected double getTripTimeRange(double tripTimeLimit, int numSites, boolean useBuffer) {
-		double timeAtSites = getEstimatedTimeAtCollectionSite(useBuffer) * numSites;
-		double tripTimeTravellingLimit = tripTimeLimit - timeAtSites;
-		double averageSpeed = getAverageVehicleSpeedForOperators();
-		double averageSpeedMillisol = averageSpeed / MarsClock.MILLISOLS_PER_HOUR;
-		return tripTimeTravellingLimit * averageSpeedMillisol;
-	}
-
-	/**
-	 * Gets the settlement associated with the mission.
-	 *
-	 * @return settlement or null if none.
-	 */
-	@Override
-	public Settlement getAssociatedSettlement() {
-		return getStartingSettlement();
-	}
-
-	/**
-	 * Gets the estimated time remaining for the mission.
-	 *
-	 * @param useBuffer use time buffer in estimations if true.
-	 * @return time (millisols)
-	 * @throws MissionException
-	 */
-	@Override
-	protected double getEstimatedRemainingMissionTime(boolean useBuffer) {
-		double result = super.getEstimatedRemainingMissionTime(useBuffer);
-
-		result += getEstimatedRemainingCollectionSiteTime(useBuffer);
-
-		return result;
-	}
-
-	/**
-	 * Gets the estimated time remaining for collection sites in the mission.
-	 *
-	 * @param useBuffer use time buffer in estimations if true.
-	 * @return time (millisols)
-	 * @throws MissionException if error estimating time.
-	 */
-	private double getEstimatedRemainingCollectionSiteTime(boolean useBuffer) {
-		double result = 0D;
-
-		// Add estimated remaining collection time at current site if still there.
-		if (COLLECT_RESOURCES.equals(getPhase())) {
-			double remainingTime = getEstimatedTimeAtCollectionSite(useBuffer) - getPhaseDuration();
-			if (remainingTime > 0D)
-				result += remainingTime;
-		}
-
-		// Add estimated collection time at sites that haven't been visited yet.
-		int remainingCollectionSites = getNumCollectionSites() - getNumCollectionSitesVisited();
-		result += getEstimatedTimeAtCollectionSite(useBuffer) * remainingCollectionSites;
-
-		return result;
-	}
-
-	@Override
-	protected Map<Integer, Number> getResourcesNeededForRemainingMission(boolean useBuffer) {
-		// Note: currently, it has methane resource only
-		Map<Integer, Number> result = super.getResourcesNeededForRemainingMission(useBuffer);
-
-		double collectionSitesTime = getEstimatedRemainingCollectionSiteTime(useBuffer);
-		double timeSols = collectionSitesTime / 1000D;
-
-		int crewNum = getPeopleNumber();
-
-		// Determine life support supplies needed for collection.
-		addLifeSupportResources(result, crewNum, timeSols, useBuffer);
-
-		return result;
-	}
-
-	@Override
-	protected Map<Integer, Number> getSparePartsForTrip(double distance) {
-		// Load the standard parts from VehicleMission.
-		Map<Integer, Number> result = super.getSparePartsForTrip(distance);
-
-		// Determine repair parts for EVA Suits.
-		double evaTime = getEstimatedRemainingCollectionSiteTime(false);
-		double numberAccidents = evaTime * getPeopleNumber() * EVAOperation.BASE_ACCIDENT_CHANCE;
-
-		// Assume the average number malfunctions per accident is 1.5.
-		double numberMalfunctions = numberAccidents * VehicleMission.AVERAGE_EVA_MALFUNCTION;
-
-		result.putAll(super.getEVASparePartsForTrip(numberMalfunctions));
-
-		return result;
-	}
-
-	/**
-	 * Gets the total number of collection sites for this mission.
-	 *
-	 * @return number of sites.
-	 */
-	public final int getNumCollectionSites() {
-		return getNumberOfNavpoints() - 2;
-	}
-
-	/**
-	 * Gets the number of collection sites that have been currently visited by the
-	 * mission.
-	 *
-	 * @return number of sites.
-	 */
-	public final int getNumCollectionSitesVisited() {
-		int result = getCurrentNavpointIndex();
-		if (result == (getNumberOfNavpoints() - 1))
-			result -= 1;
-		return result;
-	}
-
-	/**
 	 * Gets the estimated time spent at a collection site.
 	 *
 	 * @param useBuffer Use time buffer in estimation if true.
 	 * @return time (millisols)
 	 */
-	protected double getEstimatedTimeAtCollectionSite(boolean useBuffer) {
+	@Override
+	protected double getEstimatedTimeAtEVASite(boolean useBuffer) {
 		double timePerPerson = 2 * siteResourceGoal / resourceCollectionRate;
 		if (useBuffer)
 			timePerPerson *= EVA_COLLECTION_OVERHEAD;
 		return timePerPerson / getPeopleNumber();
-	}
-
-	@Override
-	protected Map<Integer, Integer> getEquipmentNeededForRemainingMission(boolean useBuffer) {
-		Map<Integer, Integer> result = new HashMap<>();
-
-		// Include required number of containers.
-		result.put(EquipmentType.getResourceID(containerID), containerNum);
-		return result;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Delivery.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Delivery.java
@@ -83,7 +83,7 @@ public class Delivery extends DroneMission implements Serializable {
 	 */
 	public Delivery(MissionMember startingMember) {
 		// Use DroneMission constructor.
-		super(DEFAULT_DESCRIPTION, MissionType.DELIVERY, startingMember);
+		super(DEFAULT_DESCRIPTION, MissionType.DELIVERY, startingMember, null);
 
 		// Problem starting Mission
 		if (isDone()) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Delivery.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Delivery.java
@@ -350,13 +350,8 @@ public class Delivery extends DroneMission implements Serializable {
 		if (getPhaseEnded()) {
 			outbound = false;
 			resetToReturnTrip(
-					new NavPoint(tradingSettlement.getCoordinates(),
-							tradingSettlement,
-							tradingSettlement.getName()),
-
-					new NavPoint(getStartingSettlement().getCoordinates(),
-								getStartingSettlement(),
-								getStartingSettlement().getName()));
+					new NavPoint(tradingSettlement),
+					new NavPoint(getStartingSettlement()));
 			TRADE_PROFIT_CACHE.remove(getStartingSettlement());
 		}
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/DroneMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/DroneMission.java
@@ -40,17 +40,6 @@ public abstract class DroneMission extends VehicleMission {
 	private static final SimLogger logger = SimLogger.getLogger(DroneMission.class.getName());
 
 	/**
-	 * Constructor.
-	 *
-	 * @param name           the name of the mission.
-	 * @param startingMember the mission member starting the mission.
-	 */
-	protected DroneMission(String name, MissionType missionType, MissionMember startingMember) {
-		// Use VehicleMission constructor.
-		super(name, missionType, startingMember);
-	}
-
-	/**
 	 * Constructor with min people and drone. Initiated by MissionDataBean.
 	 *
 	 * @param missionName    the name of the mission.

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/EVAMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/EVAMission.java
@@ -1,0 +1,277 @@
+package org.mars_sim.msp.core.person.ai.mission;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.mars_sim.msp.core.Coordinates;
+import org.mars_sim.msp.core.logging.SimLogger;
+import org.mars_sim.msp.core.person.Person;
+import org.mars_sim.msp.core.person.ai.task.EVAOperation;
+import org.mars_sim.msp.core.person.ai.task.utils.Task;
+import org.mars_sim.msp.core.vehicle.Rover;
+
+public abstract class EVAMission extends RoverMission {
+
+    /** default logger. */
+	private static SimLogger logger = SimLogger.getLogger(EVAMission.class.getName());
+
+    private MissionPhase evaPhase;
+    private boolean activeEVA = true;
+
+    private double evaSiteTime;
+
+    protected EVAMission(String description, MissionType missionType, 
+            MissionMember startingPerson, Rover rover,
+            MissionPhase evaPhase, double evaSiteTime) {
+        super(description, missionType, startingPerson, rover);
+        
+        this.evaPhase = evaPhase;
+        this.evaSiteTime = evaSiteTime;
+    }
+
+    
+	@Override
+	protected boolean determineNewPhase() {
+		boolean handled = true;
+		if (!super.determineNewPhase()) {
+			if (TRAVELLING.equals(getPhase())) {
+				if (getCurrentNavpoint().isSettlementAtNavpoint()) {
+					startDisembarkingPhase();
+				}
+				else if (canStartEVA()) {
+					activeEVA = true;
+					setPhase(evaPhase, getCurrentNavpointDescription());
+				}
+			}
+			else if (WAIT_SUNLIGHT.equals(getPhase())) {
+				activeEVA = true;
+				setPhase(evaPhase, getCurrentNavpointDescription());
+			}
+			else if (evaPhase.equals(getPhase())) {
+				startTravellingPhase();
+			}
+			else {
+				handled = false;
+			}
+		}
+		return handled;
+	}
+
+	@Override
+	protected void performPhase(MissionMember member) {
+		super.performPhase(member);
+		if (evaPhase.equals(getPhase())) {
+			evaPhase(member);
+		}
+	}
+
+	/**
+	 * Ends the exploration at a site.
+	 */
+	@Override
+	public void abortPhase() {
+		if (evaPhase.equals(getPhase())) {
+
+			logger.info(getRover(), "EVA ended due to external trigger.");
+
+			endEVATasks();
+		}
+		else
+			super.abortPhase();
+	}
+
+    /**
+	 * End all EVA Operations
+	 */
+	protected void endEVATasks() {
+		// End each member's EVA task.
+		for(MissionMember member : getMembers()) {
+			if (member instanceof Person) {
+				Person person = (Person) member;
+				Task task = person.getMind().getTaskManager().getTask();
+				if (task instanceof EVAOperation) {
+					((EVAOperation) task).endEVA();
+				}
+			}
+		}
+	}
+    
+	/**
+	 * Performs the explore site phase of the mission.
+	 *
+	 * @param member the mission member currently performing the mission
+	 * @throws MissionException if problem performing phase.
+	 */
+	private void evaPhase(MissionMember member) {
+
+		if (activeEVA) {
+			// Check if crew has been at site for more than one sol.
+			double timeDiff = getPhaseDuration();
+			activeEVA = (timeDiff < evaSiteTime);
+
+			// If no one can explore the site and this is not due to it just being
+			// night time, end the exploring phase.
+			activeEVA = activeEVA && isEnoughSunlightForEVA();
+
+			// Anyone in the crew or a single person at the home settlement has a dangerous
+			// illness, end phase.
+			activeEVA = activeEVA && !hasEmergency();
+
+			// Check if enough resources for remaining trip. false = not using margin.
+			if (!hasEnoughResourcesForRemainingMission(false)) {
+				// If not, determine an emergency destination.
+				determineEmergencyDestination(member);
+				activeEVA = false;
+			}
+
+			// All good so do the EVA
+			if (activeEVA) {
+				activeEVA = performEVA((Person) member);
+			}
+		} 
+
+		// EVA is not active so can th phase end?
+		if (!activeEVA) {
+			if (isEveryoneInRover()) {
+				// End phase
+				setPhaseEnded(true);
+			} 
+			else {
+				// Call everyone back inside
+				endEVATasks();
+			}
+		}
+	}
+
+    /**
+     * Perform the specific EVA activities. This may cancel the EVA phase
+     * @param person
+     * @return
+     */
+	protected abstract boolean performEVA(Person person);
+
+    /**
+     * Calculate the spare parts needed for the trip
+     */
+    @Override
+	protected Map<Integer, Number> getSparePartsForTrip(double distance) {
+		// Load the standard parts from VehicleMission.
+		Map<Integer, Number> result = super.getSparePartsForTrip(distance);
+
+		// Determine repair parts for EVA Suits.
+		double evaTime = getEstimatedRemainingEVATime();
+		double numberAccidents = evaTime * getPeopleNumber() * EVAOperation.BASE_ACCIDENT_CHANCE;
+
+		// Assume the average number malfunctions per accident is 1.5.
+		double numberMalfunctions = numberAccidents * VehicleMission.AVERAGE_EVA_MALFUNCTION;
+
+		result.putAll(getEVASparePartsForTrip(numberMalfunctions));
+
+		return result;
+	}
+
+    /**
+     * Get the remaining mission tiem based on the travel and the remaining EVA time.
+     * @return Mission time left.
+     */
+    @Override
+	protected double getEstimatedRemainingMissionTime(boolean useBuffer) {
+		double result = super.getEstimatedRemainingMissionTime(useBuffer);
+		result += getEstimatedRemainingEVATime();
+		return result;
+	}
+
+    
+	/**
+	 * Gets the total number of EVA sites for this mission.
+	 *
+	 * @return number of sites.
+	 */
+	public final int getNumEVASites() {
+		return getNumberOfNavpoints() - 2;
+	}
+
+	/**
+	 * Gets the number of EVA sites that have been currently visited by the
+	 * mission.
+	 *
+	 * @return number of sites.
+	 */
+	public final int getNumEVASitesVisited() {
+		int result = getCurrentNavpointIndex();
+		if (result == (getNumberOfNavpoints() - 1))
+			result -= 1;
+		return result;
+	}
+
+	/**
+	 * Gets the estimated time remaining for exploration sites in the mission.
+	 *
+	 * @return time (millisols)
+	 * @throws MissionException if error estimating time.
+	 */
+	private double getEstimatedRemainingEVATime() {
+		double result = 0D;
+
+		// Add estimated remaining exploration time at current site if still there.
+		if (evaPhase.equals(getPhase())) {
+			double remainingTime = evaSiteTime - getPhaseDuration();
+			if (remainingTime > 0D)
+				result += remainingTime;
+		}
+
+		// Add estimated EVA time at sites that haven't been visited yet.
+		int remainingEVASites = getNumEVASites() - getNumEVASitesVisited();
+		result += evaSiteTime * remainingEVASites;
+
+		return result;
+	}
+
+	@Override
+	protected Map<Integer, Number> getResourcesNeededForRemainingMission(boolean useBuffer) {
+		Map<Integer, Number> result = super.getResourcesNeededForRemainingMission(useBuffer);
+
+		double explorationSitesTime = getEstimatedRemainingEVATime();
+		double timeSols = explorationSitesTime / 1000D;
+
+		int crewNum = getPeopleNumber();
+
+		// Add the maount for the site visits
+		addLifeSupportResources(result, crewNum, timeSols, useBuffer);
+
+		return result;
+	}
+
+    
+	/**
+	 * Order a list of Coordinates starting from a point to minimise
+	 * the travel time.
+	 * @param unorderedSites
+	 * @param startingLocation
+	 * @return
+	 */
+	public static List<Coordinates> getMinimalPath(Coordinates startingLocation, List<Coordinates> unorderedSites) {
+
+		List<Coordinates> unorderedSites2 = new ArrayList<>(unorderedSites);
+		List<Coordinates> orderedSites = new ArrayList<>(unorderedSites2.size());
+		Coordinates currentLocation = startingLocation;
+		while (!unorderedSites2.isEmpty()) {
+			Coordinates shortest = unorderedSites2.get(0);
+			double shortestDistance = Coordinates.computeDistance(currentLocation, shortest);
+			for(Coordinates site : unorderedSites2) {
+				double distance = Coordinates.computeDistance(currentLocation, site);
+				if (distance < shortestDistance) {
+					shortest = site;
+					shortestDistance = distance;
+				}
+			}
+
+			unorderedSites2.remove(shortest);
+			orderedSites.add(shortest);
+			currentLocation = shortest;
+		}
+
+		return orderedSites;
+	}
+}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/EmergencySupply.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/EmergencySupply.java
@@ -6,7 +6,6 @@
  */
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -47,7 +46,7 @@ import org.mars_sim.msp.core.vehicle.Vehicle;
  * A mission for delivering emergency supplies from one settlement to another.
  * TODO externalize strings
  */
-public class EmergencySupply extends RoverMission implements Serializable {
+public class EmergencySupply extends RoverMission {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
@@ -57,9 +56,6 @@ public class EmergencySupply extends RoverMission implements Serializable {
 
 	/** Default description. */
 	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.emergencySupply"); //$NON-NLS-1$
-
-	/** Mission Type enum. */
-	private static final MissionType MISSION_TYPE = MissionType.EMERGENCY_SUPPLY;
 
 	// Static members
 	private static final int MAX_MEMBERS = 2;
@@ -97,7 +93,7 @@ public class EmergencySupply extends RoverMission implements Serializable {
 	 */
 	public EmergencySupply(Person startingPerson) {
 		// Use RoverMission constructor.
-		super(DEFAULT_DESCRIPTION, MISSION_TYPE, startingPerson);
+		super(DEFAULT_DESCRIPTION, MissionType.EMERGENCY_SUPPLY, startingPerson, null);
 
 		if (isDone()) {
 			return;
@@ -156,7 +152,7 @@ public class EmergencySupply extends RoverMission implements Serializable {
 	public EmergencySupply(Collection<MissionMember> members, Settlement emergencySettlement,
 			Map<Good, Integer> emergencyGoods, Rover rover, String description) {
 		// Use RoverMission constructor.
-		super(description, MISSION_TYPE, (Person) members.toArray()[0], rover);
+		super(description, MissionType.EMERGENCY_SUPPLY, (Person) members.toArray()[0], rover);
 
 		outbound = true;
 
@@ -534,7 +530,7 @@ public class EmergencySupply extends RoverMission implements Serializable {
 
 					// Check if settlement is within rover range.
 					double settlementRange = Coordinates.computeDistance(settlement.getCoordinates(), startingSettlement.getCoordinates());
-					if (settlementRange <= (rover.getRange(MISSION_TYPE) * .8D)) {
+					if (settlementRange <= (rover.getRange(MissionType.EMERGENCY_SUPPLY) * .8D)) {
 
 						// Find what emergency supplies are needed at settlement.
 						Map<Integer, Double> emergencyResourcesNeeded = getEmergencyAmountResourcesNeeded(settlement);
@@ -905,9 +901,9 @@ public class EmergencySupply extends RoverMission implements Serializable {
 
 			// Vehicle with superior range should be ranked higher.
 			if (result == 0) {
-				if (firstVehicle.getRange(MISSION_TYPE) > secondVehicle.getRange(MISSION_TYPE)) {
+				if (firstVehicle.getRange(MissionType.EMERGENCY_SUPPLY) > secondVehicle.getRange(MissionType.EMERGENCY_SUPPLY)) {
 					result = 1;
-				} else if (firstVehicle.getRange(MISSION_TYPE) < secondVehicle.getRange(MISSION_TYPE)) {
+				} else if (firstVehicle.getRange(MissionType.EMERGENCY_SUPPLY) < secondVehicle.getRange(MissionType.EMERGENCY_SUPPLY)) {
 					result = -1;
 				}
 			}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Exploration.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Exploration.java
@@ -96,7 +96,7 @@ public class Exploration extends EVAMission
 
 		// Use RoverMission constructor.
 		super(DEFAULT_DESCRIPTION, MISSION_TYPE, startingPerson, null,
-				EXPLORE_SITE, EXPLORING_SITE_TIME);
+				EXPLORE_SITE);
 
 		Settlement s = getStartingSettlement();
 
@@ -141,7 +141,7 @@ public class Exploration extends EVAMission
 
 		// Use RoverMission constructor.
 		super(description, MISSION_TYPE,(MissionMember) members.toArray()[0], rover,
-				EXPLORE_SITE, EXPLORING_SITE_TIME);
+				EXPLORE_SITE);
 	
 
 		initSites(explorationSites);
@@ -163,6 +163,7 @@ public class Exploration extends EVAMission
 		// Initialize explored sites.
 		exploredSites = new ArrayList<>(NUM_SITES);
 		explorationSiteCompletion = new HashMap<>(NUM_SITES);
+		setEVAEquipment(EquipmentType.SPECIMEN_BOX, REQUIRED_SPECIMEN_CONTAINERS);
 
 		// Configure the sites to be explored with mineral concentration during the stage of mission planning
 		for(Coordinates c : explorationSites) {
@@ -180,7 +181,6 @@ public class Exploration extends EVAMission
 		if (!isVehicleLoadable()) {
 			endMission(MissionStatus.CANNOT_LOAD_RESOURCES);
 		}
-
 	}
 
 	/**
@@ -371,15 +371,6 @@ public class Exploration extends EVAMission
 		return EXPLORING_SITE_TIME * getNumEVASites();
 	}
 
-	@Override
-	protected Map<Integer, Integer> getEquipmentNeededForRemainingMission(boolean useBuffer) {
-		Map<Integer, Integer> result = new HashMap<>();
-
-		// Include required number of specimen containers.
-		result.put(EquipmentType.getResourceID(EquipmentType.SPECIMEN_BOX), REQUIRED_SPECIMEN_CONTAINERS);
-		return result;
-	}
-
 	/**
 	 * Determine the locations of the exploration sites.
 	 *
@@ -397,7 +388,7 @@ public class Exploration extends EVAMission
 		// Determining the actual traveling range.
 		double limit = 0;
 		double range = roverRange;
-		double timeRange = getTripTimeRange(tripTimeLimit);
+		double timeRange = getTripTimeRange(tripTimeLimit, getAverageVehicleSpeedForOperators());
 		if (timeRange < range) {
 			range = timeRange;
 		}
@@ -468,6 +459,14 @@ public class Exploration extends EVAMission
 		return sites;
 	}
 
+	/**
+	 * Estimate the time needed at an EVA site.
+	 * @param buffer Add a buffer allowance
+	 * @return Estimated time per EVA site
+	 */
+	protected double getEstimatedTimeAtEVASite(boolean buffer) {
+		return EXPLORING_SITE_TIME;
+	}
 
 	/**
 	 * Get a list of explored location for this Settlement that needs further investigation
@@ -543,21 +542,6 @@ public class Exploration extends EVAMission
 		}
 
 		return result;
-	}
-
-	/**
-	 * Gets the range of a trip based on its time limit and exploration sites.
-	 *
-	 * @param tripTimeLimit time (millisols) limit of trip.
-	 * @return range (km) limit.
-	 */
-	private double getTripTimeRange(double tripTimeLimit) {
-		double timeAtSites = getEstimatedTimeOfAllEVAs();
-		double tripTimeTravellingLimit = tripTimeLimit - timeAtSites;
-		double averageSpeed = getAverageVehicleSpeedForOperators();
-		double millisolsInHour = MarsClock.MILLISOLS_PER_HOUR;
-		double averageSpeedMillisol = averageSpeed / millisolsInHour;
-		return tripTimeTravellingLimit * averageSpeedMillisol;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/FieldStudyMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/FieldStudyMission.java
@@ -6,7 +6,6 @@
  */
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -32,7 +31,7 @@ import org.mars_sim.msp.core.vehicle.Rover;
  * This is an abstract Field Study mission to a remote field location for a scientific
  * study. The concrete classes determine the science that is required.
  */
-public abstract class FieldStudyMission extends RoverMission implements Serializable {
+public abstract class FieldStudyMission extends RoverMission {
 
 	private static final Set<JobType> PREFERRED_JOBS = Set.of(JobType.AREOLOGIST, JobType.ASTRONOMER, JobType.BIOLOGIST, JobType.BOTANIST, JobType.CHEMIST, JobType.METEOROLOGIST, JobType.PILOT);
 
@@ -69,7 +68,7 @@ public abstract class FieldStudyMission extends RoverMission implements Serializ
 								ScienceType science, double fieldSiteTime) {
 
 		// Use RoverMission constructor.
-		super(description, missionType, startingPerson);
+		super(description, missionType, startingPerson, null);
 
 		this.science = science;
 		this.fieldSiteTime = fieldSiteTime;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MeteorologyFieldStudy.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MeteorologyFieldStudy.java
@@ -6,9 +6,7 @@
  */
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.io.Serializable;
 import java.util.Collection;
-import java.util.Map;
 
 import org.mars_sim.msp.core.Coordinates;
 import org.mars_sim.msp.core.Msg;
@@ -24,7 +22,7 @@ import org.mars_sim.msp.core.vehicle.Rover;
  * A mission to do meteorology research at a remote field location for a scientific
  * study.
  */
-public class MeteorologyFieldStudy extends FieldStudyMission implements Serializable {
+public class MeteorologyFieldStudy extends FieldStudyMission {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
@@ -47,6 +45,9 @@ public class MeteorologyFieldStudy extends FieldStudyMission implements Serializ
 	public MeteorologyFieldStudy(Person startingPerson) {
 		super(DEFAULT_DESCRIPTION, MissionType.METEOROLOGY, startingPerson,
 			  ScienceType.METEOROLOGY, FIELD_SITE_TIME);
+		
+		setEVAEquipment(EquipmentType.SPECIMEN_BOX,
+			  getMembersNumber() * SPECIMEN_BOX_MEMBER);
 	}
 
 	/**
@@ -64,23 +65,13 @@ public class MeteorologyFieldStudy extends FieldStudyMission implements Serializ
 
 		super(description, MissionType.METEOROLOGY, leadResearcher, rover,
 				  study, FIELD_SITE_TIME, members, fieldSite);
+
+		setEVAEquipment(EquipmentType.SPECIMEN_BOX,
+						getMembersNumber() * SPECIMEN_BOX_MEMBER);
 	}
 	
 	@Override
 	protected Task createFieldStudyTask(Person person, Person leadResearcher, ScientificStudy study, Rover vehicle) {
 		return new MeteorologyStudyFieldWork(person, leadResearcher, study, vehicle);
-	}
-
-	/**
-	 * Need some Specimen boxes
-	 */
-	@Override
-	public Map<Integer, Integer> getEquipmentNeededForRemainingMission(boolean useBuffer) {
-		Map<Integer, Integer> required = super.getEquipmentNeededForRemainingMission(useBuffer);
-		
-		required.put(EquipmentType.getResourceID(EquipmentType.SPECIMEN_BOX),
-												 getMembersNumber() * SPECIMEN_BOX_MEMBER);
-		
-		return required;
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mining.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mining.java
@@ -94,7 +94,7 @@ public class Mining extends RoverMission
 	public Mining(Person startingPerson) {
 
 		// Use RoverMission constructor.
-		super(DEFAULT_DESCRIPTION, MissionType.MINING, startingPerson);
+		super(DEFAULT_DESCRIPTION, MissionType.MINING, startingPerson, null);
 		
 		if (!isDone()) {
 			// Initialize data members.

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mining.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mining.java
@@ -15,22 +15,18 @@ import java.util.logging.Level;
 
 import org.mars_sim.msp.core.Coordinates;
 import org.mars_sim.msp.core.Msg;
-import org.mars_sim.msp.core.UnitType;
 import org.mars_sim.msp.core.environment.ExploredLocation;
 import org.mars_sim.msp.core.equipment.EquipmentType;
 import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.job.JobType;
 import org.mars_sim.msp.core.person.ai.task.CollectMinedMinerals;
-import org.mars_sim.msp.core.person.ai.task.EVAOperation;
 import org.mars_sim.msp.core.person.ai.task.MineSite;
-import org.mars_sim.msp.core.person.ai.task.utils.Task;
 import org.mars_sim.msp.core.resource.AmountResource;
 import org.mars_sim.msp.core.resource.ItemResourceUtil;
 import org.mars_sim.msp.core.resource.ResourceUtil;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.time.MarsClock;
-import org.mars_sim.msp.core.tool.RandomUtil;
 import org.mars_sim.msp.core.vehicle.Crewable;
 import org.mars_sim.msp.core.vehicle.LightUtilityVehicle;
 import org.mars_sim.msp.core.vehicle.Rover;
@@ -41,7 +37,7 @@ import org.mars_sim.msp.core.vehicle.VehicleType;
 /**
  * Mission for mining mineral concentrations at an explored site.
  */
-public class Mining extends RoverMission
+public class Mining extends EVAMission
 	implements SiteMission {
 
 	private static final Set<JobType> PREFERRED_JOBS = Set.of(JobType.AREOLOGIST, JobType.ASTRONOMER, JobType.PILOT);
@@ -75,9 +71,6 @@ public class Mining extends RoverMission
 	 * exploration site for it to be considered mature enough to mine.
 	 */
 	public static final int MATURE_ESTIMATE_NUM = 10;
-
-	// Data members
-	private boolean endMiningSite;
 	
 	private ExploredLocation miningSite;
 	private LightUtilityVehicle luv;
@@ -94,12 +87,13 @@ public class Mining extends RoverMission
 	public Mining(Person startingPerson) {
 
 		// Use RoverMission constructor.
-		super(DEFAULT_DESCRIPTION, MissionType.MINING, startingPerson, null);
+		super(DEFAULT_DESCRIPTION, MissionType.MINING, startingPerson, null, MINING_SITE);
 		
 		if (!isDone()) {
 			// Initialize data members.
 			excavatedMinerals = new HashMap<>(1);
 			totalExcavatedMinerals = new HashMap<>(1);
+			setEVAEquipment(EquipmentType.LARGE_BAG, NUMBER_OF_LARGE_BAGS);
 
 			// Recruit additional members to mission.
 			if (!recruitMembersForMission(startingPerson, MIN_GOING_MEMBERS))
@@ -120,7 +114,7 @@ public class Mining extends RoverMission
 			}
 
 			// Add home settlement
-			addNavpoint(new NavPoint(s.getCoordinates(), s, s.getName()));
+			addNavpoint(s);
 
 			// Check if vehicle can carry enough supplies for the mission.
 			if (hasVehicle() && !isVehicleLoadable()) {
@@ -151,14 +145,15 @@ public class Mining extends RoverMission
 	public Mining(Collection<MissionMember> members, ExploredLocation miningSite,
 			Rover rover, LightUtilityVehicle luv, String description) {
 
-		// Use RoverMission constructor.
-		super(description, MissionType.MINING, (MissionMember) members.toArray()[0], rover);
+		// Use RoverMission constructor.,  
+		super(description, MissionType.MINING, (MissionMember) members.toArray()[0], rover, MINING_SITE);
 		
 		// Initialize data members.
 		this.miningSite = miningSite;
 		miningSite.setReserved(true);
 		excavatedMinerals = new HashMap<>(1);
 		totalExcavatedMinerals = new HashMap<>(1);
+		setEVAEquipment(EquipmentType.LARGE_BAG, NUMBER_OF_LARGE_BAGS);
 
 		addMembers(members, false);
 
@@ -238,37 +233,6 @@ public class Mining extends RoverMission
 		return result;
 	}
 
-	@Override
-	protected boolean determineNewPhase() {
-		boolean handled = true;
-		if (!super.determineNewPhase()) {
-			if (TRAVELLING.equals(getPhase())) {
-				if (isCurrentNavpointSettlement()) {
-					startDisembarkingPhase();
-				}
-				else {
-					setPhase(MINING_SITE, getCurrentNavpointDescription());
-				}
-			} 
-			
-			else if (MINING_SITE.equals(getPhase())) {
-				startTravellingPhase();
-			} 
-			else {
-				handled = false;
-			}
-		}
-		return handled;
-	}
-
-	@Override
-	protected void performPhase(MissionMember member) {
-		super.performPhase(member);
-		if (MINING_SITE.equals(getPhase())) {
-			miningPhase(member);
-		}
-	}
-
 
 	@Override
 	protected void performEmbarkFromSettlementPhase(MissionMember member) {
@@ -340,113 +304,61 @@ public class Mining extends RoverMission
 	}
 
 	/**
-	 * Perform the mining phase.
-	 * 
-	 * @param member the mission member performing the mining phase.
-	 * @throws MissionException if error performing the mining phase.
+	 * Perform the EVA
 	 */
-	private void miningPhase(MissionMember member) {
-
+	@Override
+	protected boolean performEVA(Person person) {
 		// Detach towed light utility vehicle if necessary.
 		if (getRover().getTowedVehicle() != null) {
 			getRover().setTowedVehicle(null);
 			luv.setTowingVehicle(null);
 		}
 
-		// Check if crew has been at site for more than three sols.
-		boolean timeExpired = getPhaseDuration() >= MINING_SITE_TIME;
-
-        if (isEveryoneInRover()) {
-
-			// Check if end mining flag is set.
-			if (endMiningSite) {
-				endMiningSite = false;
-				setPhaseEnded(true);
+		// Determine if no one can start the mine site or collect resources tasks.
+		boolean nobodyMineOrCollect = true;
+		for(MissionMember tempMember : getMembers()) {
+			if (MineSite.canMineSite(tempMember, getRover())) {
+				nobodyMineOrCollect = false;
 			}
-
-			// Check if crew has been at site for more than three sols, then end this phase.
-			if (timeExpired) {
-				setPhaseEnded(true);
-			}
-
-			// Determine if no one can start the mine site or collect resources tasks.
-			boolean nobodyMineOrCollect = true;
-			Iterator<MissionMember> j = getMembers().iterator();
-			while (j.hasNext()) {
-				MissionMember tempMember = j.next();
-				if (MineSite.canMineSite(tempMember, getRover())) {
-					nobodyMineOrCollect = false;
-				}
-				if (canCollectExcavatedMinerals(tempMember)) {
-					nobodyMineOrCollect = false;
-				}
-			}
-
-			// If no one can mine minerals at the site or is low light level (except in dark polar region)
-			// night time, end the mining phase.
-			boolean inDarkPolarRegion = surfaceFeatures.inDarkPolarRegion(getCurrentMissionLocation());
-			double sunlight = surfaceFeatures.getSolarIrradiance(getCurrentMissionLocation());
-			if (nobodyMineOrCollect 
-					|| ((sunlight < 12) && !inDarkPolarRegion)) {
-				setPhaseEnded(true);
-			}
-
-			// Anyone in the crew or a single person at the home settlement has a dangerous
-			// illness, end phase.
-			if (hasEmergency()) {
-				setPhaseEnded(true);
-			}
-
-			// Check if enough resources for remaining trip. false = not using margin.
-			if (!hasEnoughResourcesForRemainingMission(false)) {
-				// If not, determine an emergency destination.
-				determineEmergencyDestination(member);
-				setPhaseEnded(true);
-			}
-		} else {
-			// If mining time has expired for the site, have everyone end their
-			// mining and collection tasks.
-			if (timeExpired) {
-				Iterator<MissionMember> i = getMembers().iterator();
-				while (i.hasNext()) {
-					MissionMember tempMember = i.next();
-					if (member.getUnitType() == UnitType.PERSON) {
-						Person tempPerson = (Person) tempMember;
-
-						Task task = tempPerson.getMind().getTaskManager().getTask();
-						if (task instanceof MineSite) {
-							((MineSite) task).endEVA();
-						}
-						if (task instanceof CollectMinedMinerals) {
-							((CollectMinedMinerals) task).endEVA();
-						}
-					}
-				}
+			if (canCollectExcavatedMinerals(tempMember)) {
+				nobodyMineOrCollect = false;
 			}
 		}
 
-		if (!getPhaseEnded()) {
-			// 75% chance of assigning task, otherwise allow break.
-			if (RandomUtil.lessThanRandPercent(75D)
-				// If mining is still needed at site, assign tasks.
-				&& !endMiningSite && !timeExpired
-				// If person can collect minerals the site, start that task.
-				&& canCollectExcavatedMinerals(member)
-				&& member.getUnitType() == UnitType.PERSON) {
-					Person person = (Person) member;
-					AmountResource mineralToCollect = getMineralToCollect(person);
-					assignTask(person, new CollectMinedMinerals(person, getRover(), mineralToCollect));
-			}
-		} else {
-			// Mark site as mined.
-			miningSite.setMined(true);
-
-			// Attach light utility vehicle for towing.
-			getRover().setTowedVehicle(luv);
-			luv.setTowingVehicle(getRover());
+		// Nobody can do anything so stop
+		if (nobodyMineOrCollect) {
+			return false;
 		}
+
+		// 75% chance of assigning task, otherwise allow break.
+		if (canCollectExcavatedMinerals(person)) {
+			AmountResource mineralToCollect = getMineralToCollect(person);
+			assignTask(person, new CollectMinedMinerals(person, getRover(), mineralToCollect));
+		}
+		else {
+			assignTask(person, new MineSite(person, miningSite.getLocation(), getRover(), luv));
+		}
+
+		return true;
 	}
 
+
+	/**
+	 * Close down the mining activities
+	 */
+	protected void endEVATasks() {
+		super.endEVATasks();
+
+		// Mark site as mined.
+		miningSite.setMined(true);
+
+		// Attach light utility vehicle for towing.
+		Rover rover = getRover();
+		if (!luv.equals(rover.getTowedVehicle())) {
+			rover.setTowedVehicle(luv);
+			luv.setTowingVehicle(rover);
+		}
+	}
 
 	/**
 	 * Checks if a person can collect minerals from the excavation pile.
@@ -493,22 +405,6 @@ public class Mining extends RoverMission
 		}
 
 		return result;
-	}
-
-	/**
-	 * Ends mining at a site.
-	 */
-	@Override
-	public void abortPhase() {
-		if (MINING_SITE.equals(getPhase())) {
-
-			logger.log(Level.INFO, "Mining site phase ended due to external trigger.");
-			endMiningSite = true;
-
-			endAllEVA();
-		}
-		else
-			super.abortPhase();
 	}
 
 	/**
@@ -585,64 +481,6 @@ public class Mining extends RoverMission
 		}
 			
 		result = Math.min(100, result);
-		return result;
-	}
-
-	@Override
-	protected Map<Integer, Integer> getEquipmentNeededForRemainingMission(boolean useBuffer) {
-		Map<Integer, Integer> result = new HashMap<>();
-
-		// Include required number of bags.
-		result.put(EquipmentType.getResourceID(EquipmentType.LARGE_BAG), NUMBER_OF_LARGE_BAGS);
-
-		return result;
-	}
-
-	@Override
-	public Settlement getAssociatedSettlement() {
-		return getStartingSettlement();
-	}
-
-	@Override
-	protected double getEstimatedRemainingMissionTime(boolean useBuffer) {
-		double result = super.getEstimatedRemainingMissionTime(useBuffer);
-		result += getEstimatedRemainingMiningSiteTime();
-		return result;
-	}
-
-	/**
-	 * Gets the estimated time remaining at mining site in the mission.
-	 * 
-	 * @return time (millisols)
-	 */
-	private double getEstimatedRemainingMiningSiteTime() {
-		double result = 0D;
-
-		// Use estimated remaining mining time at site if still there.
-		if (MINING_SITE.equals(getPhase())) {
-			double remainingTime = MINING_SITE_TIME - getPhaseDuration();
-			if (remainingTime > 0D) {
-				result = remainingTime;
-			}
-		} else {
-			// If mission hasn't reached mining site yet, use estimated mining site time.
-			result = MINING_SITE_TIME;
-		}
-
-		return result;
-	}
-
-	@Override
-	protected Map<Integer, Number> getResourcesNeededForRemainingMission(boolean useBuffer) {
-		Map<Integer, Number> result = super.getResourcesNeededForRemainingMission(useBuffer);
-
-		double miningSiteTime = getEstimatedRemainingMiningSiteTime();
-		double timeSols = miningSiteTime / 1000D;
-
-		int crewNum = getPeopleNumber();
-
-		// Determine life support supplies needed for mining activity.
-		addLifeSupportResources(result, crewNum, timeSols, useBuffer);
 		return result;
 	}
 
@@ -777,23 +615,6 @@ public class Mining extends RoverMission
 	}
 
 	@Override
-	protected Map<Integer, Number> getSparePartsForTrip(double distance) {
-		// Load the standard parts from VehicleMission.
-		Map<Integer, Number> result = super.getSparePartsForTrip(distance);
-
-		// Determine repair parts for EVA Suits.
-		double evaTime = getEstimatedRemainingMiningSiteTime();
-		double numberAccidents = evaTime * getPeopleNumber() * EVAOperation.BASE_ACCIDENT_CHANCE;
-
-		// Assume the average number malfunctions per accident is 1.5.
-		double numberMalfunctions = numberAccidents * VehicleMission.AVERAGE_EVA_MALFUNCTION;
-
-		result.putAll(super.getEVASparePartsForTrip(numberMalfunctions));
-
-		return result;
-	}
-	
-	@Override
 	protected Set<JobType> getPreferredPersonJobs() {
 		return PREFERRED_JOBS;
 	}
@@ -817,5 +638,10 @@ public class Mining extends RoverMission
 	@Override
 	public double getTotalSiteScore(Settlement reviewerSettlement) {
 		return getMiningSiteValue(miningSite, reviewerSettlement);
+	}
+
+	@Override
+	protected double getEstimatedTimeAtEVASite(boolean buffer) {
+		return MINING_SITE_TIME;
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mission.java
@@ -739,6 +739,7 @@ public abstract class Mission implements Serializable, Temporal {
 
 	/**
 	 * End all EVA Operations
+	 * @deprecated
 	 */
 	protected void endAllEVA() {
 		// End each member's EVA task.

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mission.java
@@ -40,7 +40,6 @@ import org.mars_sim.msp.core.person.ShiftType;
 import org.mars_sim.msp.core.person.ai.NaturalAttributeType;
 import org.mars_sim.msp.core.person.ai.job.JobType;
 import org.mars_sim.msp.core.person.ai.social.RelationshipUtil;
-import org.mars_sim.msp.core.person.ai.task.EVAOperation;
 import org.mars_sim.msp.core.person.ai.task.utils.Task;
 import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.robot.ai.job.RobotJob;
@@ -735,25 +734,6 @@ public abstract class Mission implements Serializable, Temporal {
 	 */
 	public void abortMission() {
 		// Normal mission can not be aborted
-	}
-
-	/**
-	 * End all EVA Operations
-	 * @deprecated
-	 */
-	protected void endAllEVA() {
-		// End each member's EVA task.
-		Iterator<MissionMember> i = getMembers().iterator();
-		while (i.hasNext()) {
-			MissionMember member = i.next();
-			if (member instanceof Person) {
-				Person person = (Person) member;
-				Task task = person.getMind().getTaskManager().getTask();
-				if (task instanceof EVAOperation) {
-					((EVAOperation) task).endEVA();
-				}
-			}
-		}
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/NavPoint.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/NavPoint.java
@@ -36,7 +36,7 @@ public class NavPoint implements Serializable {
 	public NavPoint(Coordinates location, String description) {
 		if (location == null)
 			throw new IllegalArgumentException("location is null");
-		this.location = new Coordinates(location);
+		this.location = location;
 		this.description = description;
 	}
 
@@ -47,10 +47,12 @@ public class NavPoint implements Serializable {
 	 * @param settlement  the settlement at the navpoint.
 	 * @param description the navpoint description.
 	 */
-	public NavPoint(Coordinates location, Settlement settlement, String description) {
-		this(location, description);
+	public NavPoint(Settlement settlement) {
 		if (settlement == null)
 			throw new IllegalArgumentException("settlement is null");
+
+		this.location = settlement.getCoordinates();
+		this.description = settlement.getName();
 		this.settlement = settlement;
 	}
 
@@ -60,7 +62,7 @@ public class NavPoint implements Serializable {
 	 * @return the coordinate location.
 	 */
 	public Coordinates getLocation() {
-		return new Coordinates(location);
+		return location;
 	}
 
 	/**
@@ -119,6 +121,11 @@ public class NavPoint implements Serializable {
 		return location.hashCode();
 	}
 	
+	@Override
+	public String toString() {
+		return description + " @ " + location.getCoordinateString();
+	}
+
 	/**
 	 * Prepare object for garbage collection.
 	 */

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/NavPoint.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/NavPoint.java
@@ -116,7 +116,7 @@ public class NavPoint implements Serializable {
 	 * @return hash code.
 	 */
 	public int hashCode() {
-		return getLocation().hashCode() * settlement.hashCode();
+		return location.hashCode();
 	}
 	
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RescueSalvageVehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RescueSalvageVehicle.java
@@ -7,7 +7,6 @@
 
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -51,7 +50,7 @@ import org.mars_sim.msp.core.vehicle.Vehicle;
  * the vehicle back if the crew is disable or dead and (4) salvaging the vehicle
  * if it's beyond repair.
  */
-public class RescueSalvageVehicle extends RoverMission implements Serializable {
+public class RescueSalvageVehicle extends RoverMission {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
@@ -62,9 +61,6 @@ public class RescueSalvageVehicle extends RoverMission implements Serializable {
 	/** Default description. */
 	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.rescueSalvageVehicle"); //$NON-NLS-1$
 
-	/** Mission Type enum. */
-	public static final MissionType MISSION_TYPE = MissionType.RESCUE_SALVAGE_VEHICLE;
-	
 	// Static members
 	public static final int MIN_STAYING_MEMBERS = 1;
 	private static final int MIN_GOING_MEMBERS = 2;
@@ -88,11 +84,11 @@ public class RescueSalvageVehicle extends RoverMission implements Serializable {
 	 */
 	public RescueSalvageVehicle(Person startingPerson) {
 		// Use RoverMission constructor
-		super(DEFAULT_DESCRIPTION, MISSION_TYPE, startingPerson);
+		super(DEFAULT_DESCRIPTION, MissionType.RESCUE_SALVAGE_VEHICLE, startingPerson, null);
 
 		if (!isDone()) {			
 			if (vehicleTarget == null)
-				vehicleTarget = findBeaconVehicle(getStartingSettlement(), getVehicle().getRange(MISSION_TYPE));
+				vehicleTarget = findBeaconVehicle(getStartingSettlement(), getVehicle().getRange(MissionType.RESCUE_SALVAGE_VEHICLE));
 
 			if (vehicleTarget != null) {
 //					if (getRescuePeopleNum(vehicleTarget) > 0) {
@@ -140,7 +136,7 @@ public class RescueSalvageVehicle extends RoverMission implements Serializable {
 			Rover rover, String description) {
 
 		// Use RoverMission constructor.
-		super(description, MISSION_TYPE, (MissionMember) members.toArray()[0], rover);
+		super(description, MissionType.RESCUE_SALVAGE_VEHICLE, (MissionMember) members.toArray()[0], rover);
 
 		this.vehicleTarget = vehicleTarget;
 
@@ -664,7 +660,7 @@ public class RescueSalvageVehicle extends RoverMission implements Serializable {
 						while (iV.hasNext() && result) {
 							Vehicle vehicle = iV.next();
 							if (vehicle instanceof Rover) {
-								if (vehicle.getRange(MISSION_TYPE) >= (settlementDistance * 2D)) {
+								if (vehicle.getRange(MissionType.RESCUE_SALVAGE_VEHICLE) >= (settlementDistance * 2D)) {
 									result = false;
 								}
 							}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RoverMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RoverMission.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.mars_sim.msp.core.Coordinates;
 import org.mars_sim.msp.core.InventoryUtil;
 import org.mars_sim.msp.core.LocalAreaUtil;
 import org.mars_sim.msp.core.LocalPosition;
@@ -67,7 +68,7 @@ public abstract class RoverMission extends VehicleMission {
 	public static final int MIN_STAYING_MEMBERS = 1;
 	public static final int MIN_GOING_MEMBERS = 2;
 	
-	public static final double FUEL_CELL_FACTOR = .5;
+	public static final double FUEL_CELL_FACTOR = 1D; //.5;
 
 	/** Comparison to indicate a small but non-zero amount of fuel (methane) in kg that can still work on the fuel cell to propel the engine. */
     public static final double LEAST_AMOUNT = GroundVehicle.LEAST_AMOUNT;
@@ -1151,9 +1152,10 @@ public abstract class RoverMission extends VehicleMission {
 	 * @return
 	 */
 	protected boolean isEnoughSunlightForEVA() {
-		//return false;
-		boolean inDarkPolarRegion = surfaceFeatures.inDarkPolarRegion(getCurrentMissionLocation());
-		double sunlight = surfaceFeatures.getSolarIrradiance(getCurrentMissionLocation());
+		//return true;
+		Coordinates locn = getCurrentMissionLocation();
+		boolean inDarkPolarRegion = surfaceFeatures.inDarkPolarRegion(locn);
+		double sunlight = surfaceFeatures.getSolarIrradiance(locn);
 		return (sunlight >= 20D && !inDarkPolarRegion);
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RoverMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RoverMission.java
@@ -88,20 +88,6 @@ public abstract class RoverMission extends VehicleMission {
 	private static final double EXTRA_EVA_SUIT_FACTOR = .2;
 
 	/**
-	 * Constructor 1.
-	 *
-	 * @param name           the name of the mission.
-	 * @param startingMember the mission member starting the mission.
-	 */
-	protected RoverMission(String name, MissionType missionType, MissionMember startingMember) {
-		// Use VehicleMission constructor.
-		super(name, missionType, startingMember);
-		if (!isDone()) {
-			calculateMissionCapacity(getRover().getCrewCapacity());
-		}
-	}
-
-	/**
 	 * Constructor with min people and rover. Initiated by MissionDataBean.
 	 *
 	 * @param missionName    the name of the mission.

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Trade.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Trade.java
@@ -6,7 +6,6 @@
  */
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -39,7 +38,7 @@ import org.mars_sim.msp.core.vehicle.Vehicle;
 /**
  * A mission for trading between two settlements. TODO externalize strings
  */
-public class Trade extends RoverMission implements Serializable {
+public class Trade extends RoverMission {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
@@ -49,9 +48,6 @@ public class Trade extends RoverMission implements Serializable {
 
 	/** Default description. */
 	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.trade"); //$NON-NLS-1$
-
-	/** Mission Type enum. */
-	private static final MissionType MISSION_TYPE = MissionType.TRADE;
 
 	/** Mission phases. */
 	private static final MissionPhase TRADE_DISEMBARKING = new MissionPhase("Mission.phase.tradeDisembarking");
@@ -90,7 +86,7 @@ public class Trade extends RoverMission implements Serializable {
 	 */
 	public Trade(MissionMember startingMember) {
 		// Use RoverMission constructor.
-		super(DEFAULT_DESCRIPTION, MISSION_TYPE, startingMember);
+		super(DEFAULT_DESCRIPTION, MissionType.TRADE, startingMember, null);
 
 		// Problem setting up the mission
 		if (isDone()) {
@@ -174,7 +170,7 @@ public class Trade extends RoverMission implements Serializable {
 	public Trade(Collection<MissionMember> members, Settlement tradingSettlement,
 			Rover rover, String description, Map<Good, Integer> sellGoods, Map<Good, Integer> buyGoods) {
 		// Use RoverMission constructor.
-		super(description, MISSION_TYPE, (MissionMember) members.toArray()[0], rover);
+		super(description, MissionType.TRADE, (MissionMember) members.toArray()[0], rover);
 
 		outbound = true;
 		doNegotiation = false;
@@ -735,9 +731,9 @@ public class Trade extends RoverMission implements Serializable {
 
 			// Vehicle with superior range should be ranked higher.
 			if (result == 0) {
-				if (firstVehicle.getRange(MISSION_TYPE) > secondVehicle.getRange(MISSION_TYPE)) {
+				if (firstVehicle.getRange(MissionType.TRADE) > secondVehicle.getRange(MissionType.TRADE)) {
 					result = 1;
-				} else if (firstVehicle.getRange(MISSION_TYPE) < secondVehicle.getRange(MISSION_TYPE)) {
+				} else if (firstVehicle.getRange(MissionType.TRADE) < secondVehicle.getRange(MissionType.TRADE)) {
 					result = -1;
 				}
 			}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Trade.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Trade.java
@@ -373,13 +373,8 @@ public class Trade extends RoverMission {
 		if (getPhaseEnded()) {
 			outbound = false;
 			resetToReturnTrip(
-					new NavPoint(tradingSettlement.getCoordinates(),
-							tradingSettlement,
-							tradingSettlement.getName()),
-
-					new NavPoint(getStartingSettlement().getCoordinates(),
-								getStartingSettlement(),
-								getStartingSettlement().getName()));
+					new NavPoint(tradingSettlement),
+					new NavPoint(getStartingSettlement()));
 
 			TRADE_PROFIT_CACHE.remove(getStartingSettlement());
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/TravelToSettlement.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/TravelToSettlement.java
@@ -7,7 +7,6 @@
 
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -31,7 +30,7 @@ import org.mars_sim.msp.core.vehicle.Vehicle;
  * another randomly selected one within range of an available rover. TODO
  * externalize strings
  */
-public class TravelToSettlement extends RoverMission implements Serializable {
+public class TravelToSettlement extends RoverMission {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
@@ -41,9 +40,6 @@ public class TravelToSettlement extends RoverMission implements Serializable {
 
 	/** Default description. */
 	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.travelToSettlement"); //$NON-NLS-1$
-
-	/** Mission Type enum. */
-	private static final MissionType MISSION_TYPE = MissionType.TRAVEL_TO_SETTLEMENT;
 	
 	// Static members
 	public static final double BASE_MISSION_WEIGHT = 1D;
@@ -68,7 +64,7 @@ public class TravelToSettlement extends RoverMission implements Serializable {
 	 */
 	public TravelToSettlement(MissionMember startingMember) {
 		// Use RoverMission constructor
-		super(DEFAULT_DESCRIPTION, MISSION_TYPE, startingMember);
+		super(DEFAULT_DESCRIPTION, MissionType.TRAVEL_TO_SETTLEMENT, startingMember, null);
 
 		Settlement s = getStartingSettlement();
 
@@ -114,7 +110,7 @@ public class TravelToSettlement extends RoverMission implements Serializable {
 	public TravelToSettlement(Collection<MissionMember> members, 
 			Settlement destinationSettlement, Rover rover, String description) {
 		// Use RoverMission constructor.
-		super(description, MISSION_TYPE, (MissionMember) members.toArray()[0], rover);
+		super(description, MissionType.TRAVEL_TO_SETTLEMENT, (MissionMember) members.toArray()[0], rover);
 
 		// Set mission destination.
 		setDestinationSettlement(destinationSettlement);
@@ -182,7 +178,7 @@ public class TravelToSettlement extends RoverMission implements Serializable {
 	 */
 	private Settlement getRandomDestinationSettlement(MissionMember member, Settlement startingSettlement) {
 
-		double range = getVehicle().getRange(MISSION_TYPE);
+		double range = getVehicle().getRange(MissionType.TRAVEL_TO_SETTLEMENT);
 		Settlement result = null;
 
 		// Find all desirable destination settlements.
@@ -412,9 +408,9 @@ public class TravelToSettlement extends RoverMission implements Serializable {
 
 			// Vehicle with superior range should be ranked higher.
 			if (result == 0) {
-				if (firstVehicle.getRange(MISSION_TYPE) > secondVehicle.getRange(MISSION_TYPE)) {
+				if (firstVehicle.getRange(MissionType.TRAVEL_TO_SETTLEMENT) > secondVehicle.getRange(MissionType.TRAVEL_TO_SETTLEMENT)) {
 					result = 1;
-				} else if (firstVehicle.getRange(MISSION_TYPE) < secondVehicle.getRange(MISSION_TYPE)) {
+				} else if (firstVehicle.getRange(MissionType.TRAVEL_TO_SETTLEMENT) < secondVehicle.getRange(MissionType.TRAVEL_TO_SETTLEMENT)) {
 					result = -1;
 				}
 			}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/VehicleMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/VehicleMission.java
@@ -145,22 +145,6 @@ public abstract class VehicleMission extends Mission implements UnitListener {
 	private List<NavPoint> navPoints = new ArrayList<>();
 		
 	/**
-	 * Constructor 1. Started by RoverMission or DroneMission constructor 1.
-	 *
-	 * @param missionName
-	 * @param startingMember
-	 * @param minPeople
-	 * @deprecated use {@link #VehicleMission(String, MissionType, MissionMember, Vehicle)}
-	 */
-	protected VehicleMission(String missionName, MissionType missionType, MissionMember startingMember) {
-		super(missionName, missionType, startingMember);
-
-		init(startingMember);
-
-		reserveVehicle();
-	}
-
-	/**
 	 * Create a Vehicle mission
 	 *
 	 * @param missionName
@@ -1052,19 +1036,6 @@ public abstract class VehicleMission extends Mission implements UnitListener {
 			// Must use the same logic in all cases otherwise too few fuel will be loaded
 			amount = getFuelNeededForTrip(vehicle, distance, 
 							vehicle.getEstimatedFuelEconomy(), useMargin);
-			// if (getPhase() == null || getPhase().equals(VehicleMission.EMBARKING) 
-			// 		|| getPhase().equals(VehicleMission.REVIEWING)
-			// 		|| useMargin) {
-			// 	amount = getFuelNeededForTrip(vehicle, distance, 
-			// 				vehicle.getEstimatedFuelEconomy(), true);
-			// 	// Use margin only when estimating how much fuel needed before starting the mission
-			// }
-			// else {
-			// 	// If the Vehicle is already on the road then the margin should be false
-			// 	// Take an average of the initial fuel economy and  the
-			// 	amount = getFuelNeededForTrip(vehicle, distance, 
-			// 				(vehicle.getEstimatedFuelEconomy() + vehicle.getInitialFuelEconomy()) / 2, useMargin);
-			// }
 
 			result.put(vehicle.getFuelType(), amount);
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/VehicleMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/VehicleMission.java
@@ -150,6 +150,7 @@ public abstract class VehicleMission extends Mission implements UnitListener {
 	 * @param missionName
 	 * @param startingMember
 	 * @param minPeople
+	 * @deprecated use {@link #VehicleMission(String, MissionType, MissionMember, Vehicle)}
 	 */
 	protected VehicleMission(String missionName, MissionType missionType, MissionMember startingMember) {
 		super(missionName, missionType, startingMember);
@@ -160,12 +161,12 @@ public abstract class VehicleMission extends Mission implements UnitListener {
 	}
 
 	/**
-	 * Constructor 2. Manually initiated by player.
+	 * Create a Vehicle mission
 	 *
 	 * @param missionName
 	 * @param startingMember
 	 * @param minPeople
-	 * @param vehicle
+	 * @param vehicle Optional, if null then reserve a Vehicle
 	 */
 	protected VehicleMission(String missionName, MissionType missionType, MissionMember startingMember, Vehicle vehicle) {
 		super(missionName, missionType, startingMember);
@@ -173,7 +174,12 @@ public abstract class VehicleMission extends Mission implements UnitListener {
 		init(startingMember);
 
 		// Set the vehicle.
-		setVehicle(vehicle);
+		if (vehicle != null) {
+			setVehicle(vehicle);
+		}
+		else {
+			reserveVehicle();
+		}
 	}
 
 	/**
@@ -1043,19 +1049,22 @@ public abstract class VehicleMission extends Mission implements UnitListener {
 		if (vehicle != null) {
 			double amount = 0;
 
-			if (getPhase() == null || getPhase().equals(VehicleMission.EMBARKING) 
-					|| getPhase().equals(VehicleMission.REVIEWING)
-					|| useMargin) {
-				amount = getFuelNeededForTrip(vehicle, distance, 
-							vehicle.getEstimatedFuelEconomy(), true);
-				// Use margin only when estimating how much fuel needed before starting the mission
-			}
-			else {
-				amount = getFuelNeededForTrip(vehicle, distance, 
-							(vehicle.getEstimatedFuelEconomy() + vehicle.getInitialFuelEconomy()) / FE_FACTOR, false);
-				// When the vehicle is already on the road, do NOT use margin
-				// or else it would constantly complain not having enough fuel
-			}
+			// Must use the same logic in all cases otherwise too few fuel will be loaded
+			amount = getFuelNeededForTrip(vehicle, distance, 
+							vehicle.getEstimatedFuelEconomy(), useMargin);
+			// if (getPhase() == null || getPhase().equals(VehicleMission.EMBARKING) 
+			// 		|| getPhase().equals(VehicleMission.REVIEWING)
+			// 		|| useMargin) {
+			// 	amount = getFuelNeededForTrip(vehicle, distance, 
+			// 				vehicle.getEstimatedFuelEconomy(), true);
+			// 	// Use margin only when estimating how much fuel needed before starting the mission
+			// }
+			// else {
+			// 	// If the Vehicle is already on the road then the margin should be false
+			// 	// Take an average of the initial fuel economy and  the
+			// 	amount = getFuelNeededForTrip(vehicle, distance, 
+			// 				(vehicle.getEstimatedFuelEconomy() + vehicle.getInitialFuelEconomy()) / 2, useMargin);
+			// }
 
 			result.put(vehicle.getFuelType(), amount);
 
@@ -1683,7 +1692,7 @@ public abstract class VehicleMission extends Mission implements UnitListener {
 	 */
 	@Override
 	public Settlement getAssociatedSettlement() {
-		return vehicle.getAssociatedSettlement();
+		return startingSettlement;
 	}
 
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/RescueSalvageVehicleMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/RescueSalvageVehicleMeta.java
@@ -49,10 +49,10 @@ public class RescueSalvageVehicleMeta extends AbstractMetaMission {
 
             // Check if there are any beacon vehicles within range that need help.
             try {
-                Vehicle vehicle = RoverMission.getVehicleWithGreatestRange(RescueSalvageVehicle.MISSION_TYPE, settlement, true);
+                Vehicle vehicle = RoverMission.getVehicleWithGreatestRange(MissionType.RESCUE_SALVAGE_VEHICLE, settlement, true);
                 if (vehicle != null) {
                     vehicleTarget = RescueSalvageVehicle.findBeaconVehicle(settlement,
-                            vehicle.getRange(RescueSalvageVehicle.MISSION_TYPE));
+                            vehicle.getRange(MissionType.RESCUE_SALVAGE_VEHICLE));
                     if (vehicle == vehicleTarget)
                         return 0;
                     else if (vehicleTarget == null)

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/MissionWindow.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/MissionWindow.java
@@ -189,12 +189,12 @@ public class MissionWindow extends ToolWindow {
 						if (mission != null) mission.abortMission();
 					}
 				});
-//		missionList.addListSelectionListener(
-//				new ListSelectionListener() {
-//					public void valueChanged(ListSelectionEvent e) {
-//						abortButton.setEnabled(missionList.getSelectedValue() != null);
-//					}
-//				});
+		missionList.addListSelectionListener(
+				new ListSelectionListener() {
+					public void valueChanged(ListSelectionEvent e) {
+						abortButton.setEnabled(missionList.getSelectedValue() != null);
+					}
+				});
 
 		buttonPane.add(abortButton);
 

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/edit/InfoPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/edit/InfoPanel.java
@@ -240,7 +240,7 @@ public class InfoPanel extends JPanel {
 		// Check if continue action can be added.
 		if (phase.equals(CollectResourcesMission.COLLECT_RESOURCES)) {
 			CollectResourcesMission collectResourcesMission = (CollectResourcesMission) mission;
-			if (collectResourcesMission.getNumCollectionSites() > collectResourcesMission.getNumCollectionSitesVisited())
+			if (collectResourcesMission.getNumEVASites() > collectResourcesMission.getNumEVASitesVisited())
 				actions.add(ACTION_CONTINUE);
 		}
 		


### PR DESCRIPTION
The mission abort was not working correctly because the EVA parts were not correctly aborted leaving People still outside. 

This PR adds a new ```EVAMIssion``` to consolidate the EVA logic when on a Mission. This provides an abort action that correctly waits for everyone to return 

close #547