### PR TITLE
Convert Resource process panels to a table representation

### DIFF
--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -1600,13 +1600,9 @@ TabPanelPersonality.MBTI 							= Personality Type (MBTI) :
 TabPanelPersonality.bigFive							= Big Five Personality (OCC Model) :
 
 
-TabPanelResourceProcesses.checkbox.overrideResourceProcessToggling = Override Resource Process Toggling
-TabPanelResourceProcesses.label                                    = Resource Processes
-TabPanelResourceProcesses.processLabel                             = \ {0}: {1}
+TabPanelResourceProcesses.checkbox.overrideResourceProcessToggling = Override Process Toggling
 TabPanelResourceProcesses.title                                    = Resource Processing
-TabPanelResourceProcesses.tooltip                                  = Resource Processes
 TabPanelResourceProcesses.tooltip.overrideResourceProcessToggling  = Prevents Settlers from Toggling on/off Resource Processes
-TabPanelResourceProcesses.tooltip.toggleButton                     = Toggle Process On/Off
 
 
 TabPanelSchedule.label            				= Activity Schedule
@@ -1701,13 +1697,11 @@ TabPanelVehicles.tooltip        		= Vehicles parked at the settlement or on miss
 TabPanelVehicles.mission.vehicles 		= Reserved / On Mission
 TabPanelVehicles.title          		= Vehicles
 
-TabPanelWasteProcesses.checkbox.overrideWasteProcessToggling	= Override Waste Process Toggling
-TabPanelWasteProcesses.label                                    = Waste Processes
-TabPanelWasteProcesses.processLabel                             = \ {0}: {1}
+TabPanelWasteProcesses.checkbox.overrideWasteProcessToggling	= Override Toggling
 TabPanelWasteProcesses.title                                    = Waste Processing
 TabPanelWasteProcesses.tooltip                                  = Waste Processes
 TabPanelWasteProcesses.tooltip.overrideWasteProcessToggling		= Prevents Settlers from Toggling on/off Waste Processes
-TabPanelWasteProcesses.tooltip.toggleButton                     = Toggle Process On/Off
+ResourceProcessPanel.tooltip.toggling                     = Toggle Process On/Off
 
 Task.description.areologyFieldWork                       = Doing Areological Field Work
 Task.description.assistScientificStudyResearcher         = Assisting Researcher

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelAirComposition.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelAirComposition.java
@@ -42,6 +42,8 @@ import org.mars_sim.msp.ui.swing.NumberCellRenderer;
 import org.mars_sim.msp.ui.swing.StyleManager;
 import org.mars_sim.msp.ui.swing.tool.SpringUtilities;
 import org.mars_sim.msp.ui.swing.unit_window.TabPanel;
+import org.mars_sim.msp.ui.swing.utils.UnitModel;
+import org.mars_sim.msp.ui.swing.utils.UnitTableLauncher;
 
 /**
  * This is a tab panel for displaying the composition of air of each inhabitable building in a settlement.
@@ -282,6 +284,7 @@ public class TabPanelAirComposition extends TabPanel {
 
 		tableModel = new TableModel(settlement);
 		table = new JTable(tableModel);
+		table.addMouseListener(new UnitTableLauncher(getDesktop()));
 
 		table.setRowSelectionAllowed(true);
 		TableColumnModel tableColumnModel = table.getColumnModel();
@@ -481,7 +484,8 @@ public class TabPanelAirComposition extends TabPanel {
 	/**
 	 * Internal class used as model for the table.
 	 */
-	private class TableModel extends AbstractTableModel {
+	private class TableModel extends AbstractTableModel 
+				implements UnitModel {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
@@ -598,6 +602,11 @@ public class TabPanelAirComposition extends TabPanel {
 			}
 
 			fireTableDataChanged();
+		}
+
+		@Override
+		public Unit getAssociatedUnit(int row) {
+			return buildings.get(row);
 		}
 	}
 	

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelPowerGrid.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelPowerGrid.java
@@ -11,7 +11,6 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.Iterator;
 import java.util.List;
@@ -24,7 +23,6 @@ import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.SpringLayout;
 import javax.swing.SwingConstants;
-import javax.swing.SwingUtilities;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.JTableHeader;
@@ -46,6 +44,8 @@ import org.mars_sim.msp.ui.swing.MainDesktopPane;
 import org.mars_sim.msp.ui.swing.StyleManager;
 import org.mars_sim.msp.ui.swing.tool.SpringUtilities;
 import org.mars_sim.msp.ui.swing.unit_window.TabPanel;
+import org.mars_sim.msp.ui.swing.utils.UnitModel;
+import org.mars_sim.msp.ui.swing.utils.UnitTableLauncher;
 
 
 /**
@@ -201,17 +201,7 @@ public class TabPanelPowerGrid extends TabPanel {
 		// Prepare power table.
 		powerTable = new JTable(powerTableModel);
 		// Call up the building window when clicking on a row on the table
-		powerTable.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				if (e.getClickCount() == 2 && !e.isConsumed()) {
-					// Get the mouse-selected row
-		            int r = powerTable.getSelectedRow();
-		            SwingUtilities.invokeLater(() -> 
-		            	desktop.openUnitWindow((Unit)powerTable.getValueAt(r, 1), false));
-				}
-			}
-		});
+		powerTable.addMouseListener(new UnitTableLauncher(desktop));
 
 		powerTable.setRowSelectionAllowed(true);
 		TableColumnModel powerColumns = powerTable.getColumnModel();
@@ -348,7 +338,8 @@ public class TabPanelPowerGrid extends TabPanel {
 	/**
 	 * Internal class used as model for the power table.
 	 */
