### PR TITLE
Create TaskJob concept

### DIFF
--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/CommandHelper.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/CommandHelper.java
@@ -71,6 +71,7 @@ public class CommandHelper {
 	public static final String KG_FORMAT = "%.2f kg";
 	public static final String KM_FORMAT = "%.2f km";
 	public static final String PERC_FORMAT = "%.0f%%";
+	public static final String PERC1_FORMAT = "%.1f%%";
 	public static final String MILLISOL_FORMAT = "%.1f millisol";
 	public static final String KMPH_FORMAT = "%.2f km/h";
     public static final String MONEY_FORMAT = "$%,.2f";

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/unit/WorkerWorkCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/unit/WorkerWorkCommand.java
@@ -19,6 +19,7 @@ import org.mars_sim.msp.core.person.ai.task.util.MetaTask;
 import org.mars_sim.msp.core.person.ai.task.util.TaskManager;
 import org.mars_sim.msp.core.person.ai.task.util.Worker;
 import org.mars_sim.msp.core.person.ai.task.util.TaskCache;
+import org.mars_sim.msp.core.person.ai.task.util.TaskJob;
 
 /** 
  * What work in terms of Tasks is available for this Person to do
@@ -54,16 +55,11 @@ public class WorkerWorkCommand extends AbstractUnitCommand {
 		double sum = tasks.getTotal();
 		response.appendTableHeading("Task", CommandHelper.TASK_WIDTH, 
 									"P Score", 9,
-									"P %", 6,
-									"Trait", 25, 
-									"Favourite", 18);
-		for (Entry<MetaTask, Double> item : tasks.getTasks().entrySet()) {
-			MetaTask mt = item.getKey();
-			response.appendTableRow(mt.getName(), 
-									item.getValue(),
-									Math.round(item.getValue()/sum*10_000.0)/100.0,							
-									mt.getTraits(),
-									mt.getFavourites()
+									"P %", 6);
+		for (TaskJob item : tasks.getTasks()) {
+			response.appendTableRow(item.getDescription(), 
+									item.getScore(),
+									String.format(CommandHelper.PERC1_FORMAT, (100D * item.getScore())/sum)
 									);
 		}
 		

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/unit/WorkerWorkCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/unit/WorkerWorkCommand.java
@@ -7,7 +7,7 @@
 
 package org.mars.sim.console.chat.simcommand.unit;
 
-import java.util.Map.Entry;
+import java.util.List;
 
 import org.mars.sim.console.chat.Conversation;
 import org.mars.sim.console.chat.ConversationRole;
@@ -15,11 +15,10 @@ import org.mars.sim.console.chat.simcommand.CommandHelper;
 import org.mars.sim.console.chat.simcommand.StructuredResponse;
 import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.person.Person;
-import org.mars_sim.msp.core.person.ai.task.util.MetaTask;
-import org.mars_sim.msp.core.person.ai.task.util.TaskManager;
-import org.mars_sim.msp.core.person.ai.task.util.Worker;
 import org.mars_sim.msp.core.person.ai.task.util.TaskCache;
 import org.mars_sim.msp.core.person.ai.task.util.TaskJob;
+import org.mars_sim.msp.core.person.ai.task.util.TaskManager;
+import org.mars_sim.msp.core.person.ai.task.util.Worker;
 
 /** 
  * What work in terms of Tasks is available for this Person to do
@@ -50,19 +49,34 @@ public class WorkerWorkCommand extends AbstractUnitCommand {
 			response.appendLabeledString("Job", p.getMind().getJob().getName());
 			response.appendLabeledString("Favourite", p.getFavorite().getFavoriteActivity().getName());
 		}
-		
-		TaskCache tasks = tm.getLatestTaskProbability();
-		double sum = tasks.getTotal();
-		response.appendTableHeading("Task", 45, 
-									"P Score", 9,
-									"P %", 6);
-		for (TaskJob item : tasks.getTasks()) {
-			response.appendTableRow(item.getDescription(), 
-									item.getScore(),
-									String.format(CommandHelper.PERC1_FORMAT, (100D * item.getScore())/sum)
-									);
+
+		// List pending tasks first
+		List<TaskJob> pending = tm.getPendingTasks();
+		if (!pending.isEmpty()) {
+			response.appendTableHeading("Pending Task", 45, 
+							"P Score", 9);
+			for (TaskJob item : pending) {
+				response.appendTableRow(item.getDescription(), item.getScore());
+			}
+			response.appendBlankLine();
 		}
-		
+
+		TaskCache tasks = tm.getLatestTaskProbability();
+		if (tasks == null) {
+			response.append("No Tasks planned yet");
+		}
+		else {
+			double sum = tasks.getTotal();
+			response.appendTableHeading("Potential Task", 45, 
+										"P Score", 9,
+										"P %", 6);
+			for (TaskJob item : tasks.getTasks()) {
+				response.appendTableRow(item.getDescription(), 
+										item.getScore(),
+										String.format(CommandHelper.PERC1_FORMAT, (100D * item.getScore())/sum)
+										);
+			}
+		}		
 		context.println(response.getOutput());
 		return true;
 	}

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/unit/WorkerWorkCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/unit/WorkerWorkCommand.java
@@ -53,7 +53,7 @@ public class WorkerWorkCommand extends AbstractUnitCommand {
 		
 		TaskCache tasks = tm.getLatestTaskProbability();
 		double sum = tasks.getTotal();
-		response.appendTableHeading("Task", CommandHelper.TASK_WIDTH, 
+		response.appendTableHeading("Task", 45, 
 									"P Score", 9,
 									"P %", 6);
 		for (TaskJob item : tasks.getTasks()) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/Simulation.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/Simulation.java
@@ -57,7 +57,6 @@ import org.mars_sim.msp.core.person.ai.role.Role;
 import org.mars_sim.msp.core.person.ai.role.RoleUtil;
 import org.mars_sim.msp.core.person.ai.social.Relation;
 import org.mars_sim.msp.core.person.ai.task.util.MetaTaskUtil;
-import org.mars_sim.msp.core.person.ai.task.util.Task;
 import org.mars_sim.msp.core.person.ai.task.util.TaskManager;
 import org.mars_sim.msp.core.person.ai.task.util.TaskSchedule;
 import org.mars_sim.msp.core.person.health.HealthProblem;
@@ -405,11 +404,12 @@ public class Simulation implements ClockListener, Serializable {
 
 		medicalManager = new MedicalManager();
 		scientificStudyManager = new ScientificStudyManager();
+		eventManager = new HistoricalEventManager();
 
 		// Initialize units prior to starting the unit manager
 		Unit.initializeInstances(masterClock, marsClock, earthClock, this, 
 				weather, surfaceFeatures, missionManager);
-		TaskManager.initializeInstances(marsClock);
+		TaskManager.initializeInstances(this, simulationConfig);
 
 		// Initialize UnitManager instance
 		unitManager = new UnitManager();
@@ -441,7 +441,6 @@ public class Simulation implements ClockListener, Serializable {
 		// Initialize meta tasks
 		MetaTaskUtil.initializeMetaTasks();
 
-		eventManager = new HistoricalEventManager();
 		transportManager = new TransportManager(simulationConfig, this);
 
         // Initialize ManufactureUtil
@@ -467,8 +466,7 @@ public class Simulation implements ClockListener, Serializable {
 		// Set instances for classes that extend Unit and Task and Mission
 		AbstractMission.initializeInstances(this, marsClock, eventManager, unitManager,
 				surfaceFeatures, missionManager, pc);
-		Task.initializeInstances(masterClock, marsClock, eventManager, unitManager,
-				scientificStudyManager, surfaceFeatures, orbitInfo, missionManager, pc);
+
 		LocalAreaUtil.initializeInstances(unitManager, marsClock);
 		
 		doneInitializing = true;
@@ -721,7 +719,7 @@ public class Simulation implements ClockListener, Serializable {
 		PhysicalCondition.initializeInstances(this, masterClock, marsClock, medicalManager);
 		RadiationExposure.initializeInstances(masterClock, marsClock);
 		Role.initializeInstances(marsClock);
-		TaskManager.initializeInstances(marsClock);
+		TaskManager.initializeInstances(this, simulationConfig);
 		HealthProblem.initializeInstances(medicalManager, eventManager);
 
 		// Re-initialize Structure related class
@@ -739,9 +737,6 @@ public class Simulation implements ClockListener, Serializable {
 		RobotJob.initializeInstances(unitManager, missionManager);
 //		CreditEvent.initializeInstances(unitManager, missionManager);
 
-		// Re-initialize Task related class
-		Task.initializeInstances(masterClock, marsClock, eventManager, unitManager,
-				scientificStudyManager, surfaceFeatures, orbitInfo, missionManager, pc);
 		LocalAreaUtil.initializeInstances(unitManager, marsClock);
 		
 		// Re-initialize Mission related class

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/goods/AmountResourceGood.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/goods/AmountResourceGood.java
@@ -1292,7 +1292,8 @@ class AmountResourceGood extends Good {
 		else if (resource == ResourceUtil.epsomSaltID)
 			return demand * EPSOM_SALT_VALUE_MODIFIER;
 		else if (resource == ResourceUtil.soilID)
-			return demand * settlement.getCropsNeedingTending() * SOIL_VALUE_MODIFIER;
+			// TODO Should be based on growing area
+			return demand * settlement.getTotalCropArea() * SOIL_VALUE_MODIFIER;
 		else if (resource == ResourceUtil.cementID) {
 			double cementDemand = owner.getAmountDemandValue(ResourceUtil.cementID);
 			double concreteDemand = owner.getAmountDemandValue(ResourceUtil.concreteID);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/EatDrinkMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/EatDrinkMeta.java
@@ -17,6 +17,7 @@ import org.mars_sim.msp.core.person.ai.task.CookMeal;
 import org.mars_sim.msp.core.person.ai.task.EatDrink;
 import org.mars_sim.msp.core.person.ai.task.util.MetaTask;
 import org.mars_sim.msp.core.person.ai.task.util.Task;
+import org.mars_sim.msp.core.resource.ResourceUtil;
 import org.mars_sim.msp.core.structure.building.Building;
 import org.mars_sim.msp.core.structure.building.BuildingManager;
 import org.mars_sim.msp.core.structure.building.function.cooking.Cooking;
@@ -32,6 +33,9 @@ public class EatDrinkMeta extends MetaTask {
 	private static final String NAME = Msg.getString("Task.description.eatDrink"); //$NON-NLS-1$
 
 	private static final int CAP = 6_000;
+		
+	private static final int FOOD_ID = ResourceUtil.foodID;
+	private static final int WATER_ID = ResourceUtil.waterID;
 	
     public EatDrinkMeta() {
 		super(NAME, WorkerType.PERSON, TaskScope.ANY_HOUR);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/BasicTaskJob.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/BasicTaskJob.java
@@ -18,10 +18,14 @@ public class BasicTaskJob implements TaskJob {
     private static final double MAX_TASK_SCORE = 35_000;
 
     private double score;
-    private MetaTask mt;
+    private String taskName;
+
+    // MetaTask cannot be serialised
+    private transient MetaTask mt;
 
     BasicTaskJob(MetaTask metaTask, double score) {
         this.mt = metaTask;
+        this.taskName = mt.getName();
 
         if (Double.isNaN(score) || Double.isInfinite(score) || (score > MAX_TASK_SCORE)) {
             score = MAX_TASK_SCORE;
@@ -36,16 +40,31 @@ public class BasicTaskJob implements TaskJob {
 
     @Override
     public String getDescription() {
-        return mt.getName();
+        return taskName;
     }
 
+    /**
+     * Reconnects to the MetaTask even fter a deserialised instance.
+     */
+    private MetaTask getMeta() {
+        if (mt == null) {
+            mt = MetaTaskUtil.getMetaTask(taskName);
+        }
+
+        return mt;
+    }
     @Override
     public Task createTask(Person person) {
-        return mt.constructInstance(person);
+        return getMeta().constructInstance(person);
     }
 
     @Override
     public Task createTask(Robot robot) {
-        return mt.constructInstance(robot);
+        return getMeta().constructInstance(robot);
+    }
+
+    @Override
+    public String toString() {
+        return getDescription();
     }
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/BasicTaskJob.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/BasicTaskJob.java
@@ -1,0 +1,51 @@
+/*
+ * Mars Simulation Project
+ * BasicTaskJob.java
+ * @date 2022-11-04
+ * @author Barry Evans
+ */
+package org.mars_sim.msp.core.person.ai.task.util;
+
+import org.mars_sim.msp.core.person.Person;
+import org.mars_sim.msp.core.robot.Robot;
+
+/**
+ * This is an implementation of a TaskJob that delegates the Task creation to a
+ * MetaTask instance. Tasks have no extra entities defined in the creation.
+ */
+public class BasicTaskJob implements TaskJob {
+
+    private static final double MAX_TASK_SCORE = 35_000;
+
+    private double score;
+    private MetaTask mt;
+
+    BasicTaskJob(MetaTask metaTask, double score) {
+        this.mt = metaTask;
+
+        if (Double.isNaN(score) || Double.isInfinite(score) || (score > MAX_TASK_SCORE)) {
+            score = MAX_TASK_SCORE;
+        }
+        this.score = score;
+    }
+
+    @Override
+    public double getScore() {
+        return score;
+    }
+
+    @Override
+    public String getDescription() {
+        return mt.getName();
+    }
+
+    @Override
+    public Task createTask(Person person) {
+        return mt.constructInstance(person);
+    }
+
+    @Override
+    public Task createTask(Robot robot) {
+        return mt.constructInstance(robot);
+    }
+}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/MetaTask.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/MetaTask.java
@@ -6,8 +6,10 @@
  */
 package org.mars_sim.msp.core.person.ai.task.util;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.mars_sim.msp.core.Simulation;
@@ -235,6 +237,41 @@ public abstract class MetaTask {
 	 */
 	public double getProbability(Robot robot) {
 		throw new UnsupportedOperationException("Can not calculated the probability of " + name + " for Robot.");
+	}
+	
+	/**
+	 * Gets the list of Task that this Person can perform all individually scored.
+	 * 
+	 * @param person the Person to perform the task.
+	 * @return List of TasksJob specifications.
+	 */
+	public List<TaskJob> getTaskJobs(Person person) {
+		return createTaskJob(getProbability(person));
+	}
+
+	/**
+	 * Gets the list of Task that this Robot can perform all individually scored.
+	 * 
+	 * @param robot the robot to perform the task.
+	 * @return List of TasksJob specifications.
+	 */
+	public List<TaskJob> getTaskJobs(Robot robot) {
+		return createTaskJob(getProbability(robot));
+	}
+
+	/**
+	 * Creates a TaskJob instance delegate where this instance handles Task creation.
+	 * @param score Score to the job to create.
+	 */
+	private List<TaskJob> createTaskJob(double score) {
+		// This is a convience to avoid a massive rework in the subclasses.
+		if (score <= 0) {
+			return null;
+		}
+
+		List<TaskJob> result = new ArrayList<>(1);
+		result.add(new BasicTaskJob(this, score));
+		return result;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/MetaTask.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/MetaTask.java
@@ -52,17 +52,14 @@ public abstract class MetaTask {
 				TaskTrait.TREATMENT,
 				TaskTrait.LEADERSHIP,
 				TaskTrait.MEDICAL);
-
-	// If a person Job is not the preferred old
-	private static final double JOB_BOOST = 1.25D;
 	
 	/** Probability penalty for starting a non-job-related task. */
 	private static final double NON_JOB_PENALTY = .25D;
 	
-	private static Simulation sim = Simulation.instance();
+
 	/** The static instance of the mars clock */
-	protected static MarsClock marsClock = sim.getMasterClock().getMarsClock();
-	protected static SurfaceFeatures surfaceFeatures = sim.getSurfaceFeatures();
+	protected static MarsClock marsClock;
+	protected static SurfaceFeatures surfaceFeatures;
 	
 	private String name;
 	private WorkerType workerType;
@@ -323,4 +320,11 @@ public abstract class MetaTask {
         return score;
 	}
 
+	/**
+	 * Attached to the common controllign classes.
+	 */
+	static void initialiseInstances(Simulation sim) {
+		marsClock = sim.getMasterClock().getMarsClock();
+		surfaceFeatures = sim.getSurfaceFeatures();
+	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/MetaTask.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/MetaTask.java
@@ -17,7 +17,6 @@ import org.mars_sim.msp.core.environment.SurfaceFeatures;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.fav.FavoriteType;
 import org.mars_sim.msp.core.person.ai.job.util.JobType;
-import org.mars_sim.msp.core.resource.ResourceUtil;
 import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.time.MarsClock;
 
@@ -26,11 +25,6 @@ import org.mars_sim.msp.core.time.MarsClock;
  * constructing task instances.
  */
 public abstract class MetaTask {
-	
-	protected static final int FOOD_ID = ResourceUtil.foodID;
-	protected static final int WATER_ID = ResourceUtil.waterID;
-	protected static final int ICE_ID = ResourceUtil.iceID;
-	protected static final int REGOLITH_ID = ResourceUtil.regolithID;
 	
 	/**
 	 *  Defines the type of Worker support by this Task

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/PersonTaskManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/PersonTaskManager.java
@@ -33,8 +33,6 @@ public class PersonTaskManager extends TaskManager {
 	private static TaskCache defaultInsideTasks;
 	private static TaskCache defaultOutsideTasks;
 
-	private static final int MAX_TASK_PROBABILITY = 35_000;
-
 	// Data members
 	/** The mind of the person the task manager is responsible for. */
 	private Mind mind;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/PersonTaskManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/PersonTaskManager.java
@@ -228,9 +228,9 @@ public class PersonTaskManager extends TaskManager {
 	public void startNewTask() {
 		// Check if there are any assigned tasks that are pending
 		if (!getPendingTasks().isEmpty()) {
-			MetaTask metaTask = getAPendingMetaTask();
-			if (metaTask != null) {
-				Task newTask = metaTask.constructInstance(person);
+			TaskJob pending = getPendingTask();
+			if (pending != null) {
+				Task newTask = pending.createTask(person);
 				startTask(newTask);
 			}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/Task.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/Task.java
@@ -1552,7 +1552,7 @@ public abstract class Task implements Serializable, Comparable<Task> {
 	 * @param m  {@link MissionManager}
 	 * @param pc  {@link PersonConfig}
 	 */
-	public static void initializeInstances(MasterClock ms, MarsClock c, HistoricalEventManager e, UnitManager u,
+	static void initializeInstances(MasterClock ms, MarsClock c, HistoricalEventManager e, UnitManager u,
 			ScientificStudyManager s, SurfaceFeatures sf, OrbitInfo oi, MissionManager m, PersonConfig pc) {
 		masterClock = ms;
 		marsClock = c;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskCache.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskCache.java
@@ -6,17 +6,17 @@
  */
 package org.mars_sim.msp.core.person.ai.task.util;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.mars_sim.msp.core.tool.RandomUtil;
 
 /**
- * Class represents a set of MetaTask that can be used to select a new Task for a Work. 
+ * Class represents a set of TaskJob that can be used to select a new Task for a Work. 
  * They are weighted to the probability of being selected.
  */
 public class TaskCache {
-	private Map<MetaTask, Double> tasks = new HashMap<>();
+	private List<TaskJob> tasks = new ArrayList<>();
     private double totalProb = 0;
     private String context;
 
@@ -25,14 +25,28 @@ public class TaskCache {
     }
 
     /**
-     * Add a new MetaTask to the cache with a probility score
-     * @param mt Meta task
-     * @param probability The probability score.
+     * Add a new potetential TaskJob to the cache.
+     * @param job The new potential Task.
      */
-	public void put(MetaTask mt, double probability) {
-		tasks.put(mt, probability);
-		totalProb += probability;
+	public void put(TaskJob job) {
+		tasks.add(job);
+		totalProb += job.getScore();
 	}
+
+    /**
+     * This creates a basic Task Job delegated to a MetaType class with a default score.
+     */
+    public void putDefault(MetaTask metaTask) {
+        TaskJob newJob = new BasicTaskJob(metaTask, 1D);
+        put(newJob);
+    }
+
+    public void add(List<TaskJob> jobs) {
+        for(TaskJob j : jobs) {
+            tasks.add(j);
+            totalProb += j.getScore(); 
+        }
+    }
 
     /**
      * Get the total probability score for all tasks.
@@ -51,25 +65,24 @@ public class TaskCache {
     }
 
     /**
-     * Get the MetaTasks registered
+     * Get the jobs registered
      */
-    public Map<MetaTask, Double> getTasks() {
+    public List<TaskJob> getTasks() {
         return tasks;
     }
 
     /** 
-     * Choose a MetaTask at random.
+     * Choose a Task to work at random.
     */
-    MetaTask getRandomSelection() {			
+    TaskJob getRandomSelection() {			
         // Comes up with a random double based on probability
         double r = RandomUtil.getRandomDouble(totalProb);
         // Determine which task is selected.
-        for (Map.Entry<MetaTask, Double> entry: tasks.entrySet()) {
-            MetaTask mt = entry.getKey();
-            double probWeight = entry.getValue();
+        for (TaskJob entry: tasks) {
+            double probWeight = entry.getScore();
             if (r <= probWeight) {
                 // Select this task
-                return mt;
+                return entry;
             }
             else {
                 r -= probWeight;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskJob.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskJob.java
@@ -6,6 +6,8 @@
  */
 package org.mars_sim.msp.core.person.ai.task.util;
 
+import java.io.Serializable;
+
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.robot.Robot;
 
@@ -13,7 +15,7 @@ import org.mars_sim.msp.core.robot.Robot;
  * This rerpresents a potential Task that can be xecuted. The Task has a score for the benefit of
  * doing the Task. 
  */
-public interface TaskJob {
+public interface TaskJob extends Serializable {
 
     /**
      * Retrns the score benefit of running this Task.

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskJob.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskJob.java
@@ -1,0 +1,39 @@
+/*
+ * Mars Simulation Project
+ * TaskJob.java
+ * @date 2022-11-04
+ * @author Barry Evans
+ */
+package org.mars_sim.msp.core.person.ai.task.util;
+
+import org.mars_sim.msp.core.person.Person;
+import org.mars_sim.msp.core.robot.Robot;
+
+/**
+ * This rerpresents a potential Task that can be xecuted. The Task has a score for the benefit of
+ * doing the Task. 
+ */
+public interface TaskJob {
+
+    /**
+     * Retrns the score benefit of running this Task.
+     */
+    double getScore();
+
+    /**
+     * Description of the task to be performed
+     */
+    String getDescription();
+
+    /**
+     * Create the Task for a person
+     */
+    Task createTask(Person person);
+
+    /**
+     * Create the Task for a Robot
+     * @param robot 
+     */
+    Task createTask(Robot robot);
+
+}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskManager.java
@@ -12,9 +12,10 @@ import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.mars_sim.msp.core.Simulation;
+import org.mars_sim.msp.core.SimulationConfig;
 import org.mars_sim.msp.core.SimulationFiles;
 import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.UnitEventType;
@@ -761,10 +762,14 @@ public abstract class TaskManager implements Serializable, Temporal {
 	/**
 	 * Reloads instances after loading from a saved sim.
 	 * 
-	 * @param clock
+	 * @param sim
 	 */
-	public static void initializeInstances(MarsClock clock) {
-		marsClock = clock;
-	}
+	public static void initializeInstances(Simulation sim, SimulationConfig conf) {
+		marsClock = sim.getMasterClock().getMarsClock();
 
+		MetaTask.initialiseInstances(sim);
+		Task.initializeInstances(sim.getMasterClock(), marsClock, sim.getEventManager(), sim.getUnitManager(),
+									sim.getScientificStudyManager(), sim.getSurfaceFeatures(), sim.getOrbitInfo(),
+						sim.getMissionManager(), conf.getPersonConfig());
+	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskManager.java
@@ -502,7 +502,7 @@ public abstract class TaskManager implements Serializable, Temporal {
 	 */
 	public void startNewTask() {
 		Task selectedTask = null;
-		MetaTask selectedMetaTask = null;
+		TaskJob selectedMetaTask = null;
 
 		// If cache is not current, calculate the probabilities.
 		if (!useCache()) {
@@ -540,7 +540,7 @@ public abstract class TaskManager implements Serializable, Temporal {
 	 * @param selectedMetaTask Type of task to create.
 	 * @return New Task.
 	 */
-	protected abstract Task createTask(MetaTask selectedMetaTask);
+	protected abstract Task createTask(TaskJob selectedMetaTask);
 
 	/**
 	 * Returns the last calculated probability map.
@@ -562,8 +562,8 @@ public abstract class TaskManager implements Serializable, Temporal {
 			diagnosticFile.println("Worker:" + worker.getName());
 			diagnosticFile.println(current.getContext());				
 			diagnosticFile.println("Total:" + current.getTotal());
-			for (Entry<MetaTask, Double> task : taskProbCache.getTasks().entrySet()) {
-				diagnosticFile.println(task.getKey().getName() + ":" + task.getValue());
+			for (TaskJob task : taskProbCache.getTasks()) {
+				diagnosticFile.println(task.getDescription() + ":" + task.getScore());
 			}
 			
 			diagnosticFile.println();

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/robot/ai/task/BotTaskManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/robot/ai/task/BotTaskManager.java
@@ -194,9 +194,9 @@ public class BotTaskManager extends TaskManager {
 	public void startNewTask() {
 		// Check if there are any assigned tasks that are pending
 		if (!getPendingTasks().isEmpty()) {
-			MetaTask metaTask = getAPendingMetaTask();
-			if (metaTask != null) {
-				Task newTask = metaTask.constructInstance(robot);
+			TaskJob pending = getPendingTask();
+			if (pending != null) {
+				Task newTask = pending.createTask(robot);
 				startTask(newTask);
 			}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/robot/ai/task/BotTaskManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/robot/ai/task/BotTaskManager.java
@@ -14,6 +14,7 @@ import org.mars_sim.msp.core.person.ai.task.util.MetaTask;
 import org.mars_sim.msp.core.person.ai.task.util.MetaTaskUtil;
 import org.mars_sim.msp.core.person.ai.task.util.Task;
 import org.mars_sim.msp.core.person.ai.task.util.TaskCache;
+import org.mars_sim.msp.core.person.ai.task.util.TaskJob;
 import org.mars_sim.msp.core.person.ai.task.util.TaskManager;
 import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.robot.ai.BotMind;
@@ -59,8 +60,8 @@ public class BotTaskManager extends TaskManager {
 	}
 
 	@Override
-	protected Task createTask(MetaTask selectedMetaTask) {
-		return selectedMetaTask.constructInstance(robot);
+	protected Task createTask(TaskJob selectedWork) {
+		return selectedWork.createTask(robot);
 	}
 	
 
@@ -165,10 +166,10 @@ public class BotTaskManager extends TaskManager {
 		
 		// Determine probabilities.
 		for (MetaTask mt : mtList) {
-			double probability = mt.getProbability(robot);
+			List<TaskJob> job = mt.getTaskJobs(robot);
 	
-			if ((probability > 0D) && (!Double.isNaN(probability)) && (!Double.isInfinite(probability))) {
-				newCache.put(mt, probability);
+			if (job != null) {
+				newCache.add(job);
 			}
 		}
 		
@@ -181,7 +182,7 @@ public class BotTaskManager extends TaskManager {
 	private static synchronized TaskCache getChargeTaskMap() {
 		if (chargeMap == null) {
 			chargeMap = new TaskCache("Robot Charge");
-			chargeMap.put(new ChargeMeta(), 1D);
+			chargeMap.putDefault(new ChargeMeta());
 		}
 		return chargeMap;
 	}

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/commander/CommanderWindow.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/commander/CommanderWindow.java
@@ -47,6 +47,7 @@ import org.mars_sim.msp.core.UnitManager;
 import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.mission.MissionType;
+import org.mars_sim.msp.core.person.ai.task.util.TaskJob;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.structure.building.Building;
 import org.mars_sim.msp.core.structure.building.BuildingManager;
@@ -101,9 +102,6 @@ public class CommanderWindow extends ToolWindow {
 	public static final String ACCEPT_NO = "Accept NO Trading initiated by other settlements";
 	public static final String SEE_RIGHT = ".    -->";
 
-	// Private members
-	private String deletingTaskType;
-
 	private final Font SERIF = new Font("Serif", Font.PLAIN, 10);
 	private final Font DIALOG = new Font( "Dialog", Font.PLAIN, 14);
 
@@ -115,7 +113,7 @@ public class CommanderWindow extends ToolWindow {
 	private WebComboBox settlementListBox;
 	
 	private ListModel listModel;
-	private JList<String> list;
+	private JList<TaskJob> list;
 	private JTextArea logBookTA;
 
 	private WebPanel emptyPanel = new WebPanel();
@@ -475,7 +473,7 @@ public class CommanderWindow extends ToolWindow {
 		listModel = new ListModel();
 
 		// Create list
-		list = new JList<String>(listModel);
+		list = new JList<>(listModel);
 		listScrollPanel.setViewportView(list);
 		list.addListSelectionListener(event -> {
 		        if (!event.getValueIsAdjusting() && event != null){
@@ -796,10 +794,9 @@ public class CommanderWindow extends ToolWindow {
 	 * Picks a task and delete it.
 	 */
 	public void deleteATask() {
-		String n = (String) list.getSelectedValue();
+		TaskJob n = list.getSelectedValue();
 		if (n != null) {
-			deletingTaskType = n;
-			((Person) personComboBox.getSelectedItem()).getMind().getTaskManager().deleteAPendingTask(deletingTaskType);
+			((Person) personComboBox.getSelectedItem()).getMind().getTaskManager().deleteAPendingTask(n);
 			logBookTA.append("Delete '" + n + "' from the list of task orders.\n");
 		}
 		else
@@ -843,26 +840,26 @@ public class CommanderWindow extends ToolWindow {
 	/**
 	 * Lists model for the tasks in queue.
 	 */
-	private class ListModel extends AbstractListModel<String> {
+	private class ListModel extends AbstractListModel<TaskJob> {
 
 	    /** default serial id. */
 	    private static final long serialVersionUID = 1L;
 
-	    private List<String> list = new ArrayList<>();
+	    private List<TaskJob> list = new ArrayList<>();
 
 	    private ListModel() {
 	    	Person selected = (Person) personComboBox.getSelectedItem();
 
 	    	if (selected != null) {
-	        	List<String> tasks = selected.getMind().getTaskManager().getPendingTasks();
+	        	List<TaskJob> tasks = selected.getMind().getTaskManager().getPendingTasks();
 		        if (tasks != null)
 		        	list.addAll(tasks);
 	    	}
 	    }
 
         @Override
-        public String getElementAt(int index) {
-        	String result = null;
+        public TaskJob getElementAt(int index) {
+        	TaskJob result = null;
 
             if ((index >= 0) && (index < list.size())) {
                 result = list.get(index);
@@ -883,18 +880,13 @@ public class CommanderWindow extends ToolWindow {
          */
         public void update() {
 
-        	List<String> newTasks = ((Person) personComboBox.getSelectedItem()).getMind().getTaskManager().getPendingTasks();
+        	List<TaskJob> newTasks = ((Person) personComboBox.getSelectedItem()).getMind().getTaskManager().getPendingTasks();
 
         	if (newTasks != null) {
 	    		// if the list contains duplicate items, it somehow pass this test
-	    		if (list.size() != newTasks.size() || !list.containsAll(newTasks) || !newTasks.containsAll(list)) {
-	                List<String> oldList = list;
-	                List<String> tempList = new ArrayList<String>(newTasks);
-	
-	                list = tempList;
+	    		if (list.size() != newTasks.size() || !list.containsAll(newTasks) || !newTasks.containsAll(list)) {	
+	                list = new ArrayList<>(newTasks);
 	                fireContentsChanged(this, 0, getSize());
-
-	                oldList.clear();
 	    		}
         	}
         }


### PR DESCRIPTION
This pull introduces the ```TaskJob``` concept which acts as a definition of a Task that can be executed. The Task cache is converted to contain TaskJob instances instead of directly referencing the MetaTask. 

Secondly it allows the same MetaTask to create multiple jobs to convert multiple demands of the same Task. This PR contains the ```TendCropTask``` converted into this new multiple job approach.

Part of #740