### PR TITLE
Fixed typo in TabPanelGeneral.java

### DIFF
--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/person/TabPanelGeneral.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/person/TabPanelGeneral.java
@@ -90,7 +90,7 @@ public class TabPanelGeneral extends TabPanel {
 		
 		// Prepare height name label
 		infoPanel.addTextField(Msg.getString("TabPanelGeneral.height"), //$NON-NLS-1$
-					 StyleManager.DECIMAL_PLACES1.format(person.getHeight()) + " m", null);
+					 StyleManager.DECIMAL_PLACES1.format(person.getHeight()) + " cm", null);
 
 		// Prepare BMI label
 		double height = person.getHeight()/100D;


### PR DESCRIPTION
Human height as listed in the general tab of the details window is shown in cm but labelled as m; I changed the label to cm to prevent the >100 m tall giants.