-	private class PowerTableModel extends AbstractTableModel {
+	private class PowerTableModel extends AbstractTableModel
+				implements UnitModel  {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
@@ -483,6 +474,11 @@ public class TabPanelPowerGrid extends TabPanel {
 			 * //Collections.sort(buildings); } }
 			 */
 			fireTableDataChanged();
+		}
+
+		@Override
+		public Unit getAssociatedUnit(int row) {
+			return buildings.get(row);
 		}
 	}
 

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelResourceProcesses.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelResourceProcesses.java
@@ -86,7 +86,7 @@ public class TabPanelResourceProcesses extends TabPanel implements ActionListene
 		}
 
 		// Prepare process list panel.n
-		processPanel = new ResourceProcessPanel(processes);
+		processPanel = new ResourceProcessPanel(processes, getDesktop());
 		processPanel.setPreferredSize(new Dimension(160, 120));
 		content.add(processPanel, BorderLayout.CENTER);
 		
@@ -114,7 +114,7 @@ public class TabPanelResourceProcesses extends TabPanel implements ActionListene
 		levelPanel.setAlignmentY(TOP_ALIGNMENT);
 		topPanel.add(levelPanel);
 		
-		JLabel levelLabel = new JLabel("Overall Effort Level :");
+		JLabel levelLabel = new JLabel("Overall Effort :");
 		levelPanel.add(levelLabel);
 			
 		// Prepare level combo box

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelThermalSystem.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelThermalSystem.java
@@ -11,8 +11,6 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
 import java.util.Iterator;
 import java.util.List;
 
@@ -26,7 +24,6 @@ import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.SpringLayout;
 import javax.swing.SwingConstants;
-import javax.swing.SwingUtilities;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumnModel;
@@ -47,6 +44,8 @@ import org.mars_sim.msp.ui.swing.MainDesktopPane;
 import org.mars_sim.msp.ui.swing.StyleManager;
 import org.mars_sim.msp.ui.swing.tool.SpringUtilities;
 import org.mars_sim.msp.ui.swing.unit_window.TabPanel;
+import org.mars_sim.msp.ui.swing.utils.UnitTableLauncher;
+import org.mars_sim.msp.ui.swing.utils.UnitModel;
 
 /**
  * This is a tab panel for settlement's Thermal System .
@@ -225,33 +224,7 @@ extends TabPanel {
 		// Prepare thermal control table.
 		heatTable = new JTable(heatTableModel);
 		// Call up the building window when clicking on a row on the table
-		heatTable.addMouseListener(new MouseListener() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				if (e.getClickCount() == 2 && !e.isConsumed()) {
-					// Get the mouse-selected row
-		            int r = heatTable.getSelectedRow();
-		            SwingUtilities.invokeLater(() -> 
-		            	desktop.openUnitWindow((Unit)heatTable.getValueAt(r, 1), false));
-				}
-			}
-			@Override
-			public void mousePressed(MouseEvent e) {
-				// nothing
-			}
-			@Override
-			public void mouseReleased(MouseEvent e) {
-				// nothing
-			}
-			@Override
-			public void mouseEntered(MouseEvent e) {
-				// nothing
-			}
-			@Override
-			public void mouseExited(MouseEvent e) {
-				// nothing
-			}
-		});
+		heatTable.addMouseListener(new UnitTableLauncher(desktop));
 		
 		heatTable.setRowSelectionAllowed(true);
 		TableColumnModel heatColumns = heatTable.getColumnModel();
@@ -395,7 +368,8 @@ extends TabPanel {
 	/**
 	 * Internal class used as model for the thermal control table.
 	 */
