### PR TITLE
EVA Suit has history

### DIFF
--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/Simulation.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/Simulation.java
@@ -349,12 +349,12 @@ public class Simulation implements ClockListener, Serializable {
 		unitManager.addUnit(outerSpace);
 		
 		// Initialize Moon instance
-		Moon moon = new Moon();
+		Moon moon = new Moon(outerSpace);
 		// Add it to unitManager
 		unitManager.addUnit(moon);
 		
 		// Build planetary objects
-		MarsSurface marsSurface = new MarsSurface();
+		MarsSurface marsSurface = new MarsSurface(outerSpace);
 		// Add it to unitManager
 		unitManager.addUnit(marsSurface);
 	
@@ -453,12 +453,12 @@ public class Simulation implements ClockListener, Serializable {
 		unitManager.addUnit(outerSpace);
 		
 		// Initialize Moon instance
-		Moon moon = new Moon();
+		Moon moon = new Moon(outerSpace);
 		// Add it to unitManager
 		unitManager.addUnit(moon);
 		
 		// Initialize MarsSurface instance
-		MarsSurface marsSurface = new MarsSurface();
+		MarsSurface marsSurface = new MarsSurface(outerSpace);
 		// Add it to unitManager
 		unitManager.addUnit(marsSurface);
 		

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/Unit.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/Unit.java
@@ -390,16 +390,11 @@ public abstract class Unit implements Serializable, Loggable, UnitIdentifer, Com
 	 */
 	public void setCoordinates(Coordinates newLocation) {
 		location = newLocation;
-		fireUnitUpdate(UnitEventType.LOCATION_EVENT, newLocation);
+		if (location != null) {
+			fireUnitUpdate(UnitEventType.LOCATION_EVENT, newLocation);
+		}
 	}
 
-	/**
-	 * Sets unit's location coordinates to null.
-	 */
-	public void setNullCoordinates() {
-		location = null;
-		// fireUnitUpdate(UnitEventType.LOCATION_EVENT, getTopContainerUnit().getCoordinates());
-	}
 	
 	/**
 	 * Gets the unit's container unit. Returns null if unit has no container unit.
@@ -456,87 +451,6 @@ public abstract class Unit implements Serializable, Loggable, UnitIdentifer, Com
 		}
 
 		return topID;
-	}
-
-	/**
-	 * Sets the unit's container unit.
-	 *
-	 * @param newContainer the unit to contain this unit.
-	 */
-	protected void setContainerUnit(Unit newContainer) {
-		if (newContainer != null && newContainer.equals(getContainerUnit())) {
-			return;
-		}
-
-		// 1. Set Coordinates
-		if (newContainer == null || newContainer.getUnitType() == UnitType.MARS) {
-			// Since it's on the surface of Mars,
-			// First set its initial location to its old parent's location as it's leaving its parent.
-			// Later it will move around and updates its coordinates by itself
-			setCoordinates(getContainerUnit().getCoordinates());
-		}
-		else {
-			// Null its coordinates since it's now slaved after its parent
-			setNullCoordinates();
-		}
-		
-		// 2. Set LocationStateType
-		if (getUnitType() == UnitType.MARS) {
-			currentStateType = LocationStateType.OUTER_SPACE;
-			containerID = (Integer) OUTER_SPACE_UNIT_ID;
-		} else if (getUnitType() == UnitType.CONSTRUCTION) {
-			currentStateType = LocationStateType.MARS_SURFACE;
-			containerID = (Integer) MARS_SURFACE_UNIT_ID;
-		} else if (getUnitType() == UnitType.BUILDING) {
-			currentStateType = LocationStateType.INSIDE_SETTLEMENT;
-		} else {
-			currentStateType = LocationStateType.UNKNOWN;
-			containerID = (Integer) UNKNOWN_UNIT_ID;
-		}
-
-		// 3. Set containerID
-		if (newContainer == null || newContainer.getIdentifier() == UNKNOWN_UNIT_ID) {
-			containerID = (Integer) UNKNOWN_UNIT_ID;
-		} else {
-			containerID = newContainer.getIdentifier();
-		}
-
-		fireUnitUpdate(UnitEventType.CONTAINER_UNIT_EVENT, newContainer);
-	}
-
-	/**
-	 * Gets the location state type based on the type of the new container unit.
-	 *
-	 * @param newContainer
-	 * @return {@link LocationStateType}
-	 */
-	public LocationStateType getNewLocationState(Unit newContainer) {
-
-		if (newContainer.getUnitType() == UnitType.SETTLEMENT) {
-			if (getUnitType() == UnitType.PERSON 
-					|| getUnitType() == UnitType.ROBOT
-					|| getUnitType() == UnitType.CONTAINER)
-				return LocationStateType.INSIDE_SETTLEMENT;
-			else if (getUnitType() == UnitType.VEHICLE)
-				return LocationStateType.WITHIN_SETTLEMENT_VICINITY;
-		}
-
-		if (newContainer.getUnitType() == UnitType.BUILDING)
-			return LocationStateType.INSIDE_SETTLEMENT;
-
-		if (newContainer.getUnitType() == UnitType.VEHICLE)
-			return LocationStateType.INSIDE_VEHICLE;
-
-		if (newContainer.getUnitType() == UnitType.CONSTRUCTION)
-			return LocationStateType.MARS_SURFACE; // or WITHIN_SETTLEMENT_VICINITY
-
-		if (newContainer.getUnitType() == UnitType.PERSON)
-			return LocationStateType.ON_PERSON_OR_ROBOT;
-
-		if (newContainer.getUnitType() == UnitType.MARS)
-			return LocationStateType.MARS_SURFACE;
-
-		return null;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/data/History.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/data/History.java
@@ -47,12 +47,32 @@ public class History<T> implements Serializable {
 
     private static MasterClock master;
     private List<HistoryItem<T>> history = new ArrayList<>();
+    private int maxItems;
     
+    /**
+     * Create a History but define the maximum items to hold
+     * @param maxItems
+     */
+    public History(int maxItems) {
+        this.maxItems = maxItems;
+    }
+
+    /**
+     * Crete a history that hold infinite items
+     */
+    public History() {
+        this(-1);
+    }
+
     /**
      * Add a value to the history and timestamp it
      * @param value New value to add
      */
     public void add(T value) {
+        if (history.size() == maxItems) {
+            // Rrmove first item (oldest)
+            history.remove(0);
+        }
         history.add(new HistoryItem<>(master.getMarsTime(), value));
     }
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/environment/MarsSurface.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/environment/MarsSurface.java
@@ -7,161 +7,20 @@
 
 package org.mars_sim.msp.core.environment;
 
-import java.util.Set;
-
 import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.UnitType;
-import org.mars_sim.msp.core.data.UnitSet;
-import org.mars_sim.msp.core.person.Person;
-import org.mars_sim.msp.core.robot.Robot;
-import org.mars_sim.msp.core.structure.Settlement;
-import org.mars_sim.msp.core.vehicle.Vehicle;
 
 /**
  * MarsSurface is the object unit that represents the surface of Mars
  */
-public class MarsSurface extends Unit {
+public class MarsSurface extends PlanetaryEntity {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 123L;
 
 	private static final String NAME = "Mars Surface";
 
-	private Set<Person> personList;
-
-	private Set<Robot> robotList;
-
-	private Set<Vehicle> vehicleList;
-
-	public MarsSurface() {
-		super(NAME, Unit.MARS_SURFACE_UNIT_ID, Unit.OUTER_SPACE_UNIT_ID);
-
-		personList = new UnitSet<>();
-		robotList = new UnitSet<>();
-		vehicleList = new UnitSet<>();
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		return super.equals(obj);
-	}
-
-	@Override
-	public UnitType getUnitType() {
-		return UnitType.MARS;
-	}
-
-	public Settlement getSettlement() {
-		return null;
-	}
-
-	/**
-	 * Adds a person.
-	 *
-	 * @param person
-	 * @param true if the person can be added
-	 */
-	public boolean addPerson(Person person) {
-		synchronized (personList) {
-			return personList.add(person);
-		}
-	}
-
-	/**
-	 * Removes a person.
-	 *
-	 * @param person
-	 * @param true if the person can be removed
-	 */
-	public boolean removePerson(Person person) {
-		synchronized (personList) {
-			return personList.remove(person);
-		}
-	}
-
-	/**
-	 * Adds a robot.
-	 *
-	 * @param robot
-	 * @param true if the robot can be added
-	 */
-	public boolean addRobot(Robot robot) {
-		synchronized (robotList) {
-			return robotList.add(robot);
-		}
-	}
-
-	/**
-	 * Removes a robot.
-	 *
-	 * @param robot
-	 * @param true if the robot can be removed
-	 */
-	public boolean removeRobot(Robot robot) {
-		synchronized (robotList) {
-			return robotList.remove(robot);
-		}
-	}
-
-	/**
-	 * Adds a vehicle.
-	 *
-	 * @param vehicle
-	 * @param true if the vehicle can be added
-	 */
-	public boolean addVehicle(Vehicle vehicle) {
-		synchronized (vehicleList) {
-			// There is a bug somewhere because Drones in delivery remains on the Surface
-			if (vehicleList.contains(vehicle)) {
-				return true;
-			}
-			return vehicleList.add(vehicle);
-		}
-	}
-
-	/**
-	 * Removes a vehicle.
-	 *
-	 * @param vehicle
-	 * @param true if the vehicle can be removed
-	 */
-	public boolean removeVehicle(Vehicle vehicle) {
-		synchronized (vehicleList) {
-			return vehicleList.remove(vehicle);
-		}
-	}
-
-	/**
-	 * Gets the unit's container unit.
-	 *
-	 * @return the unit's container unit
-	 */
-	@Override
-	public Unit getContainerUnit() {
-		if (unitManager == null) // for maven test
-			return null;
-		// Return outer space unit
-		return unitManager.getOuterSpace();
-	}
-
-	/**
-	 * Is this unit inside a settlement ?
-	 *
-	 * @return true if the unit is inside a settlement
-	 */
-	@Override
-	public boolean isInSettlement() {
-		return false;
-	}
-
-
-	/**
-	 * Gets the hash code for this object.
-	 *
-	 * @return hash code.
-	 */
-	@Override
-	public int hashCode() {
-		return super.hashCode();
+	public MarsSurface(Unit outerSpace) {
+		super(NAME, Unit.MARS_SURFACE_UNIT_ID, outerSpace.getIdentifier(), outerSpace, UnitType.MARS);
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/environment/OuterSpace.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/environment/OuterSpace.java
@@ -7,159 +7,24 @@
 
 package org.mars_sim.msp.core.environment;
 
-import java.util.Set;
-
 import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.UnitType;
-import org.mars_sim.msp.core.data.UnitSet;
 import org.mars_sim.msp.core.location.LocationStateType;
-import org.mars_sim.msp.core.person.Person;
-import org.mars_sim.msp.core.robot.Robot;
-import org.mars_sim.msp.core.structure.Settlement;
-import org.mars_sim.msp.core.vehicle.Vehicle;
 
 /**
  * OuterSpace is the object unit that represents the outer space
  */
-public class OuterSpace extends Unit {
+public class OuterSpace extends PlanetaryEntity {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 123L;
 
 	private static final String NAME = "Outer Space";
 
-	private Set<Unit> unitList;
-
 	public OuterSpace() {
-		super(NAME, Unit.OUTER_SPACE_UNIT_ID, Unit.OUTER_SPACE_UNIT_ID);
-
-		unitList = new UnitSet<>();
-		
-		// Set currentStateType to OUTER_SPACE
+		super(NAME, Unit.OUTER_SPACE_UNIT_ID, Unit.OUTER_SPACE_UNIT_ID, null,
+				UnitType.OUTER_SPACE);
 		currentStateType = LocationStateType.OUTER_SPACE;
-	}
 
-	@Override
-	public boolean equals(Object obj) {
-		return super.equals(obj);
-	}
-
-	@Override
-	public UnitType getUnitType() {
-		return UnitType.OUTER_SPACE;
-	}
-
-	public Settlement getSettlement() {
-		return null;
-	}
-
-	/**
-	 * Adds a person.
-	 *
-	 * @param person
-	 * @param true if the person can be added
-	 */
-	public boolean addPerson(Person person) {
-		synchronized (unitList) {
-			return unitList.add(person);
-		}
-	}
-
-	/**
-	 * Removes a person.
-	 *
-	 * @param person
-	 * @param true if the person can be removed
-	 */
-	public boolean removePerson(Person person) {
-		synchronized (unitList) {
-			return unitList.remove(person);
-		}
-	}
-
-	/**
-	 * Adds a robot.
-	 *
-	 * @param robot
-	 * @param true if the robot can be added
-	 */
-	public boolean addRobot(Robot robot) {
-		synchronized (unitList) {
-			return unitList.add(robot);
-		}
-	}
-
-	/**
-	 * Removes a robot.
-	 *
-	 * @param robot
-	 * @param true if the robot can be removed
-	 */
-	public boolean removeRobot(Robot robot) {
-		synchronized (unitList) {
-			return unitList.remove(robot);
-		}
-	}
-
-	/**
-	 * Adds a vehicle.
-	 *
-	 * @param vehicle
-	 * @param true if the vehicle can be added
-	 */
-	public boolean addVehicle(Vehicle vehicle) {
-		synchronized (unitList) {
-			// There is a bug somewhere because Drones in delivery remains on the Surface
-			if (unitList.contains(vehicle)) {
-				return true;
-			}
-			return unitList.add(vehicle);
-		}
-	}
-
-	/**
-	 * Removes a vehicle.
-	 *
-	 * @param vehicle
-	 * @param true if the vehicle can be removed
-	 */
-	public boolean removeVehicle(Vehicle vehicle) {
-		synchronized (unitList) {
-			return unitList.remove(vehicle);
-		}
-	}
-
-	/**
-	 * Gets the unit's container unit.
-	 *
-	 * @return the unit's container unit
-	 */
-	@Override
-	public Unit getContainerUnit() {
-		if (unitManager == null) // for maven test
-			return null;
-		// Should it return itself or return null ?
-		return null;
-	}
-
-	/**
-	 * Is this unit inside a settlement ?
-	 *
-	 * @return true if the unit is inside a settlement
-	 */
-	@Override
-	public boolean isInSettlement() {
-		return false;
-	}
-
-
-	/**
-	 * Gets the hash code for this object.
-	 *
-	 * @return hash code.
-	 */
-	@Override
-	public int hashCode() {
-		return super.hashCode();
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/environment/PlanetaryEntity.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/environment/PlanetaryEntity.java
@@ -1,0 +1,163 @@
+/*
+ * Mars Simulation Project
+ * PlanetaryEntity.java
+ * @date 2023-07-02
+ * @author MBarry Evans
+ */
+
+package org.mars_sim.msp.core.environment;
+
+import java.util.Set;
+
+import org.mars_sim.msp.core.Unit;
+import org.mars_sim.msp.core.UnitType;
+import org.mars_sim.msp.core.data.UnitSet;
+import org.mars_sim.msp.core.person.Person;
+import org.mars_sim.msp.core.robot.Robot;
+import org.mars_sim.msp.core.structure.Settlement;
+import org.mars_sim.msp.core.vehicle.Vehicle;
+
+/**
+ * Planetary entity that just hold Units
+ */
+public abstract class PlanetaryEntity extends Unit {
+
+	/** default serial id. */
+	private static final long serialVersionUID = 123L;
+
+	private Set<Unit> unitList;
+
+	private Unit owner;
+
+	private UnitType objectType;
+
+	protected PlanetaryEntity(String name, int id, int containerId, Unit owner,
+							UnitType objectType) {
+		super(name, id, containerId);
+
+		unitList = new UnitSet<>();
+		this.owner = owner;
+		this.objectType = objectType;				
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return super.equals(obj);
+	}
+
+	@Override
+	public UnitType getUnitType() {
+		return objectType;
+	}
+
+	public Settlement getSettlement() {
+		return null;
+	}
+
+	/**
+	 * Adds a person.
+	 *
+	 * @param person
+	 * @param true if the person can be added
+	 */
+	public boolean addPerson(Person person) {
+		synchronized (unitList) {
+			return unitList.add(person);
+		}
+	}
+
+	/**
+	 * Removes a person.
+	 *
+	 * @param person
+	 * @param true if the person can be removed
+	 */
+	public boolean removePerson(Person person) {
+		synchronized (unitList) {
+			return unitList.remove(person);
+		}
+	}
+
+	/**
+	 * Adds a robot.
+	 *
+	 * @param robot
+	 * @param true if the robot can be added
+	 */
+	public boolean addRobot(Robot robot) {
+		synchronized (unitList) {
+			return unitList.add(robot);
+		}
+	}
+
+	/**
+	 * Removes a robot.
+	 *
+	 * @param robot
+	 * @param true if the robot can be removed
+	 */
+	public boolean removeRobot(Robot robot) {
+		synchronized (unitList) {
+			return unitList.remove(robot);
+		}
+	}
+
+	/**
+	 * Adds a vehicle.
+	 *
+	 * @param vehicle
+	 * @param true if the vehicle can be added
+	 */
+	public boolean addVehicle(Vehicle vehicle) {
+		synchronized (unitList) {
+			// There is a bug somewhere because Drones in delivery remains on the Surface
+			if (unitList.contains(vehicle)) {
+				return true;
+			}
+			return unitList.add(vehicle);
+		}
+	}
+
+	/**
+	 * Removes a vehicle.
+	 *
+	 * @param vehicle
+	 * @param true if the vehicle can be removed
+	 */
+	public boolean removeVehicle(Vehicle vehicle) {
+		synchronized (unitList) {
+			return unitList.remove(vehicle);
+		}
+	}
+
+	/**
+	 * Gets the unit's container unit.
+	 *
+	 * @return the unit's container unit
+	 */
+	@Override
+	public Unit getContainerUnit() {
+		return owner;
+	}
+
+	/**
+	 * Is this unit inside a settlement ?
+	 *
+	 * @return true if the unit is inside a settlement
+	 */
+	@Override
+	public boolean isInSettlement() {
+		return false;
+	}
+
+
+	/**
+	 * Gets the hash code for this object.
+	 *
+	 * @return hash code.
+	 */
+	@Override
+	public int hashCode() {
+		return super.hashCode();
+	}
+}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/equipment/EVASuit.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/equipment/EVASuit.java
@@ -6,6 +6,7 @@
  */
 package org.mars_sim.msp.core.equipment;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
@@ -15,6 +16,8 @@ import org.mars_sim.msp.core.SimulationConfig;
 import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.UnitType;
 import org.mars_sim.msp.core.air.AirComposition;
+import org.mars_sim.msp.core.data.History;
+import org.mars_sim.msp.core.data.History.HistoryItem;
 import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.malfunction.MalfunctionFactory;
 import org.mars_sim.msp.core.malfunction.MalfunctionManager;
@@ -120,6 +123,7 @@ public class EVASuit extends Equipment
 	private MalfunctionManager malfunctionManager;
 	/** The MicroInventory instance. */
 	private MicroInventory microInventory;
+	private History<Unit> locnHistory;
 
 	
 	/**
@@ -164,6 +168,8 @@ public class EVASuit extends Equipment
 		
 		// Sets the base mass of the bag.
 		setBaseMass(EquipmentFactory.getEquipmentMass(EquipmentType.EVA_SUIT));
+
+		locnHistory = new History<>(10);
 	}
 	
 	static {
@@ -462,11 +468,19 @@ public class EVASuit extends Equipment
 		boolean result = super.setContainerUnit(parent);
 		if (result) {
 			// Add new parent to owner history
+			locnHistory.add(parent);
 		}
 
 		return result;
 	}
 
+	/**
+	 * History of the EVASuit
+	 * @return
+	 */
+	public List<HistoryItem<Unit>> getHistory() {
+		return locnHistory.getChanges();
+	}
 	/**
 	 * Return the parts that normally fail on a EVA Suit
 	 * 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/equipment/EVASuit.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/equipment/EVASuit.java
@@ -280,18 +280,18 @@ public class EVASuit extends Equipment
 		try {
 			// With the minimum required O2 partial pressure of 11.94 kPa (1.732 psi), the minimum mass of O2 is 0.1792 kg
 			if (getAmountResourceStored(OXYGEN_ID) <= MASS_O2_MINIMUM_LIMIT) {
-				logger.log(getOwner(), Level.WARNING, 30_000,
+				logger.log(this, Level.WARNING, 30_000,
 						"Less than 0.1792 kg oxygen (below the safety limit).");
 				return false;
 			}
 
 			if (getAmountResourceStored(WATER_ID) <= 0D) {
-				logger.log(getOwner(), Level.WARNING, 30_000,
+				logger.log(this, Level.WARNING, 30_000,
 						"Ran out of water.");
 			}
 
 			if (malfunctionManager.getOxygenFlowModifier() < 100D) {
-				logger.log(getOwner(), Level.WARNING, 30_000,
+				logger.log(this, Level.WARNING, 30_000,
 						"Oxygen flow sensor malfunction.", null);
 				return false;
 			}
@@ -299,13 +299,13 @@ public class EVASuit extends Equipment
 
 			double p = getAirPressure();
 			if (p > PhysicalCondition.MAXIMUM_AIR_PRESSURE || p <= MIN_O2_PRESSURE) {
-				logger.log(getOwner(), Level.WARNING, 30_000,
+				logger.log(this, Level.WARNING, 30_000,
 						"Detected improper o2 pressure at " + Math.round(p * 100.0D) / 100.0D + " kPa.");
 				return false;
 			}
 			double t = getTemperature();
 			if (t > NORMAL_TEMP + 15 || t < NORMAL_TEMP - 20) {
-				logger.log(getOwner(), Level.WARNING, 30_000,
+				logger.log(this, Level.WARNING, 30_000,
 						"Detected improper temperature at " + Math.round(t * 100.0D) / 100.0D + " deg C");
 				return false;
 			}
@@ -386,7 +386,7 @@ public class EVASuit extends Equipment
 		// Assuming that we can maintain a constant oxygen partial pressure unless it falls below massO2NominalLimit
 		if (oxygenLeft < MASS_O2_NOMINAL_LIMIT) {
 			double pp = AirComposition.getOxygenPressure(oxygenLeft, TOTAL_VOLUME);
-			logger.log(this, getOwner(), Level.WARNING, 30_000,
+			logger.log(this, Level.WARNING, 30_000,
 					"Only " + Math.round(oxygenLeft*1000.0)/1000.0
 						+ " kg O2 left at partial pressure of " + Math.round(pp*1000.0)/1000.0 + " kPa.");
 			return pp;
@@ -457,20 +457,6 @@ public class EVASuit extends Equipment
 		return s;
 	}
 
-	/**
-	 * Gets the owner of this suit
-	 *
-	 * @return owner
-	 */
-	// TODO Rework this method
-	public Person getOwner() {
-		Unit container = getContainerUnit();
-		if (UnitType.PERSON == container.getUnitType()) {
-			return (Person)container;
-		}
-		return null;
-	}
-
 	@Override
 	public boolean setContainerUnit(Unit parent) {
 		boolean result = super.setContainerUnit(parent);
@@ -480,7 +466,6 @@ public class EVASuit extends Equipment
 
 		return result;
 	}
-
 
 	/**
 	 * Return the parts that normally fail on a EVA Suit

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/equipment/EVASuit.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/equipment/EVASuit.java
@@ -263,6 +263,7 @@ public class EVASuit extends Equipment
 	 *
 	 * @return malfunction manager
 	 */
+	@Override
 	public MalfunctionManager getMalfunctionManager() {
 		return malfunctionManager;
 	}
@@ -274,6 +275,7 @@ public class EVASuit extends Equipment
 	 * @return true if life support is OK
 	 * @throws Exception if error checking life support.
 	 */
+	@Override
 	public boolean lifeSupportCheck() {
 		try {
 			// With the minimum required O2 partial pressure of 11.94 kPa (1.732 psi), the minimum mass of O2 is 0.1792 kg
@@ -319,6 +321,7 @@ public class EVASuit extends Equipment
 	 *
 	 * @return the capacity of the life support system.
 	 */
+	@Override
 	public int getLifeSupportCapacity() {
 		return 1;
 	}
@@ -330,6 +333,7 @@ public class EVASuit extends Equipment
 	 * @return the amount of oxygen actually received from system (kg)
 	 * @throws Exception if error providing oxygen.
 	 */
+	@Override
 	public double provideOxygen(double oxygenTaken) {
 		double oxygenLacking = 0;
 
@@ -353,6 +357,7 @@ public class EVASuit extends Equipment
 	 * @return the amount of water actually received from system (kg)
 	 * @throws Exception if error providing water.
 	 */
+	@Override
 	public double provideWater(double waterTaken) {
 		double lacking = retrieveAmountResource(WATER_ID, waterTaken);
 
@@ -364,6 +369,7 @@ public class EVASuit extends Equipment
 	 *
 	 * @return air pressure (Pa)
 	 */
+	@Override
 	public double getAirPressure() {
 		// Based on some pre-calculation,
 		// In a 3.9 liter system, 1 kg of O2 can create 66.61118 kPa partial pressure
@@ -394,6 +400,7 @@ public class EVASuit extends Equipment
 	 *
 	 * @return temperature (degrees C)
 	 */
+	@Override
 	public double getTemperature() {
 		return NORMAL_TEMP;// * (malfunctionManager.getTemperatureModifier() / 100D);
 //		double ambient = weather.getTemperature(getCoordinates());
@@ -455,6 +462,7 @@ public class EVASuit extends Equipment
 	 *
 	 * @return owner
 	 */
+	// TODO Rework this method
 	public Person getOwner() {
 		Unit container = getContainerUnit();
 		if (UnitType.PERSON == container.getUnitType()) {
@@ -462,6 +470,17 @@ public class EVASuit extends Equipment
 		}
 		return null;
 	}
+
+	@Override
+	public boolean setContainerUnit(Unit parent) {
+		boolean result = super.setContainerUnit(parent);
+		if (result) {
+			// Add new parent to owner history
+		}
+
+		return result;
+	}
+
 
 	/**
 	 * Return the parts that normally fail on a EVA Suit

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/equipment/Equipment.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/equipment/Equipment.java
@@ -340,12 +340,12 @@ public abstract class Equipment extends Unit implements Indoor, Salvagable {
 	 * Sets the unit's container unit.
 	 *
 	 * @param newContainer the unit to contain this unit.
+	 * @return Was a changed applied
 	 */
-	@Override
-	public void setContainerUnit(Unit newContainer) {
+	public boolean setContainerUnit(Unit newContainer) {
 		if (newContainer != null) {
 			if (newContainer.equals(getContainerUnit())) {
-				return;
+				return false;
 			}
 			// 1. Set Coordinates
 			if (newContainer.getUnitType() == UnitType.MARS) {
@@ -356,7 +356,7 @@ public abstract class Equipment extends Unit implements Indoor, Salvagable {
 			}
 			else {
 				// Null its coordinates since it's now slaved after its parent
-				setNullCoordinates();
+				setCoordinates(null);
 			}
 			// 2. Set LocationStateType
 			updateEquipmentState(newContainer);
@@ -366,6 +366,7 @@ public abstract class Equipment extends Unit implements Indoor, Salvagable {
 			// 4. Fire the container unit event
 			fireUnitUpdate(UnitEventType.CONTAINER_UNIT_EVENT, newContainer);
 		}
+		return true;
 	}
 
 	/**
@@ -388,7 +389,6 @@ public abstract class Equipment extends Unit implements Indoor, Salvagable {
 	 * @param newContainer
 	 * @return {@link LocationStateType}
 	 */
-	@Override
 	public LocationStateType getNewLocationState(Unit newContainer) {
 
 		if (newContainer.getUnitType() == UnitType.SETTLEMENT)

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/equipment/Equipment.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/equipment/Equipment.java
@@ -280,7 +280,7 @@ public abstract class Equipment extends Unit implements Indoor, Salvagable {
 	public int getRegisteredOwnerID() {
 		return registeredOwner;
 	}
-
+	
 	public EquipmentType getEquipmentType() {
 		return equipmentType;
 	}
@@ -342,7 +342,7 @@ public abstract class Equipment extends Unit implements Indoor, Salvagable {
 	 * @param newContainer the unit to contain this unit.
 	 * @return Was a changed applied
 	 */
-	public boolean setContainerUnit(Unit newContainer) {
+	boolean setContainerUnit(Unit newContainer) {
 		if (newContainer != null) {
 			if (newContainer.equals(getContainerUnit())) {
 				return false;
@@ -446,11 +446,6 @@ public abstract class Equipment extends Unit implements Indoor, Salvagable {
 			// if the unit is on a robot
 			return ((Robot)getContainerUnit()).isInSettlement();
 		}
-
-		// Note: may consider the scenario of this unit
-		// being carried in by another person or a robot
-//		if (LocationStateType.ON_PERSON_OR_ROBOT == currentStateType)
-//			return getContainerUnit().isInSettlement();
 
 		return false;
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/equipment/EquipmentInventory.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/equipment/EquipmentInventory.java
@@ -9,6 +9,7 @@ package org.mars_sim.msp.core.equipment;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -98,8 +99,8 @@ public class EquipmentInventory
 	public Set<Equipment> getEquipmentSet() {
 		if (equipmentSet == null)
 			equipmentSet = new UnitSet<>();
-		return equipmentSet;
-//		return Collections.unmodifiableSet(equipmentSet);
+		//return equipmentSet;
+		return Collections.unmodifiableSet(equipmentSet);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/malfunction/MalfunctionManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/malfunction/MalfunctionManager.java
@@ -611,7 +611,7 @@ public class MalfunctionManager implements Serializable, Temporal {
 			else if (actor.getUnitType() == UnitType.EVA_SUIT) {
 				eventType = EventType.MALFUNCTION_PARTS_FAILURE;
 				whileDoing = ""; 
-				whoAffected = ((EVASuit)actor).getOwner().getName();
+				whoAffected = ((EVASuit)actor).getContainerUnit().getName();
 			}
 			else {
 				eventType = EventType.MALFUNCTION_PARTS_FAILURE;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/moon/Moon.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/moon/Moon.java
@@ -7,159 +7,26 @@
 
 package org.mars_sim.msp.core.moon;
 
-import java.util.Set;
-
 import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.UnitType;
-import org.mars_sim.msp.core.data.UnitSet;
+import org.mars_sim.msp.core.environment.PlanetaryEntity;
 import org.mars_sim.msp.core.location.LocationStateType;
-import org.mars_sim.msp.core.person.Person;
-import org.mars_sim.msp.core.robot.Robot;
-import org.mars_sim.msp.core.structure.Settlement;
-import org.mars_sim.msp.core.vehicle.Vehicle;
 
 /**
  * Moon is the object unit that represents Earth's Moon
  */
-public class Moon extends Unit {
+public class Moon extends PlanetaryEntity {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 123L;
 
 	private static final String NAME = "Moon";
 
-	private Set<Unit> unitList;
 
-	public Moon() {
-		super(NAME, Unit.MOON_UNIT_ID, Unit.OUTER_SPACE_UNIT_ID);
-
-		unitList = new UnitSet<>();
-		
+	public Moon(Unit outerSpace) {
+		super(NAME, Unit.MOON_UNIT_ID, outerSpace.getIdentifier(), outerSpace, UnitType.MOON);
+	
 		// Set currentStateType
 		currentStateType = LocationStateType.MOON;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		return super.equals(obj);
-	}
-
-	@Override
-	public UnitType getUnitType() {
-		return UnitType.MOON;
-	}
-
-	public Settlement getSettlement() {
-		return null;
-	}
-
-	/**
-	 * Adds a person.
-	 *
-	 * @param person
-	 * @param true if the person can be added
-	 */
-	public boolean addPerson(Person person) {
-		synchronized (unitList) {
-			return unitList.add(person);
-		}
-	}
-
-	/**
-	 * Removes a person.
-	 *
-	 * @param person
-	 * @param true if the person can be removed
-	 */
-	public boolean removePerson(Person person) {
-		synchronized (unitList) {
-			return unitList.remove(person);
-		}
-	}
-
-	/**
-	 * Adds a robot.
-	 *
-	 * @param robot
-	 * @param true if the robot can be added
-	 */
-	public boolean addRobot(Robot robot) {
-		synchronized (unitList) {
-			return unitList.add(robot);
-		}
-	}
-
-	/**
-	 * Removes a robot.
-	 *
-	 * @param robot
-	 * @param true if the robot can be removed
-	 */
-	public boolean removeRobot(Robot robot) {
-		synchronized (unitList) {
-			return unitList.remove(robot);
-		}
-	}
-
-	/**
-	 * Adds a vehicle.
-	 *
-	 * @param vehicle
-	 * @param true if the vehicle can be added
-	 */
-	public boolean addVehicle(Vehicle vehicle) {
-		synchronized (unitList) {
-			// There is a bug somewhere because Drones in delivery remains on the Surface
-			if (unitList.contains(vehicle)) {
-				return true;
-			}
-			return unitList.add(vehicle);
-		}
-	}
-
-	/**
-	 * Removes a vehicle.
-	 *
-	 * @param vehicle
-	 * @param true if the vehicle can be removed
-	 */
-	public boolean removeVehicle(Vehicle vehicle) {
-		synchronized (unitList) {
-			return unitList.remove(vehicle);
-		}
-	}
-
-	/**
-	 * Gets the unit's container unit.
-	 *
-	 * @return the unit's container unit
-	 */
-	@Override
-	public Unit getContainerUnit() {
-		if (unitManager == null) // for maven test
-			return null;
-		// Return itself
-		return unitManager.getOuterSpace();
-	}
-
-	/**
-	 * Is this unit inside a settlement ?
-	 *
-	 * @return true if the unit is inside a settlement
-	 */
-	@Override
-	public boolean isInSettlement() {
-		return false;
-	}
-
-
-	/**
-	 * Gets the hash code for this object.
-	 *
-	 * @return hash code.
-	 */
-	@Override
-	public int hashCode() {
-		return super.hashCode();
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/Person.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/Person.java
@@ -2243,16 +2243,12 @@ public class Person extends Unit implements Worker, Temporal, ResearcherInterfac
 
 		if (!hasThermalBottle() && isInside()) {
 			Equipment aBottle = null;
-			Iterator<Equipment> i = ((EquipmentOwner)getContainerUnit()).getEquipmentSet().iterator();
-			while (i.hasNext()){
-				Equipment e = i.next();
+			for(Equipment e : ((EquipmentOwner)getContainerUnit()).getEquipmentSet()) {
 				if (e.getEquipmentType() == EquipmentType.THERMAL_BOTTLE) {
 					Person originalOwner = e.getRegisteredOwner();
 					if (originalOwner != null && originalOwner.equals(this)) {
 						// Remove it from the container unit
-						i.remove();
-						// Add to this person's inventory
-						addEquipment(e);
+						e.transfer(this);
 						// Register the person as the owner of this bottle
 						e.setRegisteredOwner(this);
 						
@@ -2270,9 +2266,7 @@ public class Person extends Unit implements Worker, Temporal, ResearcherInterfac
 			// get the first saved one 
 			if (aBottle != null) {
 				// Remove it from the container unit
-				i.remove();
-				// Add to this person's inventory
-				addEquipment(aBottle);
+				aBottle.transfer(this);
 				// Register the person as the owner of this bottle
 				aBottle.setRegisteredOwner(this);
 			}
@@ -2286,15 +2280,10 @@ public class Person extends Unit implements Worker, Temporal, ResearcherInterfac
 
 		if (hasThermalBottle() && isInside()) {
 
-			Iterator<Equipment> i = getEquipmentSet().iterator();
-			while (i.hasNext()){
-				Equipment e = i.next();
+			for(Equipment e : getEquipmentSet()) {
 				if (e.getEquipmentType() == EquipmentType.THERMAL_BOTTLE) {
-					i.remove();
 					// Transfer to this person's container unit 
 					e.transfer(getContainerUnit());
-					// Register the person as the owner of this bottle if not done
-					e.setRegisteredOwner(this);
 					
 					break;
 				}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/Person.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/Person.java
@@ -1739,7 +1739,6 @@ public class Person extends Unit implements Worker, Temporal, ResearcherInterfac
 	@Override
 	public boolean addEquipment(Equipment e) {
 		if (eqmInventory.addEquipment(e)) {
-			e.setContainerUnit(this);
 			fireUnitUpdate(UnitEventType.ADD_ASSOCIATED_EQUIPMENT_EVENT, this);
 			return true;
 		}
@@ -2293,7 +2292,7 @@ public class Person extends Unit implements Worker, Temporal, ResearcherInterfac
 				if (e.getEquipmentType() == EquipmentType.THERMAL_BOTTLE) {
 					i.remove();
 					// Transfer to this person's container unit 
-					((EquipmentOwner)getContainerUnit()).addEquipment(e);
+					e.transfer(getContainerUnit());
 					// Register the person as the owner of this bottle if not done
 					e.setRegisteredOwner(this);
 					

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/Person.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/Person.java
@@ -1992,11 +1992,10 @@ public class Person extends Unit implements Worker, Temporal, ResearcherInterfac
 	 *
 	 * @param newContainer the unit to contain this unit.
 	 */
-	@Override
-	public void setContainerUnit(Unit newContainer) {
+	public boolean setContainerUnit(Unit newContainer) {
 		if (newContainer != null) {
 			if (newContainer.equals(getContainerUnit())) {
-				return;
+				return false;
 			}
 			// 1. Set Coordinates
 			if (newContainer.getUnitType() == UnitType.MARS) {
@@ -2007,7 +2006,7 @@ public class Person extends Unit implements Worker, Temporal, ResearcherInterfac
 			}
 			else {
 				// Null its coordinates since it's now slaved after its parent
-				setNullCoordinates();
+				setCoordinates(null);
 			}
 			// 2. Set new LocationStateType
 			updatePersonState(newContainer);
@@ -2017,6 +2016,7 @@ public class Person extends Unit implements Worker, Temporal, ResearcherInterfac
 			// 4. Fire the container unit event
 			fireUnitUpdate(UnitEventType.CONTAINER_UNIT_EVENT, newContainer);
 		}
+		return true;
 	}
 
 	/**
@@ -2039,8 +2039,7 @@ public class Person extends Unit implements Worker, Temporal, ResearcherInterfac
 	 * @param newContainer
 	 * @return {@link LocationStateType}
 	 */
-	@Override
-	public LocationStateType getNewLocationState(Unit newContainer) {
+	private LocationStateType getNewLocationState(Unit newContainer) {
 
 		if (newContainer.getUnitType() == UnitType.SETTLEMENT)
 			return LocationStateType.INSIDE_SETTLEMENT;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ExitAirlock.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ExitAirlock.java
@@ -906,7 +906,7 @@ public class ExitAirlock extends Task {
 			// 0. Drop off the thermal bottle 
 			person.dropOffThermalBottle();
 			// 1. Get a good EVA suit's instance from entity inventory
-			suit = EVASuitUtil.findEVASuitWithResources((EquipmentOwner)housing, person);
+			suit = EVASuitUtil.findEVASuitWithResources(housing, person);
 	
 			if (suit == null) {
 				logger.log((Unit)airlock.getEntity(), person, Level.WARNING, 4_000,

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/robot/Robot.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/robot/Robot.java
@@ -782,7 +782,6 @@ public class Robot extends Unit implements Salvagable, Temporal, Malfunctionable
 	@Override
 	public boolean addEquipment(Equipment e) {
 		if (eqmInventory.addEquipment(e)) {
-			e.setContainerUnit(this);
 			fireUnitUpdate(UnitEventType.ADD_ASSOCIATED_EQUIPMENT_EVENT, this);
 			return true;
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/robot/Robot.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/robot/Robot.java
@@ -1027,11 +1027,10 @@ public class Robot extends Unit implements Salvagable, Temporal, Malfunctionable
 	 *
 	 * @param newContainer the unit to contain this unit.
 	 */
-	@Override
-	public void setContainerUnit(Unit newContainer) {
+	public boolean setContainerUnit(Unit newContainer) {
 		if (newContainer != null) {
 			if (newContainer.equals(getContainerUnit())) {
-				return;
+				return false;
 			}
 			// 1. Set Coordinates
 			if (newContainer.getUnitType() == UnitType.MARS) {
@@ -1042,7 +1041,7 @@ public class Robot extends Unit implements Salvagable, Temporal, Malfunctionable
 			}
 			else {
 				// Null its coordinates since it's now slaved after its parent
-				setNullCoordinates();
+				setCoordinates(null);
 			}
 			// 2. Set LocationStateType
 			updateRobotState(newContainer);
@@ -1052,6 +1051,8 @@ public class Robot extends Unit implements Salvagable, Temporal, Malfunctionable
 			// 4. Fire the container unit event
 			fireUnitUpdate(UnitEventType.CONTAINER_UNIT_EVENT, newContainer);
 		}
+
+		return true;
 	}
 
 	/**
@@ -1074,8 +1075,7 @@ public class Robot extends Unit implements Salvagable, Temporal, Malfunctionable
 	 * @param newContainer
 	 * @return {@link LocationStateType}
 	 */
-	@Override
-	public LocationStateType getNewLocationState(Unit newContainer) {
+	private LocationStateType getNewLocationState(Unit newContainer) {
 
 		if (newContainer.getUnitType() == UnitType.SETTLEMENT)
 			return LocationStateType.INSIDE_SETTLEMENT;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/Settlement.java
@@ -2070,7 +2070,6 @@ public class Settlement extends Structure implements Temporal,
 	@Override
 	public boolean addEquipment(Equipment e) {
 		if (eqmInventory.addEquipment(e)) {
-			e.setContainerUnit(this);
 			fireUnitUpdate(UnitEventType.ADD_ASSOCIATED_EQUIPMENT_EVENT, this);
 			return true;
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/SettlementBuilder.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/SettlementBuilder.java
@@ -24,7 +24,6 @@ import org.mars_sim.msp.core.SimulationConfig;
 import org.mars_sim.msp.core.UnitManager;
 import org.mars_sim.msp.core.configuration.Scenario;
 import org.mars_sim.msp.core.configuration.UserConfigurableConfig;
-import org.mars_sim.msp.core.equipment.Equipment;
 import org.mars_sim.msp.core.equipment.EquipmentFactory;
 import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.person.Crew;
@@ -246,11 +245,7 @@ public final class SettlementBuilder {
 		for (String type : equipmentMap.keySet()) {
 			int number = equipmentMap.get(type);
 			for (int x = 0; x < number; x++) {
-				Equipment equipment = EquipmentFactory.createEquipment(type, settlement);
-				unitManager.addUnit(equipment);
-				settlement.addEquipment(equipment);
-				// Set the container unit
-				equipment.setContainerUnit(settlement);
+				EquipmentFactory.createEquipment(type, settlement);
 			}
 		}
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/Building.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/Building.java
@@ -1450,15 +1450,13 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 	 *
 	 * @param newContainer the unit to contain this unit.
 	 */
-	@Override
-	public void setContainerUnit(Unit newContainer) {
+	public boolean setContainerUnit(Unit newContainer) {
 		if (newContainer != null) {
 			if (newContainer.equals(getContainerUnit())) {
-				return;
+				return false;
 			}
 			// 1. Set Coordinates
-//			setCoordinates(newContainer.getCoordinates());
-			setNullCoordinates();
+			setCoordinates(null);
 			// 2. Set LocationStateType
 			currentStateType = LocationStateType.INSIDE_SETTLEMENT;
 			// 3. Set containerID
@@ -1467,18 +1465,8 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 			// 4. Fire the container unit event
 			fireUnitUpdate(UnitEventType.CONTAINER_UNIT_EVENT, newContainer);
 		}
-	}
 
-	/**
-	 * Gets the unit's container unit. Returns null if unit has no container unit.
-	 *
-	 * @return the unit's container unit
-	 */
-	@Override
-	public Unit getContainerUnit() {
-		if (unitManager == null) // for maven test
-			return null;
-		return unitManager.getSettlementByID(containerID);
+		return true;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/function/FoodProduction.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/function/FoodProduction.java
@@ -394,13 +394,6 @@ public class FoodProduction extends Function {
 						for (int x = 0; x < number; x++) {
 							Equipment equipment = EquipmentFactory.createEquipment(equipmentType,
 									settlement);
-							
-							// Place this equipment within a settlement
-							unitManager.addUnit(equipment);
-							// Add this equipment as being owned by this settlement
-							settlement.addEquipment(equipment);
-							// Set the container unit
-							equipment.setContainerUnit(settlement);
 							// Add to the daily output
 							settlement.addOutput(equipment.getIdentifier(), number, process.getTotalWorkTime());
 						}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/function/Manufacture.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/building/function/Manufacture.java
@@ -510,13 +510,6 @@ public class Manufacture extends Function {
 						for (int x = 0; x < number; x++) {
 							Equipment equipment = EquipmentFactory.createEquipment(equipmentType,
 									settlement);
-
-							// Place this equipment within a settlement
-							unitManager.addUnit(equipment);
-							// Add this equipment as being owned by this settlement
-							settlement.addEquipment(equipment);
-							// Set the container unit
-							equipment.setContainerUnit(settlement);
 							// Add to the daily output
 							settlement.addOutput(equipment.getIdentifier(), number, process.getTotalWorkTime());
 						}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Vehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Vehicle.java
@@ -1749,7 +1749,6 @@ public abstract class Vehicle extends Unit
 	@Override
 	public boolean addEquipment(Equipment e) {
 		if (eqmInventory.addEquipment(e)) {
-			e.setContainerUnit(this);
 			fireUnitUpdate(UnitEventType.ADD_ASSOCIATED_EQUIPMENT_EVENT, this);
 			return true;
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Vehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/vehicle/Vehicle.java
@@ -2008,11 +2008,10 @@ public abstract class Vehicle extends Unit
 	 *
 	 * @param newContainer the unit to contain this unit.
 	 */
-	@Override
-	public void setContainerUnit(Unit newContainer) {
+	public boolean setContainerUnit(Unit newContainer) {
 		if (newContainer != null) {
 			if (newContainer.equals(getContainerUnit())) {
-				return;
+				return false;
 			}
 			// 1. Set Coordinates
 			if (newContainer.getUnitType() == UnitType.MARS) {
@@ -2023,7 +2022,7 @@ public abstract class Vehicle extends Unit
 			}
 			else {
 				// Null its coordinates since it's now slaved after its parent
-				setNullCoordinates();
+				setCoordinates(null);
 			}
 			// 2. Set new LocationStateType
 			updateVehicleState(newContainer);
@@ -2032,6 +2031,7 @@ public abstract class Vehicle extends Unit
 			// 4. Fire the container unit event
 			fireUnitUpdate(UnitEventType.CONTAINER_UNIT_EVENT, newContainer);
 		}
+		return true;
 	}
 
 	/**
@@ -2070,8 +2070,7 @@ public abstract class Vehicle extends Unit
 	 * @param newContainer
 	 * @return {@link LocationStateType}
 	 */
-	@Override
-	public LocationStateType getNewLocationState(Unit newContainer) {
+	private LocationStateType getNewLocationState(Unit newContainer) {
 
 		if (newContainer.getUnitType() == UnitType.SETTLEMENT) {
 			if (isInAGarage()) {

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/equipment/TabPanelSuitGeneral.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/equipment/TabPanelSuitGeneral.java
@@ -7,11 +7,18 @@
 package org.mars_sim.msp.ui.swing.unit_window.equipment;
 
 import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.util.List;
 
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.table.AbstractTableModel;
 
 import org.mars_sim.msp.core.Msg;
+import org.mars_sim.msp.core.Unit;
+import org.mars_sim.msp.core.data.History.HistoryItem;
 import org.mars_sim.msp.core.equipment.EVASuit;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.ui.swing.ImageLoader;
@@ -32,17 +39,11 @@ public class TabPanelSuitGeneral extends TabPanel {
 	private EVASuit suit;
 	
 	private JLabel registeredOwnerLabel;
-
-	private JLabel containerUnitLabel;
-
-	private JLabel topContainerUnitLabel;
 	
 	private String pOwnerCache;
 	
-	private String cUnitCache;
-	
-	private String topContainerUnitCache;
-	
+	private HistoryTableModel historyTableModel;
+		
 	/**
 	 * Constructor.
 	 * 
@@ -65,7 +66,7 @@ public class TabPanelSuitGeneral extends TabPanel {
 	protected void buildUI(JPanel content) {
 
 		// Prepare spring layout info panel.
-		AttributePanel infoPanel = new AttributePanel(3);
+		AttributePanel infoPanel = new AttributePanel(1);
 		
 		content.add(infoPanel, BorderLayout.NORTH);
 
@@ -77,16 +78,17 @@ public class TabPanelSuitGeneral extends TabPanel {
 		}		
 		registeredOwnerLabel = infoPanel.addTextField(Msg.getString("TabPanelSuitGeneral.regOwner"), //$NON-NLS-1$
 				pOwnerCache, null);
-	
-		// Prepare container unit label
-		topContainerUnitCache = suit.getTopContainerUnit().getName();
-		topContainerUnitLabel = infoPanel.addTextField(Msg.getString("TabPanelSuitGeneral.topContainerUnit"), //$NON-NLS-1$
-				topContainerUnitCache, null);
+
 		
-		// Prepare container unit label
-		cUnitCache = suit.getContainerUnit().getName();
-		containerUnitLabel = infoPanel.addTextField(Msg.getString("TabPanelSuitGeneral.containerUnit"), //$NON-NLS-1$
-				cUnitCache, null);
+		JScrollPane scrollPanel = new JScrollPane();
+		scrollPanel.setBorder(StyleManager.createLabelBorder("History"));
+		historyTableModel = new HistoryTableModel(suit.getHistory());
+		JTable table = new JTable(historyTableModel);
+		table.setPreferredScrollableViewportSize(new Dimension(225, 100));
+		scrollPanel.setViewportView(table);
+
+		content.add(scrollPanel, BorderLayout.CENTER);
+
 	}
 	
 	/**
@@ -104,17 +106,81 @@ public class TabPanelSuitGeneral extends TabPanel {
 			pOwnerCache = pOwner;
 			registeredOwnerLabel.setText(pOwner); 
 		}
-			
-		String topContainerUnit = suit.getTopContainerUnit().getName();
-		if (!topContainerUnitCache.equalsIgnoreCase(topContainerUnit)) {
-			topContainerUnitCache = topContainerUnit;
-			topContainerUnitLabel.setText(topContainerUnit); 
+
+		historyTableModel.update();
+	}
+
+	/**
+	 * Internal class used as model for the attribute table.
+	 */
+	private static class HistoryTableModel extends AbstractTableModel {
+
+		private static final long serialVersionUID = 1L;
+
+		private List<HistoryItem<Unit>> history;
+		private int origSize;
+
+		private Object firstTime;
+
+		/**
+		 * hidden constructor.
+		 *
+		 * @param unit {@link Unit}
+		 */
+		HistoryTableModel(List<HistoryItem<Unit>> history) {
+			this.history = history;
+			origSize = history.size();
+			firstTime = (history.isEmpty() ? null : history.get(0).getWhen());
 		}
-		
-		String cUnit = suit.getContainerUnit().getName();
-		if (!cUnitCache.equalsIgnoreCase(cUnit)) {
-			cUnitCache = cUnit;
-			containerUnitLabel.setText(cUnit); 
+
+		@Override
+		public int getRowCount() {
+			if (history != null)
+				return history.size();
+			else
+				return 0;
+		}
+
+		@Override
+		public int getColumnCount() {
+			return 2;
+		}
+
+		@Override
+		public Class<?> getColumnClass(int columnIndex) {
+			return String.class;
+		}
+
+		@Override
+		public String getColumnName(int columnIndex) {
+			return switch(columnIndex) {
+				case 0 -> "Date";
+				case 1 -> "Location";
+				default -> null;
+			};
+		}
+
+		public Object getValueAt(int row, int column) {
+			int r = history.size() - row - 1;
+			HistoryItem<Unit> item = history.get(r);
+			return switch(column) {
+				case 0 -> item.getWhen().getTruncatedDateTimeStamp();
+				case 1 -> item.getWhat().getName();
+				default -> null;
+			};
+		}
+
+		/**
+		 * Prepares the job history of the person.
+		 */
+		void update() {
+			// Has the size changed or the time of the first item (handles fixed size history)
+			if ((origSize != history.size()) 
+				|| !history.get(0).getWhen().equals(firstTime)) {
+				origSize = history.size();
+				firstTime = history.get(0).getWhen();
+				fireTableDataChanged();
+			}
 		}
 	}
 }

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/vehicle/TabPanelCrew.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/vehicle/TabPanelCrew.java
@@ -200,6 +200,7 @@ public class TabPanelCrew extends TabPanel implements ActionListener {
 		
 		crewNumTF = null;
 		memberTable = null;
+		memberTableModel.clearMembers();
 		memberTableModel = null;
 	}
 
@@ -313,6 +314,9 @@ public class TabPanelCrew extends TabPanel implements ActionListener {
 			UnitEventType type = event.getType();
 			Worker member = (Worker) event.getSource();
 			int index = members.indexOf(member);
+			if (index < 0) {
+				return;
+			}
 			if (type == UnitEventType.NAME_EVENT) {
 				fireTableCellUpdated(index, 0);
 			} else if ((type == UnitEventType.TASK_DESCRIPTION_EVENT) || (type == UnitEventType.TASK_EVENT)


### PR DESCRIPTION
This PR add a History to the EVA Suit so that the location is recorded. The history is shown in the EVA general tab.

There is a general tidy up of the ``setContainerUnit``` in the Unit class. Only units that can move need to support the changing of a container and hence the set method has been removed from the base Unit class.

In particular, for Equipment the method was called randomly but should only be used from the transfer method. This may account for the leakage of EVASuits,

The selection of EVASuits for Vehicle & settlements use the same logic; the previous Vehicle logic would never select an empty suit as the resources feel below the mission threshold. 

Due to the important of the EVASuit fix I haven't done as much testing as normal for such a large PR. Hence there may still be some issues.
Relates to #888 & #958