### PR TITLE
Convert to Java17

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,13 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
+    
+    # Setup java 17
+    - name: Setup Java JDK
+      uses: actions/setup-java@v1.3.0
+      with:
+        java-version: 17
+        
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,6 +54,7 @@ jobs:
     - name: Setup Java JDK
       uses: actions/setup-java@v3
       with:
+        distribution: 'temurin'
         java-version: 17
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,7 +52,7 @@ jobs:
     
     # Setup java 17
     - name: Setup Java JDK
-      uses: actions/setup-java@v1.3.0
+      uses: actions/setup-java@v3
       with:
         java-version: 17
         

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
           
       - name: Build with Maven
         run: mvn -B package -DskipTests=true --file pom.xml 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,10 +9,10 @@ jobs:
         
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
         cache: 'maven'
         

--- a/CHANGELOG_3.5.0.md
+++ b/CHANGELOG_3.5.0.md
@@ -25,8 +25,11 @@ Copyright (C) 2023 Scott Davis
   <LI>      Tab : Add new tab to the Monitor Tool to show task backlog of each settlement. </LI>
   <LI>  Styling : Single styling via look and feel applied to all components.</LI>
   <li>      L&F : Look and Feel can be changed via Settings menu item.</li>
-  <li>   Panels : Panel lists converted into Tables for Maintenance, Waste & Resource processing. </li>
-  
+  <li>  Desktop : Windows in the Desktop remember their position and contents between runs, if possible.</li>
+
+### RUNTIME ENVIRONMENT:
+  <LI>Java : Java 17 required. </LI> 
+ 
 ### FIXES :
  <LI> EVA Suit : Allow suit repair in a vehicle using Repair task. </LI>
  <LI> Jar file : Make settlement template name readable by using lowercase. </LI>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Only a packing stage. JAR must be available
 # Package stage
-FROM openjdk:11.0.16-jre-slim
+FROM amazoncorretto:17
 WORKDIR /app
 
 # Version name

--- a/Dockerfile-compile
+++ b/Dockerfile-compile
@@ -1,6 +1,6 @@
 # Build stage
 # the Maven project
-FROM maven:3.8.6-openjdk-11-slim AS build
+FROM maven:3.9.0-amazoncorretto-17 AS build
 WORKDIR /app/src
 
 # Ideally the source code shouo dbe under a src subdirectory in GitHub repo
@@ -15,7 +15,7 @@ COPY mars-sim-ui mars-sim-ui/
 RUN mvn -DskipTests=true package
 
 # Package stage
-FROM openjdk:11.0.16-jre
+FROM amazoncorretto:17
 WORKDIR /app
 # Override when building
 COPY --from=build /app/src/mars-sim-headless/target/mars-sim-headless.jar mars-sim-headless.jar

--- a/README.md
+++ b/README.md
@@ -213,11 +213,10 @@ planetary surface.
         width="100">
 </a>
 
-Currently, mars-sim supports Java 11. We will transition to Java 17 in near future
-as JDK 17 is the latest long-term support (LTS) release.
+Currently, mars-sim supports Java 17 which is the latest long-term support (LTS) release.
 
-* Requires only JRE 11 for running mars-sim
-* Requires only JDK 11 (or openjdk 11) for compiling binary
+* Requires only JRE 17 for running mars-sim
+* Requires only JDK 17 (or openjdk 17) for compiling binary
 
 ### JDK and JavaFX
 
@@ -255,7 +254,7 @@ For windows platform, choose MSI version that will automatically set up the envi
 
 ### OS Platforms
 
-Assuming that OpenJDK 11 is being used.
+Assuming that OpenJDK 17 is being used.
 
 #### Linux
 
