### PR TITLE
Convert ScheduledEvent logic to MarsTIme

### DIFF
--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/FutureEventCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/FutureEventCommand.java
@@ -35,7 +35,7 @@ public class FutureEventCommand extends AbstractSettlementCommand {
 							
 		// Display each farm separately
 		for (ScheduledEvent event : settlement.getFutureManager().getEvents()) {			
-			response.appendTableRow(event.getWhen().getTrucatedDateTimeStamp(), event.getDescription());
+			response.appendTableRow(event.getWhen().getTruncatedDateTimeStamp(), event.getDescription());
 		}
 		context.println(response.getOutput());
 		return true;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/SimulationBuilder.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/SimulationBuilder.java
@@ -318,7 +318,7 @@ public class SimulationBuilder {
 
 		if (!loaded) {
 			// initialize getTransportManager	
-			sim.getTransportManager().init();
+			sim.getTransportManager().init(sim);
 		}
 
 		while (true) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/events/ScheduledEventHandler.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/events/ScheduledEventHandler.java
@@ -8,7 +8,7 @@ package org.mars_sim.msp.core.events;
 
 import java.io.Serializable;
 
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 
 /**
  * Represents a handler that is notified when a scheduled event arrives.
@@ -27,5 +27,5 @@ public interface ScheduledEventHandler extends Serializable {
      * @param currentTime The time when this handler was triggered
      * @return The millisols to a rescheduled event.
      */
-    int execute(MarsClock currentTime);
+    int execute(MarsTime currentTime);
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/goods/GoodsManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/goods/GoodsManager.java
@@ -27,7 +27,7 @@ import org.mars_sim.msp.core.person.ai.mission.MissionManager;
 import org.mars_sim.msp.core.person.ai.mission.MissionType;
 import org.mars_sim.msp.core.resource.ResourceUtil;
 import org.mars_sim.msp.core.structure.Settlement;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.core.vehicle.Vehicle;
 import org.mars_sim.msp.core.vehicle.VehicleType;
 
@@ -51,7 +51,7 @@ public class GoodsManager implements Serializable {
 		 * @param now Current time not used.
 		 */
 		@Override
-		public int execute(MarsClock now) {
+		public int execute(MarsTime now) {
 			calculateBuyList();
 			calculateSellList();
 			return LIST_VALIDITY;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/interplanetary/transport/TransportManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/interplanetary/transport/TransportManager.java
@@ -51,16 +51,16 @@ public class TransportManager implements Serializable, Temporal {
 	public TransportManager(Simulation sim) {
 		this.eventManager = sim.getEventManager();
 
-		Transportable.initalizeInstances(sim.getMasterClock().getMarsClock(), this);
+		Transportable.initalizeInstances(sim.getMasterClock(), this);
 
 		// Initialize data
 		transportItems = new ArrayList<>();
 
-		this.futures = new ScheduledEventManager(sim.getMasterClock().getMarsClock());
+		this.futures = new ScheduledEventManager(sim.getMasterClock());
 	}
 	
-	public void init() {
-		transportItems.addAll(ResupplyUtil.loadInitialResupplyMissions());
+	public void init(Simulation sim) {
+		transportItems.addAll(ResupplyUtil.loadInitialResupplyMissions(sim));
 	}
 	
 	/**
@@ -83,7 +83,7 @@ public class TransportManager implements Serializable, Temporal {
 			
 			a.scheduleLaunch(futures);
 			logger.config("Scheduling a new settlement called '" + a.getName() + "' to arrive at Sol "
-						+ a.getArrivalDate().getTrucatedDateTimeStamp());
+						+ a.getArrivalDate().getTruncatedDateTimeStamp());
 			transportItems.add(a);
 		}
 	}
@@ -138,7 +138,7 @@ public class TransportManager implements Serializable, Temporal {
 	 */
 	public void reinitalizeInstances(Simulation sim) {
 		this.eventManager = sim.getEventManager();
-		Transportable.initalizeInstances(sim.getMasterClock().getMarsClock(), this);
+		Transportable.initalizeInstances(sim.getMasterClock(), this);
 
 		UnitManager um = sim.getUnitManager();
 		for(Transportable t : transportItems) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/interplanetary/transport/Transportable.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/interplanetary/transport/Transportable.java
@@ -15,7 +15,8 @@ import org.mars_sim.msp.core.events.ScheduledEventHandler;
 import org.mars_sim.msp.core.events.ScheduledEventManager;
 import org.mars_sim.msp.core.interplanetary.transport.resupply.ResupplyUtil;
 import org.mars_sim.msp.core.person.EventType;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
+import org.mars_sim.msp.core.time.MasterClock;
 
 /**
  * An class for an item that is transported between planets/moons/etc.
@@ -26,14 +27,14 @@ public abstract class Transportable
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
 	
-	private MarsClock arrivalDate;
-	private MarsClock launchDate;
+	private MarsTime arrivalDate;
+	private MarsTime launchDate;
 	private TransitState state;
 	private Coordinates landingSite;
 	private String name;
 
 	protected static TransportManager tm;
-	protected static MarsClock now;
+	protected static MasterClock master;
 
 	public Transportable(String name, Coordinates landingSite) {
 		this.name = name;
@@ -63,8 +64,8 @@ public abstract class Transportable
 		return state;
 	}
 
-	public MarsClock getLaunchDate() {
-		return new MarsClock(launchDate);
+	public MarsTime getLaunchDate() {
+		return launchDate;
 	}
 
 	/**
@@ -77,10 +78,10 @@ public abstract class Transportable
 	/**
 	 * Gets the arrival date at the destination.
 	 * 
-	 * @return arrival date as a MarsClock instance.
+	 * @return arrival date as a MarsTime instance.
 	 */
-	public MarsClock getArrivalDate() {
-		return new MarsClock(arrivalDate);
+	public MarsTime getArrivalDate() {
+		return arrivalDate;
 	}
 
 	/**
@@ -88,20 +89,20 @@ public abstract class Transportable
 	 * 
 	 * @param arrivalDate the arrival date.
 	 */
-	public void setArrivalDate(MarsClock arrivalDate) {
-		this.arrivalDate = new MarsClock(arrivalDate);
+	public void setArrivalDate(MarsTime arrivalDate) {
+		this.arrivalDate = arrivalDate;
 
 		// Determine launch date.
-		launchDate = new MarsClock(arrivalDate);
-		launchDate.addTime(-1D * ResupplyUtil.getAverageTransitTime() * 1000D);
+		launchDate = arrivalDate.addTime(-1D * ResupplyUtil.getAverageTransitTime() * 1000D);
 
 		// Set resupply state based on launch and arrival time.
-		MarsClock nextScheduledEvent = launchDate;
+		MarsTime now = master.getMarsTime();
+		MarsTime nextScheduledEvent = launchDate;
 		state = TransitState.PLANNED;
-		if (MarsClock.getTimeDiff(now, launchDate) > 0D) {
+		if (now.getTimeDiff(launchDate) > 0D) {
 			state = TransitState.IN_TRANSIT;
 			nextScheduledEvent = arrivalDate;
-			if (MarsClock.getTimeDiff(now, arrivalDate) > 0D) {
+			if (now.getTimeDiff(arrivalDate) > 0D) {
 				// Should have already arrived
 				nextScheduledEvent = now;
 			}
@@ -155,14 +156,14 @@ public abstract class Transportable
 	 * @param now Current time
 	 * @return return the milliosols to the next phase
 	 */
-	public int execute(MarsClock now) {
+	public int execute(MarsTime now) {
 		int nextEvent = 0;
 		switch(state) {
 			case PLANNED:
 				// Launch has arrived
 				state = TransitState.IN_TRANSIT;
 				tm.fireEvent(this, EventType.TRANSPORT_ITEM_LAUNCHED);
-				nextEvent = (int) MarsClock.getTimeDiff(arrivalDate, now);
+				nextEvent = (int) arrivalDate.getTimeDiff(now);
 				break;
 			case IN_TRANSIT:
 				// Arrvived
@@ -180,7 +181,7 @@ public abstract class Transportable
 	public int compareTo(Transportable o) {
 		int result = 0;
 
-		double arrivalTimeDiff = MarsClock.getTimeDiff(getArrivalDate(), o.getArrivalDate());
+		double arrivalTimeDiff = getArrivalDate().getTimeDiff(o.getArrivalDate());
 		if (arrivalTimeDiff < 0D) {
 			result = -1;
 		} else if (arrivalTimeDiff > 0D) {
@@ -193,8 +194,8 @@ public abstract class Transportable
 		return result;
 	}
 
-	static void initalizeInstances(MarsClock mc, TransportManager transportManager) {
-		now = mc;
+	static void initalizeInstances(MasterClock mc, TransportManager transportManager) {
+		master = mc;
 		tm = transportManager;
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/interplanetary/transport/resupply/Resupply.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/interplanetary/transport/resupply/Resupply.java
@@ -39,7 +39,7 @@ import org.mars_sim.msp.core.structure.building.BuildingConfig;
 import org.mars_sim.msp.core.structure.building.BuildingManager;
 import org.mars_sim.msp.core.structure.building.BuildingSpec;
 import org.mars_sim.msp.core.structure.building.function.FunctionType;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.core.tool.RandomUtil;
 
 /**
@@ -100,7 +100,7 @@ public class Resupply extends Transportable implements SettlementSupplies {
 	 * @param arrivalDate the arrival date of the supplies.
 	 * @param settlement  the settlement receiving the supplies.
 	 */
-	public Resupply(ResupplySchedule template, int cycle, MarsClock arrivalDate, Settlement settlement) {
+	public Resupply(ResupplySchedule template, int cycle, MarsTime arrivalDate, Settlement settlement) {
 		this(template.getName() + " #" + cycle, arrivalDate, settlement);
 
 		// Initialize data members.
@@ -120,7 +120,7 @@ public class Resupply extends Transportable implements SettlementSupplies {
 	/**
 	 * Bespoke resupply mission.
 	 */
-	public Resupply(String name, MarsClock arrivalDate, Settlement destination) {
+	public Resupply(String name, MarsTime arrivalDate, Settlement destination) {
 		super(name, destination.getCoordinates());
 
 		this.settlement = destination;
@@ -171,8 +171,7 @@ public class Resupply extends Transportable implements SettlementSupplies {
 		// If a schedule then create the next one
 		if (template.getFrequency() > 0) {
 			// Scheduled the follow on
-			MarsClock newArrival = new MarsClock(getArrivalDate());
-			newArrival.addTime(template.getActiveMissions() * template.getFrequency() * 1000.0);
+			MarsTime newArrival = getArrivalDate().addTime(template.getActiveMissions() * template.getFrequency() * 1000.0);
 			Resupply followOn = new Resupply(this.getTemplate(), cycle + template.getActiveMissions(),
 												newArrival, settlement);
 			tm.addNewTransportItem(followOn);
@@ -1240,7 +1239,7 @@ public class Resupply extends Transportable implements SettlementSupplies {
 	@Override
 	public String toString() {
 		StringBuffer buff = new StringBuffer();
-		buff.append(getArrivalDate().getDateString());
+		buff.append(getArrivalDate().getDateTimeStamp());
 		buff.append(" : ");
 		buff.append(getSettlement().getName());
 		return buff.toString();

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/interplanetary/transport/resupply/ResupplyUtil.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/interplanetary/transport/resupply/ResupplyUtil.java
@@ -14,7 +14,7 @@ import org.mars_sim.msp.core.SimulationConfig;
 import org.mars_sim.msp.core.UnitManager;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.structure.SettlementConfig;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 
 /**
  * Utility class for resupply missions.
@@ -24,17 +24,11 @@ public final class ResupplyUtil {
 
 
     public static int MAX_NUM_SOLS_PLANNED = 2007; // 669 * 3 = 2007
-
-    private static SimulationConfig simulationConfig = SimulationConfig.instance();
-	private static SettlementConfig settlementConfig = simulationConfig.getSettlementConfiguration();
 	
     // Average transit time for resupply missions from Earth to Mars [in sols]
-    private static int averageTransitTime = simulationConfig.getAverageTransitTime();
+    private static int averageTransitTime = SimulationConfig.instance().getAverageTransitTime();
 
-    
-    private static Simulation sim = Simulation.instance();
-	private static MarsClock currentTime = sim.getMasterClock().getMarsClock();
-	private static UnitManager unitManager = sim.getUnitManager();
+
     
 	/**
 	 * Private constructor for utility class.
@@ -51,7 +45,11 @@ public final class ResupplyUtil {
 	/**
 	 * Creates the initial resupply missions from the configuration XML files.
 	 */
-	public static List<Resupply> loadInitialResupplyMissions() {
+	public static List<Resupply> loadInitialResupplyMissions(Simulation sim) {
+		MarsTime currentTime = sim.getMasterClock().getMarsTime();
+		UnitManager unitManager = sim.getUnitManager();
+		SettlementConfig settlementConfig = SimulationConfig.instance().getSettlementConfiguration();
+
 		List<Resupply> resupplies = new ArrayList<>();
 			
 		for(Settlement settlement : unitManager.getSettlements()) {
@@ -59,16 +57,14 @@ public final class ResupplyUtil {
 
 			// For each Settlement get the resupply scheduled defined by the SettlementTemplate
 			for(ResupplySchedule template : settlementConfig.getItem(templateName).getResupplyMissionTemplates()) {
-				MarsClock arrivalDate = new MarsClock(currentTime);
-				arrivalDate.addTime(template.getFirstArrival() * 1000D);
+				MarsTime arrivalDate = currentTime.addTime(template.getFirstArrival() * 1000D);
 
 				// If the frequency is less than transport time also add the next ones
 				for(int cycle = 0; cycle < template.getActiveMissions(); cycle++) {
 					Resupply resupply = new Resupply(template, cycle+1, arrivalDate, settlement);
 					resupplies.add(resupply);
 
-					arrivalDate = new MarsClock(arrivalDate);
-					arrivalDate.addTime(template.getFrequency() * 1000D);
+					arrivalDate = arrivalDate.addTime(template.getFrequency() * 1000D);
 				}
 			}
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/interplanetary/transport/settlement/ArrivingSettlement.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/interplanetary/transport/settlement/ArrivingSettlement.java
@@ -15,7 +15,7 @@ import org.mars_sim.msp.core.interplanetary.transport.Transportable;
 import org.mars_sim.msp.core.structure.InitialSettlement;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.structure.SettlementBuilder;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.core.tool.RandomUtil;
 
 /**
@@ -177,7 +177,7 @@ public class ArrivingSettlement extends Transportable {
 		StringBuffer buff = new StringBuffer();
 		buff.append(getName());
 		buff.append(": ");
-		buff.append(getArrivalDate().getDateString());
+		buff.append(getArrivalDate().getDateTimeStamp());
 		return buff.toString();
 	}
 
@@ -198,8 +198,7 @@ public class ArrivingSettlement extends Transportable {
 	 */
 	public void scheduleLaunch(ScheduledEventManager futures) {
 		// Determine the arrival date
-		MarsClock proposedArrival = new MarsClock(now);
-		proposedArrival.addTime(
+		MarsTime proposedArrival = master.getMarsTime().addTime(
 					(arrivalSols - 1) * 1000D
 					+ 100 
 					+ RandomUtil.getRandomDouble(890));

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/Settlement.java
@@ -375,7 +375,7 @@ public class Settlement extends Structure implements Temporal,
 		eqmInventory = new EquipmentInventory(this, GEN_MAX);
 
 		// Initialize schedule event manager
-		futureEvents = new ScheduledEventManager(marsClock);
+		futureEvents = new ScheduledEventManager(masterClock);
 
 		creditManager = new CreditManager(this, unitManager);
 
@@ -488,7 +488,7 @@ public class Settlement extends Structure implements Temporal,
 		buildingManager.createAdjacentBuildingMap();
 		
 		// Initialize schedule event manager
-		futureEvents = new ScheduledEventManager(marsClock);
+		futureEvents = new ScheduledEventManager(masterClock);
 
 		// Get the rotation about the planet and convert that to a fraction of the Sol.
 		double fraction = getCoordinates().getTheta()/(Math.PI * 2D); 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/Shift.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/Shift.java
@@ -8,7 +8,7 @@ package org.mars_sim.msp.core.structure;
 
 
 import org.mars_sim.msp.core.events.ScheduledEventHandler;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 
 /**
  * This class represents an active work shift that has a number of slots for works allocated.
@@ -128,7 +128,7 @@ public class Shift implements ScheduledEventHandler {
      * @param now Time now when the handler was called; not used
      */
     @Override
-    public int execute(MarsClock now) {
+    public int execute(MarsTime now) {
         // Flip the on duty flag
         onDuty = !onDuty;
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/ShiftManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/ShiftManager.java
@@ -10,7 +10,7 @@ import org.mars_sim.msp.core.events.ScheduledEventManager;
 import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.structure.ShiftSlot.WorkStatus;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.core.tool.RandomUtil;
 
 /**
@@ -36,7 +36,7 @@ public class ShiftManager implements Serializable {
          * @param now Current time not used
          */
         @Override
-        public int execute(MarsClock now) {
+        public int execute(MarsTime now) {
             rotateShift();
             return rotationSols * 1000;
         }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/ShiftSlot.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/ShiftSlot.java
@@ -8,7 +8,7 @@ package org.mars_sim.msp.core.structure;
 
 import org.mars_sim.msp.core.events.ScheduledEventHandler;
 import org.mars_sim.msp.core.person.Person;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 
 /**
  * This class represents a slot on a specific shift for work.
@@ -101,7 +101,7 @@ public class ShiftSlot implements ScheduledEventHandler {
      * @param now Current time not used
      */
     @Override
-    public int execute(MarsClock now) {
+    public int execute(MarsTime now) {
         onLeave = false;
         return 0;
     }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/time/ClockPulse.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/time/ClockPulse.java
@@ -11,49 +11,28 @@ public class ClockPulse {
 	 * The sols passed since last pulse.
 	 */
 	private double elapsed;
-	
-	/**
-	 * The last integer millisol.
-	 */
 	private int lastIntMillisol;
-	
-	/**
-	 * Updated Mars time for this simulation.
-	 */
-	private MarsClock marsTime;
-
-	/**
-	 * Master clock.
-	 */
+	private MarsTime marsTime;
 	private MasterClock master;
-	
-	/**
-	 * Has this pulse crossed into a new Sol.
-	 */
 	private boolean isNewSol;
-
-	/**
-	 * Has this pulse crossed into a new integer millisol 
-	 */
 	private boolean isNewIntMillisol;
-
-	/**
-	 * Pulse id
-	 */
 	private long id;
+	private MarsClock oldMarsTime;
 	
 	/**
 	 * Creates a pulse defining a step forward in the simulation.
 	 * 
 	 * @param id Unique pulse ID. Sequential.
 	 * @param elapsed This must be a final & positive number.
+	 * @param oldMarsTime This is a deprecated argument and will be dropped once MarsClock is removed
 	 * @param marsTime
 	 * @param master
 	 * @param newSol Has a new Mars day started with this pulse?
 	 * @param newMSol Does this pulse start a new msol (an integer millisol) ?
 	 */
-	public ClockPulse(long id, double elapsed, MarsClock marsTime, MasterClock master, 
-			boolean newSol, boolean newMSol) {
+	public ClockPulse(long id, double elapsed, MarsClock oldMarsTime,
+					MarsTime marsTime, MasterClock master, 
+					boolean newSol, boolean newMSol) {
 		super();
 		
 		if ((elapsed <= 0) || !Double.isFinite(elapsed)) {
@@ -63,6 +42,7 @@ public class ClockPulse {
 		this.id = id;
 		this.elapsed = elapsed;
 		this.marsTime = marsTime;
+		this.oldMarsTime = oldMarsTime;
 		this.master = master;
 		this.isNewSol = newSol;
 		this.isNewIntMillisol = newMSol;
@@ -87,8 +67,19 @@ public class ClockPulse {
 	 * @return
 	 */
 	public MarsClock getMarsTime() {
+		return oldMarsTime;
+	}
+
+	/**
+	 * Gets MarsTime when this pulse fires.
+	 * This will be renamed once the old MarsClock is removed 
+	 * 
+	 * @return
+	 */
+	public MarsTime getNewMarsTime() {
 		return marsTime;
 	}
+
 
 	/**
 	 * Gets MasterClock instance.
@@ -137,6 +128,6 @@ public class ClockPulse {
 			lastIntMillisol = thisIntMillisol;
 		}
 		
-		return new ClockPulse(id, actualElapsed, marsTime, master, actualNewSol, isNewIntMillisol);
+		return new ClockPulse(id, actualElapsed, oldMarsTime, marsTime, master, actualNewSol, isNewIntMillisol);
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/time/MasterClock.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/time/MasterClock.java
@@ -205,6 +205,14 @@ public class MasterClock implements Serializable {
 	}
 
 	/**
+	 * Override the mars time. This must be used with caution
+	 * @param newTime New Mars time
+	 */
+    public void setMarsTime(MarsTime newTime) {
+		marsTime = newTime;
+    }
+	
+	/**
 	 * Gets the initial Mars time at the start of the simulation.
 	 *
 	 * @return initial Mars time.
@@ -701,7 +709,7 @@ public class MasterClock implements Serializable {
 		int logIndex = (int)(newPulseId % MAX_PULSE_LOG);
 		pulseLog[logIndex] = System.currentTimeMillis();
 
-		currentPulse = new ClockPulse(newPulseId, time, marsClock, this, isNewSol, isNewIntMillisol);
+		currentPulse = new ClockPulse(newPulseId, time, marsClock, marsTime, this, isNewSol, isNewIntMillisol);
 		// Note: for-loop may handle checked exceptions better than forEach()
 		// See https://stackoverflow.com/questions/16635398/java-8-iterable-foreach-vs-foreach-loop?rq=1
 
@@ -975,4 +983,5 @@ public class MasterClock implements Serializable {
 		clockThreadTask = null;
 		listenerExecutor = null;
 	}
+
 }

--- a/mars-sim-core/src/test/java/org/mars_sim/msp/core/AbstractMarsSimUnitTest.java
+++ b/mars-sim-core/src/test/java/org/mars_sim/msp/core/AbstractMarsSimUnitTest.java
@@ -26,6 +26,7 @@ import org.mars_sim.msp.core.structure.building.function.FunctionType;
 import org.mars_sim.msp.core.structure.building.function.VehicleGarage;
 import org.mars_sim.msp.core.time.ClockPulse;
 import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.core.vehicle.Rover;
 
 import junit.framework.TestCase;
@@ -197,7 +198,7 @@ public abstract class AbstractMarsSimUnitTest extends TestCase {
      * @return
      */
     protected ClockPulse createPulse(int missionSol, int mSol, boolean newSol) {
-        MarsClock marsTime = new MarsClock(1, 1, missionSol, mSol, missionSol);
+        MarsTime marsTime = new MarsTime(1, 1, missionSol, mSol, missionSol);
 		return createPulse(marsTime, newSol);
 	}
 
@@ -212,7 +213,15 @@ public abstract class AbstractMarsSimUnitTest extends TestCase {
         return createPulse(marsTime, false);
     }
 
+	/**
+	 * This method will be removed ocne MarsClock is deleted.
+	 */
 	protected ClockPulse createPulse(MarsClock marsTime, boolean newSol) {
-        return new ClockPulse(pulseID++, 1D, marsTime, null, newSol, true);
+        return new ClockPulse(pulseID++, 1D, marsTime, null, null, newSol, true);
+    }
+
+	protected ClockPulse createPulse(MarsTime marsTime, boolean newSol) {
+		sim.getMasterClock().setMarsTime(marsTime);
+        return new ClockPulse(pulseID++, 1D, null, marsTime, null, newSol, true);
     }
 }

--- a/mars-sim-core/src/test/java/org/mars_sim/msp/core/TestSaving.java
+++ b/mars-sim-core/src/test/java/org/mars_sim/msp/core/TestSaving.java
@@ -43,7 +43,7 @@ public class TestSaving extends TestCase implements SimulationListener {
 
         // Simulate a clock pulse to trigger the save
         MasterClock mc = sim.getMasterClock();
-        ClockPulse pulse = new ClockPulse(1, 0.01D, mc.getMarsClock(), mc, false, false);
+        ClockPulse pulse = new ClockPulse(1, 0.01D, mc.getMarsClock(), null, mc, false, false);
         sim.clockPulse(pulse);
 
         // Check simulations saved and it contains data

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/resupply/ArrivingSettlementDetailPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/resupply/ArrivingSettlementDetailPanel.java
@@ -19,7 +19,7 @@ import org.mars_sim.msp.core.interplanetary.transport.settlement.ArrivingSettlem
 import org.mars_sim.msp.core.structure.SettlementConfig;
 import org.mars_sim.msp.core.structure.SettlementSupplies;
 import org.mars_sim.msp.core.time.ClockPulse;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.ui.swing.MainDesktopPane;
 import org.mars_sim.msp.ui.swing.StyleManager;
 import org.mars_sim.msp.ui.swing.utils.AttributePanel;
@@ -139,7 +139,7 @@ extends JPanel
 		stateValueLabel.setText(arrivingSettlement.getTransitState().getName());
 		arrivalDateValueLabel.setText(arrivingSettlement.getArrivalDate().getDateTimeStamp());
 
-		MarsClock marsTime = desktop.getSimulation().getMasterClock().getMarsClock();
+		MarsTime marsTime = desktop.getSimulation().getMasterClock().getMarsTime();
 		updateTimeToArrival(marsTime);
 
 		templateValueLabel.setText(arrivingSettlement.getTemplate());
@@ -153,10 +153,10 @@ extends JPanel
 	 * Update the time to arrival label.
 	 * @param currentTime
 	 */
-	private void updateTimeToArrival(MarsClock currentTime) {
+	private void updateTimeToArrival(MarsTime currentTime) {
 		String timeArrival = Msg.getString("ArrivingSettlementDetailPanel.noTime"); //$NON-NLS-1$
 		solsToArrival = -1;
-		double timeDiff = MarsClock.getTimeDiff(arrivingSettlement.getArrivalDate(), currentTime);
+		double timeDiff = arrivingSettlement.getArrivalDate().getTimeDiff(currentTime);
 		if (timeDiff > 0D) {
 			solsToArrival = (int) Math.abs(timeDiff / 1000D);
 			timeArrival = Msg.getString(
@@ -167,10 +167,10 @@ extends JPanel
 		timeArrivalValueLabel.setText(timeArrival);
 	}
 
-	private void updateArrival(MarsClock currentTime) {
+	private void updateArrival(MarsTime currentTime) {
 		// Determine if change in time to arrival display value.
 		if ((arrivingSettlement != null) && (solsToArrival >= 0)) {
-			double timeDiff = MarsClock.getTimeDiff(arrivingSettlement.getArrivalDate(), currentTime);
+			double timeDiff = arrivingSettlement.getArrivalDate().getTimeDiff(currentTime);
 			double newSolsToArrival = (int) Math.abs(timeDiff / 1000D);
 			if (newSolsToArrival != solsToArrival) {
 				// Update time to arrival label.
@@ -184,6 +184,6 @@ extends JPanel
 	 * @param pulse Amount of clock movement
 	 */	
 	void update(ClockPulse pulse) {
-		updateArrival(pulse.getMarsTime());			
+		updateArrival(pulse.getNewMarsTime());			
 	}
 }

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/resupply/ArrivingSettlementEditingPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/resupply/ArrivingSettlementEditingPanel.java
@@ -46,8 +46,9 @@ import org.mars_sim.msp.core.interplanetary.transport.TransportManager;
 import org.mars_sim.msp.core.interplanetary.transport.settlement.ArrivingSettlement;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.structure.SettlementTemplate;
-import org.mars_sim.msp.core.time.MarsClock;
-import org.mars_sim.msp.core.time.MarsClockFormat;
+import org.mars_sim.msp.core.time.MarsTime;
+import org.mars_sim.msp.core.time.MarsTimeFormat;
+import org.mars_sim.msp.core.time.MasterClock;
 import org.mars_sim.msp.ui.swing.JComboBoxMW;
 import org.mars_sim.msp.ui.swing.MarsPanelBorder;
 import org.mars_sim.msp.ui.swing.tool.SpringUtilities;
@@ -95,7 +96,7 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 	private NewTransportItemDialog newTransportItemDialog;
 	private ArrivingSettlement settlement;
 
-	private MarsClock marsClock;
+	private MasterClock master;
 
 	private TransportManager transportManager;
 	private UnitManager unitManager;
@@ -117,7 +118,7 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		// Initialize data members.
 		this.settlement = settlement;
 		Simulation sim = resupplyWindow.getDesktop().getSimulation();
-		this.marsClock = sim.getMasterClock().getMarsClock();
+		this.master = sim.getMasterClock();
 		this.transportManager = sim.getTransportManager();
 		this.unitManager = sim.getUnitManager();
 
@@ -275,7 +276,7 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		arrivalDateSelectionPane.add(arrivalDateTitleLabel);
 
 		// Get default arriving settlement Martian time.
-		MarsClock arrivingTime = marsClock;
+		MarsTime arrivingTime = master.getMarsTime();
 		if (settlement != null) {
 			arrivingTime = settlement.getArrivalDate();
 		}
@@ -295,7 +296,7 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		arrivalDateSelectionPane.add(monthLabel);
 
 		// Create month combo box.
-		monthCB = new JComboBoxMW<>(MarsClockFormat.getMonthNames());
+		monthCB = new JComboBoxMW<>(MarsTimeFormat.getMonthNames());
 		monthCB.setSelectedItem(arrivingTime.getMonthName());
 		monthCB.addActionListener(e -> {
 			// Update the solCB based on orbit and month
@@ -357,8 +358,8 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		timeUntilArrivalPane.add(timeUntilArrivalLabel);
 
 		// Create sols text field.
-//		MarsClock currentTime = Simulation.instance().getMasterClock().getMarsClock();
-		int solsDiff = (int) Math.round((MarsClock.getTimeDiff(arrivingTime, marsClock) / 1000D));
+		MarsTime currentTime = master.getMarsTime();
+		int solsDiff = (int) Math.round((arrivingTime.getTimeDiff(currentTime) / 1000D));
 		solsTF = new JTextField(4);
 		solsTF.setText(Integer.toString(solsDiff));
 		solsTF.setHorizontalAlignment(JTextField.RIGHT);
@@ -773,17 +774,17 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 				// 		if (transportItem instanceof Resupply) {
 				// 			// Create modify resupply mission dialog.
 				// 			Resupply resupply = (Resupply) transportItem;
-				// 			MarsClock arrivingTime = resupply.getArrivalDate();
-				// 			int solsDiff = (int) Math.round((MarsClock.getTimeDiff(arrivingTime, marsClock) / 1000D));
+				// 			MarsTime arrivingTime = resupply.getArrivalDate();
+				// 			int solsDiff = (int) Math.round((MarsTime.getTimeDiff(arrivingTime, MarsTime) / 1000D));
 				// 			sols.add(solsDiff);
 
 				// 		} else if (transportItem instanceof ArrivingSettlement) {
 				// 			// Create modify arriving settlement dialog.
 				// 			ArrivingSettlement newS = (ArrivingSettlement) transportItem;
 				// 			if (!newS.equals(settlement)) {
-				// 				MarsClock arrivingTime = newS.getArrivalDate();
+				// 				MarsTime arrivingTime = newS.getArrivalDate();
 				// 				int solsDiff = (int) Math
-				// 						.round((MarsClock.getTimeDiff(arrivingTime, marsClock) / 1000D));
+				// 						.round((MarsTime.getTimeDiff(arrivingTime, MarsTime) / 1000D));
 				// 				sols.add(solsDiff);
 				// 			}
 				// 		}
@@ -935,7 +936,7 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		settlement.setSponsorCode((String) sponsorCB.getSelectedItem());
 
 		// Populate arrival date.
-		MarsClock arrivalDate = getArrivalDate();
+		MarsTime arrivalDate = getArrivalDate();
 		settlement.setArrivalDate(arrivalDate);
 
 		// Set population number.
@@ -954,11 +955,11 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 	/**
 	 * Gets the arrival date from the UI values.
 	 * 
-	 * @return arrival date as MarsClock instance.
+	 * @return arrival date as MarsTime instance.
 	 */
-	private MarsClock getArrivalDate() {
+	private MarsTime getArrivalDate() {
 
-		MarsClock result = new MarsClock(marsClock);
+		MarsTime result = master.getMarsTime();
 
 		if (arrivalDateRB.isSelected()) {
 			// Determine arrival date from arrival date combo boxes.
@@ -969,12 +970,12 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 
 				// Set millisols to current time if resupply is current date, otherwise 0.
 				double millisols = 0D;
-				if ((sol == marsClock.getSolOfMonth()) && (month == marsClock.getMonth())
-						&& (orbit == marsClock.getOrbit())) {
-					millisols = marsClock.getMillisol();
+				if ((sol == result.getSolOfMonth()) && (month == result.getMonth())
+						&& (orbit == result.getOrbit())) {
+					millisols = result.getMillisol();
 				}
 
-				result = new MarsClock(orbit, month, sol, millisols, -1);
+				result = new MarsTime(orbit, month, sol, millisols, -1);
 			} catch (NumberFormatException e) {
 				e.printStackTrace(System.err);
 			}
@@ -983,9 +984,9 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 			try {
 				int solsDiff = Integer.parseInt(solsTF.getText());
 				if (solsDiff > 0) {
-					result.addTime(solsDiff * 1000D);
+					result = result.addTime(solsDiff * 1000D);
 				} else {
-					result.addTime(marsClock.getMillisol());
+					result = result.addTime(master.getMarsTime().getMillisol());
 				}
 			} catch (NumberFormatException e) {
 				e.printStackTrace(System.err);

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/resupply/ResupplyDetailPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/resupply/ResupplyDetailPanel.java
@@ -17,7 +17,7 @@ import javax.swing.SwingConstants;
 import org.mars_sim.msp.core.interplanetary.transport.resupply.Resupply;
 import org.mars_sim.msp.core.interplanetary.transport.resupply.ResupplySchedule;
 import org.mars_sim.msp.core.time.ClockPulse;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.ui.swing.MainDesktopPane;
 import org.mars_sim.msp.ui.swing.StyleManager;
 import org.mars_sim.msp.ui.swing.utils.AttributePanel;
@@ -129,11 +129,11 @@ public class ResupplyDetailPanel extends JPanel {
 											+ " (every " + schedule.getFrequency() + " sols)" : ""));
 		destinationValueLabel.setText(resupply.getSettlement().getName());
 		stateValueLabel.setText(resupply.getTransitState().getName());
-		launchDateValueLabel.setText(resupply.getLaunchDate().getDateString());
-		arrivalDateValueLabel.setText(resupply.getArrivalDate().getDateTimeStamp());
+		launchDateValueLabel.setText(resupply.getLaunchDate().getTruncatedDateTimeStamp());
+		arrivalDateValueLabel.setText(resupply.getArrivalDate().getTruncatedDateTimeStamp());
 		immigrantsValueLabel.setText(Integer.toString(resupply.getNewImmigrantNum()));
 		
-		updateTimeToArrival(desktop.getSimulation().getMasterClock().getMarsClock());
+		updateTimeToArrival(desktop.getSimulation().getMasterClock().getMarsTime());
 		suppliesPanel.show(resupply);
 
 		validate();
@@ -143,10 +143,10 @@ public class ResupplyDetailPanel extends JPanel {
 	 * Updates the time to arrival label.
 	 * @param currentTime 
 	 */
-	private void updateTimeToArrival(MarsClock currentTime) {
+	private void updateTimeToArrival(MarsTime currentTime) {
 		String timeArrival = "---";
 		solsToArrival = -1;
-		double timeDiff = MarsClock.getTimeDiff(resupply.getArrivalDate(), currentTime);
+		double timeDiff = resupply.getArrivalDate().getTimeDiff(currentTime);
 		if (timeDiff > 0D) {
 			solsToArrival = (int) Math.abs(timeDiff / 1000D);
 			timeArrival = Integer.toString(solsToArrival) + " Sols";
@@ -154,10 +154,10 @@ public class ResupplyDetailPanel extends JPanel {
 		timeArrivalValueLabel.setText(timeArrival);
 	}
 
-	private void updateArrival(MarsClock currentTime) {
+	private void updateArrival(MarsTime currentTime) {
 		// Determine if change in time to arrival display value.
 		if ((resupply != null) && (solsToArrival >= 0)) {
-			double timeDiff = MarsClock.getTimeDiff(resupply.getArrivalDate(), currentTime);
+			double timeDiff = resupply.getArrivalDate().getTimeDiff(currentTime);
 			double newSolsToArrival = (int) Math.abs(timeDiff / 1000D);
 			if (newSolsToArrival != solsToArrival) {
 				if (resupply != null) {
@@ -168,6 +168,6 @@ public class ResupplyDetailPanel extends JPanel {
 	}
 
 	void update(ClockPulse pulse) {
-		updateArrival(pulse.getMarsTime());
+		updateArrival(pulse.getNewMarsTime());
 	}
 }

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/resupply/ResupplyWindow.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/resupply/ResupplyWindow.java
@@ -195,7 +195,7 @@ public class ResupplyWindow extends ToolWindow
 			Enumeration<TreeNode> existing = sNode.children();
 			while(existing.hasMoreElements()) {
 				Transportable n = (Transportable) ((DefaultMutableTreeNode)existing.nextElement()).getUserObject();
-				if (MarsClock.getTimeDiff(at.getArrivalDate(), n.getArrivalDate()) < 0D) {
+				if (at.getArrivalDate().getTimeDiff(n.getArrivalDate()) < 0D) {
 					// Found the Transportable arriving later than the target
 					break;
 				} 
@@ -379,7 +379,7 @@ public class ResupplyWindow extends ToolWindow
 				else if (t instanceof ArrivingSettlement a) {
 					name.append(a.getTemplate());
 				}				
-				name.append(" @ ").append(t.getArrivalDate().getDateString());
+				name.append(" @ ").append(t.getArrivalDate().getTruncatedDateTimeStamp());
 				this.setText(name.toString());
 			}
 			return this;


### PR DESCRIPTION
Changes:
- ScheduledEventManager & ScheduledEventHandler converted from MarsClock to MarsTime
- ClockPulse has new attribute of current MarsTime
- AbstractMarsSimUnitTest supports creating a ClockPulse based on MarsTIme
- Update tests to new createClockPulse method based on MarsTime
- MasterClock allows the MarsTime to be set

Part of #650