### PR TITLE
Create Mission command

### DIFF
--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/MissionSummaryCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/MissionSummaryCommand.java
@@ -35,7 +35,7 @@ public class MissionSummaryCommand extends ChatCommand {
 		
 		StructuredResponse response = new StructuredResponse();
 		response.appendTableHeading("Name",  24,
-									"Phase", 18,
+									"Phase", 20,
 									"Vehicle", CommandHelper.PERSON_WIDTH,
 									"Settlement", CommandHelper.PERSON_WIDTH);
 		for(Mission m : mgr.getMissions()) {
@@ -46,7 +46,7 @@ public class MissionSummaryCommand extends ChatCommand {
 				vName = (v != null ? v.getName() : "");
 			}
 			if (showAll || !m.isDone()) {
-				response.appendTableRow(m.getTypeID(),
+				response.appendTableRow(m.getName(),
 										m.getPhase().getName(),
 										vName,
 										m.getAssociatedSettlement());

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/MissionCreateCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/MissionCreateCommand.java
@@ -1,0 +1,77 @@
+/*
+ * Mars Simulation Project
+ * MissionCommand.java
+ * @date 2022-06-11
+ * @author Barry Evans
+ */
+
+package org.mars.sim.console.chat.simcommand.settlement;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.mars.sim.console.chat.ChatCommand;
+import org.mars.sim.console.chat.Conversation;
+import org.mars.sim.console.chat.simcommand.CommandHelper;
+import org.mars_sim.msp.core.person.Person;
+import org.mars_sim.msp.core.person.ai.mission.Mission;
+import org.mars_sim.msp.core.person.ai.mission.meta.MetaMission;
+import org.mars_sim.msp.core.person.ai.mission.meta.MetaMissionUtil;
+import org.mars_sim.msp.core.structure.Settlement;
+
+public class MissionCreateCommand extends AbstractSettlementCommand {
+	public static final ChatCommand MISSION = new MissionCreateCommand();
+
+	private MissionCreateCommand() {
+		super("cm", "create mission", "Create a Mission");
+	}
+
+	@Override
+	protected boolean execute(Conversation context, String input, Settlement settlement) {
+
+		// Get the user to select the Mission
+		List<MetaMission> missions = MetaMissionUtil.getMetaMissions().stream()
+						.filter(m -> settlement.isMissionEnable(m.getType()))
+						.collect(Collectors.toList());
+		List<String> names = missions.stream().map(MetaMission::getName).collect(Collectors.toList());				
+		int choice = CommandHelper.getOptionInput(context, names, "Pick a mission from above by entering a number");
+		if (choice < 0) {
+			return false;
+		}
+		MetaMission choosen = missions.get(choice);
+
+		// Select leader
+		List<Person> leaders = settlement.getAllAssociatedPeople().stream()
+								.filter(p -> p.getMission() == null && p.isInSettlement())
+								.collect(Collectors.toList());
+		
+		// Create name and the suitability
+		List<String> pNames = leaders.stream()
+								.map(p -> p.getName() + ", suitability "
+										+ (choosen.getLeaderSuitability(p) > 0.5D ? "high" : "low"))
+								.collect(Collectors.toList());
+		int leaderNum = CommandHelper.getOptionInput(context, pNames, "Pick a leader from above by entering a number");
+		if (leaderNum < 0) {
+			return false;
+		}
+		Person leader = leaders.get(leaderNum);
+
+		// Confirmation
+		context.println("Create a " + choosen.getName() + " Mission with leader " + leader.getName());
+		String confirmation = context.getInput("Y/N");
+		if ("Y".equals(confirmation)) {
+			// Create without a review
+			Mission newMission = choosen.constructInstance(leader, false);
+			if (newMission.isDone()) {
+				context.println("Mission failed to start " + newMission.getMissionStatus());
+			}
+			else {
+				context.println("Create Mission " + newMission.getTypeID());
+				context.getSim().getMissionManager().addMission(newMission);
+			}
+		}
+
+		return true;
+	}
+
+}

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/SettlementChat.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/SettlementChat.java
@@ -41,6 +41,7 @@ public class SettlementChat extends ConnectedUnitCommand {
 																	MealCommand.MEALS,
 																	MissionNowCommand.MISSION_NOW,
 																	MissionRadiusCommand.RADIUS,
+																	MissionCreateCommand.MISSION,
 																	PeopleCommand.PEOPLE,
 																	LevelCommand.LEVEL,
 																	TradeCommand.TRADE,

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AreologyFieldStudy.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AreologyFieldStudy.java
@@ -6,11 +6,9 @@
  */
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.io.Serializable;
 import java.util.Collection;
 
 import org.mars_sim.msp.core.Coordinates;
-import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.task.AreologyStudyFieldWork;
 import org.mars_sim.msp.core.person.ai.task.utils.Task;
@@ -22,13 +20,10 @@ import org.mars_sim.msp.core.vehicle.Rover;
  * A mission to do areology research at a remote field location for a scientific
  * study.
  */
-public class AreologyFieldStudy extends FieldStudyMission implements Serializable {
+public class AreologyFieldStudy extends FieldStudyMission {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
-
-	/** Default description. */
-	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.areologyFieldStudy"); //$NON-NLS-1$
 
 	/** Amount of time to field a site. */
 	private static final double FIELD_SITE_TIME = 1000D;
@@ -41,7 +36,7 @@ public class AreologyFieldStudy extends FieldStudyMission implements Serializabl
 	 * @throws MissionException if problem constructing mission.
 	 */
 	public AreologyFieldStudy(Person startingPerson, boolean needsReview) {
-		super(DEFAULT_DESCRIPTION, MissionType.AREOLOGY, startingPerson, ScienceType.AREOLOGY, FIELD_SITE_TIME, needsReview);
+		super(MissionType.AREOLOGY, startingPerson, ScienceType.AREOLOGY, FIELD_SITE_TIME, needsReview);
 	}
 
 	/**
@@ -52,13 +47,12 @@ public class AreologyFieldStudy extends FieldStudyMission implements Serializabl
 	 * @param study              the scientific study.
 	 * @param rover              the rover used by the mission.
 	 * @param fieldSite          the field site to research.
-	 * @param description        the mission description.
 	 * @throws MissionException if error creating mission.
 	 */
 	public AreologyFieldStudy(Collection<MissionMember> members, Person leadResearcher,
-			ScientificStudy study, Rover rover, Coordinates fieldSite, String description) {
+			ScientificStudy study, Rover rover, Coordinates fieldSite) {
 
-		super(description, MissionType.AREOLOGY, leadResearcher, rover,
+		super(MissionType.AREOLOGY, leadResearcher, rover,
 			  study, FIELD_SITE_TIME, members, fieldSite);
 	}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AreologyFieldStudy.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AreologyFieldStudy.java
@@ -37,10 +37,11 @@ public class AreologyFieldStudy extends FieldStudyMission implements Serializabl
 	 * Constructor.
 	 * 
 	 * @param startingPerson {@link Person} the person starting the mission.
+	 * @param needsReview
 	 * @throws MissionException if problem constructing mission.
 	 */
-	public AreologyFieldStudy(Person startingPerson) {
-		super(DEFAULT_DESCRIPTION, MissionType.AREOLOGY, startingPerson, ScienceType.AREOLOGY, FIELD_SITE_TIME);
+	public AreologyFieldStudy(Person startingPerson, boolean needsReview) {
+		super(DEFAULT_DESCRIPTION, MissionType.AREOLOGY, startingPerson, ScienceType.AREOLOGY, FIELD_SITE_TIME, needsReview);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BiologyFieldStudy.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BiologyFieldStudy.java
@@ -6,11 +6,9 @@
  */
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.io.Serializable;
 import java.util.Collection;
 
 import org.mars_sim.msp.core.Coordinates;
-import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.task.BiologyStudyFieldWork;
 import org.mars_sim.msp.core.person.ai.task.utils.Task;
@@ -20,19 +18,15 @@ import org.mars_sim.msp.core.vehicle.Rover;
 
 /**
  * A mission to do biology research at a remote field location for a scientific
- * study. TODO externalize strings
+ * study. 
  */
-public class BiologyFieldStudy extends FieldStudyMission implements Serializable {
+public class BiologyFieldStudy extends FieldStudyMission {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
 
-	/** Default description. */
-	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.biologyFieldStudy"); //$NON-NLS-1$
-
 	/** Amount of time to field a site. */
 	public static final double FIELD_SITE_TIME = 1000D;
-
 
 	/**
 	 * Constructor.
@@ -41,7 +35,7 @@ public class BiologyFieldStudy extends FieldStudyMission implements Serializable
 	 * @throws MissionException if problem constructing mission.
 	 */
 	public BiologyFieldStudy(Person startingPerson, boolean needsReview) {
-		super(DEFAULT_DESCRIPTION, MissionType.BIOLOGY, startingPerson,
+		super(MissionType.BIOLOGY, startingPerson,
 			  ScienceType.BIOLOGY, FIELD_SITE_TIME, needsReview);
 
 	}
@@ -54,11 +48,10 @@ public class BiologyFieldStudy extends FieldStudyMission implements Serializable
 	 * @param study              the scientific study.
 	 * @param rover              the rover used by the mission.
 	 * @param fieldSite          the field site to research.
-	 * @param description        the mission description.
 	 */
 	public BiologyFieldStudy(Collection<MissionMember> members, Person leadResearcher,
-			ScientificStudy study, Rover rover, Coordinates fieldSite, String description) {
-		super(description, MissionType.BIOLOGY, leadResearcher, rover,
+			ScientificStudy study, Rover rover, Coordinates fieldSite) {
+		super(MissionType.BIOLOGY, leadResearcher, rover,
 				  study, FIELD_SITE_TIME, members, fieldSite);
 	}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BiologyFieldStudy.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BiologyFieldStudy.java
@@ -40,9 +40,9 @@ public class BiologyFieldStudy extends FieldStudyMission implements Serializable
 	 * @param startingPerson {@link Person} the person starting the mission.
 	 * @throws MissionException if problem constructing mission.
 	 */
-	public BiologyFieldStudy(Person startingPerson) {
+	public BiologyFieldStudy(Person startingPerson, boolean needsReview) {
 		super(DEFAULT_DESCRIPTION, MissionType.BIOLOGY, startingPerson,
-			  ScienceType.BIOLOGY, FIELD_SITE_TIME);
+			  ScienceType.BIOLOGY, FIELD_SITE_TIME, needsReview);
 
 	}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingConstructionMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingConstructionMission.java
@@ -151,10 +151,10 @@ public class BuildingConstructionMission extends Mission implements Serializable
 
 		if (!isDone()) {
 			// Set initial mission phase.
-//			if (sim.getUseGUI()) {
-//				setPhase(SELECT_SITE_PHASE, settlement.getName());
-//			}
-//			else {
+			if (site == null) {
+				endMission(MissionStatus.CONSTRUCTION_SITE_NOT_FOUND_OR_CREATED);
+			}
+			else {
 				// Reserve construction vehicles.
 				reserveConstructionVehicles();
 				// Retrieve construction LUV attachment parts.
@@ -234,6 +234,7 @@ public class BuildingConstructionMission extends Mission implements Serializable
 				else {
 					logger.warning(settlement, "New construction stage could not be determined.");
 					endMission(MissionStatus.NEW_CONSTRUCTION_STAGE_NOT_DETERMINED);
+					return;
 				}
 
 				initCase1Step2(site, info, skill, values);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingConstructionMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingConstructionMission.java
@@ -160,7 +160,7 @@ public class BuildingConstructionMission extends Mission implements Serializable
 				// Retrieve construction LUV attachment parts.
 				retrieveConstructionLUVParts();
 				setPhase(PREPARE_SITE_PHASE, settlement.getName());
-//			}
+			}
 		}
 
 	}
@@ -273,7 +273,8 @@ public class BuildingConstructionMission extends Mission implements Serializable
 			if (stage != null) {
 				site.setUndergoingConstruction(true);
 			}
-		} else {
+		}
+		else {
 			endMission(MissionStatus.CONSTRUCTION_SITE_NOT_FOUND_OR_CREATED);
 		}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingConstructionMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingConstructionMission.java
@@ -8,7 +8,6 @@ package org.mars_sim.msp.core.person.ai.mission;
 
 import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -59,17 +58,13 @@ import org.mars_sim.msp.core.vehicle.VehicleType;
  * Mission for construction a stage for a settlement building. TODO externalize
  * strings
  */
-public class BuildingConstructionMission extends Mission implements Serializable {
+public class BuildingConstructionMission extends Mission {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
 
 	/** default logger. */
 	private static final SimLogger logger = SimLogger.getLogger(BuildingConstructionMission.class.getName());
-
-		
-	/** Default description. */
-	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.buildingConstructionMission"); //$NON-NLS-1$
 
 	/** Mission Type enum. */
 	public static final MissionType missionType = MissionType.BUILDING_CONSTRUCTION;
@@ -123,7 +118,7 @@ public class BuildingConstructionMission extends Mission implements Serializable
 	 */
 	public BuildingConstructionMission(MissionMember startingMember) {
 		// Use Mission constructor.
-		super(DEFAULT_DESCRIPTION, missionType, startingMember);
+		super(missionType, startingMember);
 
 
 		if (!isDone()) {
@@ -305,7 +300,7 @@ public class BuildingConstructionMission extends Mission implements Serializable
 			List<GroundVehicle> vehicles) {
 
 		// Use Mission constructor.
-		super(DEFAULT_DESCRIPTION, missionType, (MissionMember) members.toArray()[0]);
+		super(missionType, (MissionMember) members.toArray()[0]);
 
 		// this.site = no_site;
 		this.members = members;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingSalvageMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingSalvageMission.java
@@ -6,7 +6,6 @@
  */
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -46,16 +45,13 @@ import org.mars_sim.msp.core.vehicle.Vehicle;
 /**s
  * Mission for salvaging a construction stage at a building construction site.
  */
-public class BuildingSalvageMission extends Mission implements Serializable {
+public class BuildingSalvageMission extends Mission {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
 
 	/** default logger. */
 	private static final Logger logger = Logger.getLogger(BuildingSalvageMission.class.getName());
-	
-	/** Default description. */
-	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.buildingSalvageMission"); //$NON-NLS-1$
 
 	/** Mission Type enum. */
 	public static final MissionType missionType = MissionType.BUILDING_SALVAGE;
@@ -94,7 +90,7 @@ public class BuildingSalvageMission extends Mission implements Serializable {
 	 */
 	public BuildingSalvageMission(MissionMember startingMember) {
 		// Use Mission constructor.
-		super(DEFAULT_DESCRIPTION, missionType, startingMember);
+		super(missionType, startingMember);
 
 		// Set wear condition to 100% by default.
 		wearCondition = 100D;
@@ -198,7 +194,7 @@ public class BuildingSalvageMission extends Mission implements Serializable {
 			ConstructionSite site, List<GroundVehicle> vehicles) {
 
 		// Use Mission constructor.
-		super(DEFAULT_DESCRIPTION, missionType, (MissionMember) members.toArray()[0]);
+		super(missionType, (MissionMember) members.toArray()[0]);
 
 		this.settlement = settlement;
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectIce.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectIce.java
@@ -43,12 +43,13 @@ public class CollectIce extends CollectResourcesMission {
 	 * Constructor
 	 *
 	 * @param startingPerson the person starting the mission.
+	 * @param needsReview
 	 * @throws MissionException if problem constructing mission.
 	 */
-	public CollectIce(Person startingPerson) {
+	public CollectIce(Person startingPerson, boolean needsReview) {
 		// Use CollectResourcesMission constructor.
 		super(DEFAULT_DESCRIPTION, MissionType.COLLECT_ICE, startingPerson, ResourceUtil.iceID,
-				EquipmentType.BARREL, REQUIRED_BARRELS, NUM_SITES);
+				EquipmentType.BARREL, REQUIRED_BARRELS, NUM_SITES, needsReview);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectIce.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectIce.java
@@ -10,7 +10,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.mars_sim.msp.core.Coordinates;
-import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.environment.TerrainElevation;
 import org.mars_sim.msp.core.equipment.EquipmentType;
 import org.mars_sim.msp.core.person.Person;
@@ -27,9 +26,6 @@ public class CollectIce extends CollectResourcesMission {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
-
-	/** Default description. */
-	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.collectIce"); //$NON-NLS-1$
 
 	/** Number of barrels required for the mission. */
 	public static final int REQUIRED_BARRELS = 20;
@@ -48,7 +44,7 @@ public class CollectIce extends CollectResourcesMission {
 	 */
 	public CollectIce(Person startingPerson, boolean needsReview) {
 		// Use CollectResourcesMission constructor.
-		super(DEFAULT_DESCRIPTION, MissionType.COLLECT_ICE, startingPerson, ResourceUtil.iceID,
+		super(MissionType.COLLECT_ICE, startingPerson, ResourceUtil.iceID,
 				EquipmentType.BARREL, REQUIRED_BARRELS, NUM_SITES, needsReview);
 	}
 
@@ -58,13 +54,12 @@ public class CollectIce extends CollectResourcesMission {
 	 * @param members            collection of mission members.
 	 * @param iceCollectionSites the sites to collect ice.
 	 * @param rover              the rover to use.
-	 * @param description        the mission's description.
 	 */
 	public CollectIce(Collection<MissionMember> members,
-			List<Coordinates> iceCollectionSites, Rover rover, String description) {
+			List<Coordinates> iceCollectionSites, Rover rover) {
 
 		// Use CollectResourcesMission constructor.
-		super(description, MissionType.COLLECT_ICE, members, ResourceUtil.iceID,
+		super(MissionType.COLLECT_ICE, members, ResourceUtil.iceID,
 				EquipmentType.BARREL, REQUIRED_BARRELS,
 				rover, iceCollectionSites);
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectRegolith.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectRegolith.java
@@ -11,7 +11,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.mars_sim.msp.core.Coordinates;
-import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.environment.TerrainElevation;
 import org.mars_sim.msp.core.equipment.EquipmentType;
 import org.mars_sim.msp.core.person.Person;
@@ -29,9 +28,6 @@ public class CollectRegolith extends CollectResourcesMission {
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
 
-	/** Default description. */
-	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.collectRegolith"); //$NON-NLS-1$
-
 	/** Number of large bags required for the mission. */
 	public static final int REQUIRED_LARGE_BAGS = 20;
 
@@ -48,7 +44,7 @@ public class CollectRegolith extends CollectResourcesMission {
 	 */
 	public CollectRegolith(Person startingPerson, boolean needsReview) {
 		// Use CollectResourcesMission constructor.
-		super(DEFAULT_DESCRIPTION, MissionType.COLLECT_REGOLITH, startingPerson, ResourceUtil.regolithID,
+		super(MissionType.COLLECT_REGOLITH, startingPerson, ResourceUtil.regolithID,
 				EquipmentType.LARGE_BAG, REQUIRED_LARGE_BAGS, NUM_SITES, needsReview);
 	}
 
@@ -58,14 +54,13 @@ public class CollectRegolith extends CollectResourcesMission {
 	 * @param members                 collection of mission members.
 	 * @param regolithCollectionSites the sites to collect regolith.
 	 * @param rover                   the rover to use.
-	 * @param description             the mission's description.
 	 * @throws MissionException if error constructing mission.
 	 */
 	public CollectRegolith(Collection<MissionMember> members,
-			List<Coordinates> regolithCollectionSites, Rover rover, String description) {
+			List<Coordinates> regolithCollectionSites, Rover rover) {
 
 		// Use CollectResourcesMission constructor.
-		super(description, MissionType.COLLECT_REGOLITH, members, ResourceUtil.regolithID,
+		super(MissionType.COLLECT_REGOLITH, members, ResourceUtil.regolithID,
 				EquipmentType.LARGE_BAG, REQUIRED_LARGE_BAGS,
 				rover, regolithCollectionSites);
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectRegolith.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectRegolith.java
@@ -43,12 +43,13 @@ public class CollectRegolith extends CollectResourcesMission {
 	 * Constructor.
 	 *
 	 * @param startingPerson the person starting the mission.
+	 * @param needsReview Needs to be reviewed
 	 * @throws MissionException if problem constructing mission.
 	 */
-	public CollectRegolith(Person startingPerson) {
+	public CollectRegolith(Person startingPerson, boolean needsReview) {
 		// Use CollectResourcesMission constructor.
 		super(DEFAULT_DESCRIPTION, MissionType.COLLECT_REGOLITH, startingPerson, ResourceUtil.regolithID,
-				EquipmentType.LARGE_BAG, REQUIRED_LARGE_BAGS, NUM_SITES);
+				EquipmentType.LARGE_BAG, REQUIRED_LARGE_BAGS, NUM_SITES, needsReview);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectResourcesMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectResourcesMission.java
@@ -77,7 +77,6 @@ public abstract class CollectResourcesMission extends EVAMission
 	/**
 	 * Constructor
 	 *
-	 * @param missionName            The name of the mission.
 	 * @param startingPerson         The person starting the mission.
 	 * @param resourceID           The type of resource.
 	 * @param containerID          The type of container needed for the mission or
@@ -89,11 +88,11 @@ public abstract class CollectResourcesMission extends EVAMission
 	 * @param minPeople              The mimimum number of people for the mission.
 	 * @throws MissionException if problem constructing mission.
 	 */
-	protected CollectResourcesMission(String missionName, MissionType missionType, Person startingPerson, int resourceID,
+	protected CollectResourcesMission(MissionType missionType, Person startingPerson, int resourceID,
 			EquipmentType containerID, int containerNum, int numSites, boolean needsReview) {
 
 		// Use RoverMission constructor
-		super(missionName, missionType, startingPerson, null, COLLECT_RESOURCES);
+		super(missionType, startingPerson, null, COLLECT_RESOURCES);
 
 		// Problem starting mission
 		if (isDone()) {
@@ -129,7 +128,7 @@ public abstract class CollectResourcesMission extends EVAMission
 				if (timeRange < range)
 					range = timeRange;
 				if (range <= 0D) {
-					logger.warning(getVehicle(), "Has zero range for mission " + missionName);
+					logger.warning(getVehicle(), "Has zero range for mission " + getName());
 					endMission(MissionStatus.NO_AVAILABLE_VEHICLES);
 					return;
 				}
@@ -144,12 +143,12 @@ public abstract class CollectResourcesMission extends EVAMission
 					if (!isValidScore(totalSiteScore)) {
 						totalSiteScore = 0;
 						unorderedSites = null;
-						logger.warning(startingPerson, missionName + " attempt another collection site find");
+						logger.warning(startingPerson, getName() + " attempt another collection site find");
 					}
 
 					// Mission might be aborted at determine site step
 					if (isDone()) {
-						logger.warning(startingPerson, missionName + " site searched & mission aborted");
+						logger.warning(startingPerson, getName() + " site searched & mission aborted");
 						return;
 					}
 				}
@@ -175,20 +174,13 @@ public abstract class CollectResourcesMission extends EVAMission
 		}
 
 		if (!isDone()) {
-			if (needsReview) {
-				// Set initial mission phase.
-				setPhase(REVIEWING, null);
-			}
-			else {
-				setPhase(EMBARKING, s.getName());
-			}
+			setInitialPhase(needsReview);
 		}
 	}
 
 	/**
 	 * Constructor with explicit data
 	 *
-	 * @param missionName            The name of the mission.
 	 * @param members                collection of mission members
 	 * @param resourceID           The type of resource.
 	 * @param containerID          The type of container needed for the mission or
@@ -199,12 +191,12 @@ public abstract class CollectResourcesMission extends EVAMission
 	 * @param rover                  the rover to use.
 	 * @param collectionSites     the sites to collect ice.
 	 */
-	protected CollectResourcesMission(String missionName, MissionType missionType, Collection<MissionMember> members,
+	protected CollectResourcesMission(MissionType missionType, Collection<MissionMember> members,
 			Integer resourceID, EquipmentType containerID,
 			int containerNum, Rover rover, List<Coordinates> collectionSites) {
 
 		// Use RoverMission constructor
-		super(missionName, missionType, (MissionMember) members.toArray()[0], rover, COLLECT_RESOURCES);
+		super(missionType, (MissionMember) members.toArray()[0], rover, COLLECT_RESOURCES);
 
 		this.resourceID = resourceID;
 		double containerCap = ContainerUtil.getContainerCapacity(containerID);
@@ -223,12 +215,12 @@ public abstract class CollectResourcesMission extends EVAMission
 		// Add mission members.
 		addMembers(members, false);
 
-		// Set initial mission phase.
-		setPhase(EMBARKING, s.getName());
-
 		// Check if vehicle can carry enough supplies for the mission.
 		if (hasVehicle() && !isVehicleLoadable()) {
 			endMission(MissionStatus.CANNOT_LOAD_RESOURCES);
+		}
+		else {
+			setInitialPhase(false);
 		}
 	}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectResourcesMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectResourcesMission.java
@@ -85,11 +85,12 @@ public abstract class CollectResourcesMission extends EVAMission
 	 * @param containerNum           The number of containers needed for the
 	 *                               mission.
 	 * @param numSites               The number of collection sites.
+	 * @param needsReview
 	 * @param minPeople              The mimimum number of people for the mission.
 	 * @throws MissionException if problem constructing mission.
 	 */
 	protected CollectResourcesMission(String missionName, MissionType missionType, Person startingPerson, int resourceID,
-			EquipmentType containerID, int containerNum, int numSites) {
+			EquipmentType containerID, int containerNum, int numSites, boolean needsReview) {
 
 		// Use RoverMission constructor
 		super(missionName, missionType, startingPerson, null, COLLECT_RESOURCES);
@@ -174,8 +175,13 @@ public abstract class CollectResourcesMission extends EVAMission
 		}
 
 		if (!isDone()) {
-			// Set initial mission phase.
-			setPhase(REVIEWING, null);
+			if (needsReview) {
+				// Set initial mission phase.
+				setPhase(REVIEWING, null);
+			}
+			else {
+				setPhase(EMBARKING, s.getName());
+			}
 		}
 	}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Delivery.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Delivery.java
@@ -11,9 +11,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.logging.Level;
 
-import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.equipment.EVASuit;
 import org.mars_sim.msp.core.goods.CommerceMission;
 import org.mars_sim.msp.core.goods.CommerceUtil;
@@ -41,9 +39,6 @@ public class Delivery extends DroneMission implements CommerceMission {
 
 	/** default logger. */
 	private static final SimLogger logger = SimLogger.getLogger(Delivery.class.getName());
-
-	/** Default description. */
-	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.delivery"); //$NON-NLS-1$
 
 	/** Mission phases. */
 	private static final MissionPhase TRADE_DISEMBARKING = new MissionPhase("Mission.phase.deliveryDisembarking");
@@ -77,7 +72,7 @@ public class Delivery extends DroneMission implements CommerceMission {
 	 */
 	public Delivery(MissionMember startingMember, boolean needsReview) {
 		// Use DroneMission constructor.
-		super(DEFAULT_DESCRIPTION, MissionType.DELIVERY, startingMember, null);
+		super(MissionType.DELIVERY, startingMember, null);
 
 		// Problem starting Mission
 		if (isDone()) {
@@ -106,16 +101,16 @@ public class Delivery extends DroneMission implements CommerceMission {
 				desiredBuyLoad = deal.getBuyingLoad();
 				sellLoad = deal.getSellingLoad();
 				desiredProfit = deal.getProfit();
+			
+				// Recruit additional members to mission.
+				recruitMembersForMission(startingMember, true, 2);
 			}
 
-			// Recruit additional members to mission.
-			if (!isDone() && !recruitMembersForMission(startingMember, true, 2)) {
-				return;
+			if (!isDone()) {
+				// Set initial phase
+				setInitialPhase(needsReview);
 			}
 		}
-
-		// Set initial phase
-		setInitialPhase(needsReview);
 	}
 
 	/**
@@ -129,9 +124,9 @@ public class Delivery extends DroneMission implements CommerceMission {
 	 * @param buyGoods
 	 */
 	public Delivery(MissionMember startingMember, Collection<MissionMember> members, Settlement tradingSettlement,
-			Drone drone, String description, Map<Good, Integer> sellGoods, Map<Good, Integer> buyGoods) {
+			Drone drone, Map<Good, Integer> sellGoods, Map<Good, Integer> buyGoods) {
 		// Use DroneMission constructor.
-		super(description, MissionType.DELIVERY, startingMember, drone);
+		super(MissionType.DELIVERY, startingMember, drone);
 
 		outbound = true;
 		doNegotiation = false;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Delivery.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Delivery.java
@@ -75,7 +75,7 @@ public class Delivery extends DroneMission implements CommerceMission {
 	 *
 	 * @param startingMember the mission member starting the settlement.
 	 */
-	public Delivery(MissionMember startingMember) {
+	public Delivery(MissionMember startingMember, boolean needsReview) {
 		// Use DroneMission constructor.
 		super(DEFAULT_DESCRIPTION, MissionType.DELIVERY, startingMember, null);
 
@@ -115,12 +115,7 @@ public class Delivery extends DroneMission implements CommerceMission {
 		}
 
 		// Set initial phase
-		setPhase(VehicleMission.REVIEWING, null);
-		if (logger.isLoggable(Level.INFO)) {
-			if (startingMember != null && getDrone() != null) {
-				logger.info(startingMember, "Starting Delivery mission on " + getDrone().getName() + ".");
-			}
-		}
+		setInitialPhase(needsReview);
 	}
 
 	/**
@@ -160,12 +155,7 @@ public class Delivery extends DroneMission implements CommerceMission {
 		desiredProfit = profit;
 
 		// Set initial phase
-		setPhase(EMBARKING, getStartingSettlement().getName());
-		if (logger.isLoggable(Level.INFO)) {
-			if (startingMember != null && getDrone() != null) {
-				logger.info(startingMember, "Starting Delivery mission on " + getDrone().getName() + ".");
-			}
-		}
+		setInitialPhase(false);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/DroneMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/DroneMission.java
@@ -41,14 +41,14 @@ public abstract class DroneMission extends VehicleMission {
 	/**
 	 * Constructor with min people and drone. Initiated by MissionDataBean.
 	 *
-	 * @param missionName    the name of the mission.
+	 * @param missionType    the type of the mission.
 	 * @param startingMember the mission member starting the mission.
 	 * @param minPeople      the minimum number of people required for mission.
 	 * @param drone          the drone to use on the mission.
 	 */
-	protected DroneMission(String missionName, MissionType missionType, MissionMember startingMember, Drone drone) {
+	protected DroneMission(MissionType missionType, MissionMember startingMember, Drone drone) {
 		// Use VehicleMission constructor.
-		super(missionName, missionType, startingMember, drone);
+		super(missionType, startingMember, drone);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/EVAMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/EVAMission.java
@@ -41,12 +41,18 @@ public abstract class EVAMission extends RoverMission {
 	private int containerID;
 	private int containerNum;
 
-    protected EVAMission(String description, MissionType missionType, 
+    protected EVAMission(MissionType missionType, 
             MissionMember startingPerson, Rover rover,
             MissionPhase evaPhase) {
-        super(description, missionType, startingPerson, rover);
+        super(missionType, startingPerson, rover);
         
         this.evaPhase = evaPhase;
+
+		// Check suit although these may be claimed before loading
+		int suits = getNumberAvailableEVASuitsAtSettlement(getStartingSettlement());
+		if (suits < getMembersNumber()) {
+			endMission(MissionStatus.EVA_SUIT_CANNOT_BE_LOADED);
+		}
     }
 
     

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/EmergencySupply.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/EmergencySupply.java
@@ -15,7 +15,6 @@ import org.mars_sim.msp.core.Coordinates;
 import org.mars_sim.msp.core.InventoryUtil;
 import org.mars_sim.msp.core.LocalAreaUtil;
 import org.mars_sim.msp.core.LocalPosition;
-import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.equipment.ContainerUtil;
 import org.mars_sim.msp.core.equipment.EVASuit;
 import org.mars_sim.msp.core.equipment.EquipmentType;
@@ -54,9 +53,6 @@ public class EmergencySupply extends RoverMission {
 	/** default logger. */
 	private static final SimLogger logger = SimLogger.getLogger(EmergencySupply.class.getName());
 
-	/** Default description. */
-	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.emergencySupply"); //$NON-NLS-1$
-
 	// Static members
 	private static final int MAX_MEMBERS = 2;
 
@@ -93,7 +89,7 @@ public class EmergencySupply extends RoverMission {
 	 */
 	public EmergencySupply(Person startingPerson, boolean needsReview) {
 		// Use RoverMission constructor.
-		super(DEFAULT_DESCRIPTION, MissionType.EMERGENCY_SUPPLY, startingPerson, null);
+		super(MissionType.EMERGENCY_SUPPLY, startingPerson, null);
 
 		if (isDone()) {
 			return;
@@ -143,12 +139,11 @@ public class EmergencySupply extends RoverMission {
 	 * @param members             collection of mission members.
 	 * @param emergencySettlement the starting settlement.
 	 * @param rover               the rover used on the mission.
-	 * @param description         the mission's description.
 	 */
 	public EmergencySupply(Collection<MissionMember> members, Settlement emergencySettlement,
-			Map<Good, Integer> emergencyGoods, Rover rover, String description) {
+			Map<Good, Integer> emergencyGoods, Rover rover) {
 		// Use RoverMission constructor.
-		super(description, MissionType.EMERGENCY_SUPPLY, (Person) members.toArray()[0], rover);
+		super(MissionType.EMERGENCY_SUPPLY, (Person) members.toArray()[0], rover);
 
 		outbound = true;
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/EmergencySupply.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/EmergencySupply.java
@@ -91,7 +91,7 @@ public class EmergencySupply extends RoverMission {
 	 *
 	 * @param startingPerson the person starting the settlement.
 	 */
-	public EmergencySupply(Person startingPerson) {
+	public EmergencySupply(Person startingPerson, boolean needsReview) {
 		// Use RoverMission constructor.
 		super(DEFAULT_DESCRIPTION, MissionType.EMERGENCY_SUPPLY, startingPerson, null);
 
@@ -127,17 +127,13 @@ public class EmergencySupply extends RoverMission {
 			} else {
 				endMission(MissionStatus.NO_SETTLEMENT_FOUND_TO_DELIVER_EMERGENCY_SUPPLIES);
 				logger.warning("No settlement could be found to deliver emergency supplies to.");
+				return;
 			}
 		}
 
 		if (s != null) {
 			// Set initial phase
-			setPhase(REVIEWING, null);
-
-			logger.info(s, startingPerson
-					+ "Reviewing an emergency supply mission to help out "
-					+ getEmergencySettlement() + " using "
-					+ getRover().getName());
+			setInitialPhase(needsReview);
 		}
 	}
 
@@ -209,14 +205,7 @@ public class EmergencySupply extends RoverMission {
 		addMembers(members, false);
 
 		// Set initial phase
-		setPhase(EMBARKING, getStartingSettlement().getName());
-		Person startingPerson = getStartingPerson();
-		if (startingPerson != null && getRover() != null) {
-			logger.info(startingPerson,
-					"Reviewing an emergency supply mission to help out "
-					+ getEmergencySettlement() + " using "
-					+ getRover().getName());
-		}
+		setInitialPhase(false);
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Exploration.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Exploration.java
@@ -49,9 +49,6 @@ public class Exploration extends EVAMission
 	/** default logger. */
 	private static SimLogger logger = SimLogger.getLogger(Exploration.class.getName());
 
-	/** Default description. */
-	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.exploration"); //$NON-NLS-1$
-
 	/** Mission Type enum. */
 	public static final MissionType MISSION_TYPE = MissionType.EXPLORATION;
 
@@ -88,7 +85,7 @@ public class Exploration extends EVAMission
 	public Exploration(Person startingPerson, boolean needsReview) {
 
 		// Use RoverMission constructor.
-		super(DEFAULT_DESCRIPTION, MISSION_TYPE, startingPerson, null,
+		super(MISSION_TYPE, startingPerson, null,
 				EXPLORE_SITE);
 
 		Settlement s = getStartingSettlement();
@@ -126,15 +123,13 @@ public class Exploration extends EVAMission
 	 * @param members            collection of mission members.
 	 * @param explorationSites   the sites to explore.
 	 * @param rover              the rover to use.
-	 * @param description        the mission's description.
 	 */
 	public Exploration(Collection<MissionMember> members,
-			List<Coordinates> explorationSites, Rover rover, String description) {
+			List<Coordinates> explorationSites, Rover rover) {
 
 		// Use RoverMission constructor.
-		super(description, MISSION_TYPE,(MissionMember) members.toArray()[0], rover,
+		super(MISSION_TYPE,(MissionMember) members.toArray()[0], rover,
 				EXPLORE_SITE);
-	
 
 		initSites(explorationSites);
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Exploration.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Exploration.java
@@ -85,7 +85,7 @@ public class Exploration extends EVAMission
 	 * @param startingPerson the person starting the mission.
 	 * @throws MissionException if problem constructing mission.
 	 */
-	public Exploration(Person startingPerson) {
+	public Exploration(Person startingPerson, boolean needsReview) {
 
 		// Use RoverMission constructor.
 		super(DEFAULT_DESCRIPTION, MISSION_TYPE, startingPerson, null,
@@ -109,16 +109,15 @@ public class Exploration extends EVAMission
 					NUM_SITES, skill);
 
 			if (explorationSites.isEmpty()) {
-					endMission(MissionStatus.NO_EXPLORATION_SITES);
+				endMission(MissionStatus.NO_EXPLORATION_SITES);
+				return;
 			}
 
 			initSites(explorationSites);
 
 			// Set initial mission phase.
-			setPhase(REVIEWING, null);
+			setInitialPhase(needsReview);
 		}
-
-		logger.fine(startingPerson, "Just finished creating an Exploration mission.");
 	}
 
 	/**
@@ -144,7 +143,7 @@ public class Exploration extends EVAMission
 			addMembers(members, false);
 
 			// Set initial mission phase.
-			setPhase(EMBARKING, getStartingSettlement().getName());
+			setInitialPhase(false);
 		}
 	}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/FieldStudyMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/FieldStudyMission.java
@@ -58,11 +58,12 @@ public abstract class FieldStudyMission extends EVAMission {
 	 * Constructor.
 	 * 
 	 * @param startingPerson {@link Person} the person starting the mission.
+	 * @param needsReview
 	 * @throws MissionException if problem constructing mission.
 	 */
 	protected FieldStudyMission(String description, MissionType missionType,
 								Person startingPerson,
-								ScienceType science, double fieldSiteTime) {
+								ScienceType science, double fieldSiteTime, boolean needsReview) {
 
 		// Use RoverMission constructor.
 		super(description, missionType, startingPerson, null, RESEARCH_SITE);
@@ -95,12 +96,12 @@ public abstract class FieldStudyMission extends EVAMission {
 			// Check if vehicle can carry enough supplies for the mission.
 			if (hasVehicle() && !isVehicleLoadable()) {
 				endMission(MissionStatus.CANNOT_LOAD_RESOURCES);
+				return;
 			}
 		}
 
-		if (s != null) {
-			// Set initial mission phase.
-			setPhase(REVIEWING, null);
+		if (!isDone()) {
+			setInitialPhase(needsReview);
 		}
 	}
 
@@ -136,13 +137,15 @@ public abstract class FieldStudyMission extends EVAMission {
 		Settlement s = getStartingSettlement();
 		addNavpoint(s);
 
-		// Set initial mission phase.
-		setPhase(EMBARKING, s.getName());
-		
+			
 		// Check if vehicle can carry enough supplies for the mission.
 		if (hasVehicle() && !isVehicleLoadable()) {
 			endMission(MissionStatus.CANNOT_LOAD_RESOURCES);
+			return;
 		}
+
+		// Set initial mission phase.
+		setInitialPhase(false);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/FieldStudyMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/FieldStudyMission.java
@@ -61,12 +61,12 @@ public abstract class FieldStudyMission extends EVAMission {
 	 * @param needsReview
 	 * @throws MissionException if problem constructing mission.
 	 */
-	protected FieldStudyMission(String description, MissionType missionType,
+	protected FieldStudyMission(MissionType missionType,
 								Person startingPerson,
 								ScienceType science, double fieldSiteTime, boolean needsReview) {
 
 		// Use RoverMission constructor.
-		super(description, missionType, startingPerson, null, RESEARCH_SITE);
+		super(missionType, startingPerson, null, RESEARCH_SITE);
 
 		this.science = science;
 		this.fieldSiteTime = fieldSiteTime;
@@ -115,14 +115,14 @@ public abstract class FieldStudyMission extends EVAMission {
 	 * @param fieldSite          the field site to research.
 	 * @param description        the mission description.
 	 */
-	protected FieldStudyMission(String description, MissionType missionType,
+	protected FieldStudyMission(MissionType missionType,
 			Person leadResearcher,
 			Rover rover, ScientificStudy study, double fieldSiteTime,
 			Collection<MissionMember> members,
 			Coordinates fieldSite) {
 
 		// Use RoverMission constructor.
-		super(description, missionType, leadResearcher, rover, RESEARCH_SITE);
+		super(missionType, leadResearcher, rover, RESEARCH_SITE);
 
 		this.study = study;
 		this.science = study.getScience();

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MeteorologyFieldStudy.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MeteorologyFieldStudy.java
@@ -42,9 +42,9 @@ public class MeteorologyFieldStudy extends FieldStudyMission {
 	 * @param startingPerson {@link Person} the person starting the mission.
 	 * @throws MissionException if problem constructing mission.
 	 */
-	public MeteorologyFieldStudy(Person startingPerson) {
+	public MeteorologyFieldStudy(Person startingPerson, boolean needsReview) {
 		super(DEFAULT_DESCRIPTION, MissionType.METEOROLOGY, startingPerson,
-			  ScienceType.METEOROLOGY, FIELD_SITE_TIME);
+			  ScienceType.METEOROLOGY, FIELD_SITE_TIME, needsReview);
 		
 		setEVAEquipment(EquipmentType.SPECIMEN_BOX,
 			  getMembersNumber() * SPECIMEN_BOX_MEMBER);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MeteorologyFieldStudy.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MeteorologyFieldStudy.java
@@ -9,7 +9,6 @@ package org.mars_sim.msp.core.person.ai.mission;
 import java.util.Collection;
 
 import org.mars_sim.msp.core.Coordinates;
-import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.equipment.EquipmentType;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.task.MeteorologyStudyFieldWork;
@@ -26,9 +25,6 @@ public class MeteorologyFieldStudy extends FieldStudyMission {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
-	
-	/** Default description. */
-	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.meteorologyFieldStudy"); //$NON-NLS-1$
 
 	/** Amount of time to field a site. */
 	public static final double FIELD_SITE_TIME = 500D;
@@ -43,7 +39,7 @@ public class MeteorologyFieldStudy extends FieldStudyMission {
 	 * @throws MissionException if problem constructing mission.
 	 */
 	public MeteorologyFieldStudy(Person startingPerson, boolean needsReview) {
-		super(DEFAULT_DESCRIPTION, MissionType.METEOROLOGY, startingPerson,
+		super(MissionType.METEOROLOGY, startingPerson,
 			  ScienceType.METEOROLOGY, FIELD_SITE_TIME, needsReview);
 		
 		setEVAEquipment(EquipmentType.SPECIMEN_BOX,
@@ -58,12 +54,11 @@ public class MeteorologyFieldStudy extends FieldStudyMission {
 	 * @param study              the scientific study.
 	 * @param rover              the rover used by the mission.
 	 * @param fieldSite          the field site to research.
-	 * @param description        the mission description.
 	 */
 	public MeteorologyFieldStudy(Collection<MissionMember> members, Person leadResearcher,
-			ScientificStudy study, Rover rover, Coordinates fieldSite, String description) {
+			ScientificStudy study, Rover rover, Coordinates fieldSite) {
 
-		super(description, MissionType.METEOROLOGY, leadResearcher, rover,
+		super(MissionType.METEOROLOGY, leadResearcher, rover,
 				  study, FIELD_SITE_TIME, members, fieldSite);
 
 		setEVAEquipment(EquipmentType.SPECIMEN_BOX,

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mining.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mining.java
@@ -86,7 +86,7 @@ public class Mining extends EVAMission
 	 * @param startingPerson the person starting the mission.
 	 * @throws MissionException if error creating mission.
 	 */
-	public Mining(Person startingPerson) {
+	public Mining(Person startingPerson, boolean needsReview) {
 
 		// Use RoverMission constructor.
 		super(DEFAULT_DESCRIPTION, MissionType.MINING, startingPerson, null, MINING_SITE);
@@ -128,12 +128,12 @@ public class Mining extends EVAMission
 				luv = reserveLightUtilityVehicle();
 				if (luv == null) {
 					endMission(MissionStatus.LUV_NOT_AVAILABLE);
+					return;
 				}
 			}
 		}
 
-		// Set initial mission phase.
-		setPhase(REVIEWING, null);
+		setInitialPhase(needsReview);
 	}
 
 	/**
@@ -181,7 +181,8 @@ public class Mining extends EVAMission
 		}
 
 		// Set initial mission phase.
-		setPhase(EMBARKING, s.getName());
+		setInitialPhase(false);
+
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mining.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mining.java
@@ -48,9 +48,6 @@ public class Mining extends EVAMission
 	/** default logger. */
 	private static SimLogger logger = SimLogger.getLogger(Mining.class.getName());
 	
-	/** Default description. */
-	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.mining");
-	
 	/** Mission phases */
 	private static final MissionPhase MINING_SITE = new MissionPhase("Mission.phase.miningSite");
 
@@ -89,7 +86,7 @@ public class Mining extends EVAMission
 	public Mining(Person startingPerson, boolean needsReview) {
 
 		// Use RoverMission constructor.
-		super(DEFAULT_DESCRIPTION, MissionType.MINING, startingPerson, null, MINING_SITE);
+		super(MissionType.MINING, startingPerson, null, MINING_SITE);
 		
 		if (!isDone()) {
 			// Initialize data members.
@@ -130,10 +127,10 @@ public class Mining extends EVAMission
 					endMission(MissionStatus.LUV_NOT_AVAILABLE);
 					return;
 				}
+				setInitialPhase(needsReview);
 			}
 		}
 
-		setInitialPhase(needsReview);
 	}
 
 	/**
@@ -145,10 +142,10 @@ public class Mining extends EVAMission
 	 * @param description        the mission's description.
 	 */
 	public Mining(Collection<MissionMember> members, ExploredLocation miningSite,
-			Rover rover, LightUtilityVehicle luv, String description) {
+			Rover rover, LightUtilityVehicle luv) {
 
 		// Use RoverMission constructor.,  
-		super(description, MissionType.MINING, (MissionMember) members.toArray()[0], rover, MINING_SITE);
+		super(MissionType.MINING, (MissionMember) members.toArray()[0], rover, MINING_SITE);
 		
 		// Initialize data members.
 		this.miningSite = miningSite;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionManager.java
@@ -316,8 +316,8 @@ public class MissionManager implements Serializable, Temporal {
 			throw new IllegalStateException(person + " could not determine a new mission.");
 		}
 
-		// Construct the mission
-		result = selectedMetaMission.constructInstance(person);
+		// Construct the mission and needs a review
+		result = selectedMetaMission.constructInstance(person, true);
 
 		return result;
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionType.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionType.java
@@ -59,12 +59,4 @@ public enum MissionType {
     	}
     	return true;
     }
-
-    public static boolean isTravelMission(MissionType missionType) {
-    	if (missionType == BUILDING_CONSTRUCTION
-    		|| missionType == BUILDING_SALVAGE) {
-    		return false;
-    	}
-    	return true;
-    }
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RescueSalvageVehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RescueSalvageVehicle.java
@@ -82,7 +82,7 @@ public class RescueSalvageVehicle extends RoverMission {
 	 * @param startingPerson the person starting the mission.
 	 * @throws MissionException if error constructing mission.
 	 */
-	public RescueSalvageVehicle(Person startingPerson) {
+	public RescueSalvageVehicle(Person startingPerson, boolean needsReview) {
 		// Use RoverMission constructor
 		super(DEFAULT_DESCRIPTION, MissionType.RESCUE_SALVAGE_VEHICLE, startingPerson, null);
 
@@ -110,13 +110,11 @@ public class RescueSalvageVehicle extends RoverMission {
 				// Check if vehicle can carry enough supplies for the mission.
 				if (hasVehicle() && !isVehicleLoadable()) {			
 					endMission(MissionStatus.CANNOT_LOAD_RESOURCES);
+					return;
 				}
 				
 				// Set initial phase
-				setPhase(VehicleMission.REVIEWING, null);
-				
-				logger.info(startingPerson, "Started a Rescue Vehicle Mission.");
-				
+				setInitialPhase(needsReview);
 			} else {
 				endMission(MissionStatus.TARGET_VEHICLE_NOT_FOUND);
 			}
@@ -152,15 +150,13 @@ public class RescueSalvageVehicle extends RoverMission {
 		// Add mission members.
 		addMembers(members, false);
 
-		// Set initial phase
-		setPhase(EMBARKING, s.getName());
-
 		// Check if vehicle can carry enough supplies for the mission.
 		if (hasVehicle() && !isVehicleLoadable()) {
 			endMission(MissionStatus.CANNOT_LOAD_RESOURCES);
 		}
-		
-		logger.info(getStartingPerson(), "Had started RescueSalvageVehicle");
+		else {
+			setInitialPhase(false);
+		}
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RescueSalvageVehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RescueSalvageVehicle.java
@@ -58,9 +58,6 @@ public class RescueSalvageVehicle extends RoverMission {
 	/** default logger. */
 	private static final SimLogger logger = SimLogger.getLogger(RescueSalvageVehicle.class.getName());
 
-	/** Default description. */
-	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.rescueSalvageVehicle"); //$NON-NLS-1$
-
 	// Static members
 	public static final int MIN_STAYING_MEMBERS = 1;
 	private static final int MIN_GOING_MEMBERS = 2;
@@ -84,7 +81,7 @@ public class RescueSalvageVehicle extends RoverMission {
 	 */
 	public RescueSalvageVehicle(Person startingPerson, boolean needsReview) {
 		// Use RoverMission constructor
-		super(DEFAULT_DESCRIPTION, MissionType.RESCUE_SALVAGE_VEHICLE, startingPerson, null);
+		super(MissionType.RESCUE_SALVAGE_VEHICLE, startingPerson, null);
 
 		if (!isDone()) {			
 			if (vehicleTarget == null)
@@ -127,14 +124,13 @@ public class RescueSalvageVehicle extends RoverMission {
 	 * @param members            collection of mission members.
 	 * @param vehicleTarget      the vehicle to rescue/salvage.
 	 * @param rover              the rover to use.
-	 * @param description        the mission's description.
 	 * @throws MissionException if error constructing mission.
 	 */
 	public RescueSalvageVehicle(Collection<MissionMember> members, Vehicle vehicleTarget,
-			Rover rover, String description) {
+			Rover rover) {
 
 		// Use RoverMission constructor.
-		super(description, MissionType.RESCUE_SALVAGE_VEHICLE, (MissionMember) members.toArray()[0], rover);
+		super(MissionType.RESCUE_SALVAGE_VEHICLE, (MissionMember) members.toArray()[0], rover);
 
 		this.vehicleTarget = vehicleTarget;
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RoverMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RoverMission.java
@@ -84,14 +84,14 @@ public abstract class RoverMission extends VehicleMission {
 	/**
 	 * Constructor with min people and rover. Initiated by MissionDataBean.
 	 *
-	 * @param missionName    the name of the mission.
+	 * @param missionType    the type of the mission.
 	 * @param startingMember the mission member starting the mission.
 	 * @param minPeople      the minimum number of people required for mission.
 	 * @param rover          the rover to use on the mission.
 	 */
-	protected RoverMission(String missionName, MissionType missionType, MissionMember startingMember, Rover rover) {
+	protected RoverMission(MissionType missionType, MissionMember startingMember, Rover rover) {
 		// Use VehicleMission constructor.
-		super(missionName, missionType, startingMember, rover);
+		super(missionType, startingMember, rover);
 		if (!isDone()) {
 			calculateMissionCapacity(getRover().getCrewCapacity());
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Trade.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Trade.java
@@ -11,12 +11,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.logging.Level;
 
 import org.mars_sim.msp.core.InventoryUtil;
 import org.mars_sim.msp.core.LocalAreaUtil;
 import org.mars_sim.msp.core.LocalPosition;
-import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.equipment.EVASuit;
 import org.mars_sim.msp.core.equipment.EquipmentType;
 import org.mars_sim.msp.core.goods.CommerceMission;
@@ -46,9 +44,6 @@ public class Trade extends RoverMission implements CommerceMission {
 
 	/** default logger. */
 	private static final SimLogger logger = SimLogger.getLogger(Trade.class.getName());
-
-	/** Default description. */
-	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.trade"); //$NON-NLS-1$
 
 	/** Mission phases. */
 	private static final MissionPhase TRADE_DISEMBARKING = new MissionPhase("Mission.phase.tradeDisembarking");
@@ -83,7 +78,7 @@ public class Trade extends RoverMission implements CommerceMission {
 	 */
 	public Trade(MissionMember startingMember, boolean needsReview) {
 		// Use RoverMission constructor.
-		super(DEFAULT_DESCRIPTION, MissionType.TRADE, startingMember, null);
+		super(MissionType.TRADE, startingMember, null);
 
 		// Problem setting up the mission
 		if (isDone()) {
@@ -135,9 +130,9 @@ public class Trade extends RoverMission implements CommerceMission {
 	 * @param buyGoods
 	 */
 	public Trade(Collection<MissionMember> members, Settlement tradingSettlement,
-			Rover rover, String description, Map<Good, Integer> sellGoods, Map<Good, Integer> buyGoods) {
+			Rover rover, Map<Good, Integer> sellGoods, Map<Good, Integer> buyGoods) {
 		// Use RoverMission constructor.
-		super(description, MissionType.TRADE, (MissionMember) members.toArray()[0], rover);
+		super(MissionType.TRADE, (MissionMember) members.toArray()[0], rover);
 
 		outbound = true;
 		doNegotiation = false;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Trade.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Trade.java
@@ -81,7 +81,7 @@ public class Trade extends RoverMission implements CommerceMission {
 	 *
 	 * @param startingMember the mission member starting the settlement.
 	 */
-	public Trade(MissionMember startingMember) {
+	public Trade(MissionMember startingMember, boolean needsReview) {
 		// Use RoverMission constructor.
 		super(DEFAULT_DESCRIPTION, MissionType.TRADE, startingMember, null);
 
@@ -120,12 +120,7 @@ public class Trade extends RoverMission implements CommerceMission {
 		}
 
 		// Set initial phase
-		setPhase(VehicleMission.REVIEWING, null);
-		if (logger.isLoggable(Level.INFO)) {
-			if (startingMember != null && getRover() != null) {
-				logger.info(startingMember, "Starting Trade mission on " + getRover().getName() + ".");
-			}
-		}
+		setInitialPhase(needsReview);
 	}
 
 	/**
@@ -167,13 +162,7 @@ public class Trade extends RoverMission implements CommerceMission {
 		desiredProfit = profit;
 
 		// Set initial phase
-		setPhase(EMBARKING, getStartingSettlement().getName());
-		if (logger.isLoggable(Level.INFO)) {
-			MissionMember startingMember = getStartingPerson();
-			if (startingMember != null && getRover() != null) {
-				logger.info(startingMember, "Starting Trade mission on " + getRover().getName() + ".");
-			}
-		}
+		setInitialPhase(false);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/TravelToSettlement.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/TravelToSettlement.java
@@ -37,9 +37,6 @@ public class TravelToSettlement extends RoverMission {
 
 	/** default logger. */
 	private static final Logger logger = Logger.getLogger(TravelToSettlement.class.getName());
-
-	/** Default description. */
-	private static final String DEFAULT_DESCRIPTION = Msg.getString("Mission.description.travelToSettlement"); //$NON-NLS-1$
 	
 	// Static members
 	public static final double BASE_MISSION_WEIGHT = 1D;
@@ -64,7 +61,7 @@ public class TravelToSettlement extends RoverMission {
 	 */
 	public TravelToSettlement(MissionMember startingMember, boolean needsReview) {
 		// Use RoverMission constructor
-		super(DEFAULT_DESCRIPTION, MissionType.TRAVEL_TO_SETTLEMENT, startingMember, null);
+		super(MissionType.TRAVEL_TO_SETTLEMENT, startingMember, null);
 
 		Settlement s = getStartingSettlement();
 
@@ -109,9 +106,9 @@ public class TravelToSettlement extends RoverMission {
 	}
 
 	public TravelToSettlement(Collection<MissionMember> members, 
-			Settlement destinationSettlement, Rover rover, String description) {
+			Settlement destinationSettlement, Rover rover) {
 		// Use RoverMission constructor.
-		super(description, MissionType.TRAVEL_TO_SETTLEMENT, (MissionMember) members.toArray()[0], rover);
+		super(MissionType.TRAVEL_TO_SETTLEMENT, (MissionMember) members.toArray()[0], rover);
 
 		// Set mission destination.
 		setDestinationSettlement(destinationSettlement);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/TravelToSettlement.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/TravelToSettlement.java
@@ -62,7 +62,7 @@ public class TravelToSettlement extends RoverMission {
 	 * 
 	 * @param startingMember the mission member starting the mission.
 	 */
-	public TravelToSettlement(MissionMember startingMember) {
+	public TravelToSettlement(MissionMember startingMember, boolean needsReview) {
 		// Use RoverMission constructor
 		super(DEFAULT_DESCRIPTION, MissionType.TRAVEL_TO_SETTLEMENT, startingMember, null);
 
@@ -100,10 +100,11 @@ public class TravelToSettlement extends RoverMission {
 			// Check if vehicle can carry enough supplies for the mission.
 			if (hasVehicle() && !isVehicleLoadable()) {
 				endMission(MissionStatus.CANNOT_LOAD_RESOURCES);
+				return;
 			}
 
 			// Set initial phase
-			setPhase(VehicleMission.REVIEWING, null);
+			setInitialPhase(needsReview);
 		}
 	}
 
@@ -119,13 +120,13 @@ public class TravelToSettlement extends RoverMission {
 		// Add mission members.
 		addMembers(members, false);
 
-		// Set initial phase
-		setPhase(EMBARKING, getStartingPerson().getName());
-
 		// Check if vehicle can carry enough supplies for the mission.
 		if (hasVehicle() && !isVehicleLoadable()) {
 			endMission(MissionStatus.CANNOT_LOAD_RESOURCES);
+			return;
 		}
+
+		setInitialPhase(false);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/VehicleMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/VehicleMission.java
@@ -191,16 +191,32 @@ public abstract class VehicleMission extends Mission implements UnitListener {
 	}
 
 	/**
+	 * Set the starting state of the mission
+	 * @return
+	 */
+	protected void setInitialPhase(boolean needsReview) {
+		if (needsReview) {
+			// Set initial mission phase.
+			setPhase(REVIEWING, null);
+		}
+		else {
+			// Set initial mission phase.
+			setPhase(EMBARKING, getStartingSettlement().getName());
+		}
+
+		MissionMember startingMember = getStartingPerson();
+		logger.info(startingMember, "Started mission " + getTypeID() + " using " + getVehicle().getName());
+	}
+
+	/**
 	 * Reserve a vehicle
 	 *
 	 * @return
 	 */
 	protected boolean reserveVehicle() {
-		MissionMember startingMember = getStartingPerson();
-		if (startingMember.getSettlement() == null)
-			return false;
 		// Reserve a vehicle.
-		if (!reserveVehicle(startingMember)) {
+		MissionMember startingMember = getStartingPerson();
+		if (startingMember.getSettlement() == null || !reserveVehicle(startingMember)) {
 			endMission(MissionStatus.NO_RESERVABLE_VEHICLES);
 			logger.warning(startingMember, "Could not reserve a vehicle for " + getTypeID() + ".");
 			return false;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/VehicleMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/VehicleMission.java
@@ -147,13 +147,13 @@ public abstract class VehicleMission extends Mission implements UnitListener {
 	/**
 	 * Create a Vehicle mission
 	 *
-	 * @param missionName
+	 * @param missionType
 	 * @param startingMember
 	 * @param minPeople
 	 * @param vehicle Optional, if null then reserve a Vehicle
 	 */
-	protected VehicleMission(String missionName, MissionType missionType, MissionMember startingMember, Vehicle vehicle) {
-		super(missionName, missionType, startingMember);
+	protected VehicleMission(MissionType missionType, MissionMember startingMember, Vehicle vehicle) {
+		super(missionType, startingMember);
 
 		init(startingMember);
 
@@ -201,11 +201,12 @@ public abstract class VehicleMission extends Mission implements UnitListener {
 		}
 		else {
 			// Set initial mission phase.
+			createFullDesignation();
 			setPhase(EMBARKING, getStartingSettlement().getName());
 		}
 
 		MissionMember startingMember = getStartingPerson();
-		logger.info(startingMember, "Started mission " + getTypeID() + " using " + getVehicle().getName());
+		logger.info(startingMember, "Started mission " + getName() + " using " + getVehicle().getName());
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/AbstractMetaMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/AbstractMetaMission.java
@@ -8,7 +8,6 @@ package org.mars_sim.msp.core.person.ai.mission.meta;
 
 import java.util.Set;
 
-import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.job.JobType;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
@@ -27,14 +26,13 @@ public class AbstractMetaMission implements MetaMission {
 	/**
 	 * Creates a new Mission meta instance
 	 * @param type 
-	 * @param nameKey This is used as a lookup in the Msg bundle to find the name.
 	 * @param preferredLeaderJob Jobs that a leader should have; null means no preference
 	 */
-	protected AbstractMetaMission(MissionType type, String nameKey, Set<JobType> preferredLeaderJob) {
+	protected AbstractMetaMission(MissionType type, Set<JobType> preferredLeaderJob) {
 		super();
 		this.type = type;
 		this.preferredLeaderJob = preferredLeaderJob;
-		this.name = Msg.getString("Mission.description." + nameKey);
+		this.name = type.getName();
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/AbstractMetaMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/AbstractMetaMission.java
@@ -48,7 +48,7 @@ public class AbstractMetaMission implements MetaMission {
 	}
 
 	@Override
-	public Mission constructInstance(Person person) {
+	public Mission constructInstance(Person person, boolean needsReview) {
 		throw new UnsupportedOperationException("Mission Meta "+ name + " does not support mission for Person.");
 	}
 
@@ -72,7 +72,8 @@ public class AbstractMetaMission implements MetaMission {
 	 * @param person
 	 * @return
 	 */
-	protected double getLeaderSuitability(Person person) {
+	@Override
+	public double getLeaderSuitability(Person person) {
 		double result = 0.25D;
 		
 		JobType jt = person.getMind().getJob();

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/AreologyFieldStudyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/AreologyFieldStudyMeta.java
@@ -21,7 +21,7 @@ import org.mars_sim.msp.core.science.ScienceType;
 public class AreologyFieldStudyMeta extends FieldStudyMeta {
 
     AreologyFieldStudyMeta() {
-		super(MissionType.AREOLOGY, "areologyFieldStudy",
+		super(MissionType.AREOLOGY, 
 				Set.of(JobType.AREOLOGIST, JobType.CHEMIST),
 				ScienceType.AREOLOGY);
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/AreologyFieldStudyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/AreologyFieldStudyMeta.java
@@ -27,7 +27,7 @@ public class AreologyFieldStudyMeta extends FieldStudyMeta {
 	}
 
     @Override
-    public Mission constructInstance(Person person) {
-        return new AreologyFieldStudy(person);
+    public Mission constructInstance(Person person, boolean needsReview) {
+        return new AreologyFieldStudy(person, needsReview);
     }
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BiologyFieldStudyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BiologyFieldStudyMeta.java
@@ -20,7 +20,7 @@ import org.mars_sim.msp.core.science.ScienceType;
  */
 public class BiologyFieldStudyMeta extends FieldStudyMeta {
     BiologyFieldStudyMeta() {
-		super(MissionType.BIOLOGY, "biologyFieldStudy",
+		super(MissionType.BIOLOGY, 
 				Set.of(JobType.BIOLOGIST, JobType.BOTANIST),
 				ScienceType.BIOLOGY);
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BiologyFieldStudyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BiologyFieldStudyMeta.java
@@ -26,7 +26,7 @@ public class BiologyFieldStudyMeta extends FieldStudyMeta {
 	}
 
     @Override
-    public Mission constructInstance(Person person) {
-        return new BiologyFieldStudy(person);
+    public Mission constructInstance(Person person, boolean needsReview) {
+        return new BiologyFieldStudy(person, needsReview);
     }
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BuildingConstructionMissionMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BuildingConstructionMissionMeta.java
@@ -39,7 +39,7 @@ public class BuildingConstructionMissionMeta extends AbstractMetaMission {
     }
     
     @Override
-    public Mission constructInstance(Person person) {
+    public Mission constructInstance(Person person, boolean needsReview) {
         return new BuildingConstructionMission(person);
     }
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BuildingConstructionMissionMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BuildingConstructionMissionMeta.java
@@ -34,8 +34,7 @@ public class BuildingConstructionMissionMeta extends AbstractMetaMission {
     private static final Logger logger = Logger.getLogger(MiningMeta.class.getName());
       
     BuildingConstructionMissionMeta() {
-    	super(MissionType.BUILDING_CONSTRUCTION, "buildingConstructionMission",
-    			Set.of(JobType.ARCHITECT));
+    	super(MissionType.BUILDING_CONSTRUCTION, Set.of(JobType.ARCHITECT));
     }
     
     @Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BuildingSalvageMissionMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BuildingSalvageMissionMeta.java
@@ -36,7 +36,7 @@ public class BuildingSalvageMissionMeta extends AbstractMetaMission {
     }
     
     @Override
-    public Mission constructInstance(Person person) {
+    public Mission constructInstance(Person person, boolean needsReview) {
         return new BuildingSalvageMission(person);
     }
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BuildingSalvageMissionMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BuildingSalvageMissionMeta.java
@@ -31,8 +31,7 @@ public class BuildingSalvageMissionMeta extends AbstractMetaMission {
     private static final Logger logger = Logger.getLogger(BuildingSalvageMissionMeta.class.getName());
 
     BuildingSalvageMissionMeta() {
-    	super(MissionType.BUILDING_SALVAGE, "buildingSalvageMission",
-    			Set.of(JobType.ARCHITECT));
+    	super(MissionType.BUILDING_SALVAGE, Set.of(JobType.ARCHITECT));
     }
     
     @Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectIceMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectIceMeta.java
@@ -26,8 +26,7 @@ public class CollectIceMeta extends AbstractMetaMission {
 	private static final double VALUE = 30D;
 
 	CollectIceMeta() {
-		super(MissionType.COLLECT_ICE, "collectIce",
-				Set.of(JobType.AREOLOGIST, JobType.CHEMIST));
+		super(MissionType.COLLECT_ICE, Set.of(JobType.AREOLOGIST, JobType.CHEMIST));
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectIceMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectIceMeta.java
@@ -31,8 +31,8 @@ public class CollectIceMeta extends AbstractMetaMission {
 	}
 
 	@Override
-	public Mission constructInstance(Person person) {
-		return new CollectIce(person);
+	public Mission constructInstance(Person person, boolean needsReview) {
+		return new CollectIce(person, needsReview);
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectRegolithMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectRegolithMeta.java
@@ -28,8 +28,7 @@ public class CollectRegolithMeta extends AbstractMetaMission {
 	public final static int MIN_STARTING_SOL = 1;
 
 	CollectRegolithMeta() {
-		super(MissionType.COLLECT_REGOLITH, "collectRegolith",
-				Set.of(JobType.AREOLOGIST, JobType.CHEMIST));
+		super(MissionType.COLLECT_REGOLITH, Set.of(JobType.AREOLOGIST, JobType.CHEMIST));
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectRegolithMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectRegolithMeta.java
@@ -33,8 +33,8 @@ public class CollectRegolithMeta extends AbstractMetaMission {
 	}
 
 	@Override
-	public Mission constructInstance(Person person) {
-		return new CollectRegolith(person);
+	public Mission constructInstance(Person person, boolean needsReview) {
+		return new CollectRegolith(person, needsReview);
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/DeliveryMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/DeliveryMeta.java
@@ -38,8 +38,8 @@ public class DeliveryMeta extends AbstractMetaMission {
 	}
 
 	@Override
-	public Mission constructInstance(Person person) {
-		return new Delivery(person);
+	public Mission constructInstance(Person person, boolean needsReview) {
+		return new Delivery(person, needsReview);
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/DeliveryMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/DeliveryMeta.java
@@ -34,7 +34,7 @@ public class DeliveryMeta extends AbstractMetaMission {
 
 	DeliveryMeta() {
 		// Everyone can start Delivery ??
-		super(MissionType.DELIVERY, "delivery", null);
+		super(MissionType.DELIVERY, null);
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/EmergencySupplyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/EmergencySupplyMeta.java
@@ -28,8 +28,8 @@ public class EmergencySupplyMeta extends AbstractMetaMission {
     }
 
     @Override
-    public Mission constructInstance(Person person) {
-        return new EmergencySupply(person);
+    public Mission constructInstance(Person person, boolean needsReview) {
+        return new EmergencySupply(person, needsReview);
     }
 
     @Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/EmergencySupplyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/EmergencySupplyMeta.java
@@ -24,7 +24,7 @@ public class EmergencySupplyMeta extends AbstractMetaMission {
     private double jobModifier;
 
 	EmergencySupplyMeta() {
-    	super(MissionType.EMERGENCY_SUPPLY, "emergencySupply", null);
+    	super(MissionType.EMERGENCY_SUPPLY,  null);
     }
 
     @Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/ExplorationMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/ExplorationMeta.java
@@ -41,8 +41,8 @@ public class ExplorationMeta extends AbstractMetaMission {
 	}
 
 	@Override
-	public Mission constructInstance(Person person) {
-		return new Exploration(person);
+	public Mission constructInstance(Person person, boolean needsReview) {
+		return new Exploration(person, needsReview);
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/ExplorationMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/ExplorationMeta.java
@@ -36,7 +36,7 @@ public class ExplorationMeta extends AbstractMetaMission {
 	private static final Logger logger = Logger.getLogger(ExplorationMeta.class.getName());
 
 	ExplorationMeta() {
-		super(MissionType.EXPLORATION, "exploration",
+		super(MissionType.EXPLORATION, 
 					Set.of(JobType.AREOLOGIST, JobType.ASTRONOMER, JobType.METEOROLOGIST));
 	}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/FieldStudyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/FieldStudyMeta.java
@@ -31,9 +31,9 @@ public class FieldStudyMeta extends AbstractMetaMission {
     private static final double WEIGHT = 10D;
 	private ScienceType science;
 
-	public FieldStudyMeta(MissionType type, String nameKey, Set<JobType> preferredLeaderJob,
+	public FieldStudyMeta(MissionType type, Set<JobType> preferredLeaderJob,
 			ScienceType science) {
-		super(type, nameKey, preferredLeaderJob);
+		super(type, preferredLeaderJob);
 		this.science = science;
 	}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/MetaMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/MetaMission.java
@@ -41,12 +41,20 @@ public interface MetaMission {
 	public String getName();
 
 	/**
+	 * Check the suitability for this Person to be the leader. It currently checks their Job
+	 * @param person
+	 * @return
+	 */
+	public double getLeaderSuitability(Person person);
+
+	/**
 	 * Constructs an instance of the associated mission.
 	 * 
 	 * @param person the person to perform the mission.
+	 * @param needsReview Mission must be reviewed
 	 * @return mission instance.
 	 */
-	public Mission constructInstance(Person person);
+	public Mission constructInstance(Person person, boolean needsReview);
 
 	public Mission constructInstance(Robot robot);
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/MeteorologyFieldStudyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/MeteorologyFieldStudyMeta.java
@@ -21,7 +21,7 @@ import org.mars_sim.msp.core.science.ScienceType;
 public class MeteorologyFieldStudyMeta extends FieldStudyMeta {
 
     MeteorologyFieldStudyMeta() {
-    	super(MissionType.METEOROLOGY, "meteorologyFieldStudy",
+    	super(MissionType.METEOROLOGY, 
     		 Set.of(JobType.METEOROLOGIST),
     		 ScienceType.METEOROLOGY);
     }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/MeteorologyFieldStudyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/MeteorologyFieldStudyMeta.java
@@ -27,7 +27,7 @@ public class MeteorologyFieldStudyMeta extends FieldStudyMeta {
     }
     
     @Override
-    public Mission constructInstance(Person person) {
-        return new MeteorologyFieldStudy(person);
+    public Mission constructInstance(Person person, boolean needsReview) {
+        return new MeteorologyFieldStudy(person, needsReview);
     }
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/MiningMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/MiningMeta.java
@@ -32,8 +32,7 @@ public class MiningMeta extends AbstractMetaMission {
     private static final Logger logger = Logger.getLogger(MiningMeta.class.getName());
 
     MiningMeta() {
-    	super(MissionType.MINING, "mining",
-    			Set.of(JobType.AREOLOGIST));
+    	super(MissionType.MINING, Set.of(JobType.AREOLOGIST));
     }
 
     @Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/MiningMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/MiningMeta.java
@@ -37,8 +37,8 @@ public class MiningMeta extends AbstractMetaMission {
     }
 
     @Override
-    public Mission constructInstance(Person person) {
-        return new Mining(person);
+    public Mission constructInstance(Person person, boolean needsReview) {
+        return new Mining(person, needsReview);
     }
 
     @Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/RescueSalvageVehicleMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/RescueSalvageVehicleMeta.java
@@ -32,8 +32,8 @@ public class RescueSalvageVehicleMeta extends AbstractMetaMission {
     }
   
     @Override
-    public Mission constructInstance(Person person) {
-        return new RescueSalvageVehicle(person);
+    public Mission constructInstance(Person person, boolean needsReview) {
+        return new RescueSalvageVehicle(person, needsReview);
     }
 
     @Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/RescueSalvageVehicleMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/RescueSalvageVehicleMeta.java
@@ -28,7 +28,7 @@ public class RescueSalvageVehicleMeta extends AbstractMetaMission {
 	private static SimLogger logger = SimLogger.getLogger(RescueSalvageVehicleMeta.class.getName());
 
     RescueSalvageVehicleMeta() {
-    	super(MissionType.RESCUE_SALVAGE_VEHICLE, "rescueSalvageVehicle", null);
+    	super(MissionType.RESCUE_SALVAGE_VEHICLE, null);
     }
   
     @Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/TradeMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/TradeMeta.java
@@ -32,7 +32,7 @@ public class TradeMeta extends AbstractMetaMission {
 
 
 	TradeMeta() {
-		super(MissionType.TRADE, "trade",
+		super(MissionType.TRADE, 
 				Set.of(JobType.POLITICIAN, JobType.TRADER, JobType.REPORTER));
 	}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/TradeMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/TradeMeta.java
@@ -37,8 +37,8 @@ public class TradeMeta extends AbstractMetaMission {
 	}
 
 	@Override
-	public Mission constructInstance(Person person) {
-		return new Trade(person);
+	public Mission constructInstance(Person person, boolean needsReview) {
+		return new Trade(person, needsReview);
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/TravelToSettlementMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/TravelToSettlementMeta.java
@@ -34,8 +34,8 @@ public class TravelToSettlementMeta extends AbstractMetaMission {
     }
     
     @Override
-    public Mission constructInstance(Person person) {
-        return new TravelToSettlement(person);
+    public Mission constructInstance(Person person, boolean needsReview) {
+        return new TravelToSettlement(person, needsReview);
     }
 
     @Override

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/TravelToSettlementMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/TravelToSettlementMeta.java
@@ -30,7 +30,7 @@ public class TravelToSettlementMeta extends AbstractMetaMission {
 
 	public TravelToSettlementMeta() {
 		// Anyone can start ??
-    	super(MissionType.TRAVEL_TO_SETTLEMENT, "travelToSettlement", null);
+    	super(MissionType.TRAVEL_TO_SETTLEMENT, null);
     }
     
     @Override

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/MainDetailPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/MainDetailPanel.java
@@ -649,7 +649,7 @@ public class MainDetailPanel extends WebPanel implements MissionListener, UnitLi
 			if (d == null || d.equals(""))
 				d = "";
 			designationLabel.setText(d);
-			typeLabel.setText(mission.getTypeID());
+			typeLabel.setText(mission.getName());
 			startingLabel.setText(mission.getStartingPerson().getName()); // $NON-NLS-1$
 	
 			String phaseText = mission.getPhaseDescription();
@@ -658,8 +658,7 @@ public class MainDetailPanel extends WebPanel implements MissionListener, UnitLi
 				phaseText = phaseText.substring(0, 48) + "...";
 			phaseLabel.setText(phaseText); // $NON-NLS-1$
 	
-			String settlementText = mission.getSettlmentName();
-			settlementLabel.setText(settlementText);
+			settlementLabel.setText(mission.getAssociatedSettlement().getName());
 	
 			logTableModel.setMission(mission);
 			memberTableModel.setMission(mission);

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/MissionDataBean.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/MissionDataBean.java
@@ -106,17 +106,17 @@ class MissionDataBean {
 	    Mission mission = null;
 	    if (MissionType.AREOLOGY == missionType) {
 	        mission = new AreologyFieldStudy(mixedMembers, leadResearcher, study,
-	                rover, fieldSite, description);
+	                rover, fieldSite);
 	    }
 	    
 	    else if (MissionType.BIOLOGY == missionType) {
 	        mission = new BiologyFieldStudy(mixedMembers, leadResearcher, study,
-	                rover, fieldSite, description);
+	                rover, fieldSite);
 	    }
 	    
 	    else if (MissionType.METEOROLOGY == missionType) {
 	        mission = new MeteorologyFieldStudy(mixedMembers, leadResearcher, study,
-	                rover, fieldSite, description);
+	                rover, fieldSite);
 	    }
 	    
 	    else if (MissionType.BUILDING_CONSTRUCTION == missionType) {
@@ -126,15 +126,15 @@ class MissionDataBean {
 	    }
 
 	    else if (MissionType.COLLECT_ICE == missionType) {
-	        List<Coordinates> collectionSites = new ArrayList<Coordinates>(1);
+	        List<Coordinates> collectionSites = new ArrayList<>(1);
 	        collectionSites.add(iceCollectionSite);
-	        mission = new CollectIce(mixedMembers, collectionSites, rover, description);
+	        mission = new CollectIce(mixedMembers, collectionSites, rover);
 	    }
 	    
 	    else if (MissionType.COLLECT_REGOLITH == missionType) {
-	        List<Coordinates> collectionSites = new ArrayList<Coordinates>(1);
+	        List<Coordinates> collectionSites = new ArrayList<>(1);
 	        collectionSites.add(regolithCollectionSite);
-	        mission = new CollectRegolith(mixedMembers, collectionSites, rover, description);
+	        mission = new CollectRegolith(mixedMembers, collectionSites, rover);
 	    }
 	    
 	    else if (MissionType.DELIVERY == missionType) {
@@ -144,27 +144,27 @@ class MissionDataBean {
 	    			startingMember = (Person)mm;
 	    	}
 		
-	        mission = new Delivery(startingMember, mixedMembers, destinationSettlement, drone, description,
+	        mission = new Delivery(startingMember, mixedMembers, destinationSettlement, drone,
 	                sellGoods, buyGoods);
 	    }	 
 	        
 	    else if (MissionType.EMERGENCY_SUPPLY == missionType) {
 	        mission = new EmergencySupply(mixedMembers, destinationSettlement,
-	                emergencyGoods, rover, description);
+	                emergencyGoods, rover);
 	    }
 	    
 	    else if (MissionType.EXPLORATION == missionType) {
 	        List<Coordinates> collectionSites = new ArrayList<>(explorationSites.length);
 	        collectionSites.addAll(Arrays.asList(explorationSites));
-	        mission = new Exploration(mixedMembers, collectionSites, rover, description);
+	        mission = new Exploration(mixedMembers, collectionSites, rover);
 	    }
 	    
 	    else if (MissionType.MINING == missionType) {
-	        mission = new Mining(mixedMembers, miningSite, rover, luv, description);
+	        mission = new Mining(mixedMembers, miningSite, rover, luv);
 	    }
 	    
 	    else if (MissionType.RESCUE_SALVAGE_VEHICLE == missionType) {
-	        mission = new RescueSalvageVehicle(mixedMembers, rescueRover, rover, description);
+	        mission = new RescueSalvageVehicle(mixedMembers, rescueRover, rover);
 	    }
 	    
 	    else if (MissionType.BUILDING_SALVAGE == missionType) {
@@ -173,17 +173,17 @@ class MissionDataBean {
 	    }
 	    
 	    else if (MissionType.TRADE == missionType) {
-	        mission = new Trade(mixedMembers, destinationSettlement, rover, description,
+	        mission = new Trade(mixedMembers, destinationSettlement, rover,
 	                sellGoods, buyGoods);
 	    }  
 	    
 	    else if (MissionType.TRAVEL_TO_SETTLEMENT == missionType) {
-	        mission = new TravelToSettlement(mixedMembers, destinationSettlement, rover,
-	                description);
+	        mission = new TravelToSettlement(mixedMembers, destinationSettlement, rover);
 	    }
 	    
 	    else throw new IllegalStateException("Mission type: " + type + " unknown");
 
+		mission.setName(description);
 	    missionManager.addMission(mission);
 	}
  

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/MissionTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/MissionTableModel.java
@@ -372,7 +372,7 @@ public class MissionTableModel extends AbstractTableModel
 					break;
 
 				case TYPE_ID: {
-					result = mission.getTypeID();//.getDescription();
+					result = mission.getName();
 				}
 					break;
 
@@ -382,11 +382,7 @@ public class MissionTableModel extends AbstractTableModel
 					break;
 
 				case PHASE: {
-					if (mission.getPlan() == null) {
-						result = "Submitting Plan";
-					}
-					else if (mission.getPhase() != null 
-							&& VehicleMission.REVIEWING.equals(mission.getPhase())) {
+					if (VehicleMission.REVIEWING.equals(mission.getPhase())) {
 						int percent = (int) mission.getPlan().getPercentComplete();
 						if (percent > 100)
 							percent = 100;


### PR DESCRIPTION
The PR delivers a new 'create mission' console command under a Settlement. The command reuses the automatic nature of the existing commands to remove the need for numerous extra details to be specified. The difference is these Mission bypass the review phase.

Secondly the assignment of Mission names is cleaned up.

#506 