-	private class HeatTableModel extends AbstractTableModel {
+	private class HeatTableModel extends AbstractTableModel
+		implements UnitModel {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
@@ -509,6 +483,11 @@ extends TabPanel {
 			heatScrollPane.validate();
 
 			fireTableDataChanged();
+		}
+
+		@Override
+		public Unit getAssociatedUnit(int row) {
+			return buildings.get(row);
 		}
 	}
 	

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelWasteProcesses.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelWasteProcesses.java
@@ -7,21 +7,17 @@
 package org.mars_sim.msp.ui.swing.unit_window.structure;
 
 import java.awt.BorderLayout;
-import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.FlowLayout;
-import java.awt.GridLayout;
-import java.awt.Insets;
-import java.util.Collections;
-import java.util.Iterator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.swing.JCheckBox;
-import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.Unit;
-import org.mars_sim.msp.core.resource.ResourceUtil;
 import org.mars_sim.msp.core.structure.OverrideType;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.structure.building.Building;
@@ -31,10 +27,8 @@ import org.mars_sim.msp.core.structure.building.function.ResourceProcess;
 import org.mars_sim.msp.core.structure.building.function.WasteProcessing;
 import org.mars_sim.msp.ui.swing.ImageLoader;
 import org.mars_sim.msp.ui.swing.MainDesktopPane;
-import org.mars_sim.msp.ui.swing.MarsPanelBorder;
-import org.mars_sim.msp.ui.swing.StyleManager;
 import org.mars_sim.msp.ui.swing.unit_window.TabPanel;
-import org.mars_sim.msp.ui.swing.utils.JProcessButton;
+import org.mars_sim.msp.ui.swing.unit_window.structure.building.ResourceProcessPanel;
 
 /**
  * A tab panel for displaying all of the waste processes in a settlement.
@@ -46,14 +40,7 @@ public class TabPanelWasteProcesses extends TabPanel {
 
 	/** The Settlement instance. */
 	private Settlement settlement;
-	
-	private List<Building> buildings;
-	private JPanel processListPanel;
-	private JCheckBox overrideCheckbox;
-
-	private BuildingManager mgr;
-
-	private int size;
+	private ResourceProcessPanel processPanel;
 
 	/**
 	 * Constructor.
@@ -76,23 +63,24 @@ public class TabPanelWasteProcesses extends TabPanel {
 	
 	@Override
 	protected void buildUI(JPanel content) {
-		mgr = settlement.getBuildingManager();
-		buildings = mgr.getBuildings(FunctionType.WASTE_PROCESSING);
-		size = buildings.size();
+		BuildingManager mgr = settlement.getBuildingManager();
+		Map<Building,List<ResourceProcess>> processes = new HashMap<>();
+		for(Building building : mgr.getBuildings(FunctionType.WASTE_PROCESSING)) {
+			WasteProcessing processing = building.getWasteProcessing();
+			processes.put(building, processing.getProcesses());
+		}
 
-		// Prepare process list panel.
-		processListPanel = new JPanel(new GridLayout(0, 1, 5, 2));
-		processListPanel.setAlignmentY(TOP_ALIGNMENT);
-		processListPanel.setBorder(new MarsPanelBorder());
-		content.add(processListPanel, BorderLayout.CENTER);
-		populateProcessList();
+		// Prepare process list panel.n
+		processPanel = new ResourceProcessPanel(processes);
+		processPanel.setPreferredSize(new Dimension(160, 120));
+		content.add(processPanel, BorderLayout.CENTER);
 
 		// Create override check box panel.
 		JPanel overrideCheckboxPane = new JPanel(new FlowLayout(FlowLayout.CENTER));
 		content.add(overrideCheckboxPane, BorderLayout.NORTH);
 
 		// Create override check box.
-		overrideCheckbox = new JCheckBox(Msg.getString("TabPanelWasteProcesses.checkbox.overrideWasteProcessToggling")); //$NON-NLS-1$
+		JCheckBox overrideCheckbox = new JCheckBox(Msg.getString("TabPanelWasteProcesses.checkbox.overrideWasteProcessToggling")); //$NON-NLS-1$
 		overrideCheckbox.setToolTipText(Msg.getString("TabPanelWasteProcesses.tooltip.overrideWasteProcessToggling")); //$NON-NLS-1$
 		overrideCheckbox.addActionListener(e ->
 			setWasteProcessesOverride(overrideCheckbox.isSelected())
@@ -101,52 +89,10 @@ public class TabPanelWasteProcesses extends TabPanel {
 		overrideCheckboxPane.add(overrideCheckbox);
 	}
 
-	/**
-	 * Populates the process list panel with all building processes.
-	 */
-	private void populateProcessList() {
-		// Clear the list.
-		processListPanel.removeAll();
-
-		// Add a label for each process in each processing building.
-		Iterator<Building> i = buildings.iterator();
-		while (i.hasNext()) {
-			Building building = i.next();
-			WasteProcessing processing = building.getWasteProcessing();
-			for(ResourceProcess process : processing.getProcesses()) {
-				processListPanel.add(new WasteProcessPanel(process, building));
-			}
-		}
-	}
 
 	@Override
 	public void update() {
-		// Check if building list has changed.
-		List<Building> newBuildings = selectBuildings();
-		int newSize = buildings.size();
-		if (size != newSize) {
-			size = newSize;
-			buildings = selectBuildings();
-			Collections.sort(buildings);
-			populateProcessList();
-		}
-		else if (!buildings.equals(newBuildings)) {
-			buildings = newBuildings;
-			Collections.sort(buildings);
-			populateProcessList();
-		}
-		else {
-			// Update process list.
-			Component[] components = processListPanel.getComponents();
-			for (Component component : components) {
-				WasteProcessPanel panel = (WasteProcessPanel) component;
-				panel.update();
-			}
-		}
-	}
-
-	private List<Building> selectBuildings() {
-		return mgr.getBuildings(FunctionType.WASTE_PROCESSING);
+		processPanel.update();
 	}
 
 	/**
@@ -156,115 +102,4 @@ public class TabPanelWasteProcesses extends TabPanel {
 	private void setWasteProcessesOverride(boolean override) {
 		settlement.setProcessOverride(OverrideType.WASTE_PROCESSING, override);
 	}
-
-	/**
-	 * An internal class for a waste process panel.
-	 */
-	private static class WasteProcessPanel
-	extends JPanel {
-
-		/** default serial id. */
-		private static final long serialVersionUID = 1L;
-
-		// Data members.
-		private ResourceProcess process;
-		private JLabel label;
-		private JProcessButton toggleButton;
-
-		/**
-		 * Constructor.
-		 * @param process2 the waste process.
-		 * @param building the building the process is in.
-		 */
-		WasteProcessPanel(ResourceProcess process2, Building building) {
-			// Use JPanel constructor.
-			super();
-
-			setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
-
-			this.process = process2;
-
-			toggleButton = new JProcessButton();
-			toggleButton.setMargin(new Insets(0, 0, 0, 0));
-			toggleButton.addActionListener(e -> {
-				ResourceProcess p = getProcess();
-				p.setProcessRunning(!p.isProcessRunning());
-				update();
-			});
-			toggleButton.setToolTipText(Msg.getString("TabPanelWasteProcesses.tooltip.toggleButton")); //$NON-NLS-1$
-			add(toggleButton);
-			label = new JLabel(Msg.getString("TabPanelWasteProcesses.processLabel", building.getNickName(), process2.getProcessName())); //$NON-NLS-1$
-			add(label);
-
-			toggleButton.setRunning(process2.isProcessRunning());
-
-			setToolTipText(getToolTipString(building));
-		}
-
-		// NOTE: internationalize the waste processes' dynamic tooltip
-		// Align text to improved tooltip readability (for English Locale only)
-		private String getToolTipString(Building building) {
-			StringBuilder result = new StringBuilder("<html>");
-			result.append("&emsp;&nbsp;Process:&emsp;").append(process.getProcessName()).append("<br>");
-			result.append("&emsp;&nbsp;Building:&emsp;").append(building.getNickName()).append("<br>");
-			result.append("Power Req:&emsp;").append(StyleManager.DECIMAL_KW.format(process.getPowerRequired())).append("<br>");
-			result.append("&emsp;&emsp;&nbsp;Inputs:&emsp;");
-			Iterator<Integer> i = process.getInputResources().iterator();
-			String ambientStr = "";
-			int ii = 0;
-			while (i.hasNext()) {
-				if (ii!=0)	result.append("&nbsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;");
-				Integer resource = i.next();
-				double rate = process.getMaxInputRate(resource) * 1000D;
-				String rateString = StyleManager.DECIMAL_PLACES2.format(rate);
-				if (process.isAmbientInputResource(resource)) ambientStr = "*";
-				result.append(ResourceUtil.findAmountResource(resource).getName())
-					.append(ambientStr).append(" @ ")
-					.append(rateString).append(" kg/sol<br>");
-				ii++;
-			}
-			result.append("&emsp;&nbsp;&nbsp;Outputs:&emsp;");
-			Iterator<Integer> j = process.getOutputResources().iterator();
-			int jj = 0;
-			while (j.hasNext()) {
-				if (jj!=0) result.append("&nbsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;");
-				Integer resource = j.next();
-				double rate = process.getMaxOutputRate(resource) * 1000D;
-				String rateString = StyleManager.DECIMAL_PLACES2.format(rate);
-				result.append(ResourceUtil.findAmountResource(resource).getName())
-					.append(" @ ").append(rateString).append(" kg/sol<br>");
-				jj++;
-			}
-			// Added a note to denote an ambient input resource
-			if (ambientStr.equals("*"))
-				result.append("&emsp;<i>Note: * denotes an ambient resource</i>");
-			result.append("</html>");
-			return result.toString();
-		}
-
-		/**
-		 * Update the label.
-		 */
-		void update() {
-			toggleButton.setRunning(process.isProcessRunning());
-		}
-
-		private ResourceProcess getProcess() {
-			return process;
-		}
-	}
-	
-	/**
-	 * Prepare object for garbage collection.
-	 */
-	@Override
-	public void destroy() {
-		super.destroy();
-		
-		buildings = null;
-		processListPanel = null;
-		overrideCheckbox = null;
-		settlement = null;
-		mgr = null;
-	}	
 }

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelWasteProcesses.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelWasteProcesses.java
@@ -71,7 +71,7 @@ public class TabPanelWasteProcesses extends TabPanel {
 		}
 
 		// Prepare process list panel.n