@@ -275,41 +274,43 @@ See [DZone](https://dzone.com/articles/installing-openjdk-11-on-macos) for more 
 
 
 #### Windows
+A Java Installatino for Window will normally configure the path correctly so a command prompt a java cpmmand will be executable. `java -version`. Here are some implementaion of OpenJDK for Windows:
 
-1. Start a command prompt and type this `set PATH="C:\Program Files\Java\jre-11.0.17\bin";%PATH%`.
+* [Amazon Cornetto](https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/downloads-list.html)
 
-2. Alternatively, pre-set the `JAVA_HOME` and `PATH` in *Environment Variables* in Control Panel.
+* [Microsoft](https://learn.microsoft.com/en-us/java/openjdk/download)
 
-- a. Add `C:\Program Files\Java\jre-11.0.17\bin` to the `PATH` variable.
+If java cannot be found then follow the steps below. 
+
+1. Locate the Java  installation.
+
+2. Start a command prompt and type this `set JAVA_HOM£="<java home>\bin"`.
+
+3. Set the PATH variable to include the Java installation `set PATH="%JAVA_HOME%\bin";%PATH%`.
 
 > Note 2 : The order of precedence inside `PATH` is crucial. The first available folder having Java
 executable inside will be the one to be loaded by Windows OS.
-
-- b. Set `JAVA_HOME` to a JRE or JDK's destination such as `C:\Program Files\Java\jdk-11.0.17\bin\` or
-`C:\Program Files\Java\jre-11.0.17\bin`.
 
 > Note 2a : The `\bin` is crucial. When running `java -jar xxxx.jar`, mars-sim will look for the
 presence of the `java.exe` in Windows OS. If `\bin` is missing in the `JAVA_HOME` variable,
 the Windows OS may not be able to locate the `java.exe` and may continue to go down the `PATH`
 variable to look for a valid JDK folder. If it's not found, java cannot start mars-sim.
 
-- c. Add `%JAVA_HOME%;` to `PATH`. Type "path" in a command prompt to double check
-the order of precedence when it comes to searching for the JDK.
 
 > Note 3 : The BEST approach is to enable only one Java build (such as Java 11.0.17)
 inside `PATH` and remove all other folders referencing other java versions/builds.
 
-3. Remove any path similar to `C:\ProgramData\Oracle\Java\javapath;`  in `PATH` variable. It can
+4. Remove any path similar to `C:\ProgramData\Oracle\Java\javapath;`  in `PATH` variable. It can
 interfere with the correct version of Java that you would like to use.
 
 > Note 4 : Depending on the order of precedence in Path variable,
 `C:\ProgramData\Oracle\Java\javapath` can load the undesired version of jre/jdk,
 instead of the java version you prefer.
 
-4. To test the version of Java that your machine is using, type "java -version"
+5. To test the version of Java that your machine is using, type "java -version"
 in a command prompt window.
 
-5. It's very typical for a machine to have multiple versions of Java installed.
+6. It's possible for a machine to have multiple versions of Java installed.
 To check if a particular Oracle version of Java is being *enabled*,
 start [Java Control Panel (JCP)](https://www.java.com/en/download/help/win_controlpanel.html)
 from the Control Panel as follows :
@@ -326,7 +327,7 @@ only tracks the official Oracle versions. If you install any openJDK's on
 your machine, JCP won't be able to recognize them.
 
 
-6. To track what versions of openjdk have been installed on your machine.
+7. To track what versions of openjdk have been installed on your machine.
 Use [JDKMon](https://harmoniccode.blogspot.com/2021/04/friday-fun-lxiii-jdkmon.html).
 
 ### Remote Console Connection

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/TaskCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/TaskCommand.java
@@ -60,24 +60,18 @@ public class TaskCommand extends AbstractSettlementCommand {
 
 			// Add the rows for each person
 			for (Person p : plist) {
-				StringBuilder shift = new StringBuilder();
 				ShiftSlot slot = p.getShiftSlot();
 				Shift s = slot.getShift();
 				WorkStatus status = slot.getStatus();
-				switch(status) {
-					case OFF_DUTY:
-						shift.append("Off (").append(s.getName()).append(')');
-						break;
-					case ON_CALL:
-						shift.append("On Call (").append(s.getName()).append(')');
-						break;
-					case ON_DUTY:
-						shift.append("On (").append(s.getName()).append(')');
-						break;
-					case ON_LEAVE:
-						shift.append("On Leave (").append(s.getName()).append(')');
-						break;
-				}
+				String shiftDesc = switch(status) {
+					case OFF_DUTY -> "Off Duty";
+					case ON_CALL -> "On Call";
+					case ON_DUTY -> "On";
+					case ON_LEAVE -> "On Leave";
+				};
+
+				StringBuilder shift = new StringBuilder();
+				shift.append(shiftDesc).append(" (").append(s.getName()).append(')');
 
 				response.appendTableRow(tableGroup, p.getName(), shift.toString());
 				tableGroup = ""; // Reset table subgroup

--- a/mars-sim-headless/pom.xml
+++ b/mars-sim-headless/pom.xml
@@ -30,7 +30,12 @@
 		    <groupId>commons-cli</groupId>
 		    <artifactId>commons-cli</artifactId>
 		    <version>${commons-cli.version}</version>
-		</dependency>		
+		</dependency>	
+		<dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>slf4j-api</artifactId>
+		    <version>${slf4j.version}</version>
+		</dependency>	
 	</dependencies>	
 	<build>
 		<defaultGoal>clean package install</defaultGoal>

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/MainDesktopPane.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/MainDesktopPane.java
@@ -398,9 +398,9 @@ public class MainDesktopPane extends JDesktopPane
 			Point location = null;
 			WindowSpec previousDetails = config.getInternalWindowDetails(toolName);
 			if (previousDetails != null) {
-				location = previousDetails.getPosition();
+				location = previousDetails.position();
 				if (window.isResizable()) {
-					window.setSize(previousDetails.getSize());
+					window.setSize(previousDetails.size());
 				}
 			} else if (toolName.equals(TimeWindow.NAME))
 				location = computeLocation(window, 0, 2);
@@ -506,7 +506,7 @@ public class MainDesktopPane extends JDesktopPane
 
 			Point newPosition = null;
 			if (initProps != null) {
-				newPosition = initProps.getPosition();
+				newPosition = initProps.position();
 			}
 			if (newPosition == null) {
 				newPosition = getRandomLocation(tempWindow);
@@ -698,13 +698,13 @@ public class MainDesktopPane extends JDesktopPane
 		if (!startingWindows.isEmpty()) {
 			UnitManager uMgr = mainWindow.getDesktop().getSimulation().getUnitManager();
 			for(WindowSpec w : startingWindows) {
-				switch(w.getType()) {
+				switch(w.type()) {
 					case UIConfig.TOOL:
-						openToolWindow(w.getName());
+						openToolWindow(w.name());
 					break;
 
 					case UIConfig.UNIT:
-						Unit u = UnitWindow.getUnit(uMgr, w.getProps());
+						Unit u = UnitWindow.getUnit(uMgr, w.props());
 						if (u != null) {
 							openUnitWindow(u, w);
 						}

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/UIConfig.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/UIConfig.java
@@ -22,7 +22,6 @@ import java.util.Properties;
 import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import javax.swing.JFrame;
 import javax.swing.JInternalFrame;
@@ -47,47 +46,13 @@ public class UIConfig {
 	/**
 	 * The stored details of a window
 	 */
-	public static class WindowSpec {
-		private String name;
-		private Point position;
-		private Dimension size;
-		private int order;
-		private String type;
-		private Properties props;
-
-		public WindowSpec(String name, Point position, Dimension size, int order, String type, Properties props) {
-			this.name = name;
-			this.position = position;
-			this.size = size;
-			this.order = order;
-			this.type = type;
-			this.props = props;
-		}
-
-		public String getName() {
-			return name;
-		}
-
-		public Point getPosition() {
-			return position;
-		}
-
-		public Dimension getSize() {
-			return size;
-		}
-
-		public int getOrder() {
-			return order;
-		}
-
-		public String getType() {
-			return type;
-		}
-
-		public Properties getProps() {
-			return props;
-		}
-	}
+	public record WindowSpec(
+		 String name,
+		 Point position,
+		 Dimension size,
+		 int order,
+		 String type,
+		 Properties props) {};
 
 	/** default logger. */
 	private static final Logger logger = Logger.getLogger(UIConfig.class.getName());
@@ -273,8 +238,7 @@ public class UIConfig {
 				windowElement.setAttribute(Z_ORDER, Integer.toString(desktop.getComponentZOrder(window1)));
 				windowElement.setAttribute(DISPLAY, Boolean.toString(!window1.isIcon()));
 
-				if (window1 instanceof ConfigurableWindow) {
-					ConfigurableWindow cw = (ConfigurableWindow) window1;
+				if (window1 instanceof ConfigurableWindow cw) {
 					outputProperties(windowElement, "props", cw.getUIProps());
 				}
 
@@ -406,7 +370,7 @@ public class UIConfig {
 	public List<WindowSpec> getConfiguredWindows() {
 		return windows.entrySet().stream().sorted((f1, f2) -> Integer.compare(f2.getValue().order, f1.getValue().order))
 										  .map(v -> v.getValue())
-										  .collect(Collectors.toList());
+										  .toList();
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/UnitWindow.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/UnitWindow.java
@@ -12,7 +12,6 @@ import java.awt.FlowLayout;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 import javax.swing.Icon;
 import javax.swing.JLabel;
@@ -162,7 +161,7 @@ public abstract class UnitWindow extends ModalInternalFrame
 	protected void sortTabPanels() {
 		tabPanels = tabPanels.stream()
 				.sorted((t1, t2) -> t1.getTabTitle().compareTo(t2.getTabTitle()))
-				.collect(Collectors.toList());
+				.toList();
 	}
 	
 	/**
@@ -171,15 +170,6 @@ public abstract class UnitWindow extends ModalInternalFrame
 	protected void addTabIconPanels() {
 		tabPanels.forEach(panel -> {
 			tabPane.addTab(null, panel.getTabIcon(), panel, panel.getTabToolTip());
-		});
-	}
-	
-	/**
-	 * Adds tab panels with titles.
-	 */
-	protected void addTabTitlePanels() {
-		tabPanels.forEach(panel -> {
-			tabPane.addTab(panel.getTabTitle(), null, panel, panel.getTabToolTip());
 		});
 	}
 	
@@ -212,10 +202,6 @@ public abstract class UnitWindow extends ModalInternalFrame
 			return unit.getName() +"'s unit window";
 		return null;
     }
-
-	public void setTitle(String value) {
-		super.setTitle(unit.getName());
-	}
 
 	/**
 	 * Return the currently selected tab.

--- a/mars-sim-ui/src/main/resources/docs/help/whatsnew.html
+++ b/mars-sim-ui/src/main/resources/docs/help/whatsnew.html
@@ -29,7 +29,13 @@
   <LI>  Styling : Single styling via look and feel applied to all components.</LI>
   <li>      L&F : Look and Feel can be changed via Settings menu item.</li>
   <li>   Panels : Panel lists converted into Tables for Maintenance, Waste & Resource processing. </li>
+  <li>  Desktop : Windows in the Desktop remember their position and contents between runs, if possible.</li>
 </OL>  
+
+<H4> RUNTIME ENVIRONMENT:</H4>
+<OL>
+  <LI>Java : Java 17 required. </LI> 
+</OL>
 
 <H4> FIXES :</H4>
 <OL>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<url>https://github.com/mars-sim/mars-sim</url>
 	<inceptionYear>2009</inceptionYear>
 	<properties>
-		<release>11</release>
+		<release>17</release>
 		<project.version>3.5.0</project.version>
 		<fxgl.version>11.17</fxgl.version>
 		<junit-jupiter.version>5.9.2</junit-jupiter.version>

--- a/setup.md
+++ b/setup.md
@@ -14,7 +14,7 @@ https://github.com/mars-sim/mars-sim
 
 - 220 MB free disk space
 
-- Java 11 or openjdk 11
+- Java 17 or openjdk 17
 
 ---------------------------------------------------------------------
 
@@ -33,7 +33,7 @@ mars-sim may come in under a few flavors as follows :
 
 A. Swing Edition
 
-- Double-click on `[$VERSION]_swing_java11.jar` to begin
+- Double-click on `[$VERSION]_swing_java17.jar` to begin
 a new simulation in GUI mode. The jar file is executable
 in most operating systems.
 
@@ -43,11 +43,11 @@ Alternatively, players may start mars-sim from a terminal / command line.
 
 - Go to the directory containing the jar file and type :
 
-> java -jar [$VERSION]_swing_java11.jar
+> java -jar [$VERSION]_swing_java17.jar
 
 	OR
 
-> java -jar [$VERSION]_swing_java11.jar new
+> java -jar [$VERSION]_swing_java17.jar new
 
 This gives users the advantage of seeing mars-sim's internal logging
 statements while running mars-sim.
@@ -73,11 +73,11 @@ of running the entire simulation on its own. Therefore, one may
 prefer to run it in a terminal for hours/days without GUI and in the 
 least intrusive manner utilizing minimal CPU resources. Type :
 
-> java -jar [$VERSION]_headless_java11.jar
+> java -jar [$VERSION]_headless_java17.jar
 
 	OR
 
-> java -jar [$VERSION]_headless_java11.jar new
+> java -jar [$VERSION]_headless_java17.jar new
 
 Note a: the 'new' argument is optional.
 
@@ -92,11 +92,11 @@ simulation.xml :
   by adding `512x` or `1024x` as follows when starting a new
   sim or loading from a saved sim :
 
-> java -jar [$VERSION]_headless_java11.jar -timeratio 512
+> java -jar [$VERSION]_headless_java17.jar -timeratio 512
 
 	OR
 
-> java -jar [$VERSION]_headless_java11.jar -timeratio 1024
+> java -jar [$VERSION]_headless_java17.jar -timeratio 1024
 
 Note d: the time ratio argument is optional and is by default
         `256` as defined in Simulations.xml.
@@ -122,7 +122,7 @@ of the jarfile.
 
 ## Command-Line Arguments Summary
 
-> java -jar [$VERSION]_{$EDITION]_java11.jar
+> java -jar [$VERSION]_{$EDITION]_java17.jar
 >                    (Note : start a new sim)
 >   or
 >

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,2 @@
-# Not sure why this i sneeded
-sonar.java.source=11
+# Not sure why this is needed
+sonar.java.source=17


### PR DESCRIPTION
This PR upgrades the minimum Java to 17.

This involves changing the ```release``` property main POM.xml. To prove the change a few classes have been changed to use Java 17 features.

In addition the Dockerfiles have bee changed to use a AWS Corretto Java17 image. The Docker OpenJDK images are now deprecated.

Note this will require a Java 17 installation to run or build the project.

Part of #820 