### PR TITLE
Update Meta mission

### DIFF
--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/Simulation.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/Simulation.java
@@ -583,8 +583,6 @@ public class Simulation implements ClockListener, Serializable {
 		CropConfig cc = simulationConfig.getCropConfiguration();
 		MedicalConfig mc = simulationConfig.getMedicalConfiguration();
 		
-		// Gets the MasterClock instance
-//		MasterClock masterClock = masterClock;
 
 		// Gets the MarsClock instance
 		MarsClock marsClock = masterClock.getMarsClock();
@@ -963,7 +961,7 @@ public class Simulation implements ClockListener, Serializable {
 				break;
 			
 			case AUTOSAVE:
-				int missionSol = masterClock.getMarsClock().getMissionSol();
+				int missionSol = masterClock.getMarsTime().getMissionSol();
 				String saveTime = new SystemDateTime().getDateTimeStr();
 				String autosaveFilename = saveTime + "_sol" + missionSol + "_r" + BUILD
 						+ SAVE_FILE_EXTENSION;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractMission.java
@@ -37,6 +37,7 @@ import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.PersonConfig;
 import org.mars_sim.msp.core.person.ai.NaturalAttributeType;
 import org.mars_sim.msp.core.person.ai.job.util.JobType;
+import org.mars_sim.msp.core.person.ai.mission.meta.AbstractMetaMission;
 import org.mars_sim.msp.core.person.ai.social.RelationshipUtil;
 import org.mars_sim.msp.core.person.ai.task.util.Task;
 import org.mars_sim.msp.core.person.ai.task.util.Worker;
@@ -327,7 +328,6 @@ public abstract class AbstractMission implements Mission, Temporal {
 	 */
 	private void registerHistoricalEvent(Worker member, EventType type, String message) {
 		Unit container = null;
-		String hometown = null;
 		Coordinates coordinates = null;
 		if (member.isInSettlement()) {
 			Building workPlace = member.getBuildingLocation();
@@ -1367,5 +1367,6 @@ public abstract class AbstractMission implements Mission, Temporal {
 
 		MissionLog.initialise(c);
 		MissionUtil.initializeInstances(u, m);
+		AbstractMetaMission.initializeInstances(si.getMasterClock(), m);
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionManager.java
@@ -196,7 +196,7 @@ public class MissionManager implements Serializable {
 		Settlement startingSettlement = person.getAssociatedSettlement();
 
 		// Determine probabilities.
-		for (MetaMission metaMission : List.copyOf(MetaMissionUtil.getMetaMissions())) {
+		for (MetaMission metaMission : MetaMissionUtil.getMetaMissions()) {
 			if (startingSettlement.isMissionEnable(metaMission.getType())) {
 				double baseProb = metaMission.getProbability(person);
 				if (Double.isNaN(baseProb) || Double.isInfinite(baseProb)) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BuildingConstructionMissionMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BuildingConstructionMissionMeta.java
@@ -49,7 +49,7 @@ public class BuildingConstructionMissionMeta extends AbstractMetaMission {
         double missionProbability = 0D;
          
         // No construction until after the x sols of the simulation.
-        if (marsClock.getMissionSol() < BuildingConstructionMission.FIRST_AVAILABLE_SOL) {
+        if (getMarsTime().getMissionSol() < BuildingConstructionMission.FIRST_AVAILABLE_SOL) {
         	return 0;
         }
         

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BuildingSalvageMissionMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/BuildingSalvageMissionMeta.java
@@ -46,7 +46,7 @@ public class BuildingSalvageMissionMeta extends AbstractMetaMission {
         double missionProbability = 0D;
   
       
-        if (marsClock.getMissionSol() < BuildingSalvageMission.FIRST_AVAILABLE_SOL)
+        if (getMarsTime().getMissionSol() < BuildingSalvageMission.FIRST_AVAILABLE_SOL)
         	return 0;
 
         // Check if person is in a settlement.

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectIceMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectIceMeta.java
@@ -13,7 +13,6 @@ import org.mars_sim.msp.core.person.ai.job.util.JobType;
 import org.mars_sim.msp.core.person.ai.mission.CollectIce;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
 import org.mars_sim.msp.core.person.ai.mission.MissionType;
-import org.mars_sim.msp.core.person.ai.mission.MissionUtil;
 import org.mars_sim.msp.core.person.ai.role.RoleType;
 import org.mars_sim.msp.core.structure.Settlement;
 
@@ -59,26 +58,11 @@ public class CollectIceMeta extends AbstractMetaMission {
 					|| RoleType.SUB_COMMANDER == roleType
 					) {
 
-				missionProbability = 1D;
-	    		int numEmbarked = MissionUtil.numEmbarkingMissions(settlement);
-	    		int numThisMission = missionManager.numParticularMissions(MissionType.COLLECT_ICE, settlement);
-				int pop = settlement.getNumCitizens();
-				
-		   		// Check for # of embarking missions.
-	    		if (Math.max(1, pop / 8.0) < numEmbarked + numThisMission) {
-	    			return 0;
-	    		}
-
-	    		if (numThisMission > Math.max(1, pop / 8.0)) {
-	    			return 0;
-	    		}
-
-	    		missionProbability = settlement.getIceProbabilityValue() / VALUE;
-
-	    		int f1 = numEmbarked + 1;
-	    		int f2 = numThisMission + 1;
-
-	    		missionProbability *= (double)Math.max(1, pop / 8.0) / f1 / f2;
+				missionProbability = getSettlementPopModifier(settlement, 8);
+				if (missionProbability == 0) {
+					return 0;
+				}
+	    		missionProbability *= settlement.getIceProbabilityValue() / VALUE;
 
 				// Job modifier.
 	    		missionProbability *= getLeaderSuitability(person);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectRegolithMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectRegolithMeta.java
@@ -13,7 +13,6 @@ import org.mars_sim.msp.core.person.ai.job.util.JobType;
 import org.mars_sim.msp.core.person.ai.mission.CollectRegolith;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
 import org.mars_sim.msp.core.person.ai.mission.MissionType;
-import org.mars_sim.msp.core.person.ai.mission.MissionUtil;
 import org.mars_sim.msp.core.person.ai.role.RoleType;
 import org.mars_sim.msp.core.structure.Settlement;
 
@@ -58,25 +57,11 @@ public class CollectRegolithMeta extends AbstractMetaMission {
 					|| RoleType.SUB_COMMANDER == roleType
 					) {
 
-	    		int numEmbarked = MissionUtil.numEmbarkingMissions(settlement);
-	    		int numThisMission = missionManager.numParticularMissions(MissionType.COLLECT_REGOLITH, settlement);
-				int pop = settlement.getNumCitizens();
-				
-		   		// Check for # of embarking missions.
-	    		if (Math.max(1, pop / 8.0) < numEmbarked + numThisMission) {
+	    		missionProbability = getSettlementPopModifier(settlement, 8);
+				if (missionProbability == 0) {
 	    			return 0;
 	    		}
-
-	    		if (numThisMission > Math.max(1, pop / 8.0)) {
-	    			return 0;
-	    		}
-
 	    		missionProbability = settlement.getRegolithProbabilityValue() / VALUE;
-
-	    		int f1 = numEmbarked + 1;
-	    		int f2 = 4 * numThisMission + 1;
-
-	    		missionProbability *= (double)Math.max(1, pop / 8.0) / f1 / f2;
 
 				// Job modifier.
 	    		missionProbability *= getLeaderSuitability(person);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/EmergencySupplyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/EmergencySupplyMeta.java
@@ -77,25 +77,9 @@ public class EmergencySupplyMeta extends AbstractMetaMission {
 	    	    }
 	
 	            missionProbability = EmergencySupply.BASE_STARTING_PROBABILITY;
-	
-	    		int numEmbarked = MissionUtil.numEmbarkingMissions(settlement);	
-	    		int numThisMission = missionManager.numParticularMissions(MissionType.EMERGENCY_SUPPLY, settlement);
-	    		
-		   		// Check for # of embarking missions.
-	    		if (Math.max(1, settlement.getNumCitizens() / 8.0) < numEmbarked + numThisMission) {
-	    			return 0;
-	    		}	
-	    		
-	    		if (numThisMission > 1)
-	    			return 0;	
-
+	        	missionProbability *= getSettlementPopModifier(settlement, 8);
 	    		if (missionProbability <= 0)
 	    			return 0;
-	    		
-	    		int f1 = 2 * numEmbarked + 1;
-	    		int f2 = 2 * numThisMission + 1;
-	    		
-	    		missionProbability *= settlement.getNumCitizens() / f1 / f2 / 2D;
 	    		
 	           	RoleType roleType = person.getRole().getType();
             	

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/ExplorationMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/ExplorationMeta.java
@@ -16,7 +16,6 @@ import org.mars_sim.msp.core.person.ai.job.util.JobType;
 import org.mars_sim.msp.core.person.ai.mission.Exploration;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
 import org.mars_sim.msp.core.person.ai.mission.MissionType;
-import org.mars_sim.msp.core.person.ai.mission.MissionUtil;
 import org.mars_sim.msp.core.person.ai.mission.RoverMission;
 import org.mars_sim.msp.core.person.ai.role.RoleType;
 import org.mars_sim.msp.core.structure.Settlement;
@@ -72,16 +71,8 @@ public class ExplorationMeta extends AbstractMetaMission {
 					return 0;
 				}
 
-				int numEmbarked = MissionUtil.numEmbarkingMissions(settlement);
-				int numThisMission = missionManager.numParticularMissions(MissionType.EXPLORATION, settlement);
-				int pop = settlement.getNumCitizens();
-				
-		   		// Check for # of embarking missions.
-	    		if (Math.max(1, pop / 8.0) < numEmbarked + numThisMission) {
-	    			return 0;
-	    		}
-
-	    		if (numThisMission > Math.max(1, pop / 8.0)) {
+				missionProbability = getSettlementPopModifier(settlement, 8);
+				if (missionProbability == 0) {
 	    			return 0;
 	    		}
 
@@ -100,11 +91,6 @@ public class ExplorationMeta extends AbstractMetaMission {
 					logger.log(Level.SEVERE, "Error exploring mineral values.", e);
 					return 0;
 				}
-
-				int f1 = numEmbarked + 1;
-				int f2 = numThisMission + 1;
-
-				missionProbability *= (double)pop / f1 / f2;
 
 				// Job modifier.
 				missionProbability *= getLeaderSuitability(person)

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/FieldStudyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/FieldStudyMeta.java
@@ -15,7 +15,6 @@ import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.job.util.JobType;
 import org.mars_sim.msp.core.person.ai.mission.FieldStudyMission;
 import org.mars_sim.msp.core.person.ai.mission.MissionType;
-import org.mars_sim.msp.core.person.ai.mission.MissionUtil;
 import org.mars_sim.msp.core.person.ai.mission.RoverMission;
 import org.mars_sim.msp.core.person.ai.role.RoleType;
 import org.mars_sim.msp.core.science.ScienceType;
@@ -61,17 +60,8 @@ public class FieldStudyMeta extends AbstractMetaMission {
 					|| RoleType.COMMANDER == roleType
 					|| RoleType.SUB_COMMANDER == roleType
 					) {
-
 				missionProbability = 1D;
 				
-				int numEmbarked = MissionUtil.numEmbarkingMissions(settlement);
-				int numThisMission = missionManager.numParticularMissions(mType, settlement);
-				
-		   		// Check for # of embarking missions.
-	    		if (Math.max(1, settlement.getNumCitizens() / 4.0) < numEmbarked + numThisMission) {
-	    			return 0;
-	    		}
-
 	            try {
 	                // Get available rover.
 	                Rover rover = (Rover) RoverMission.getVehicleWithGreatestRange(settlement, false);
@@ -102,10 +92,7 @@ public class FieldStudyMeta extends AbstractMetaMission {
 	                return 0;
 	            }
 
-				int f1 = numEmbarked + 1;
-				int f2 = numThisMission + 1;
-
-				missionProbability *= 4.0 * settlement.getNumCitizens() / f1 / f2;
+				missionProbability *= getSettlementPopModifier(settlement, 4);
 
 	            // Crowding modifier
 	            int crowding = settlement.getIndoorPeopleCount() - settlement.getPopulationCapacity();

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/MetaMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/MetaMission.java
@@ -6,14 +6,10 @@
  */
 package org.mars_sim.msp.core.person.ai.mission.meta;
 
-import org.mars_sim.msp.core.Simulation;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
-import org.mars_sim.msp.core.person.ai.mission.MissionManager;
 import org.mars_sim.msp.core.person.ai.mission.MissionType;
 import org.mars_sim.msp.core.robot.Robot;
-import org.mars_sim.msp.core.science.ScientificStudyManager;
-import org.mars_sim.msp.core.time.MarsClock;
 
 /**
  * Interface for a meta mission, responsible for determining mission probability
@@ -22,11 +18,6 @@ import org.mars_sim.msp.core.time.MarsClock;
 public interface MetaMission {
 
     public static final double LIMIT = 200D;
-    
-	static Simulation sim = Simulation.instance();
-    static MissionManager missionManager = sim.getMissionManager();
-    static MarsClock marsClock = sim.getMasterClock().getMarsClock();
-    static ScientificStudyManager studyManager = sim.getScientificStudyManager();
 	
 	/**
 	 * Type of Mission created by this Meta object

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/MiningMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/MiningMeta.java
@@ -16,7 +16,6 @@ import org.mars_sim.msp.core.person.ai.job.util.JobType;
 import org.mars_sim.msp.core.person.ai.mission.Mining;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
 import org.mars_sim.msp.core.person.ai.mission.MissionType;
-import org.mars_sim.msp.core.person.ai.mission.MissionUtil;
 import org.mars_sim.msp.core.person.ai.mission.RoverMission;
 import org.mars_sim.msp.core.person.ai.role.RoleType;
 import org.mars_sim.msp.core.structure.Settlement;
@@ -74,16 +73,10 @@ public class MiningMeta extends AbstractMetaMission {
 	            if (!Mining.areAvailableAttachmentParts(settlement))
 	            	return 0;
 
-				int numEmbarked = MissionUtil.numEmbarkingMissions(settlement);
-				int numThisMission = missionManager.numParticularMissions(MissionType.MINING, settlement);
-
-		   		// Check for # of embarking missions.
-	    		if (Math.max(1, settlement.getNumCitizens() / 6.0) < numEmbarked + numThisMission) {
+				missionProbability = getSettlementPopModifier(settlement, 8);
+				if (missionProbability == 0) {
 	    			return 0;
 	    		}
-
-	    		if (numThisMission > 1)
-	    			return 0;
 
 	            try {
 	                // Get available rover.
@@ -91,7 +84,7 @@ public class MiningMeta extends AbstractMetaMission {
 
 	                if (rover != null) {
 	                    // Find best mining site.
-	                	missionProbability = Mining.getMatureMiningSitesTotalScore(rover, settlement);
+	                	missionProbability *= Mining.getMatureMiningSitesTotalScore(rover, settlement);
 	                }
 	            } catch (Exception e) {
 	                logger.log(Level.SEVERE, "Error getting mining site.", e);
@@ -104,11 +97,6 @@ public class MiningMeta extends AbstractMetaMission {
 	            if (crowding > 0) {
 	                missionProbability *= (crowding + 1);
 	            }
-
-				int f1 = numEmbarked + 1;
-				int f2 = 2 * numThisMission + 1;
-
-				missionProbability *= (double)settlement.getNumCitizens() / f1 / f2;
 
 	            // Job modifier.
 				missionProbability *= getLeaderSuitability(person)

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/RescueSalvageVehicleMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/RescueSalvageVehicleMeta.java
@@ -82,18 +82,10 @@ public class RescueSalvageVehicleMeta extends AbstractMetaMission {
             else if (all > 3)	
             	min_num = RescueSalvageVehicle.MIN_STAYING_MEMBERS;
     	    
-            // FIXME : need to know how many extra EVA suits needed in the broken vehicle
-			int numEmbarked = MissionUtil.numEmbarkingMissions(settlement);
-
             // Check if min number of EVA suits at settlement.
             if (MissionUtil.getNumberAvailableEVASuitsAtSettlement(settlement) < min_num) {
     	        return 0;
     	    }
-
-            // Check for embarking missions.
-            else if (numEmbarked == 0) {
-                return missionProbability * 2;
-            }
    
             // Check if minimum number of people are available at the settlement.
             if (!MissionUtil.minAvailablePeopleAtSettlement(settlement, min_num)) {
@@ -105,24 +97,11 @@ public class RescueSalvageVehicleMeta extends AbstractMetaMission {
                 return 0;
             }
             
+			missionProbability *= getSettlementPopModifier(settlement, 4);
     		if (missionProbability <= 0)
     			return 0;
-    		
-			int numThisMission = missionManager.numParticularMissions(MissionType.RESCUE_SALVAGE_VEHICLE, settlement);
-            
-	   		// Check for # of embarking missions.
-    		if (Math.max(1, settlement.getNumCitizens() / 8.0) < numThisMission + numEmbarked) {
-    			return 0;
-    		}	
-    		
-    		if (numThisMission > 0)
-    			return 0;	
+    	
 
-			int f1 = 2 * numEmbarked + 1;
-			int f2 = numThisMission + 1;
-			
-			missionProbability = (1 + missionProbability) * settlement.getNumCitizens() / f2 / f1;
-			
            	RoleType roleType = person.getRole().getType();
         	
         	if (RoleType.MISSION_SPECIALIST == roleType)

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/TravelToSettlementMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/TravelToSettlementMeta.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
 import org.mars_sim.msp.core.person.ai.mission.MissionType;
-import org.mars_sim.msp.core.person.ai.mission.MissionUtil;
 import org.mars_sim.msp.core.person.ai.mission.RoverMission;
 import org.mars_sim.msp.core.person.ai.mission.TravelToSettlement;
 import org.mars_sim.msp.core.person.ai.task.util.Worker;
@@ -40,7 +39,7 @@ public class TravelToSettlementMeta extends AbstractMetaMission {
     @Override
     public double getProbability(Person person) {
 
-    	if (marsClock.getMissionSol() < EARLIEST_SOL_TRAVEL) {
+    	if (getMarsTime().getMissionSol() < EARLIEST_SOL_TRAVEL) {
     		return 0;
     	}
     	
@@ -105,23 +104,8 @@ public class TravelToSettlementMeta extends AbstractMetaMission {
         // Determine mission probability.
         missionProbability = TravelToSettlement.BASE_MISSION_WEIGHT
                 + (topSettlementDesirability / 100D);
-
-		int numEmbarked = MissionUtil.numEmbarkingMissions(settlement);
-		int numThisMission = missionManager.numParticularMissions(MissionType.TRAVEL_TO_SETTLEMENT, settlement);
-
-   		// Check for # of embarking missions.
-		if (Math.max(1, settlement.getNumCitizens() / 8.0) < numEmbarked + numThisMission) {
-			return 0;
-		}			
-		
-		else if (numThisMission > 1)
-			return 0;	
-		
-
-		int f1 = 2*numEmbarked + 1;
-		int f2 = 2*numThisMission + 1;
-		
-		missionProbability *= settlement.getNumCitizens() / f1 / f2 / 2D;
+        
+        missionProbability *= getSettlementPopModifier(settlement, 8);
 		
         // Crowding modifier.
         int crowding = settlement.getIndoorPeopleCount()

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/PlanMissionMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/PlanMissionMeta.java
@@ -6,85 +6,116 @@
  */
 package org.mars_sim.msp.core.person.ai.task.meta;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.mars_sim.msp.core.Msg;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.PhysicalCondition;
-import org.mars_sim.msp.core.person.ai.role.RoleType;
 import org.mars_sim.msp.core.person.ai.task.PlanMission;
-import org.mars_sim.msp.core.person.ai.task.util.FactoryMetaTask;
+import org.mars_sim.msp.core.person.ai.task.util.MetaTask;
+import org.mars_sim.msp.core.person.ai.task.util.SettlementMetaTask;
+import org.mars_sim.msp.core.person.ai.task.util.SettlementTask;
 import org.mars_sim.msp.core.person.ai.task.util.Task;
+import org.mars_sim.msp.core.robot.Robot;
+import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.structure.building.Building;
 import org.mars_sim.msp.core.structure.building.function.Administration;
 
 /**
  * The Meta task for the PlanMission task.
  */
-public class PlanMissionMeta extends FactoryMetaTask {
+public class PlanMissionMeta extends MetaTask implements SettlementMetaTask {
+
+    private static class PlanTaskJob extends SettlementTask {
+		
+		private static final long serialVersionUID = 1L;
+
+        public PlanTaskJob(SettlementMetaTask owner, double score) {
+            super(owner, "Plan Mission", score);
+        }
+
+        @Override
+        public Task createTask(Person person) {
+            return new PlanMission(person);
+        }
+
+        @Override
+        public Task createTask(Robot robot) {
+            throw new UnsupportedOperationException("Robots cannot plan missions");
+        }
+    }
+
 
     /** Task name */
     private static final String NAME = Msg.getString("Task.description.planMission"); //$NON-NLS-1$
 
     private static final int START_FACTOR = 50;
-    
+    private static final int PERSON_PER_MISSION = 4;
+
     public PlanMissionMeta() {
 		super(NAME, WorkerType.PERSON, TaskScope.WORK_HOUR);
 	}
 
+    /**
+     * Create a SettlmentTask to plan a mission. The score is based on how many missions can be
+     * supported at the settlement
+     */
     @Override
-    public Task constructInstance(Person person) {
-        return new PlanMission(person);
+    public List<SettlementTask> getSettlementTasks(Settlement settlement) {
+        List<SettlementTask> results = new ArrayList<>();
+        int settlementMissions = missionManager.getMissionsForSettlement(settlement).size();
+        int pop = settlement.getNumCitizens();
+
+        int optimalMissions = (pop/PERSON_PER_MISSION);
+        int shortfall = optimalMissions - settlementMissions;
+        if (shortfall > 0) {
+            results.add(new PlanTaskJob(this, shortfall * START_FACTOR));
+        }
+        return results;
+    }
+
+    /**
+     * Create the person modifier base don their role in the settlement
+     */
+    @Override
+    public double getPersonSettlementModifier(SettlementTask t, Person p) {
+        if (!p.isInSettlement() || !p.getMind().canStartNewMission()) {
+            return 0;
+        }
+    		
+        // Probability affected by the person's stress and fatigue.
+        PhysicalCondition condition = p.getPhysicalCondition();
+        double fatigue = condition.getFatigue();
+        double stress = condition.getStress();
+        double hunger = condition.getHunger();            
+        if (fatigue > 1000 || stress > 75 || hunger > 750)
+            return 0;
+            
+        double result = (10/(fatigue + 1) + 10/(stress + 1) + 10/(hunger + 1));
+
+        if (result > 0) {	 
+            double roleFactor = switch (p.getRole().getType()) {
+                case MISSION_SPECIALIST -> 3.125;
+                case CHIEF_OF_MISSION_PLANNING  -> 2.25;
+                case SUB_COMMANDER -> 1.375;
+                case COMMANDER -> 1.25;
+                default -> 1;
+            };
+            result *= roleFactor;
+
+            // Get an available office space.
+            Building building = Administration.getAvailableOffice(p);
+            result *= getBuildingModifier(building, p);
+
+            result *= getPersonModifier(p);
+        }
+
+        return result;
     }
 
     @Override
-    public double getProbability(Person person) {
-
-        double result = 0D;
-
-        if (person.isInSettlement()) { 					
-        	
-    		boolean canDo = person.getMind().canStartNewMission();
-    		if (!canDo)
-    			return 0;
-    		
-            // Probability affected by the person's stress and fatigue.
-            PhysicalCondition condition = person.getPhysicalCondition();
-            double fatigue = condition.getFatigue();
-            double stress = condition.getStress();
-            double hunger = condition.getHunger();
-            
-            if (fatigue > 1000 || stress > 75 || hunger > 750)
-            	return 0;
-            
-            // This has been reduced
-            result = START_FACTOR * (1/(fatigue + 1) + 1/(stress + 1) + 1/(hunger + 1));
-
-            if (result > 0) {
-            	 
-            	RoleType roleType = person.getRole().getType();
-            	
-            	if (RoleType.MISSION_SPECIALIST == roleType)
-            		result *= 3.125;
-            	else if (RoleType.CHIEF_OF_MISSION_PLANNING == roleType)
-            		result *= 2.25;
-            	else if (RoleType.SUB_COMMANDER == roleType)
-            		result *= 1.375;
-            	else if (RoleType.COMMANDER == roleType)
-            		result *= 1.25;
-            	
-                // Get an available office space.
-                Building building = Administration.getAvailableOffice(person);
-                result *= getBuildingModifier(building, person);
-
-                result *= getPersonModifier(person);
-            }
-            
-            if (result < 0) {
-                result = 0;
-            }
-        }
-
-//      if (result > 0) logger.info(person + " (" + person.getRole().getType() + ") was at PlanMissionMeta : " + Math.round(result*100.0)/100.0)
-
-        return result;
+    public double getRobotSettlementModifier(SettlementTask t, Robot r) {
+        return 0;
     }
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/MetaTask.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/MetaTask.java
@@ -15,6 +15,7 @@ import org.mars_sim.msp.core.environment.SurfaceFeatures;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.fav.FavoriteType;
 import org.mars_sim.msp.core.person.ai.job.util.JobType;
+import org.mars_sim.msp.core.person.ai.mission.MissionManager;
 import org.mars_sim.msp.core.person.ai.task.EVAOperation;
 import org.mars_sim.msp.core.reportingAuthority.PreferenceKey;
 import org.mars_sim.msp.core.robot.RobotType;
@@ -56,6 +57,7 @@ public abstract class MetaTask {
 	
 	protected static SurfaceFeatures surfaceFeatures;
 	private static MasterClock masterClock;
+	protected static MissionManager missionManager;
 	
 	private boolean effortDriven = true;
 	private String name;
@@ -342,5 +344,6 @@ public abstract class MetaTask {
 	static void initialiseInstances(Simulation sim) {
 		masterClock = sim.getMasterClock();
 		surfaceFeatures = sim.getSurfaceFeatures();
+		missionManager = sim.getMissionManager();
 	}
 }

--- a/mars-sim-core/src/test/java/org/mars_sim/msp/core/TestSaving.java
+++ b/mars-sim-core/src/test/java/org/mars_sim/msp/core/TestSaving.java
@@ -43,7 +43,7 @@ public class TestSaving extends TestCase implements SimulationListener {
 
         // Simulate a clock pulse to trigger the save
         MasterClock mc = sim.getMasterClock();
-        ClockPulse pulse = new ClockPulse(1, 0.01D, mc.getMarsClock(), null, mc, false, false);
+        ClockPulse pulse = new ClockPulse(1, 0.01D, null, mc.getMarsTime(), mc, false, false);
         sim.clockPulse(pulse);
 
         // Check simulations saved and it contains data


### PR DESCRIPTION
This PR updates the MetaMission interface to remove the static references. It's generally not  good idea to have static references to mangers inside an interface.
The functionality has been relocated to the AbstractMetaMission with the addition of some consolidation of duplicated logic.
Also it has been converted to the immutable MarsTime class.

Part of #650