-		processPanel = new ResourceProcessPanel(processes);
+		processPanel = new ResourceProcessPanel(processes, getDesktop());
 		processPanel.setPreferredSize(new Dimension(160, 120));
 		content.add(processPanel, BorderLayout.CENTER);
 

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/building/BuildingPanelResourceProcessing.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/building/BuildingPanelResourceProcessing.java
@@ -7,28 +7,14 @@
 package org.mars_sim.msp.ui.swing.unit_window.structure.building;
 
 import java.awt.BorderLayout;
-import java.awt.Component;
-import java.awt.FlowLayout;
-import java.awt.GridLayout;
-import java.awt.Insets;
-import java.util.Iterator;
-import java.util.List;
-import java.util.logging.Level;
+import java.awt.Dimension;
 
-import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import org.mars_sim.msp.core.Msg;
-import org.mars_sim.msp.core.logging.SimLogger;
-import org.mars_sim.msp.core.resource.ResourceUtil;
-import org.mars_sim.msp.core.structure.building.Building;
-import org.mars_sim.msp.core.structure.building.function.ResourceProcess;
 import org.mars_sim.msp.core.structure.building.function.ResourceProcessing;
 import org.mars_sim.msp.ui.swing.ImageLoader;
 import org.mars_sim.msp.ui.swing.MainDesktopPane;
-import org.mars_sim.msp.ui.swing.MarsPanelBorder;
-import org.mars_sim.msp.ui.swing.StyleManager;
-import org.mars_sim.msp.ui.swing.utils.JProcessButton;
 
 /**
  * The BuildingPanelResourceProcessing class is a building function panel representing
@@ -37,26 +23,11 @@ import org.mars_sim.msp.ui.swing.utils.JProcessButton;
 @SuppressWarnings("serial")
 public class BuildingPanelResourceProcessing extends BuildingFunctionPanel {
 
-	/** default logger. */
-	private static final SimLogger logger = SimLogger.getLogger(BuildingPanelResourceProcessing.class.getName());
-
 	private static final String CHEMICAL_ICON = "chemical";
