### PR TITLE
Mission/Environment Initialisation

### DIFF
--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/CommandHelper.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/CommandHelper.java
@@ -319,7 +319,7 @@ public class CommandHelper {
 		
 		if (!mission.isDone()) {
 			response.appendLabeledString("Phase", mission.getPhaseDescription());
-			response.appendLabeledString("Phase Started", mission.getPhaseStartTime().getTrucatedDateTimeStamp());
+			response.appendLabeledString("Phase Started", mission.getPhaseStartTime().getTruncatedDateTimeStamp());
 		
 			List<String> names = plist.stream().map(p -> p.getName()).sorted().collect(Collectors.toList());
 			response.appendNumberedList("Members", names);
@@ -362,7 +362,7 @@ public class CommandHelper {
 		response.appendText("Log:");
 		response.appendTableHeading("Time", TIMESTAMP_TRUNCATED_WIDTH, "Phase");
 		for (MissionLog.MissionLogEntry entry : mission.getLog().getEntries()) {
-			response.appendTableRow(MarsClockFormat.getTruncatedDateTimeStamp(entry.getTime()), entry.getEntry());
+			response.appendTableRow(entry.getTime().getTruncatedDateTimeStamp(), entry.getEntry());
 		}
 	}
 

--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/unit/UnitSunlightCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/unit/UnitSunlightCommand.java
@@ -38,7 +38,7 @@ public class UnitSunlightCommand extends AbstractUnitCommand {
 														surfaceFeatures.getSolarIrradiance(locn)));
 		response.appendLabeledString("Dark Polar Region", (surfaceFeatures.inDarkPolarRegion(locn) ?
 															"Yes" : "No"));
-		response.appendLabeledString("Recent Sunrise", surfaceFeatures.getSunRise(locn).getDisplayDateTimeStamp());
+		response.appendLabeledString("Recent Sunrise", surfaceFeatures.getSunRise(locn).getTruncatedDateTimeStamp());
 
 		context.println(response.getOutput());
 		return true;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/Simulation.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/Simulation.java
@@ -388,9 +388,9 @@ public class Simulation implements ClockListener, Serializable {
 
 		eventManager = new HistoricalEventManager(masterClock);
 
-		AbstractMission.initializeInstances(this, marsClock, eventManager, unitManager,
+		AbstractMission.initializeInstances(this, eventManager, unitManager,
 			surfaceFeatures, missionManager, simulationConfig.getPersonConfig());
-		MissionStep.initializeInstances(marsClock, unitManager);
+		MissionStep.initializeInstances(masterClock, unitManager);
 
 		doneInitializing = true;
 	}
@@ -527,9 +527,9 @@ public class Simulation implements ClockListener, Serializable {
 		GameManager.initializeInstances(unitManager);
 
 		// Set instances for classes that extend Unit and Task and Mission
-		AbstractMission.initializeInstances(this, marsClock, eventManager, unitManager,
+		AbstractMission.initializeInstances(this, eventManager, unitManager,
 				surfaceFeatures, missionManager, pc);	
-		MissionStep.initializeInstances(marsClock, unitManager);
+		MissionStep.initializeInstances(masterClock, unitManager);
 
 		LocalAreaUtil.initializeInstances(unitManager, marsClock);
 		
@@ -662,7 +662,7 @@ public class Simulation implements ClockListener, Serializable {
 		GameManager.initializeInstances(unitManager);
 		
 		// Re-initialize Mission related class
-		AbstractMission.initializeInstances(this, marsClock, eventManager, unitManager,
+		AbstractMission.initializeInstances(this, eventManager, unitManager,
 				surfaceFeatures, missionManager, pc);
 
 		LocalAreaUtil.initializeInstances(unitManager, marsClock);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/Simulation.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/Simulation.java
@@ -371,7 +371,7 @@ public class Simulation implements ClockListener, Serializable {
 		
 		medicalManager = new MedicalManager();
 		medicalManager.initializeInstances(mc);
-		PhysicalCondition.initializeInstances(masterClock, marsClock, medicalManager,
+		PhysicalCondition.initializeInstances(masterClock, medicalManager,
 								simulationConfig.getPersonConfig());
 
 		malfunctionFactory = new MalfunctionFactory();
@@ -474,7 +474,7 @@ public class Simulation implements ClockListener, Serializable {
 		// Initialize Unit
 		Unit.initializeInstances(masterClock, unitManager, weather, missionManager);
 	
-		PhysicalCondition.initializeInstances(masterClock, marsClock, medicalManager,
+		PhysicalCondition.initializeInstances(masterClock, medicalManager,
 										simulationConfig.getPersonConfig());
 
 		scientificStudyManager = new ScientificStudyManager();
@@ -621,7 +621,7 @@ public class Simulation implements ClockListener, Serializable {
 		// Re-initialize units prior to starting the unit manager
 		Unit.initializeInstances(masterClock, unitManager, weather, missionManager);
 
-		PhysicalCondition.initializeInstances(masterClock, marsClock, medicalManager,
+		PhysicalCondition.initializeInstances(masterClock, medicalManager,
 								simulationConfig.getPersonConfig());
 
 		

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/Simulation.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/Simulation.java
@@ -298,20 +298,17 @@ public class Simulation implements ClockListener, Serializable {
 	}
 
 	public void runSocietySim() {
-		Simulation sim = instance();
 		
 		// Create marsClock instance
 		masterClock = new MasterClock(256);
-		MarsClock marsClock = masterClock.getMarsClock();
 		
 		// Create orbit info
-		orbitInfo = new OrbitInfo(marsClock);
+		orbitInfo = new OrbitInfo(masterClock, simulationConfig);
 		// Create weather
-		weather = new Weather();
-		Weather.initializeInstances(sim, marsClock, orbitInfo);
+		weather = new Weather(masterClock, orbitInfo);
 		
 		// Create surface features
-		surfaceFeatures = new SurfaceFeatures();
+		surfaceFeatures = new SurfaceFeatures(masterClock, orbitInfo, weather);
 	}
 		
 	/**
@@ -321,7 +318,6 @@ public class Simulation implements ClockListener, Serializable {
 		
 		ResourceUtil.getInstance().initializeInstances();
 		
-		Simulation sim = Simulation.instance();
 		simulationConfig = SimulationConfig.instance();
 		
 		MedicalConfig mc = simulationConfig.getMedicalConfiguration();
@@ -336,14 +332,12 @@ public class Simulation implements ClockListener, Serializable {
 		SimuLoggingFormatter.initializeInstances(masterClock);
 		
 		// Create orbit info
-		orbitInfo = new OrbitInfo(marsClock);
+		orbitInfo = new OrbitInfo(masterClock, simulationConfig);
 		// Create weather
-		weather = new Weather();
-		Weather.initializeInstances(sim, marsClock, orbitInfo);
+		weather = new Weather(masterClock, orbitInfo);
 		
 		// Create surface features
-		surfaceFeatures = new SurfaceFeatures();
-		SurfaceFeatures.initializeInstances(this, marsClock, orbitInfo, weather);
+		surfaceFeatures = new SurfaceFeatures(masterClock, orbitInfo, weather);
 		
 		unitManager = new UnitManager();
 		EquipmentFactory.initialise(unitManager, simulationConfig.getManufactureConfiguration());
@@ -430,16 +424,13 @@ public class Simulation implements ClockListener, Serializable {
 		malfunctionFactory = new MalfunctionFactory();
 
 		// Create orbit info
-		orbitInfo = new OrbitInfo(marsClock);
+		orbitInfo = new OrbitInfo(masterClock, simulationConfig);
 		// Create weather
-		weather = new Weather();
-		
-		Weather.initializeInstances(this, marsClock, orbitInfo);
-		
+		weather = new Weather(masterClock, orbitInfo);
+
 		// Create surface features
-		surfaceFeatures = new SurfaceFeatures();
-		SurfaceFeatures.initializeInstances(this, marsClock, orbitInfo, weather);
-		
+		surfaceFeatures = new SurfaceFeatures(masterClock, orbitInfo, weather);
+
 		// Initialize MissionManager instance
 		missionManager = new MissionManager();
 		missionManager.initializeInstances(simulationConfig);
@@ -582,9 +573,6 @@ public class Simulation implements ClockListener, Serializable {
 		PersonConfig pc = simulationConfig.getPersonConfig();
 		CropConfig cc = simulationConfig.getCropConfiguration();
 		MedicalConfig mc = simulationConfig.getMedicalConfiguration();
-		
-		// Gets the MasterClock instance
-//		MasterClock masterClock = masterClock;
 
 		// Gets the MarsClock instance
 		MarsClock marsClock = masterClock.getMarsClock();
@@ -594,12 +582,6 @@ public class Simulation implements ClockListener, Serializable {
 		
 		// Set instances for logging
 		SimuLoggingFormatter.initializeInstances(masterClock);
-		
-		// Re-initialize weather
-		Weather.initializeInstances(this, marsClock, orbitInfo);
-		
-		// Re-initialize surfacefeatures
-		SurfaceFeatures.initializeInstances(this, marsClock, orbitInfo, weather);
 		
 		// Reload mission configs
 		missionManager.initializeInstances(simulationConfig);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/mission/MissionProject.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/mission/MissionProject.java
@@ -30,7 +30,7 @@ import org.mars_sim.msp.core.project.ProjectStep;
 import org.mars_sim.msp.core.project.Stage;
 import org.mars_sim.msp.core.structure.ObjectiveType;
 import org.mars_sim.msp.core.structure.Settlement;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 
 /**
  * Is a Mission astraction that allows a Mission tobe defiend in terms of a number of MissionSteps.
@@ -88,7 +88,7 @@ public abstract class MissionProject implements Mission {
 
 	/** Mission listeners. */
 	private transient Set<MissionListener> listeners = null;
-    private MarsClock stepStarted;
+    private MarsTime stepStarted;
 
     private Set<Worker> members = new HashSet<>();
     private Set<Worker> signedUp = new HashSet<>();
@@ -307,7 +307,7 @@ public abstract class MissionProject implements Mission {
     }
 
     @Override
-    public MarsClock getPhaseStartTime() {
+    public MarsTime getPhaseStartTime() {
         return stepStarted;
     }
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/mission/MissionStep.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/mission/MissionStep.java
@@ -17,7 +17,7 @@ import org.mars_sim.msp.core.project.ProjectStep;
 import org.mars_sim.msp.core.project.Stage;
 import org.mars_sim.msp.core.resource.ResourceUtil;
 import org.mars_sim.msp.core.robot.Robot;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MasterClock;
 import org.mars_sim.msp.core.vehicle.Vehicle;
 
 /**
@@ -28,9 +28,9 @@ import org.mars_sim.msp.core.vehicle.Vehicle;
 public abstract class MissionStep extends ProjectStep {
 	private static final SimLogger logger = SimLogger.getLogger(MissionStep.class.getName());
 
-    private static MarsClock marsClock;
-
     private static UnitManager unitManager;
+
+    private static MasterClock clock;
 
     private MissionProject mission;
 
@@ -48,7 +48,7 @@ public abstract class MissionStep extends ProjectStep {
      * @return mSol
      */
     protected int getStepDuration() {
-        return (int) MarsClock.getTimeDiff(marsClock, mission.getPhaseStartTime());
+        return (int) clock.getMarsTime().getTimeDiff(mission.getPhaseStartTime());
     }
 
     /**
@@ -120,8 +120,8 @@ public abstract class MissionStep extends ProjectStep {
         return unitManager;
     }
 
-    public static void initializeInstances(MarsClock mc, UnitManager um) {
-        marsClock = mc;
+    public static void initializeInstances(MasterClock mc, UnitManager um) {
+        clock = mc;
         unitManager = um;
     }
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/mission/MissionVehicleProject.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/mission/MissionVehicleProject.java
@@ -20,6 +20,7 @@ import org.mars_sim.msp.core.person.ai.task.LoadingController;
 import org.mars_sim.msp.core.project.ProjectStep;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.core.tool.RandomUtil;
 import org.mars_sim.msp.core.vehicle.Vehicle;
 
@@ -176,7 +177,7 @@ public class MissionVehicleProject extends MissionProject
     }
 
     @Override
-    public MarsClock getLegETA() {
+    public MarsTime getLegETA() {
         return null;
     }
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/PhysicalCondition.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/PhysicalCondition.java
@@ -34,7 +34,6 @@ import org.mars_sim.msp.core.person.health.RadiationExposure;
 import org.mars_sim.msp.core.person.health.RadioProtectiveAgent;
 import org.mars_sim.msp.core.resource.ResourceUtil;
 import org.mars_sim.msp.core.time.ClockPulse;
-import org.mars_sim.msp.core.time.MarsClock;
 import org.mars_sim.msp.core.time.MasterClock;
 import org.mars_sim.msp.core.tool.RandomUtil;
 
@@ -80,12 +79,6 @@ public class PhysicalCondition implements Serializable {
 
 	private static final int OXYGEN_ID = ResourceUtil.oxygenID;
 
-//	/** The amount of fatigue for the mental breakdown to occur [millisols]. */
-//	private static final double MENTAL_BREAKDOWN = 100D;
-//	/** Stress jump resulting from being in an accident. */
-//	private static final double ACCIDENT_STRESS = 10D;
-//	/** The food reserve factor. */
-//	private static final double FOOD_RESERVE_FACTOR = 1.5D;
 	/** Performance modifier for thirst. */
 	private static final double THIRST_PERFORMANCE_MODIFIER = .00015D;
 	/** Performance modifier for hunger. */
@@ -128,8 +121,6 @@ public class PhysicalCondition implements Serializable {
 	private boolean isStarving;
 	/** True if person is stressed out. */
 	private boolean isStressedOut;
-//	/** True if person is collapsed under fatigue. */
-//	private boolean isCollapsed;
 	/** True if person is dehydrated. */
 	private boolean isDehydrated;
 	/** True if person is alive. */
@@ -158,8 +149,6 @@ public class PhysicalCondition implements Serializable {
 	private double stress;
 	/** Performance factor 0.0 to 1.0. */
 	private double performance;
-	/** Person's hygiene factor (0.0 - 100.0) */
-	// private double hygiene;
 	/** Person's energy level [in kJ] */
 	private double kJoules;
 	/** Person's food appetite (0.0 to 1.0) */
@@ -192,8 +181,8 @@ public class PhysicalCondition implements Serializable {
 	private List<HealthProblem> problems;
 	/** Record of Illness frequency. */
 	private Map<ComplaintType, Integer> healthLog;
-	/** Record of illness start time. */
-	private Map<ComplaintType, List<String>> healthHistory;
+	// /** Record of illness start time. */
+	// private Map<ComplaintType, List<String>> healthHistory;
 
 	/** 
 	 * The amount a person consumes on each sol.
@@ -215,7 +204,7 @@ public class PhysicalCondition implements Serializable {
 	/** Most serious problem. */
 	private HealthProblem serious;
 
-	private static MarsClock marsClock;
+	private static MasterClock master;
 
 	private static EatDrinkMeta eatMealMeta = new EatDrinkMeta();
 	private static MedicalManager medicalManager;
@@ -241,7 +230,7 @@ public class PhysicalCondition implements Serializable {
 
 		problems = new CopyOnWriteArrayList<>();
 		healthLog = new ConcurrentHashMap<>();
-		healthHistory = new ConcurrentHashMap<>();
+		//healthHistory = new ConcurrentHashMap<>();
 		medicationList = new CopyOnWriteArrayList<>();
 
 		endurance = naturalAttributeManager.getAttribute(NaturalAttributeType.ENDURANCE);
@@ -280,16 +269,10 @@ public class PhysicalCondition implements Serializable {
 
 		isStarving = false;
 		isStressedOut = false;
-//		isCollapsed = false;
 		isDehydrated = false;
 		// Initially set performance to 1.0 (=100%) to avoid issues at startup
 		performance = 1.0D;
 
-		// initialize it to save 7 sols
-//		for (int i=0; i<4; i++) {
-//			foodConsumption[i] = new SolSingleMetricDataLogger(MAX_NUM_SOLS);
-//		}
-		
 		// Initialize the food consumption logger
 		consumption = new SolMetricDataLogger<>(MAX_NUM_SOLS);
 		consumption.increaseDataPoint(0, 0.0);
@@ -331,8 +314,6 @@ public class PhysicalCondition implements Serializable {
 		// Update the personal max energy and appetite based on one's age and weight
 		personalMaxEnergy = personalMaxEnergy + 50 * (d1 + d2 + preference);
 		appetite = personalMaxEnergy / MAX_DAILY_ENERGY_INTAKE;
-//		System.out.println(person + "  d1: " + d1 + "  d2: " + d2 + "  pref: " + preference
-//				+ "  personalMaxEnergy: " + personalMaxEnergy + "  appetite: " + appetite);
 	}
 
 	/**
@@ -1253,15 +1234,15 @@ public class PhysicalCondition implements Serializable {
 			healthLog.put(type, freq + 1);
 
 			// Register this complaint type with a time-stamp
-			List<String> clocks = null;
-			if (healthHistory.get(type) != null) {
-				clocks = healthHistory.get(type);
-			} else {
-				clocks = new CopyOnWriteArrayList<>();
-			}
+			// List<String> clocks = null;
+			// if (healthHistory.get(type) != null) {
+			// 	clocks = healthHistory.get(type);
+			// } else {
+			// 	clocks = new CopyOnWriteArrayList<>();
+			// }
 
-			clocks.add(marsClock.getDateTimeStamp());
-			healthHistory.put(type, clocks);
+			// clocks.add(marsClock.getDateTimeStamp());
+			// healthHistory.put(type, clocks);
 			logger.log(person, Level.INFO, 1_000L, "Suffered from " + type.getName() + ".");
 			recalculatePerformance();
 		}
@@ -1417,7 +1398,7 @@ public class PhysicalCondition implements Serializable {
 			this.serious = problem;
 		}
 
-		deathDetails = new DeathInfo(person, problem, reason, lastWord);
+		deathDetails = new DeathInfo(person, problem, reason, lastWord, master.getMarsTime());
 		// Declare the person dead
 		person.setDeclaredDead();
 
@@ -2149,11 +2130,11 @@ public class PhysicalCondition implements Serializable {
 	 * @param c1
 	 * @param m
 	 */
-	public static void initializeInstances(MasterClock c0, MarsClock c1, MedicalManager m,
+	public static void initializeInstances(MasterClock c0, MedicalManager m,
 											PersonConfig pc) {
-		marsClock = c1;
 		medicalManager = m;
 		personConfig = pc;
+		master = c0;
 
 		H2O_CONSUMPTION = personConfig.getWaterConsumptionRate(); // 3 kg per sol
 		O2_CONSUMPTION = personConfig.getNominalO2ConsumptionRate();
@@ -2182,8 +2163,6 @@ public class PhysicalCondition implements Serializable {
 		circadian = null;
 		starved = null;
 		dehydrated = null;
-		medicalManager = null;
-		marsClock = null;
 		medicationList = null;
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractMission.java
@@ -48,6 +48,8 @@ import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.structure.building.Building;
 import org.mars_sim.msp.core.time.ClockPulse;
 import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
+import org.mars_sim.msp.core.time.MasterClock;
 import org.mars_sim.msp.core.time.Temporal;
 import org.mars_sim.msp.core.tool.Conversion;
 import org.mars_sim.msp.core.tool.RandomUtil;
@@ -165,6 +167,7 @@ public abstract class AbstractMission implements Mission, Temporal {
 	protected static SurfaceFeatures surfaceFeatures;
 	protected static PersonConfig personConfig;
 	protected static MarsClock marsClock;
+	private static MasterClock clock;
 
 	/**
 	 * Constructor.
@@ -293,6 +296,14 @@ public abstract class AbstractMission implements Mission, Temporal {
 		return missionName;
 	}
 
+	/**
+	 * Get the current martian time.
+	 * @return
+	 */
+	protected MarsTime getMarsTime() {
+		return clock.getMarsTime();
+	}
+	
 	/**
 	 * Adds a member.
 	 * 
@@ -1228,7 +1239,7 @@ public abstract class AbstractMission implements Mission, Temporal {
 	 */
 	protected void startReview() {
 		setPhase(REVIEWING, null);
-		plan = new MissionPlanning(this, marsClock.getMissionSol());
+		plan = new MissionPlanning(this, getMarsTime().getMissionSol());
 	}
 	/**
 	 * Returns the mission plan.
@@ -1364,6 +1375,8 @@ public abstract class AbstractMission implements Mission, Temporal {
 		surfaceFeatures = sf;
 		missionManager = m;
 		personConfig = pc;
+
+		clock = si.getMasterClock();
 
 		MissionLog.initialise(c);
 		MissionUtil.initializeInstances(u, m);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractMission.java
@@ -48,7 +48,6 @@ import org.mars_sim.msp.core.structure.ObjectiveType;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.structure.building.Building;
 import org.mars_sim.msp.core.time.ClockPulse;
-import org.mars_sim.msp.core.time.MarsClock;
 import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.core.time.MasterClock;
 import org.mars_sim.msp.core.time.Temporal;
@@ -135,7 +134,7 @@ public abstract class AbstractMission implements Mission, Temporal {
 	/** The description of the current phase of operation. */
 	private String phaseDescription;
 	/** Time the phase started */
-	private MarsClock phaseStartTime;
+	private MarsTime phaseStartTime;
 	/** Log of mission activity	 */
 	private MissionLog log = new MissionLog();
 
@@ -167,7 +166,6 @@ public abstract class AbstractMission implements Mission, Temporal {
 	protected static MissionManager missionManager;
 	protected static SurfaceFeatures surfaceFeatures;
 	protected static PersonConfig personConfig;
-	protected static MarsClock marsClock;
 	private static MasterClock clock;
 
 	/**
@@ -511,7 +509,7 @@ public abstract class AbstractMission implements Mission, Temporal {
 		// Move phase on
  		phase = newPhase;
 		setPhaseEnded(false);
-		phaseStartTime = new MarsClock(marsClock);
+		phaseStartTime = clock.getMarsTime();
 
 		String template = newPhase.getDescriptionTemplate();
 		if (template != null) {
@@ -543,7 +541,7 @@ public abstract class AbstractMission implements Mission, Temporal {
 	 * Time that the current phases started
 	 */
 	@Override
-	public MarsClock getPhaseStartTime() {
+	public MarsTime getPhaseStartTime() {
 		return phaseStartTime;
 	}
 
@@ -551,7 +549,7 @@ public abstract class AbstractMission implements Mission, Temporal {
 	 * Gets duration of current Phase.
 	 */
 	protected double getPhaseDuration() {
-		return MarsClock.getTimeDiff(marsClock, phaseStartTime);
+		return clock.getMarsTime().getTimeDiff(phaseStartTime);
 	}
 
 	/**
@@ -1366,10 +1364,9 @@ public abstract class AbstractMission implements Mission, Temporal {
 	 * @param sf {@link SurfaceFeatures}
 	 * @param m {@link MissionManager}
 	 */
-	public static void initializeInstances(Simulation si, MarsClock c, HistoricalEventManager e,
+	public static void initializeInstances(Simulation si, HistoricalEventManager e,
 			UnitManager u, SurfaceFeatures sf, 
 			MissionManager m, PersonConfig pc) {
-		marsClock = c;
 		eventManager = e;
 		unitManager = u;
 		surfaceFeatures = sf;
@@ -1378,8 +1375,8 @@ public abstract class AbstractMission implements Mission, Temporal {
 
 		clock = si.getMasterClock();
 
-		MissionLog.initialise(c);
+		MissionLog.initialise(clock);
 		MissionUtil.initializeInstances(u, m);
-		AbstractMetaMission.initializeInstances(si.getMasterClock(), m);
+		AbstractMetaMission.initializeInstances(clock, m);
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractVehicleMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractVehicleMission.java
@@ -50,7 +50,7 @@ import org.mars_sim.msp.core.resource.ResourceUtil;
 import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.time.ClockPulse;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.core.tool.RandomUtil;
 import org.mars_sim.msp.core.vehicle.GroundVehicle;
 import org.mars_sim.msp.core.vehicle.Rover;
@@ -111,7 +111,7 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 															new String[] {
 																	ItemResourceUtil.FIBERGLASS});
 																	
-	
+
 	
 	// Data members
 	/** The msol cache. */
@@ -862,10 +862,10 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 	/**
 	 * Gets the estimated time of arrival (ETA) for the current leg of the mission.
 	 *
-	 * @return time (MarsClock) or null if not applicable.
+	 * @return time (MarsTime) or null if not applicable.
 	 */
 	@Override
-	public MarsClock getLegETA() {
+	public MarsTime getLegETA() {
 		if (TRAVELLING.equals(getPhase())
 				&& operateVehicleTask != null
 				&& vehicle.getOperator() != null) {
@@ -889,7 +889,7 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 			double time = getEstimatedTripTime(useMargin, distance);
 			logger.log(vehicle, Level.FINE, 20_000L, this 
 					+ " - Projected remaining waypoint time: " 
-					+  Math.round(time * MarsClock.HOURS_PER_MILLISOL * 10.0)/10.0 + " hrs ("
+					+  Math.round(time * MarsTime.HOURS_PER_MILLISOL * 10.0)/10.0 + " hrs ("
 					+  Math.round(time * 10.0)/10.0 + " millisols)");
 			return time;
 		}
@@ -911,7 +911,7 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 		double averageSpeed = getAverageVehicleSpeedForOperators() * ((1 + NIGHT_TIME_SPEED_MOD) / 2);
 		logger.log(vehicle, Level.FINE, 10_000, "Estimated average speed: " + Math.round(averageSpeed * 100.0)/100.0 + " kph.");
 		if (averageSpeed > 0) {
-			result = distance / averageSpeed * MarsClock.MILLISOLS_PER_HOUR;
+			result = distance / averageSpeed * MarsTime.MILLISOLS_PER_HOUR;
 		}
 
 		// If buffer, multiply by the the life support margin
@@ -1776,7 +1776,7 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 	 * 
 	 * @return starting time
 	 */
-	protected final MarsClock getCurrentLegStartingTime() {
+	protected final MarsTime getCurrentLegStartingTime() {
 		return getPhaseStartTime();
 	}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractVehicleMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/AbstractVehicleMission.java
@@ -634,7 +634,7 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 		else if (TRAVELLING.equals(phase)) {
 			performTravelPhase(member);
 			
-			int msol = marsClock.getMillisolInt();
+			int msol = getMarsTime().getMillisolInt();
 			if (msolCache != msol) {
 				msolCache = msol;
 				// Update the distances only once per msol
@@ -1075,7 +1075,7 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 	 * @return true if enough resources.
 	 */
 	protected final boolean hasEnoughResourcesForRemainingMission() {
-		int currentMSols = marsClock.getMillisolInt();
+		int currentMSols = getMarsTime().getMillisolInt();
 		if ((currentMSols - lastResourceCheck ) > RESOURCE_CHECK_DURATION) {
 			lastResourceCheck = currentMSols;
 			int missingResourceId = hasEnoughResources(getResourcesNeededForRemainingMission(false));

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectResourcesMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/CollectResourcesMission.java
@@ -368,7 +368,7 @@ public abstract class CollectResourcesMission extends EVAMission
 	private List<Coordinates> determineCollectionSites(Coordinates startingLocation,
 		double range, int numSites) {
 
-		int confidence = 3 + (int)RandomUtil.getRandomDouble(marsClock.getMissionSol());
+		int confidence = 3 + (int)RandomUtil.getRandomDouble(getMarsTime().getMissionSol());
 
 		List<Coordinates> unorderedSites = new ArrayList<>();
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/EVAMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/EVAMission.java
@@ -19,6 +19,7 @@ import org.mars_sim.msp.core.person.ai.task.EVAOperation;
 import org.mars_sim.msp.core.person.ai.task.util.Task;
 import org.mars_sim.msp.core.person.ai.task.util.Worker;
 import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.core.vehicle.Rover;
 
 abstract class EVAMission extends RoverMission {
@@ -100,18 +101,18 @@ abstract class EVAMission extends RoverMission {
 		}
 		else {
 			// Decide what to do
-			MarsClock sunrise = surfaceFeatures.getSunRise(getCurrentMissionLocation());
+			MarsTime sunrise = surfaceFeatures.getSunRise(getCurrentMissionLocation());
 			if (surfaceFeatures.inDarkPolarRegion(getCurrentMissionLocation())
-					|| (MarsClock.getTimeDiff(sunrise, marsClock) > MAX_WAIT_SUBLIGHT)) {
+					|| (sunrise.getTimeDiff(getMarsTime()) > MAX_WAIT_SUBLIGHT)) {
 				// No point waiting, move to next site
-				logger.info(getVehicle(), "Continue travel, sunrise too late " + sunrise.getTrucatedDateTimeStamp());
+				logger.info(getVehicle(), "Continue travel, sunrise too late " + sunrise.getTruncatedDateTimeStamp());
 				addMissionLog(NOT_ENOUGH_SUNLIGHT);
 				startTravellingPhase();
 			}
 			else {
 				// Wait for sunrise
-				logger.info(getVehicle(), "Waiting for sunrise @ " + sunrise.getTrucatedDateTimeStamp());
-				setPhase(WAIT_SUNLIGHT, sunrise.getTrucatedDateTimeStamp());
+				logger.info(getVehicle(), "Waiting for sunrise @ " + sunrise.getTruncatedDateTimeStamp());
+				setPhase(WAIT_SUNLIGHT, sunrise.getTruncatedDateTimeStamp());
 			}
 		}
 		return result;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Exploration.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Exploration.java
@@ -109,7 +109,7 @@ public class Exploration extends EVAMission
 
 			int skill = startingPerson.getSkillManager().getEffectiveSkillLevel(SkillType.AREOLOGY);
 
-			int sol = marsClock.getMissionSol();
+			int sol = getMarsTime().getMissionSol();
 			numSites = 2 + (int)(1.0 * sol / 20);
 			
 			List<Coordinates> explorationSites = determineExplorationSites(getVehicle().getRange(),
@@ -325,7 +325,7 @@ public class Exploration extends EVAMission
 	private List<Coordinates> determineExplorationSites(double roverRange, double tripTimeLimit, int numSites, int areologySkill) {
 		// Calculate the confidence score for determining the distance
 		// The longer it stays on Mars, the higher the confidence
-		int confidence = 2 * (1 + (int)RandomUtil.getRandomDouble(marsClock.getMissionSol()));
+		int confidence = 2 * (1 + (int)RandomUtil.getRandomDouble(getMarsTime().getMissionSol()));
 
 		List<Coordinates> unorderedSites = new ArrayList<>();
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/Mission.java
@@ -17,7 +17,7 @@ import org.mars_sim.msp.core.person.ai.task.util.Worker;
 import org.mars_sim.msp.core.project.Stage;
 import org.mars_sim.msp.core.structure.ObjectiveType;
 import org.mars_sim.msp.core.structure.Settlement;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 
 /**
  * Represents the behave that a Mission exhibits.
@@ -124,7 +124,7 @@ public interface Mission extends Entity, Serializable {
 	/**
 	 * Time that the current phases started
 	 */
-	MarsClock getPhaseStartTime();
+	MarsTime getPhaseStartTime();
 
     /**
 	 * Returns the mission plan.

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionLog.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionLog.java
@@ -10,7 +10,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
+import org.mars_sim.msp.core.time.MasterClock;
 
 /**
  * Holds all log details about a Missiion
@@ -26,16 +27,16 @@ public class MissionLog implements Serializable  {
     	
         private static final long serialVersionUID = 1L;
         
-        private MarsClock time;
+        private MarsTime time;
         private String entry;
         
-        private MissionLogEntry(MarsClock time, String entry) {
+        private MissionLogEntry(MarsTime time, String entry) {
             super();
             this.time = time;
             this.entry = entry;
         }
     
-        public MarsClock getTime() {
+        public MarsTime getTime() {
             return time;
         }
     
@@ -50,12 +51,12 @@ public class MissionLog implements Serializable  {
     }
 
     private List<MissionLogEntry> log = new ArrayList<>();
-    private MarsClock startDate;
+    private MarsTime startDate;
     private boolean done = false;
-    protected static MarsClock marsClock;
+    protected static MasterClock clock;
 
     public void addEntry(String entry) {
-		log.add(new MissionLogEntry(new MarsClock(marsClock), entry));
+		log.add(new MissionLogEntry(clock.getMarsTime(), entry));
     }
 
     /**
@@ -63,7 +64,7 @@ public class MissionLog implements Serializable  {
 	 *
 	 * @return
 	 */
-	public MarsClock getDateCreated() {
+	public MarsTime getDateCreated() {
 		if (!log.isEmpty()) {
 			return log.get(0).getTime();
 		}
@@ -76,7 +77,7 @@ public class MissionLog implements Serializable  {
 	 *
 	 * @return
 	 */
-	public MarsClock getDateStarted() {
+	public MarsTime getDateStarted() {
 		return startDate;
 	}
 
@@ -85,7 +86,7 @@ public class MissionLog implements Serializable  {
 	 *
 	 * @return
 	 */
-	public MarsClock getDateFinished() {
+	public MarsTime getDateFinished() {
 		if (done && !log.isEmpty()) {
             // TODO SHould this be when teh mission returned to the Settlement? 
 			return log.get(log.size()-1).getTime();
@@ -100,7 +101,7 @@ public class MissionLog implements Serializable  {
 
     public void setStarted() {
         if (startDate == null) {
-            startDate = new MarsClock(marsClock);
+            startDate = clock.getMarsTime();
         }
     }
 
@@ -108,8 +109,8 @@ public class MissionLog implements Serializable  {
         return log;
     }
 
-    public static void initialise(MarsClock mc) {
-        marsClock = mc;
+    public static void initialise(MasterClock mc) {
+        clock = mc;
     }
 
     public MissionLogEntry getLastEntry() {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/VehicleMission.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/VehicleMission.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import org.mars_sim.msp.core.person.ai.task.LoadingController;
 import org.mars_sim.msp.core.structure.Settlement;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.core.vehicle.Vehicle;
 
 public interface VehicleMission extends Mission {
@@ -58,7 +58,7 @@ public interface VehicleMission extends Mission {
 	 *
 	 * @return time (MarsClock) or null if not applicable.
 	 */
-	MarsClock getLegETA();
+	MarsTime getLegETA();
 
     /**
      * Is the Mission traveling to the current destination.

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectIceMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectIceMeta.java
@@ -21,7 +21,7 @@ import org.mars_sim.msp.core.structure.Settlement;
  */
 public class CollectIceMeta extends AbstractMetaMission {
 
-	private static final double VALUE = 3500D;
+	private static final double VALUE = 200D;
 
 	/** starting sol for this mission to commence. */
 	public final static int MIN_STARTING_SOL = 3;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectRegolithMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/CollectRegolithMeta.java
@@ -21,7 +21,7 @@ import org.mars_sim.msp.core.structure.Settlement;
  */
 public class CollectRegolithMeta extends AbstractMetaMission {
 
-	private static final double VALUE = 4000D;
+	private static final double VALUE = 200D;
 
 	/** starting sol for this mission to commence. */
 	public final static int MIN_STARTING_SOL = 2;
@@ -61,7 +61,7 @@ public class CollectRegolithMeta extends AbstractMetaMission {
 				if (missionProbability == 0) {
 	    			return 0;
 	    		}
-	    		missionProbability = settlement.getRegolithProbabilityValue() / VALUE;
+	    		missionProbability *= (settlement.getRegolithProbabilityValue() / VALUE);
 
 				// Job modifier.
 	    		missionProbability *= getLeaderSuitability(person);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/ExplorationMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/ExplorationMeta.java
@@ -27,7 +27,7 @@ import org.mars_sim.msp.core.vehicle.Rover;
 public class ExplorationMeta extends AbstractMetaMission {
 
 	/** Mission name */
-	private static final double VALUE = 2D;
+	private static final double VALUE = 20D;
 
 	private static final int MAX = 200;
 
@@ -81,7 +81,7 @@ public class ExplorationMeta extends AbstractMetaMission {
 					Rover rover = RoverMission.getVehicleWithGreatestRange(settlement, false);
 					if (rover != null) {
 						// Check if any mineral locations within rover range and obtain their concentration
-						missionProbability = Math.min(MAX, settlement.getTotalMineralValue(rover)) / VALUE;
+						missionProbability *= Math.min(MAX, settlement.getTotalMineralValue(rover)) / VALUE;
 						if (missionProbability < 0) {
 							missionProbability = 0;
 						}
@@ -95,10 +95,8 @@ public class ExplorationMeta extends AbstractMetaMission {
 				// Job modifier.
 				missionProbability *= getLeaderSuitability(person)
 						* (settlement.getGoodsManager().getTourismFactor()
-	               		 + settlement.getGoodsManager().getResearchFactor())/1.5;
+	               		 + settlement.getGoodsManager().getResearchFactor())/2;
 
-				if (missionProbability > LIMIT)
-					missionProbability = LIMIT;
 
 				// if introvert, score  0 to  50 --> -2 to 0
 				// if extrovert, score 50 to 100 -->  0 to 2
@@ -108,6 +106,8 @@ public class ExplorationMeta extends AbstractMetaMission {
 
 				if (missionProbability < 0)
 					missionProbability = 0;
+				else if (missionProbability > LIMIT)
+					missionProbability = LIMIT;
  			}
 		}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/AnalyzeMapData.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/AnalyzeMapData.java
@@ -173,7 +173,7 @@ public class AnalyzeMapData extends Task {
 			return time;
 		}
  
-        int msol = marsClock.getMillisolInt();
+        int msol = getMarsTime().getMillisolInt();
         boolean successful = false; 
         
         if (computingNeeded > 0) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/CompileScientificStudyResults.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/CompileScientificStudyResults.java
@@ -229,7 +229,7 @@ extends Task {
             return time;
         }
 
-        int msol = marsClock.getMillisolInt();
+        int msol = getMarsTime().getMillisolInt();
         
         boolean successful = false; 
         

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ConnectWithEarth.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ConnectWithEarth.java
@@ -144,7 +144,7 @@ public class ConnectWithEarth extends Task {
 			return time;
 		}
 		
-		int msol = marsClock.getMillisolInt();       
+		int msol = getMarsTime().getMillisolInt();       
         boolean successful = false; 
 
         if (computingNeeded > 0) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/CookMeal.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/CookMeal.java
@@ -333,7 +333,7 @@ public class CookMeal extends Task {
 	public static boolean isMealTime(int timeDiff, int prepTime) {
 
 		boolean result = false;
-		double timeOfDay = marsClock.getMillisol();
+		double timeOfDay = getMarsTime().getMillisol();
 		
 		double modifiedTime = timeOfDay + timeDiff + prepTime;
 		if (modifiedTime >= 1000D) {
@@ -365,7 +365,7 @@ public class CookMeal extends Task {
 	private String getTypeOfMeal() {
 		String result = "";
 
-		double timeOfDay = marsClock.getMillisol();
+		double timeOfDay = getMarsTime().getMillisol();
 		int timeDiff = getTimeDifference(worker.getCoordinates());
 		double modifiedTime = timeOfDay + timeDiff;
 		if (modifiedTime >= 1000D) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/DriveGroundVehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/DriveGroundVehicle.java
@@ -20,7 +20,7 @@ import org.mars_sim.msp.core.person.ai.SkillType;
 import org.mars_sim.msp.core.person.ai.task.util.TaskPhase;
 import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.structure.building.function.Computation;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.core.tool.RandomUtil;
 import org.mars_sim.msp.core.vehicle.GroundVehicle;
 
@@ -65,7 +65,7 @@ public class DriveGroundVehicle extends OperateVehicle {
 	 * @param startTripTime     the starting time of the trip
 	 * @param startTripDistance the starting distance to destination for the trip
 	 */
-	public DriveGroundVehicle(Person person, GroundVehicle vehicle, Coordinates destination, MarsClock startTripTime,
+	public DriveGroundVehicle(Person person, GroundVehicle vehicle, Coordinates destination, MarsTime startTripTime,
 			double startTripDistance) {
 
 		// Use OperateVehicle constructor
@@ -88,7 +88,7 @@ public class DriveGroundVehicle extends OperateVehicle {
 	 * @param startTripTime
 	 * @param startTripDistance
 	 */
-	public DriveGroundVehicle(Robot robot, GroundVehicle vehicle, Coordinates destination, MarsClock startTripTime,
+	public DriveGroundVehicle(Robot robot, GroundVehicle vehicle, Coordinates destination, MarsTime startTripTime,
 			double startTripDistance) {
 
 		// Use OperateVehicle constructor
@@ -112,7 +112,7 @@ public class DriveGroundVehicle extends OperateVehicle {
 	 * @param startTripDistance the starting distance to destination for the trip
 	 * @param startingPhase     the starting phase for the task
 	 */
-	public DriveGroundVehicle(Person person, GroundVehicle vehicle, Coordinates destination, MarsClock startTripTime,
+	public DriveGroundVehicle(Person person, GroundVehicle vehicle, Coordinates destination, MarsTime startTripTime,
 			double startTripDistance, TaskPhase startingPhase) {
 
 		// Use OperateVehicle constructor
@@ -140,7 +140,7 @@ public class DriveGroundVehicle extends OperateVehicle {
 	 * @param startTripDistance
 	 * @param startingPhase
 	 */
-	public DriveGroundVehicle(Robot robot, GroundVehicle vehicle, Coordinates destination, MarsClock startTripTime,
+	public DriveGroundVehicle(Robot robot, GroundVehicle vehicle, Coordinates destination, MarsTime startTripTime,
 			double startTripDistance, TaskPhase startingPhase) {
 
 		// Use OperateVehicle constructor
@@ -256,7 +256,7 @@ public class DriveGroundVehicle extends OperateVehicle {
 		// Drive in the direction
 		timeUsed = time - mobilizeVehicle(time);
 
-		int msol = marsClock.getMillisolInt();       
+		int msol = getMarsTime().getMillisolInt();       
         boolean successful = false; 
         
         double lastDistance = vehicle.getLastDistanceTravelled();

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ExamineBody.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ExamineBody.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.logging.Level;
 
 import org.mars_sim.msp.core.Msg;
-import org.mars_sim.msp.core.Simulation;
 import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.malfunction.Malfunctionable;
 import org.mars_sim.msp.core.person.EventType;
@@ -25,7 +24,6 @@ import org.mars_sim.msp.core.person.health.DeathInfo;
 import org.mars_sim.msp.core.person.health.HealthProblem;
 import org.mars_sim.msp.core.person.health.MedicalAid;
 import org.mars_sim.msp.core.person.health.MedicalEvent;
-import org.mars_sim.msp.core.person.health.MedicalManager;
 import org.mars_sim.msp.core.structure.building.Building;
 import org.mars_sim.msp.core.structure.building.function.FunctionType;
 import org.mars_sim.msp.core.structure.building.function.MedicalCare;
@@ -63,8 +61,6 @@ public class ExamineBody extends Task {
 	private Person patient;
 
 	private Malfunctionable malfunctionable;
-
-	private static MedicalManager medicalManager = Simulation.instance().getMedicalManager();
 	
 	/**
 	 * Constructor.
@@ -311,7 +307,7 @@ public class ExamineBody extends Task {
 		// Bury the body
 		patient.buryBody();
 		
-		medicalManager.addDeathRegistry(person.getSettlement(), deathInfo);
+		getSimulation().getMedicalManager().addDeathRegistry(person.getSettlement(), deathInfo);
 				
 		// Check for accident in medical aid.
 		checkForAccident(malfunctionable, 0.005D, time);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ObserveAstronomicalObjects.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ObserveAstronomicalObjects.java
@@ -277,7 +277,7 @@ public class ObserveAstronomicalObjects extends Task implements ResearchScientif
 			endTask();
 		}
 
-        int msol = marsClock.getMillisolInt();
+        int msol = getMarsTime().getMillisolInt();
         
         boolean successful = false; 
         

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/PerformMathematicalModeling.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/PerformMathematicalModeling.java
@@ -403,7 +403,7 @@ implements ResearchScientificStudy {
         // Check if research in study is completed.
         boolean isPrimary = study.getPrimaryResearcher().equals(person);
 
-        int msol = marsClock.getMillisolInt();
+        int msol = getMarsTime().getMillisolInt();
         boolean successful = false; 
         
         if (computingNeeded > 0) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/PilotDrone.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/PilotDrone.java
@@ -18,7 +18,7 @@ import org.mars_sim.msp.core.person.ai.SkillType;
 import org.mars_sim.msp.core.person.ai.task.util.TaskPhase;
 import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.structure.building.function.Computation;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.core.tool.RandomUtil;
 import org.mars_sim.msp.core.vehicle.Flyer;
 
@@ -64,7 +64,7 @@ public class PilotDrone extends OperateVehicle {
 	 * @param startTripTime     the starting time of the trip
 	 * @param startTripDistance the starting distance to destination for the trip
 	 */
-	public PilotDrone(Person person, Flyer flyer, Coordinates destination, MarsClock startTripTime,
+	public PilotDrone(Person person, Flyer flyer, Coordinates destination, MarsTime startTripTime,
 			double startTripDistance) {
 
 		// Use OperateVehicle constructor
@@ -78,7 +78,7 @@ public class PilotDrone extends OperateVehicle {
 		logger.log(flyer, person, Level.INFO, 20_000, "Took control of the drone.");
 	}
 
-	public PilotDrone(Robot robot, Flyer flyer, Coordinates destination, MarsClock startTripTime,
+	public PilotDrone(Robot robot, Flyer flyer, Coordinates destination, MarsTime startTripTime,
 			double startTripDistance) {
 
 		// Use OperateVehicle constructor
@@ -101,7 +101,7 @@ public class PilotDrone extends OperateVehicle {
 	 * @param startTripDistance the starting distance to destination for the trip
 	 * @param startingPhase     the starting phase for the task
 	 */
-	public PilotDrone(Person person, Flyer flyer, Coordinates destination, MarsClock startTripTime,
+	public PilotDrone(Person person, Flyer flyer, Coordinates destination, MarsTime startTripTime,
 			double startTripDistance, TaskPhase startingPhase) {
 
 		// Use OperateVehicle constructor
@@ -119,7 +119,7 @@ public class PilotDrone extends OperateVehicle {
 
 	}
 
-	public PilotDrone(Robot robot, Flyer flyer, Coordinates destination, MarsClock startTripTime,
+	public PilotDrone(Robot robot, Flyer flyer, Coordinates destination, MarsTime startTripTime,
 			double startTripDistance, TaskPhase startingPhase) {
 
 		// Use OperateVehicle constructor
@@ -221,7 +221,7 @@ public class PilotDrone extends OperateVehicle {
 		// Drive in the direction
 		timeUsed = time - mobilizeVehicle(time);
 		
-		int msol = marsClock.getMillisolInt();       
+		int msol = getMarsTime().getMillisolInt();       
         boolean successful = false; 
         
         double lastDistance = flyer.getLastDistanceTravelled();
@@ -324,14 +324,14 @@ public class PilotDrone extends OperateVehicle {
 		
 		if (ascentE > 0) {
 			// Future: Use Newton's law to determine the amount of height the flyer can climb 
-			double tSec = time * MarsClock.SECONDS_PER_MILLISOL;
+			double tSec = time * MarsTime.SECONDS_PER_MILLISOL;
 			double speed = .0025 * mod;
 			climbE = speed * tSec;
 			
 		}
 		else if (ascentE < 0) {
 			// Future: Use Newton's law to determine the amount of height the flyer can climb 
-			double tSec = time * MarsClock.SECONDS_PER_MILLISOL;
+			double tSec = time * MarsTime.SECONDS_PER_MILLISOL;
 			double speed = -.02 * mod;
 			climbE = speed * tSec;
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/PlayHoloGame.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/PlayHoloGame.java
@@ -157,7 +157,7 @@ public class PlayHoloGame extends Task {
 			endTask();
 		}
 		
-		int msol = marsClock.getMillisolInt();       
+		int msol = getMarsTime().getMillisolInt();       
         boolean successful = false; 
         
         if (computingNeeded > 0) {
@@ -229,7 +229,7 @@ public class PlayHoloGame extends Task {
 		double remainingTime = 0;
 		
 		boolean successful = false; 
-		int msol = marsClock.getMillisolInt();
+		int msol = getMarsTime().getMillisolInt();
 		
 		if (computingNeeded > 0) {
 	      	double workPerMillisol = time * seed;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/Relax.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/Relax.java
@@ -55,7 +55,6 @@ extends Task {
 		super(NAME, person, false, false, STRESS_MODIFIER, 10D);
 		
 		// If during person's work shift, only relax for short period.
-		int msols = marsClock.getMillisolInt();
         boolean isShiftHour = person.isOnDuty();
 		if (isShiftHour) {
 		    setDuration(10D);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ReviewMissionPlan.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ReviewMissionPlan.java
@@ -153,7 +153,7 @@ public class ReviewMissionPlan extends Task {
 			}
 			
 			else if (mp.getPercentComplete() >= 60) {
-				int sol = marsClock.getMissionSol();
+				int sol = getMarsTime().getMissionSol();
 				int solRequest = mp.getMissionSol();
 				if (sol - solRequest > 7) {
 					// If no one else is able to offer the review after x days, 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/Sleep.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/Sleep.java
@@ -89,7 +89,7 @@ public class Sleep extends Task {
 
 			// Adjust the duration so the person does not oversleep
 			double alarmTime = getAlarmTime();
-			double maxSleep = alarmTime - marsClock.getMillisol();
+			double maxSleep = alarmTime - getMarsTime().getMillisol();
 			if (maxSleep < 0D) {
 				// Roll over midnight
 				maxSleep += 1000D;
@@ -418,7 +418,7 @@ public class Sleep extends Task {
 	    	// Update sleep times once ending
 	    	CircadianClock circadian = person.getCircadianClock();
 			circadian.setNumSleep(circadian.getNumSleep() + 1);
-			circadian.updateSleepCycle((int) marsClock.getMillisol(), true);
+			circadian.updateSleepCycle((int) getMarsTime().getMillisol(), true);
 			circadian.setAwake(true);
 
 		} 
@@ -524,7 +524,7 @@ public class Sleep extends Task {
      * @param person
      */
     public void refreshSleepHabit(Person person, CircadianClock circadian) {
-    	int now = marsClock.getMillisolInt();
+    	int now = getMarsTime().getMillisolInt();
 
 		// if a person is on shift right now
 		if (person.isOnDuty()) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ExamineBodyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ExamineBodyMeta.java
@@ -106,7 +106,7 @@ public class ExamineBodyMeta  extends MetaTask implements SettlementMetaTask {
 			for(DeathInfo pm : deaths) {
 				if (!pm.getExamDone()) {
 					double score = DEFAULT_SCORE +
-							((getMarsTime().getMissionSol() - pm.getMissionSol()) * SOL_SCORE);
+							((getMarsTime().getMissionSol() - pm.getTimeOfDeath().getMissionSol()) * SOL_SCORE);
 					tasks.add(new ExamineBodyJob(this, pm, score));
 				}
 			}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/Task.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/Task.java
@@ -51,7 +51,7 @@ import org.mars_sim.msp.core.structure.building.function.FunctionType;
 import org.mars_sim.msp.core.structure.building.function.LifeSupport;
 import org.mars_sim.msp.core.structure.building.function.farming.CropConfig;
 import org.mars_sim.msp.core.structure.construction.ConstructionConfig;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.core.time.MasterClock;
 import org.mars_sim.msp.core.tool.RandomUtil;
 import org.mars_sim.msp.core.vehicle.Rover;
@@ -144,8 +144,6 @@ public abstract class Task implements Serializable, Comparable<Task> {
 
 	/** The static instance of the master clock */
 	protected static MasterClock masterClock;
-	/** The static instance of the mars clock */
-	protected static MarsClock marsClock;
 	/** The static instance of the event manager */
 	protected static HistoricalEventManager eventManager;
 	/** The static instance of the UnitManager */
@@ -166,6 +164,8 @@ public abstract class Task implements Serializable, Comparable<Task> {
 	protected static CropConfig cropConfig = simulationConfig.getCropConfiguration();
 	/** The static instance of the constructionConfig */
 	protected static ConstructionConfig constructionConfig = simulationConfig.getConstructionConfiguration();
+
+	private static Simulation sim;
 	
 	/**
 	 * Constructs a Task object that has a fixed duration.
@@ -1549,30 +1549,35 @@ public abstract class Task implements Serializable, Comparable<Task> {
 			subTask.reinit();
 	}
 
+	/**
+	 * Get the simualtion underpinning run
+	 */
+	protected Simulation getSimulation() {
+		return sim;
+	}
 
+	/**
+	 * Get teh current Martian time
+	 */
+	protected static MarsTime getMarsTime() {
+		return masterClock.getMarsTime();
+	}
+	
 	/**
 	 * Reloads instances after loading from a saved sim.
 	 * 
-	 * @param c  {@link MarsClock}
-	 * @param e  {@link HistoricalEventManager}
-	 * @param r  {@link RelationshipUtil}
-	 * @param u  {@link UnitManager}
-	 * @param s  {@link ScientificStudyManager}
-	 * @param sf {@link SurfaceFeatures}
-	 * @param oi {@link OrbitInfo}
-	 * @param m  {@link MissionManager}
+	 * @param s
 	 * @param pc  {@link PersonConfig}
 	 */
-	static void initializeInstances(MasterClock ms, MarsClock c, HistoricalEventManager e, UnitManager u,
-			ScientificStudyManager s, SurfaceFeatures sf, OrbitInfo oi, MissionManager m, PersonConfig pc) {
-		masterClock = ms;
-		marsClock = c;
-		eventManager = e;
-		unitManager = u;
-		scientificStudyManager = s;
-		surfaceFeatures = sf;
-		orbitInfo = oi;
-		missionManager = m;
+	static void initializeInstances(Simulation s, PersonConfig pc) {
+		sim = s;
+		masterClock = s.getMasterClock();
+		eventManager = s.getEventManager();
+		unitManager = s.getUnitManager();
+		scientificStudyManager = s.getScientificStudyManager();
+		surfaceFeatures = s.getSurfaceFeatures();
+		orbitInfo = s.getOrbitInfo();
+		missionManager = s.getMissionManager();
 		personConfig = pc;
 	}
 	

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskManager.java
@@ -816,11 +816,8 @@ public abstract class TaskManager implements Serializable, Temporal {
 	 * @param sim
 	 */
 	public static void initializeInstances(Simulation sim, SimulationConfig conf) {
-		marsClock = sim.getMasterClock().getMarsClock();
 
 		MetaTaskUtil.initialiseInstances(sim);
-		Task.initializeInstances(sim.getMasterClock(), marsClock, sim.getEventManager(), sim.getUnitManager(),
-									sim.getScientificStudyManager(), sim.getSurfaceFeatures(), sim.getOrbitInfo(),
-						sim.getMissionManager(), conf.getPersonConfig());
+		Task.initializeInstances(sim, conf.getPersonConfig());
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/Settlement.java
@@ -239,9 +239,9 @@ public class Settlement extends Structure implements Temporal,
 	/** The settlement's current dessert replenishment rate. */
 	public double dessertsReplenishmentRate = 0.4;
 	/** The settlement's current probability value for ice. */
-	private double iceProbabilityValue = 0;
+	private double iceProbabilityValue = 400D;
 	/** The settlement's current probability value for regolith. */
-	private double regolithProbabilityValue = 0;
+	private double regolithProbabilityValue = 400D;
 	/** The settlement's outside temperature. */
 	private double outside_temperature;
 	/** Total Crop area */

--- a/mars-sim-core/src/test/java/org/mars_sim/msp/core/TestSaving.java
+++ b/mars-sim-core/src/test/java/org/mars_sim/msp/core/TestSaving.java
@@ -43,7 +43,7 @@ public class TestSaving extends TestCase implements SimulationListener {
 
         // Simulate a clock pulse to trigger the save
         MasterClock mc = sim.getMasterClock();
-        ClockPulse pulse = new ClockPulse(1, 0.01D, mc.getMarsClock(), null, mc, false, false);
+        ClockPulse pulse = new ClockPulse(1, 0.01D, null, mc.getMarsTime(), mc, false, false);
         sim.clockPulse(pulse);
 
         // Check simulations saved and it contains data

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/MainDetailPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/mission/MainDetailPanel.java
@@ -964,7 +964,7 @@ public class MainDetailPanel extends JPanel implements MissionListener, UnitList
 			List<MissionLog.MissionLogEntry> entries = mission.getLog().getEntries();
 			if (row < entries.size()) {
 				if (column == 0)
-					return entries.get(row).getTime().getDisplayTruncatedTimeStamp();
+					return entries.get(row).getTime().getTruncatedDateTimeStamp();
 				else
 					return entries.get(row).getEntry();
 			} else

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/person/TabPanelDeath.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/person/TabPanelDeath.java
@@ -99,7 +99,7 @@ implements ActionListener {
 
 		JPanel wrapper2 = new JPanel(new FlowLayout(0, 0, FlowLayout.LEADING));
         timeTF = new JTextField();
-        timeTF.setText(death.getTimeOfDeath());
+        timeTF.setText(death.getTimeOfDeath().getTruncatedDateTimeStamp());
         timeTF.setEditable(false);
         timeTF.setColumns(20);
         wrapper2.add(timeTF);//, BorderLayout.CENTER);

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/vehicle/NavigationTabPanel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/vehicle/NavigationTabPanel.java
@@ -30,7 +30,7 @@ import org.mars_sim.msp.core.person.ai.mission.Mission;
 import org.mars_sim.msp.core.person.ai.mission.NavPoint;
 import org.mars_sim.msp.core.person.ai.mission.VehicleMission;
 import org.mars_sim.msp.core.structure.Settlement;
-import org.mars_sim.msp.core.time.MarsClock;
+import org.mars_sim.msp.core.time.MarsTime;
 import org.mars_sim.msp.core.vehicle.Vehicle;
 import org.mars_sim.msp.ui.swing.ImageLoader;
 import org.mars_sim.msp.ui.swing.MainDesktopPane;
@@ -242,7 +242,7 @@ public class NavigationTabPanel extends TabPanel implements ActionListener {
         // Prepare ETA label.
         etaCache = "";
         if (mission instanceof VehicleMission vm) {
-            MarsClock due = vm.getLegETA();
+            MarsTime due = vm.getLegETA();
             if (due != null) {
                 etaCache = due.toString();
             }
@@ -382,7 +382,7 @@ public class NavigationTabPanel extends TabPanel implements ActionListener {
                 remainingDistanceLabel.setText(StyleManager.DECIMAL_KM.format(remainingDistanceCache));
             }
 
-            MarsClock newETA = vehicleMission.getLegETA();
+            MarsTime newETA = vehicleMission.getLegETA();
             if (newETA != null) {
                 String newText = newETA.toString();
                 if (!etaCache.equals(newText)) {


### PR DESCRIPTION
The PR improves the initialisation of the Task & Mars Environment classes required to convert the Mission classes to MarsTIme.

The key change is that the Environment classes do not use static references to the other entities but reference them as field properties. The references do not need to be static since they are all saved and reloaded at the same time.

The Mission interface has been converted to the immutable MarsTIme this requires element of Task to be converted also. This again is an improvement and reduces the number of static references needed.

In addition this request also adjusts the mission probability score.
Part of #650