### PR TITLE
Mission preserves Vehicle used

### DIFF
--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/VehicleCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/VehicleCommand.java
@@ -48,13 +48,12 @@ public class VehicleCommand extends AbstractSettlementCommand {
 		response.appendTableHeading("Name", CommandHelper.PERSON_WIDTH, "Type", 21, 
 									"Status", 7, "Home", "Maint Due", "Mission", 25);
 
-		var missionMgr = context.getSim().getMissionManager();
 		for (Vehicle v : vlist) {
 			String vTypeStr = v.getSpecName();	
 
 			// Print mission name
 			String missionName = "";
-			Mission mission = missionMgr.getMissionForVehicle(v);
+			Mission mission = v.getMission();
 			if (mission != null) {
 				missionName = mission.getName();
 			}

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/vehicle/VehicleStatusCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/vehicle/VehicleStatusCommand.java
@@ -54,8 +54,7 @@ public class VehicleStatusCommand extends ChatCommand {
 			buffer.appendLabeledString("Operator", operator.getName());
 		}
 		
-		// TODO Why it this not on the Vehicle ????
-		Mission m = context.getSim().getMissionManager().getMissionForVehicle(source);
+		Mission m = source.getMission();
 		if (m != null) {
 			buffer.appendLabeledString("Mission", m.getName());
 			buffer.appendLabeledString("Mission Phase", m.getPhaseDescription());

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/UnitManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/UnitManager.java
@@ -24,11 +24,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.mars_sim.msp.core.data.UnitSet;
 import org.mars_sim.msp.core.environment.MarsSurface;
 import org.mars_sim.msp.core.equipment.Equipment;
+import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.malfunction.MalfunctionFactory;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.robot.Robot;
@@ -53,7 +53,7 @@ public class UnitManager implements Serializable, Temporal {
 	private static final long serialVersionUID = 1L;
 
 	/** default logger. */
-	private static final Logger logger = Logger.getLogger(UnitManager.class.getName());
+	private static final SimLogger logger = SimLogger.getLogger(UnitManager.class.getName());
 
 	public static final int THREE_SHIFTS_MIN_POPULATION = 6;
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractMission.java
@@ -470,7 +470,9 @@ public abstract class AbstractMission implements Mission, Temporal {
 	 */
 	@Override
 	public Stage getStage() {
-		return (done ? Stage.DONE : phase.getStage());
+		return (done ? Stage.DONE :
+				// If no phase that Mission is building built so stage is PREP
+				(phase != null ? phase.getStage() : Stage.PREPARATION));
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractMission.java
@@ -664,6 +664,7 @@ public abstract class AbstractMission implements Mission, Temporal {
 	 */
 	protected void abortMission(MissionStatus reason, EventType event) {
 		aborted = true;
+		logger.info(getStartingPerson(), "Mission " + getName() + " aborted " + reason.getName());
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractVehicleMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractVehicleMission.java
@@ -351,14 +351,12 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 	 */
 	protected final void leaveVehicle() {
 		if (hasVehicle()) {
-			vehicle.setReservedForMission(false);
-			if (vehicle.getMission().equals(this)) {
+			if (this.equals(vehicle.getMission())) {
+				vehicle.setReservedForMission(false);
 				vehicle.setMission(null);
+				vehicle.removeUnitListener(this);
+				fireMissionUpdate(MissionEventType.VEHICLE_EVENT);
 			}
-			vehicle.removeUnitListener(this);
-			//vehicle = null;
-
-			fireMissionUpdate(MissionEventType.VEHICLE_EVENT);
 		}
 	}
 
@@ -1707,10 +1705,14 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 
 		if (addMissionStatus(status)) {
 			// If the MissionFlag is not present then do it
-			// A resource is mission
-			determineEmergencyDestination(status);
-
-			logger.info(getVehicle(), status.getName());
+			
+			// If mission is still at home then leave the vehicle
+			if (getStage() == Stage.PREPARATION) {
+				leaveVehicle();
+			}
+			else {
+				determineEmergencyDestination(status);
+			}
 
 			// Create an event if needed
 			if (eventType != null) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractVehicleMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractVehicleMission.java
@@ -87,7 +87,6 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 	private static final MissionStatus UNREPAIRABLE_MALFUNCTION = new MissionStatus("Mission.status.unrepairable");
 
 	// Static members
-//	private static Integer batteryID = ItemResourceUtil.findIDbyItemResourceName(ItemResourceUtil.BATTERY_MODULE);
 	private static Integer wheelID = ItemResourceUtil.findIDbyItemResourceName(ItemResourceUtil.ROVER_WHEEL);
 	private static Set<Integer> unNeededParts = ItemResourceUtil.convertNameArray2ResourceIDs(
 															new String[] {
@@ -132,8 +131,6 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 	private transient double cachedDistance = -1;
 	/** The current traveling status of the mission. */
 	private String travelStatus;
-	/** The cache for the mission vehicle. */
-	private String vehicleNameCache;
 	/** The vehicle currently used in the mission. */
 	private Vehicle vehicle;
 	/** The last operator of this vehicle in the mission. */
@@ -280,15 +277,6 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 		return true;
 
 	}
-
-	/**
-	 * Gets the mission's vehicle name
-	 *
-	 * @return vehicle or null if none.
-	 */
-	public String getVehicleName() {
-		return vehicleNameCache;
-	}
 	
 	/**
 	 * Gets the mission's vehicle if there is one.
@@ -338,11 +326,9 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 		if (newVehicle != null) {
 			vehicle = newVehicle;
 			startingTravelledDistance = vehicle.getOdometerMileage();
-			newVehicle.setReservedForMission(true);
+			vehicle.setReservedForMission(true);
 			vehicle.addUnitListener(this);
-			
-			// Record the vehicle name
-			vehicleNameCache = vehicle.getName();
+			vehicle.setMission(this);
 			
 			fireMissionUpdate(MissionEventType.VEHICLE_EVENT);
 		}
@@ -366,8 +352,11 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 	protected final void leaveVehicle() {
 		if (hasVehicle()) {
 			vehicle.setReservedForMission(false);
+			if (vehicle.getMission().equals(this)) {
+				vehicle.setMission(null);
+			}
 			vehicle.removeUnitListener(this);
-			vehicle = null;
+			//vehicle = null;
 
 			fireMissionUpdate(MissionEventType.VEHICLE_EVENT);
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingConstructionMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingConstructionMission.java
@@ -313,19 +313,7 @@ public class BuildingConstructionMission extends AbstractMission
 		this.settlement = settlement;
 		this.constructionVehicles = vehicles;
 
-//		int bestConstructionSkill = 0;
-
 		setMissionCapacity(MAX_PEOPLE);
-
-//		Iterator<Worker> i = members.iterator();
-//		while (i.hasNext()) {
-//			Worker member = i.next();
-//			int constructionSkill = member.getSkillManager().getEffectiveSkillLevel(SkillType.CONSTRUCTION);
-//
-//			if (constructionSkill > bestConstructionSkill) {
-//				bestConstructionSkill = constructionSkill;
-//			}
-//		}
 
 		ConstructionManager manager = settlement.getConstructionManager();
 
@@ -351,7 +339,6 @@ public class BuildingConstructionMission extends AbstractMission
 
 				if (!isDone()) {
 					// Reserve construction vehicles.
-					// reserveConstructionVehicles();
 					// Retrieve construction LUV attachment parts.
 					retrieveConstructionLUVParts();
 					startPhase();
@@ -422,7 +409,6 @@ public class BuildingConstructionMission extends AbstractMission
 
 				if (!isDone()) {
 					// Reserve construction vehicles.
-					// reserveConstructionVehicles();
 					// Retrieve construction LUV attachment parts.
 					retrieveConstructionLUVParts();
 					startPhase();
@@ -503,6 +489,7 @@ public class BuildingConstructionMission extends AbstractMission
 					LightUtilityVehicle luv = reserveLightUtilityVehicle();
 					if (luv != null) {
 						constructionVehicles.add(luv);
+						luv.setMission(this);
 					} else {
 						logger.warning(settlement, "BuildingConstructionMission : LUV not available");
 						endMission(LUV_NOT_AVAILABLE);
@@ -766,6 +753,11 @@ public class BuildingConstructionMission extends AbstractMission
 		// Unreserve all LUV attachment parts for this mission.
 		unreserveLUVparts();
 
+		for(GroundVehicle v : getConstructionVehicles()) {
+			if (v.getMission().equals(this)) {
+				v.setMission(null);
+			}
+		}
 		super.endMission(endStatus);
 	}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingSalvageMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/BuildingSalvageMission.java
@@ -586,6 +586,9 @@ public class BuildingSalvageMission extends AbstractMission
 			while (i.hasNext()) {
 				GroundVehicle vehicle = i.next();
 				vehicle.setReservedForMission(false);
+				if (vehicle.getMission().equals(this)) {
+					vehicle.setMission(null);
+				}
 
 				// Store construction vehicle in settlement.
 				settlement.addParkedVehicle(vehicle);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/DroneMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/DroneMission.java
@@ -272,13 +272,6 @@ public abstract class DroneMission extends AbstractVehicleMission {
 			// Add vehicle to a garage if available.
 			boolean inAGarage = disembarkSettlement.getBuildingManager().addToGarage(v);
 
-			// Make sure the drone chasis is not overlapping a building structure in the settlement map
-//	        if (!inAGarage)
-//	        	drone.findNewParkingLoc();
-
-			// Reset the vehicle reservation
-			v.correctVehicleReservation();
-
 			// Unload drone if necessary.
 			boolean droneUnloaded = drone.getStoredMass() == 0D;
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/DroneMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/DroneMission.java
@@ -299,7 +299,7 @@ public abstract class DroneMission extends AbstractVehicleMission {
 				BuildingManager.removeFromGarage(v);
 
 				// Leave the vehicle.
-				leaveVehicle();
+				releaseVehicle(getVehicle());
 				setPhaseEnded(true);
 			}
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mining.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mining.java
@@ -187,7 +187,7 @@ public class Mining extends EVAMission
 			logger.warning("Light utility vehicle not available.");
 			endMission(LUV_NOT_AVAILABLE);
 		} else {
-			luv.setReservedForMission(true);
+			claimVehicle(luv);
 		}
 
 		// Set initial mission phase.
@@ -557,7 +557,7 @@ public class Mining extends EVAMission
 			miningSite.setReserved(false);
 		}
 		if (luv != null) {
-			luv.setReservedForMission(false);
+			releaseVehicle(luv);
 		}
 	}
 
@@ -567,22 +567,18 @@ public class Mining extends EVAMission
 	 * @return reserved light utility vehicle or null if none.
 	 */
 	private LightUtilityVehicle reserveLightUtilityVehicle() {
-		LightUtilityVehicle result = null;
-
-		Iterator<Vehicle> i = getStartingSettlement().getParkedVehicles().iterator();
-		while (i.hasNext() && (result == null)) {
-			Vehicle vehicle = i.next();
+		for(Vehicle vehicle : getStartingSettlement().getParkedVehicles()) {
 			if (vehicle.getVehicleType() == VehicleType.LUV) {
 				LightUtilityVehicle luvTemp = (LightUtilityVehicle) vehicle;
 				if (((luvTemp.getPrimaryStatus() == StatusType.PARKED) || (luvTemp.getPrimaryStatus() == StatusType.GARAGED))
 						&& !luvTemp.isReserved() && (luvTemp.getCrewNum() == 0) && (luvTemp.getRobotCrewNum() == 0)) {
-					result = luvTemp;
-					luvTemp.setReservedForMission(true);
+					claimVehicle(luvTemp);
+					return luvTemp;
 				}
 			}
 		}
 
-		return result;
+		return null;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionManager.java
@@ -362,7 +362,10 @@ public class MissionManager implements Serializable {
 			else if (newStatus == PlanType.NOT_APPROVED) {
 				missionPlan.setStatus(PlanType.NOT_APPROVED);
 				historicalMissions.increaseDataPoint(PlanType.NOT_APPROVED.name(), 1D);
-				removeMission(missionPlan.getMission());
+
+				Mission m = missionPlan.getMission();
+				m.abortMission("Rejected");
+				removeMission(m);
 			}
 		}
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionManager.java
@@ -10,7 +10,6 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -20,7 +19,6 @@ import java.util.stream.Collectors;
 import org.mars_sim.msp.core.SimulationConfig;
 import org.mars_sim.msp.core.data.SolMetricDataLogger;
 import org.mars_sim.msp.core.logging.SimLogger;
-import org.mars_sim.msp.core.mission.ConstructionMission;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.mission.meta.MetaMission;
 import org.mars_sim.msp.core.person.ai.mission.meta.MetaMissionUtil;
@@ -28,7 +26,6 @@ import org.mars_sim.msp.core.person.ai.task.EVAOperation;
 import org.mars_sim.msp.core.reportingAuthority.ReportingAuthority;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.tool.RandomUtil;
-import org.mars_sim.msp.core.vehicle.Vehicle;
 
 /**
  * This class keeps track of ongoing missions in the simulation.<br>
@@ -319,38 +316,6 @@ public class MissionManager implements Serializable {
 							  .collect(Collectors.toList());
 	}
 
-	/**
-	 * Gets a mission that the given vehicle is a part of.
-	 *
-	 * @param vehicle the vehicle to check for.
-	 * @return mission or null if none.
-	 */
-	public Mission getMissionForVehicle(Vehicle vehicle) {
-
-		if (vehicle == null) {
-			throw new IllegalArgumentException("vehicle is null");
-		}
-
-		Mission result = null;
-
-		Iterator<Mission> i = getMissions().iterator();
-		while (i.hasNext()) {
-			Mission mission = i.next();
-			if (!mission.isDone()) {
-				if (mission instanceof VehicleMission
-					&& ((VehicleMission) mission).getVehicle() == vehicle) {
-					result = mission;
-				} else if (mission instanceof ConstructionMission construction) {
-					if (!construction.getConstructionVehicles().isEmpty()
-						&& construction.getConstructionVehicles().contains(vehicle)) {
-							result = mission;
-					}
-				} 
-			}
-		}
-
-		return result;
-	}
 
 	/**
 	 * Adds a mission plan.

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RoverMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RoverMission.java
@@ -569,7 +569,7 @@ public abstract class RoverMission extends AbstractVehicleMission {
 		else {
 			// Complete embark once everyone is out of the Vehicle
 			// Leave the vehicle.
-			leaveVehicle();
+			releaseVehicle(rover);
 			// End the phase.
 			setPhaseEnded(true);
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RoverMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/RoverMission.java
@@ -501,7 +501,6 @@ public abstract class RoverMission extends AbstractVehicleMission {
 
 		// Make sure the rover chasis is not overlapping a building structure in the settlement map
         if (!isRoverInAGarage) {
-//        	rover.findNewParkingLoc();
 
         	// Outside so preload all EVASuits before the Unloading starts
         	int suitsNeeded = rover.getCrew().size();
@@ -571,8 +570,6 @@ public abstract class RoverMission extends AbstractVehicleMission {
 			// Complete embark once everyone is out of the Vehicle
 			// Leave the vehicle.
 			leaveVehicle();
-			// Reset the vehicle reservation
-			v.correctVehicleReservation();
 			// End the phase.
 			setPhaseEnded(true);
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/WalkSettlementInterior.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/WalkSettlementInterior.java
@@ -217,7 +217,6 @@ public class WalkSettlementInterior extends Task {
 	private double walkingPhase(double time) {
 		double remainingTime = time - minPulseTime;
 		
-		double timeHours = MarsClock.HOURS_PER_MILLISOL * time;
 		double speed = 0;
 		
 		if (person != null) {
@@ -237,15 +236,16 @@ public class WalkSettlementInterior extends Task {
 		}
 		
 		// Determine walking distance.
-		double coveredKm = speed * timeHours;
-		double coveredMeters = coveredKm * 1000D;
+		double coveredMeters =  1000D * speed * MarsClock.HOURS_PER_MILLISOL * time;
 		double remainingPathDistance = getRemainingPathDistance();
 
-		
 		if (coveredMeters > remainingPathDistance) {
 			coveredMeters = remainingPathDistance;
 
 			remainingTime = time - MarsClock.convertSecondsToMillisols(coveredMeters / 1000D / speed * 60D * 60D);	
+		}
+		else {
+			remainingTime = 0D; // Use all the remaining time
 		}
 
 		while (coveredMeters > VERY_SMALL_DISTANCE) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Vehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Vehicle.java
@@ -15,7 +15,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
 
 import org.mars_sim.msp.core.Coordinates;
 import org.mars_sim.msp.core.Direction;
@@ -41,10 +40,8 @@ import org.mars_sim.msp.core.malfunction.Malfunctionable;
 import org.mars_sim.msp.core.manufacture.Salvagable;
 import org.mars_sim.msp.core.manufacture.SalvageInfo;
 import org.mars_sim.msp.core.manufacture.SalvageProcessInfo;
-import org.mars_sim.msp.core.mission.ConstructionMission;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
-import org.mars_sim.msp.core.person.ai.mission.VehicleMission;
 import org.mars_sim.msp.core.person.ai.task.Conversation;
 import org.mars_sim.msp.core.person.ai.task.MaintainBuilding;
 import org.mars_sim.msp.core.person.ai.task.Repair;
@@ -167,6 +164,8 @@ public abstract class Vehicle extends Unit
 	private VehicleSpec spec;
 	
 	private String baseImage;
+
+	private Mission mission;
 
 	static {
 		life_support_range_error_margin = simulationConfig.getSettlementConfiguration()
@@ -1259,28 +1258,26 @@ public abstract class Vehicle extends Unit
 		// Add the location to the trail if outside on a mission
 		addToTrail(getCoordinates());
 
-		correctVehicleReservation();
-
 		return true;
 	}
 
 	/**
 	 * Resets the vehicle reservation status.
 	 */
-	public void correctVehicleReservation() {
-		if (isReservedMission
-			// Set reserved for mission to false if the vehicle is not associated with a
-			// mission.
-			&& missionManager.getMissionForVehicle(this) == null) {
-				logger.log(this, Level.FINE, 5000,
-						"Found reserved for an non-existing mission. Untagging it.");
-				setReservedForMission(false);
-		} else if (missionManager.getMissionForVehicle(this) != null) {
-				logger.log(this, Level.FINE, 5000,
-						"On a mission but not registered as mission reserved. Correcting it.");
-				setReservedForMission(true);
-		}
-	}
+	// public void correctVehicleReservation() {
+	// 	if (isReservedMission
+	// 		// Set reserved for mission to false if the vehicle is not associated with a
+	// 		// mission.
+	// 		&& missionManager.getMissionForVehicle(this) == null) {
+	// 			logger.log(this, Level.FINE, 5000,
+	// 					"Found reserved for an non-existing mission. Untagging it.");
+	// 			setReservedForMission(false);
+	// 	} else if (missionManager.getMissionForVehicle(this) != null) {
+	// 			logger.log(this, Level.FINE, 5000,
+	// 					"On a mission but not registered as mission reserved. Correcting it.");
+	// 			setReservedForMission(true);
+	// 	}
+	// }
 
 	/**
 	 * Gets a collection of people affected by this entity.
@@ -1514,30 +1511,13 @@ public abstract class Vehicle extends Unit
 
 	/**
 	 * Checks if this vehicle is involved in a mission.
-	 *
-	 * @return true if yes
 	 */
 	public Mission getMission() {
-		Iterator<Mission> i = missionManager.getMissions().iterator();
-		while (i.hasNext()) {
-			Mission mission = i.next();
-			if (!mission.isDone()) {
-				if (mission instanceof VehicleMission) {
-					if (((VehicleMission) mission).getVehicle() == this) {
-						return mission;
-					}
-					
-				} else if (mission instanceof ConstructionMission construction) {
-					if (!construction.getConstructionVehicles().isEmpty() 
-						&& construction.getConstructionVehicles().contains(this)) {
-						return mission;
-					}
+		return mission;
+	}
 
-				}
-			}
-		}
-
-		return null;
+	public void setMission(Mission newMission) {
+		this.mission = newMission;
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/MainDetailPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/MainDetailPanel.java
@@ -53,7 +53,6 @@ import org.mars_sim.msp.core.UnitListener;
 import org.mars_sim.msp.core.UnitType;
 import org.mars_sim.msp.core.mission.ConstructionMission;
 import org.mars_sim.msp.core.person.Person;
-import org.mars_sim.msp.core.person.ai.mission.AbstractVehicleMission;
 import org.mars_sim.msp.core.person.ai.mission.AreologyFieldStudy;
 import org.mars_sim.msp.core.person.ai.mission.BiologyFieldStudy;
 import org.mars_sim.msp.core.person.ai.mission.BuildingConstructionMission;
@@ -596,6 +595,9 @@ public class MainDetailPanel extends JPanel implements MissionListener, UnitList
 			if (vehicle != null) {
 				vehicleButton.setText(vehicle.getName());
 				vehicleButton.setVisible(true);
+			}
+
+			if (vehicle != null && !mission.isDone()) {
 				vehicleStatusLabel.setText(vehicle.printStatusTypes());
 				speedLabel.setText(StyleManager.DECIMAL_KMH.format(vehicle.getSpeed())); //$NON-NLS-1$
 				try {
@@ -622,12 +624,6 @@ public class MainDetailPanel extends JPanel implements MissionListener, UnitList
 				}
 			}
 			else {
-	
-				String name = ((AbstractVehicleMission)vehicleMission).getVehicleName();
-				
-				if (name != null)
-					vehicleButton.setText(name);
-				
 				vehicleStatusLabel.setText(" ");
 				speedLabel.setText(StyleManager.DECIMAL_KMH.format(0)); //$NON-NLS-1$ //$NON-NLS-2$
 				distanceNextNavLabel.setText(StyleManager.DECIMAL_KM.format(0)); //$NON-NLS-1$ //$NON-NLS-2$
@@ -639,7 +635,6 @@ public class MainDetailPanel extends JPanel implements MissionListener, UnitList
 						travelledDistance,
 						estTotalDistance
 						));
-				
 				
 				if (currentVehicle != null) {
 					currentVehicle.removeUnitListener(this);

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/MainDetailPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/MainDetailPanel.java
@@ -517,27 +517,25 @@ public class MainDetailPanel extends JPanel implements MissionListener, UnitList
 	 * @param newMission
 	 */
 	public void setMission(Mission newMission) {
+		// Remove this as previous mission listener.
+		if (missionCache != null)
+			missionCache.removeMissionListener(this);
+
 		if (newMission == null) {	
 			clearInfo();
 			return;
 		}
+				
+		missionCache = newMission;
 		
-		// Remove this as previous mission listener.
-		if (missionCache != null)
-			missionCache.removeMissionListener(this);
-					
-		if (missionCache == null || missionCache != newMission) {
-			missionCache = newMission;
-			
-			// Add this as listener for new mission.
-			newMission.addMissionListener(this);
-			
-			setCurrentMission(newMission);
-			// Update info on Main tab
-			updateMainTab(newMission);
-			// Update custom mission panel.
-			updateCustomPanel(newMission);
-		}
+		// Add this as listener for new mission.
+		newMission.addMissionListener(this);
+		
+		setCurrentMission(newMission);
+		// Update info on Main tab
+		updateMainTab(newMission);
+		// Update custom mission panel.
+		updateCustomPanel(newMission);
 	}
 
 
@@ -553,7 +551,7 @@ public class MainDetailPanel extends JPanel implements MissionListener, UnitList
 			return;
 		}
 
-		if (currentVehicle == null && mission.getMembers().isEmpty() && mission.isDone()) {
+		if (mission.isDone()) {
 			// Check if the mission is done and the members have been disbanded
 			memberOuterPane.removeAll();
 			memberOuterPane.add(memberLabel);

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/ConstructionVehiclePanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/ConstructionVehiclePanel.java
@@ -28,7 +28,6 @@ import javax.swing.event.ListSelectionListener;
 
 import org.mars_sim.msp.core.CollectionUtils;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
-import org.mars_sim.msp.core.person.ai.mission.MissionManager;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.vehicle.GroundVehicle;
 import org.mars_sim.msp.core.vehicle.LightUtilityVehicle;
@@ -51,9 +50,7 @@ class ConstructionVehiclePanel extends WizardPanel {
     private JLabel requiredLabel;
     private JLabel selectedLabel;
     private JLabel errorMessageLabel;
-    
-	private MissionManager missionManager;
-	
+    	
     /**
      * Constructor
      * @param wizard the create mission wizard.
@@ -61,9 +58,7 @@ class ConstructionVehiclePanel extends WizardPanel {
     ConstructionVehiclePanel(final CreateMissionWizard wizard) {
         // User WizardPanel constructor.
         super(wizard);
-        
-		missionManager = getSimulation().getMissionManager();
-		
+        		
         // Set the layout.
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         
@@ -233,7 +228,7 @@ class ConstructionVehiclePanel extends WizardPanel {
                     else if (column == 1) 
                         result = vehicle.printStatusTypes();
                     else if (column == 2) {
-                        Mission mission = missionManager.getMissionForVehicle(vehicle);
+                        Mission mission = vehicle.getMission();
                         if (mission != null) result = mission.getName();
                         else result = "None";
                     }
@@ -275,7 +270,7 @@ class ConstructionVehiclePanel extends WizardPanel {
                 	result = true;
             }
             else if (column == 2) {
-                Mission mission = missionManager.getMissionForVehicle(vehicle);
+                Mission mission = vehicle.getMission();
                 if (mission != null) result = true;
             }
             

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/FlyerPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/FlyerPanel.java
@@ -27,7 +27,6 @@ import javax.swing.event.ListSelectionListener;
 
 import org.mars_sim.msp.core.CollectionUtils;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
-import org.mars_sim.msp.core.person.ai.mission.MissionManager;
 import org.mars_sim.msp.core.person.ai.mission.MissionType;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.vehicle.Drone;
@@ -50,7 +49,6 @@ class FlyerPanel extends WizardPanel {
 	private VehicleTableModel vehicleTableModel;
 	private JTable vehicleTable;
 	private JLabel errorMessageLabel;
-	private MissionManager missionManager;
 
 	/**
 	 * Constructor.
@@ -60,7 +58,6 @@ class FlyerPanel extends WizardPanel {
 	FlyerPanel(final CreateMissionWizard wizard) {
 		// User WizardPanel constructor.
 		super(wizard);
-		missionManager = getSimulation().getMissionManager();
 
 		// Set the layout.
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
@@ -237,7 +234,7 @@ class FlyerPanel extends WizardPanel {
 					else if (column == 5)
 						result = vehicle.printStatusTypes();
 					else if (column == 6) {
-						Mission mission = missionManager.getMissionForVehicle(vehicle);
+						Mission mission = vehicle.getMission();
 						if (mission != null)
 							result = mission.getName();
 						else
@@ -290,7 +287,7 @@ class FlyerPanel extends WizardPanel {
 				}
 				
 			} else if (column == 9) {
-				Mission mission = missionManager.getMissionForVehicle(vehicle);
+				Mission mission = vehicle.getMission();
 				if (mission != null)
 					result = true;
 			}

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/LightUtilityVehiclePanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/LightUtilityVehiclePanel.java
@@ -9,7 +9,6 @@ package org.mars_sim.msp.ui.swing.tool.mission.create;
 
 import org.mars_sim.msp.core.CollectionUtils;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
-import org.mars_sim.msp.core.person.ai.mission.MissionManager;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.vehicle.LightUtilityVehicle;
 import org.mars_sim.msp.core.vehicle.StatusType;
@@ -38,8 +37,6 @@ extends WizardPanel {
 	private JTable vehicleTable;
 	private JLabel errorMessageLabel;
 	
-	private static MissionManager missionManager;
-
 	/**
 	 * Constructor.
 	 * @param wizard the create mission wizard.
@@ -47,9 +44,7 @@ extends WizardPanel {
 	public LightUtilityVehiclePanel(CreateMissionWizard wizard) {
 		// User WizardPanel constructor.
 		super(wizard);
-		
-		missionManager = getSimulation().getMissionManager();
-		
+				
 		// Set the layout.
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 		
@@ -188,7 +183,7 @@ extends WizardPanel {
 					else if (column == 1) 
 						result = vehicle.printStatusTypes();
 					else if (column == 2) {
-						Mission mission = missionManager.getMissionForVehicle(vehicle);
+						Mission mission = vehicle.getMission();
 						if (mission != null) result = mission.getName();
 						else result = "None";
 					}
@@ -230,7 +225,7 @@ extends WizardPanel {
 					result = true;
 			}
 			else if (column == 2) {
-				Mission mission = missionManager.getMissionForVehicle(vehicle);
+				Mission mission = vehicle.getMission();
 				if (mission != null) result = true;
 			}
 

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/SalvageVehiclePanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/SalvageVehiclePanel.java
@@ -27,7 +27,6 @@ import javax.swing.event.ListSelectionListener;
 
 import org.mars_sim.msp.core.CollectionUtils;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
-import org.mars_sim.msp.core.person.ai.mission.MissionManager;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.structure.building.Building;
 import org.mars_sim.msp.core.structure.construction.ConstructionSite;
@@ -54,9 +53,7 @@ public class SalvageVehiclePanel extends WizardPanel {
     private JLabel requiredLabel;
     private JLabel selectedLabel;
     private JLabel errorMessageLabel;
-    
-	private MissionManager missionManager;
-	
+    	
     /**
      * Constructor
      * @param wizard the create mission wizard.
@@ -64,9 +61,7 @@ public class SalvageVehiclePanel extends WizardPanel {
     SalvageVehiclePanel(CreateMissionWizard wizard) {
         // User WizardPanel constructor.
         super(wizard);
-        
-    	missionManager = getSimulation().getMissionManager();
-    	
+            	
         // Set the layout.
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         
@@ -245,7 +240,7 @@ public class SalvageVehiclePanel extends WizardPanel {
                     else if (column == 1) 
                         result = vehicle.printStatusTypes();
                     else if (column == 2) {
-                        Mission mission = missionManager.getMissionForVehicle(vehicle);
+                        Mission mission = vehicle.getMission();
                         if (mission != null) result = mission.getName();
                         else result = "None";
                     }
@@ -287,7 +282,7 @@ public class SalvageVehiclePanel extends WizardPanel {
                 	result = true;
             }
             else if (column == 2) {
-                Mission mission = missionManager.getMissionForVehicle(vehicle);
+                Mission mission = vehicle.getMission();
                 if (mission != null) result = true;
             }
             

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/VehiclePanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/create/VehiclePanel.java
@@ -27,7 +27,6 @@ import javax.swing.event.ListSelectionListener;
 
 import org.mars_sim.msp.core.CollectionUtils;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
-import org.mars_sim.msp.core.person.ai.mission.MissionManager;
 import org.mars_sim.msp.core.person.ai.mission.MissionType;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.tool.Conversion;
@@ -49,7 +48,6 @@ class VehiclePanel extends WizardPanel {
 	private VehicleTableModel vehicleTableModel;
 	private JTable vehicleTable;
 	private JLabel errorMessageLabel;
-	private MissionManager missionManager;
 
 	/**
 	 * Constructor.
@@ -59,7 +57,6 @@ class VehiclePanel extends WizardPanel {
 	VehiclePanel(final CreateMissionWizard wizard) {
 		// User WizardPanel constructor.
 		super(wizard);
-		missionManager = getSimulation().getMissionManager();
 
 		// Set the layout.
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
@@ -245,7 +242,7 @@ class VehiclePanel extends WizardPanel {
 					else if (column == 8)
 						result = vehicle.printStatusTypes();
 					else if (column == 9) {
-						Mission mission = missionManager.getMissionForVehicle(vehicle);
+						Mission mission = vehicle.getMission();
 						if (mission != null)
 							result = mission.getName();
 						else
@@ -298,7 +295,7 @@ class VehiclePanel extends WizardPanel {
 				}
 				
 			} else if (column == 9) {
-				Mission mission = missionManager.getMissionForVehicle(vehicle);
+				Mission mission = vehicle.getMission();
 				if (mission != null)
 					result = true;
 			}

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/VehicleTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/VehicleTableModel.java
@@ -188,7 +188,7 @@ public class VehicleTableModel extends UnitTableModel<Vehicle> {
 			} break;
 
 			case DESTINATION : {
-				Mission mission = missionManager.getMissionForVehicle(vehicle);
+				Mission mission = vehicle.getMission();
 				if (mission instanceof VehicleMission) {
 					VehicleMission vehicleMission = (VehicleMission) mission;
 
@@ -202,7 +202,7 @@ public class VehicleTableModel extends UnitTableModel<Vehicle> {
 			} break;
 
 			case DESTDIST : {
-				Mission mission = missionManager.getMissionForVehicle(vehicle);
+				Mission mission = vehicle.getMission();
 				if (mission instanceof VehicleMission) {
 					VehicleMission vehicleMission = (VehicleMission) mission;
 					result = vehicleMission.getDistanceCurrentLegRemaining();
@@ -211,7 +211,7 @@ public class VehicleTableModel extends UnitTableModel<Vehicle> {
 			} break;
 
 			case MISSION : {
-				Mission mission = missionManager.getMissionForVehicle(vehicle);
+				Mission mission = vehicle.getMission();
 				if (mission != null) {
 					result = mission.getFullMissionDesignation();
 				}

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/settlement/VehicleMapLayer.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/settlement/VehicleMapLayer.java
@@ -194,10 +194,9 @@ public class VehicleMapLayer implements SettlementMapLayer {
 		boolean result = false;
 
 		// For vehicle missions, check if vehicle is loading or unloading for the mission.
-		Mission mission = missionManager.getMissionForVehicle(vehicle);
-		if ((mission != null) && (mission instanceof VehicleMission)) {
-			VehicleMission vehicleMission = (VehicleMission) mission;
-			LoadingController lp = vehicleMission.getLoadingPlan();
+		Mission mission = vehicle.getMission();
+		if ((mission != null) && (mission instanceof VehicleMission vm)) {
+			LoadingController lp = vm.getLoadingPlan();
 			result = (lp != null) && !lp.isCompleted();
 		}
 

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/vehicle/NavigationTabPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/vehicle/NavigationTabPanel.java
@@ -27,7 +27,6 @@ import javax.swing.border.EmptyBorder;
 import org.mars_sim.msp.core.Coordinates;
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
-import org.mars_sim.msp.core.person.ai.mission.MissionManager;
 import org.mars_sim.msp.core.person.ai.mission.NavPoint;
 import org.mars_sim.msp.core.person.ai.mission.VehicleMission;
 import org.mars_sim.msp.core.structure.Settlement;
@@ -89,8 +88,6 @@ public class NavigationTabPanel extends TabPanel implements ActionListener {
     private Coordinates destinationLocationCache;
     private Settlement destinationSettlementCache;
 
-	private MissionManager missionManager;
-
     /**
      * Constructor
      *
@@ -107,8 +104,6 @@ public class NavigationTabPanel extends TabPanel implements ActionListener {
         );
 	
         vehicle = unit;
-
-        missionManager = desktop.getSimulation().getMissionManager();
 	}
 
     @Override
@@ -175,7 +170,7 @@ public class NavigationTabPanel extends TabPanel implements ActionListener {
         
         boolean hasDestination = false;
 
-        Mission mission = missionManager.getMissionForVehicle(vehicle);
+        Mission mission = vehicle.getMission();
         if (mission instanceof VehicleMission) {
 
             VehicleMission vehicleMission = (VehicleMission) mission;
@@ -321,7 +316,7 @@ public class NavigationTabPanel extends TabPanel implements ActionListener {
             pilotLabel.setText(pilot);
         }
         
-        Mission mission = missionManager.getMissionForVehicle(vehicle);
+        Mission mission = vehicle.getMission();
         
         boolean hasDestination = false;
         		
@@ -483,7 +478,6 @@ public class NavigationTabPanel extends TabPanel implements ActionListener {
 	    terrainDisplay = null; 
 	    destinationLocationCache = null; 
 	    destinationSettlementCache = null; 
-		missionManager = null; 
 	}
 	
     

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/vehicle/TabPanelMission.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/vehicle/TabPanelMission.java
@@ -30,7 +30,6 @@ import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
-import org.mars_sim.msp.core.person.ai.mission.MissionManager;
 import org.mars_sim.msp.core.person.ai.task.util.Worker;
 import org.mars_sim.msp.core.vehicle.Vehicle;
 import org.mars_sim.msp.ui.swing.ImageLoader;
@@ -89,9 +88,8 @@ extends TabPanel {
 
 	@Override
 	protected void buildUI(JPanel topContentPanel) {
-		MissionManager missionManager = getSimulation().getMissionManager();
 
-		Mission mission = missionManager.getMissionForVehicle(vehicle);
+		Mission mission = vehicle.getMission();
 
 		// Prepare mission top panel
 		JPanel missionTopPanel = new JPanel(new GridLayout(2, 1, 0, 0));
@@ -172,7 +170,7 @@ extends TabPanel {
 		missionButton.setToolTipText(Msg.getString("TabPanelMission.tooltip.mission")); //$NON-NLS-1$
 		missionButton.addActionListener(e -> {
 				Vehicle vehicle = (Vehicle) unit;
-				Mission m = missionManager.getMissionForVehicle(vehicle);
+				Mission m = vehicle.getMission();
 				if (m != null) {
 					getDesktop().showDetails(m);
 				}
@@ -186,7 +184,7 @@ extends TabPanel {
 		monitorButton.setToolTipText(Msg.getString("TabPanelMission.tooltip.monitor")); //$NON-NLS-1$
 		monitorButton.addActionListener(e -> {
 				Vehicle vehicle = (Vehicle) unit;
-				Mission m = missionManager.getMissionForVehicle(vehicle);
+				Mission m = vehicle.getMission();
 				if (m != null) {
 					try {
 						getDesktop().addModel(new PersonTableModel(m));
@@ -205,7 +203,7 @@ extends TabPanel {
 	@Override
 	public void update() {
 		Vehicle vehicle = (Vehicle) getUnit();
-		Mission mission = getSimulation().getMissionManager().getMissionForVehicle(vehicle);
+		Mission mission = vehicle.getMission();
 
 		if (mission != null) {
 		    missionCache = mission.getName();

--- a/mars-sim-ui/src/main/resources/docs/help/whatsnew.html
+++ b/mars-sim-ui/src/main/resources/docs/help/whatsnew.html
@@ -18,7 +18,9 @@
   <LI>Fuel    : Enable the use of methanol as fuel for vehicles</LI>
   
   <LI>Resupplies : Define resupply missions with a repeating schedule</LI>
-  <LI>Vehicle    : Enable regen braking and encapsulate propulsion calculations in motor controller class</LI>  
+  <LI>Vehicle    : Enable regen braking and encapsulate propulsion calculations in motor controller class</LI>
+  <LI>Vehicle    : Maintains own reference to assigned Mission.</LI>
+  <LI>Mission    : Retains reference to Vehicle after Mission completed.</LI>  
 </OL>
   
 <H4>B. UI IMPROVEMENT :</H4>
@@ -26,7 +28,7 @@
   <LI>Resupply : Showcase resupply missions by settlements under a tree.</LI>
   <LI>    Role : Restore previous role if change is not confirmed.</LI>
   <LI>Mars Map : Use a variety of resolutions of surface maps.</LI>
-
+  <LI>Events   : Events in the Monitor Window are clickable to drill down into the details of the entity.</LI>
 </OL>  
 
 <H4>C. RUNTIME ENVIRONMENT :</H4>


### PR DESCRIPTION
This PR changes how the representation Vehicles assigned to MIssions. Vehicles now directly reference the actual Mission instead of relying upon the MissionManager. Mission now retain the reference to Vehicles event when the Mission is completed.
This approach needs a change to how the mission is closed down; it now needs to release the assigned vehicles.

The UI MissionWindow is updated to only show the Vehicle actual details when the Mission is active.

fix #855 