-	private static final String KG_SOL = " kg/sol";
-	private static final String BR = "<br>";
-	private static final String HTML = "<html>";
-	private static final String END_HTML = "</html>";
-	private static final String INPUTS = "&emsp;&emsp;&nbsp;Inputs:&emsp;";
-	private static final String OUTPUTS = "&emsp;&nbsp;&nbsp;Outputs:&emsp;";
-	private static final String SPACES = "&nbsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;";
-	private static final String PROCESS = "&emsp;&nbsp;Process:&emsp;";
-	private static final String BUILDING_HEADER = "&emsp;&nbsp;Building:&emsp;";
-	private static final String POWER_REQ = "Power Req:&emsp;";
-	private static final String NOTE = "&emsp;<i>Note:  * denotes an ambient resource</i>";
 	
 	// Data members
 	private ResourceProcessing processor;
-	private List<ResourceProcess> processes;
-	private JPanel processListPanel;
+	private ResourceProcessPanel processPanel;
 
 	/**
 	 * Constructor.
@@ -82,152 +53,14 @@ public class BuildingPanelResourceProcessing extends BuildingFunctionPanel {
 	 */
 	@Override
 	protected void buildUI(JPanel center) {
-		// Get all processes at the building
-		processes = processor.getProcesses();
+		processPanel = new ResourceProcessPanel(processor.getBuilding(), processor.getProcesses());
+		processPanel.setPreferredSize(new Dimension(160, 120));
 
-		// Prepare process list panel.
-		processListPanel = new JPanel(new GridLayout(0, 1, 5, 2));
-		processListPanel.setAlignmentY(TOP_ALIGNMENT);
-		processListPanel.setBorder(new MarsPanelBorder());
-		center.add(processListPanel, BorderLayout.NORTH);
-		populateProcessList();
-	}
-
-	/**
-	 * Populates the process list panel with all building processes.
-	 */
-	private void populateProcessList() {
-		// Clear the list.
-		processListPanel.removeAll();
-
-		// Add a label for each process in each processing building.
-		Iterator<ResourceProcess> j = processes.iterator();
-		while (j.hasNext()) {
-			ResourceProcess process = j.next();
-			processListPanel.add(new ResourceProcessPanel(process, building));
-		}
+		center.add(processPanel, BorderLayout.CENTER);	
 	}
 	
 	@Override
 	public void update() {
-		// Update process list.
-		Component[] components = processListPanel.getComponents();
-		for (Component component : components) {
-			ResourceProcessPanel panel = (ResourceProcessPanel) component;
-			panel.update();
-		}
-	}
-	
-	/**
-	 * An internal class for a resource process panel.
-	 */
-	private static class ResourceProcessPanel
-	extends JPanel {
-
-		/** default serial id. */
-		private static final long serialVersionUID = 1L;
-
-		// Data members.
-		private ResourceProcess process;
-		private JLabel label;
-		private JProcessButton toggleButton;
-
-		/**
-		 * Constructor.
-		 * 
-		 * @param process the resource process.
-		 * @param building the building the process is in.
-		 */
-		ResourceProcessPanel(ResourceProcess process, Building building) {
-			// Use JPanel constructor.
-			super();
-
-			setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
-
-			this.process = process;
-
-			toggleButton = new JProcessButton();
-			toggleButton.setMargin(new Insets(0, 0, 0, 0));
-			toggleButton.addActionListener(e -> {
-					ResourceProcess p = getProcess();
-					boolean isRunning = p.isProcessRunning();
-					p.setProcessRunning(!isRunning);
-					update();
-					if (isRunning)
-						logger.log(building, Level.CONFIG, 0L, "Player stops the '" + p.getProcessName() + "'.");
-					else
-						logger.log(building, Level.CONFIG, 0L, "Player starts the '" + p.getProcessName() + "'.");
-			});
-			toggleButton.setToolTipText(Msg.getString("TabPanelResourceProcesses.tooltip.toggleButton")); //$NON-NLS-1$
-			add(toggleButton);
-			label = new JLabel(Msg.getString("TabPanelResourceProcesses.processLabel", //$NON-NLS-1$
-					building.getNickName(), process.getProcessName())); 
-			add(label);
-
-
-			toggleButton.setRunning(process.isProcessRunning());
-
-			setToolTipText(getToolTipString(building));
-		}
-
-		/**
-		 * Assembles the text for a tool tip.
-		 * 
-		 * @param building
-		 * @return
-		 */
-		private String getToolTipString(Building building) {
-			// NOTE: internationalize the resource processes' dynamic tooltip.
-			StringBuilder result = new StringBuilder(HTML);
-			// Future: Use another tool tip manager to align text to improve tooltip readability			
-			result.append(PROCESS).append(process.getProcessName()).append(BR);
-			result.append(BUILDING_HEADER).append(building.getNickName()).append(BR);
-			result.append(POWER_REQ).append(StyleManager.DECIMAL_KW.format(process.getPowerRequired()))
-			.append(BR);
-			result.append(INPUTS);
-			Iterator<Integer> i = process.getInputResources().iterator();
-			String ambientStr = "";
-			int ii = 0;
-			while (i.hasNext()) {
-				if (ii!=0)	result.append(SPACES);
-				Integer resource = i.next();
-				double rate = process.getMaxInputRate(resource) * 1000D;
-				String rateString = StyleManager.DECIMAL_PLACES2.format(rate);
-				if (process.isAmbientInputResource(resource)) 
-					ambientStr = "*";
-				result.append(ResourceUtil.findAmountResource(resource).getName())
-					.append(ambientStr).append(" @ ")
-					.append(rateString).append(KG_SOL).append(BR);
-				ii++;
-			}
-			result.append(OUTPUTS);
-			Iterator<Integer> j = process.getOutputResources().iterator();
-			int jj = 0;
-			while (j.hasNext()) {
-				if (jj!=0) result.append(SPACES);
-				Integer resource = j.next();
-				double rate = process.getMaxOutputRate(resource) * 1000D;
-				String rateString = StyleManager.DECIMAL_PLACES2.format(rate);
-				result.append(ResourceUtil.findAmountResource(resource).getName())
-					.append(" @ ").append(rateString).append(KG_SOL).append(BR);
-				jj++;
-			}
-			// Add a note to denote an ambient input resource
-			if (ambientStr.equals("*"))
-				result.append(NOTE);
-			result.append(END_HTML);
-			return result.toString();
-		}
-
-		/**
-		 * Updates the label.
-		 */
-		void update() {
-			toggleButton.setRunning(process.isProcessRunning());
-		}
-
-		private ResourceProcess getProcess() {
-			return process;
-		}
+		processPanel.update();
 	}
 }

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/building/ResourceProcessPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/building/ResourceProcessPanel.java
@@ -1,0 +1,358 @@
+/*
+ * Mars Simulation Project
+ * ResourceProcessPanel.java
+ * @date 2023-02-20
+ * @author Barry Evans
+ */
+package org.mars_sim.msp.ui.swing.unit_window.structure.building;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Point;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.swing.DefaultCellEditor;
+import javax.swing.Icon;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableColumnModel;
+
+import org.mars_sim.msp.core.resource.ResourceUtil;
+import org.mars_sim.msp.core.structure.building.Building;
+import org.mars_sim.msp.core.structure.building.function.ResourceProcess;
+import org.mars_sim.msp.ui.swing.ImageLoader;
+import org.mars_sim.msp.ui.swing.StyleManager;
+import org.mars_sim.msp.ui.swing.utils.JProcessButton;
+
+/**
+ * Creates a JPanel that will render a list of ResourceProcesses in a JTable.
+ * This includes creating a dynamic tooltip.
+ */
+public class ResourceProcessPanel extends JPanel {
+    private static final Icon RED_DOT = ImageLoader.getIconByName("dot/red");
+    private static final Icon GREEN_DOT = ImageLoader.getIconByName("dot/green");
+
+    private static final String KG_SOL = " kg/sol";
+	private static final String BR = "<br>";
+	private static final String INPUTS = "&emsp;&emsp;&nbsp;Inputs:&emsp;";
+	private static final String OUTPUTS = "&emsp;&nbsp;&nbsp;Outputs:&emsp;";
+	private static final String SPACES = "&nbsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;";
+	private static final String PROCESS = "&emsp;&nbsp;Process:&emsp;";
+	private static final String BUILDING_HEADER = "&emsp;&nbsp;Building:&emsp;";
+	private static final String POWER_REQ = "Power Req:&emsp;";
+	private static final String NOTE = "&emsp;<i>Note:  * denotes an ambient resource</i>";
+
+    /**
+     * Private table model to manage the Resource Processes. It  c an act it 2 modes
+     * - Single building mode
+     * - Multipel builbing mode
+     */
+	private static class ResourceProcessTableModel extends AbstractTableModel {
+		private static final int RUNNING_STATE = 0;
+        private static final int PROCESS_NAME = 1;
+        private static final int BUILDING_NAME = 2;
+
+        private List<ResourceProcess> processes = new ArrayList<>();
+
+        private Building mainBuilding;
+        private List<Building> buildings;
+
+		public ResourceProcessTableModel(Building building, List<ResourceProcess> source) {
+			processes = new ArrayList<>(source);
+            mainBuilding = building;
+		}
+
+        public ResourceProcessTableModel(Map<Building, List<ResourceProcess>> buildingProcs) {
+            // Unpacke map into a single list
+            buildings = new ArrayList<>();
+            for(Entry<Building, List<ResourceProcess>> entry : buildingProcs.entrySet()) {
+                for(ResourceProcess p : entry.getValue()) {
+                    processes.add(p);
+                    buildings.add(entry.getKey());
+                }
+            }
+        }
+
+        @Override
+		public int getRowCount() {
+			return processes.size();
+		}
+
+        @Override
+		public int getColumnCount() {
+            if (buildings == null)
+			    return 2;
+            else
+                return 3;
+		}
+
+        @Override
+        public boolean isCellEditable(int rowIndex, int columnIndex) {
+            return (columnIndex == 0);
+        }
+
+        @Override
+		public Class<?> getColumnClass(int columnIndex) {
+            int realColumn = getPropFromColumn(columnIndex);
+            switch(realColumn) {
+                case RUNNING_STATE: return Boolean.class;
+                case PROCESS_NAME: return String.class;
+                case BUILDING_NAME: return String.class;
+                default:
+                    throw new IllegalArgumentException("Column unknown " + columnIndex);
+            }
+		}
+
+        @Override
+		public String getColumnName(int columnIndex) {
+            int realColumn = getPropFromColumn(columnIndex);
+            switch(realColumn) {
+                case RUNNING_STATE: return "Active";
+                case PROCESS_NAME: return "Process";
+                case BUILDING_NAME: return "Building";
+                default:
+                    throw new IllegalArgumentException("Column unknown " + columnIndex);
+            }
+		}
+
+        @Override
+        public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
+            ResourceProcess p = processes.get(rowIndex);
+            p.setProcessRunning((boolean) aValue);
+        }
+
+        @Override
+		public Object getValueAt(int row, int column) {
+            ResourceProcess p = processes.get(row);
+            int realColumn = getPropFromColumn(column);
+            switch(realColumn) {
+                case RUNNING_STATE: return p.isProcessRunning();
+                case PROCESS_NAME: return p.getProcessName();
+                case BUILDING_NAME: return buildings.get(row);
+                default:
+                    throw new IllegalArgumentException("Column unknown " + column);
+            }
+		}
+
+        /**
+         * This maps the column index into the logicla property
+         * @param column
+         * @return
+         */
+        private int getPropFromColumn(int column) {
+            switch(column) {
+                case 0: return RUNNING_STATE;
+                case 1: {
+                    if (buildings == null)
+                        return PROCESS_NAME;
+                    else
+                        return BUILDING_NAME;
+                }
+                case 2: return PROCESS_NAME;
+                default: return -1;
+            }
+        }
+
+        /**
+         * Get the associated process object
+         */
+        ResourceProcess getProcess(int rowIndex) {
+            return processes.get(rowIndex);
+        }
+
+        /**
+         * Get the building hosting a process
+         * @param rowIndex
+         * @return
+         */
+        Building getBuilding(int rowIndex) {
+            if (buildings == null) 
+                return mainBuilding;
+            else
+                return buildings.get(rowIndex);
+        }
+	}
+
+    /**
+     * Render a booena value displaying Green/Red dots
+     */
+    private static class RunningCellRenderer extends DefaultTableCellRenderer {
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+            setHorizontalAlignment( JLabel.CENTER );
+
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            setText(null);
+            if (value instanceof Boolean && (Boolean)value) {
+                setIcon(GREEN_DOT);
+            }
+            else {
+                setIcon(RED_DOT);
+            }
+            return this;
+        }        
+    }
+
+    /**
+     * Allows a cell to be editted
+     */
+    private static class RunningCellEditor extends DefaultCellEditor {
+
+        public RunningCellEditor() {
+            super(new JCheckBox());
+        }
+
+        private JProcessButton button;
+        private boolean selected;
+        
+        @Override
+        public Component getTableCellEditorComponent(JTable table, Object value,
+                                boolean isSelected,
+                                int row, int column) {
+            selected = (boolean) value;
+
+            button = new JProcessButton();
+            button.setRunning(selected);
+            button.addActionListener(e -> {
+                selected = !selected;
+                button.setRunning(selected);
+
+                // Stop after one click
+                stopCellEditing();
+            });
+
+            return button;
+        }
+
+        @Override
+        public Object getCellEditorValue() {
+            return selected;
+        }
+
+    }
+
+    private ResourceProcessTableModel model;
+
+    /**
+     * Create a resource panel for a single Build
+     */
+    public ResourceProcessPanel(Building building, List<ResourceProcess> source) {
+        
+        model = new ResourceProcessTableModel(building, source);
+
+        buildUI();
+    }
+
+    /**
+     * Create a resource panel that encompasses multiple Buildings each with dedciated Resoruce Processes.
+     * @param processes Map.
+     */
+    public ResourceProcessPanel(Map<Building, List<ResourceProcess>> processes) {
+        model = new ResourceProcessTableModel(processes);
+
+        buildUI();
+    }
+
+    private void buildUI() {
+        // Create scroll panel for storage table
+		JScrollPane scrollPanel = new JScrollPane();
+	    scrollPanel.getViewport().setOpaque(false);
+	    scrollPanel.setOpaque(false);
+
+
+		JTable pTable = new JTable(model) {
+            //Implement table cell tool tips.           
+            public String getToolTipText(MouseEvent e) {
+                Point p = e.getPoint();
+                int rowIndex = rowAtPoint(p);
+                if (rowIndex < 0) {
+                    return null;
+                }
+                rowIndex = getRowSorter().convertRowIndexToModel(rowIndex);
+                int colIndex = columnAtPoint(p);
+                // Only display tooltip in last column
+                if ((colIndex-1) != model.getColumnCount()) {
+                    return null;
+                }
+
+                return generateToolTip(model.getProcess(rowIndex), model.getBuilding(rowIndex));
+            }
+        };
+
+		pTable.setCellSelectionEnabled(false);
+		pTable.setAutoCreateRowSorter(true);
+		scrollPanel.setViewportView(pTable);
+
+        TableColumnModel columnModel = pTable.getColumnModel();
+        columnModel.getColumn(0).setCellRenderer(new RunningCellRenderer());
+        columnModel.getColumn(0).setCellEditor(new RunningCellEditor());
+        columnModel.getColumn(0).setMaxWidth(50);
+
+        setLayout(new BorderLayout());
+        add(scrollPanel, BorderLayout.CENTER);
+    }
+
+    /**
+     * Update the status of any resource processes
+     */
+    public void update() {
+        model.fireTableDataChanged();
+    }
+    
+    private String generateToolTip(ResourceProcess process, Building building) {
+
+        // NOTE: internationalize the resource processes' dynamic tooltip.
+        StringBuilder result = new StringBuilder("<html>");
+        // Future: Use another tool tip manager to align text to improve tooltip readability			
+        result.append(PROCESS).append(process.getProcessName()).append(BR);
+        result.append(BUILDING_HEADER).append(building.getNickName()).append(BR);
+        result.append(POWER_REQ).append(StyleManager.DECIMAL_KW.format(process.getPowerRequired()))
+        .append(BR);
+
+        result.append(INPUTS);
+        boolean firstItem = true;
+        boolean hasAmbient = false;
+        for(Integer resource: process.getInputResources()) {
+            if (!firstItem) 
+                result.append(SPACES);
+            double rate = process.getMaxInputRate(resource) * 1000D;
+            String rateString = StyleManager.DECIMAL_PLACES2.format(rate);
+
+            result.append(ResourceUtil.findAmountResource(resource).getName());
+            if (process.isAmbientInputResource(resource)) {
+                result.append("*");
+                hasAmbient = true;
+            }
+            result.append(" @ ").append(rateString).append(KG_SOL).append(BR);
+            firstItem = false;    
+        }
+
+        result.append(OUTPUTS);
+        firstItem = true;
+        for(Integer resource : process.getOutputResources()) {
+            if (!firstItem)
+                result.append(SPACES);
+            double rate = process.getMaxOutputRate(resource) * 1000D;
+            String rateString = StyleManager.DECIMAL_PLACES2.format(rate);
+            result.append(ResourceUtil.findAmountResource(resource).getName())
+                .append(" @ ").append(rateString).append(KG_SOL).append(BR);
+            firstItem = false;    
+        }
+        // Add a note to denote an ambient input resource
+        if (hasAmbient)
+            result.append(NOTE);
+        result.append("</html>");   
+        
+        return result.toString();
+    }
+}

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/utils/UnitModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/utils/UnitModel.java
@@ -1,0 +1,23 @@
+/*
+ * Mars Simulation Project
+ * UnitModel.java
+ * @date 2023-02-21
+ * @author Barry Evans
+ */
+package org.mars_sim.msp.ui.swing.utils;
+
+import javax.swing.table.TableModel;
+
+import org.mars_sim.msp.core.Unit;
+
+/**
+ * This represent a TableModel that has a Unit associated with each row.
+ */
+public interface UnitModel extends TableModel {
+    /**
+     * Get ther associated Unit at a row index.
+     * @param row Index
+     * @return Unit associated 
+     */
+    public Unit getAssociatedUnit(int row);
+}

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/utils/UnitTableLauncher.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/utils/UnitTableLauncher.java
@@ -1,0 +1,57 @@
+/*
+ * Mars Simulation Project
+ * UnitTableLauncher.java
+ * @date 2023-02-21
+ * @author Barry Evans
+ */
+package org.mars_sim.msp.ui.swing.utils;
+
+import java.awt.event.MouseEvent;
+
+import javax.swing.JTable;
+import javax.swing.RowSorter;
+import javax.swing.event.MouseInputAdapter;
+import javax.swing.table.TableModel;
+
+import org.mars_sim.msp.ui.swing.MainDesktopPane;
+
+/**
+ * This class listens for double click event on a JTable. When an event triggers; a UnitDetail window
+ * is launched. The JTable has to be using a UnitTable model that allows the associated Unit
+ * of the selected Row.
+ * 
+ * @see UnitModel
+ */
+public class UnitTableLauncher extends MouseInputAdapter {
+    private MainDesktopPane desktop;
+
+    /**
+     * Create a luancher that will create a UnitDetails window.
+     * 
+     * @param desktop
+     */
+    public UnitTableLauncher(MainDesktopPane desktop) {
+        this.desktop = desktop;
+    }
+
+    /**
+     * Catch the double click mouse event. The compoenent under the click event is retrieved
+     * which should be a JTable; from this the assigned UnitModel is used to find the
+     * associated Unit. This desktop is that used to open the appropriate Unit window.
+     * This method supports the JTable being sorted.
+     */
+    @Override
+    public void mouseClicked(MouseEvent e) {
+        if (e.getClickCount() == 2 && !e.isConsumed()) {
+            JTable table = (JTable) e.getComponent();
+            // Get the mouse-selected row
+            int r = table.getSelectedRow();
+            RowSorter<? extends TableModel> sorter = table.getRowSorter();
+            if (sorter != null)
+                r = sorter.convertRowIndexToModel(r);
+
+            UnitModel model = (UnitModel)table.getModel();
+            desktop.openUnitWindow(model.getAssociatedUnit(r), false);
+        }
+    }
+}


### PR DESCRIPTION
This PR creates a new ```ResourceProcessPanel``` that takes a list of ResourceProcess objects and displays them as a JTable. 
The entries in the table can be double clicked to display the relevant Unit Window. The processes can be toggled directly from the table.
It is applied to the Waste & Resource process tabs in the Building & Settlement windows

As an addition the means to display the Unit Window direct from a table is standardised with a new ```UnitTableLauncher```. This centralises the logic to handling the sorting and table model lookup.

close #804 