### PR TITLE
Fix digging tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Copyright (C) 2023 Scott Davis
 
 ------------------------------------------|---------------------
 
-## 3.6.2 (30 Aug 2023)
+## 3.6.2 (01 Sep 2023)
 
 ### A. CORE ENGINE IMPROVEMENTS :
 <OL>
@@ -41,6 +41,7 @@ Copyright (C) 2023 Scott Davis
 ### C. FIXES :
 <OL>
   <LI>Computing: rework work time related to consuming computing resources when analyzing map data.</LI>
+  <LI>Digging Local: correct not being able to start digging ice and regolith on its own.</LI>  
   <LI>Equipment: correct transferring container back to settlement after digging regolith/ice.</LI> 
   <LI>Food Production: correct potato typo.</LI>
   <LI>Map: correct magnification and zooming issues.</LI>

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/CollectionUtils.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/CollectionUtils.java
@@ -133,12 +133,10 @@ public class CollectionUtils {
 	 * @return
 	 */
 	public static String getNearbyVehicleName(Coordinates c) {
-//		if (isSettlement(c)) {
-			Vehicle vehicle = CollectionUtils.findVehicle(c);
-			if (vehicle != null) {
-				return vehicle.getName();
-			}
-//		}
+		Vehicle vehicle = CollectionUtils.findVehicle(c);
+		if (vehicle != null) {
+			return vehicle.getName();
+		}
 		return "No Vehicle";
 	}
 	

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/mission/MissionStep.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/mission/MissionStep.java
@@ -90,7 +90,8 @@ public abstract class MissionStep extends ProjectStep {
     }
 
     /**
-     * Assign a Task to a Worker as part of this mission step
+     * Assigns a Task to a Worker as part of this mission step.
+     * 
      * @param worker Worker looking to work
      * @param task Task allocated
      */
@@ -104,6 +105,9 @@ public abstract class MissionStep extends ProjectStep {
         }
         else if (worker instanceof Person p) {
             assignTask = (!task.isEffortDriven() || (p.getPerformanceRating() != 0D));
+            
+    		if (p.isSuperUnFit())
+    			return false;
         }
 
         if (assignTask) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/Person.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/Person.java
@@ -664,7 +664,13 @@ public class Person extends Unit implements Worker, Temporal, ResearcherInterfac
 		return shiftSlot.getStatus() == WorkStatus.ON_DUTY;
 	}
 
-
+	/**
+	 * Is this Person OnDuty. This does not include On Call.
+	 */
+	public boolean isOnDuty(int time) {
+		return shiftSlot.getShift().isOnDuty(time);
+	}
+			
 	/**
 	 * Creates a string representing the birth time of the person.
 	 * @param clock

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/LoadVehicleGarage.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/LoadVehicleGarage.java
@@ -75,18 +75,18 @@ public class LoadVehicleGarage extends Task {
 
 		settlement = worker.getSettlement();
 		if (settlement == null) {
-			clearTask("Worker no in settlement");
+			clearTask("Worker not in settlement.");
 			return;
 		}
 
 		vehicle = vehicleMission.getVehicle();
 		if (vehicle == null) {
-			clearTask("Mission has no vehicle");
+			clearTask("Mission has no vehicle.");
 			return;
 		}
 		loadController = vehicleMission.getLoadingPlan();
 		if (loadController == null) {
-			clearTask("Vehicle has no loading plan");
+			clearTask("Vehicle has no loading plan.");
 			return;
 		}
  
@@ -98,7 +98,7 @@ public class LoadVehicleGarage extends Task {
 		
 			// End task if vehicle or garage not available
 			if (garage == null) {
-				clearTask("Cannot put in garage");
+				clearTask("Cannot put in garage.");
 				return;
 			}
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MaintainBuilding.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MaintainBuilding.java
@@ -169,7 +169,7 @@ public class MaintainBuilding extends Task  {
 		int shortfall = manager.transferMaintenanceParts((EquipmentOwner) containerUnit);
 		
 		if (shortfall == -1) {
-			clearTask("No spare parts for maintenance");
+			clearTask("No spare parts for maintenance.");
 			return 0;
 		}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MaintainBuildingEVA.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MaintainBuildingEVA.java
@@ -83,7 +83,7 @@ extends EVAOperation {
 		
 		double effectiveTime = manager.getEffectiveTimeSinceLastMaintenance();
 		if (effectiveTime < 10D) {
-			clearTask("Maintenance already done");
+			clearTask("Maintenance already done.");
 			return;
 		}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MaintainEVAVehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MaintainEVAVehicle.java
@@ -65,7 +65,7 @@ public class MaintainEVAVehicle extends EVAOperation {
         // Choose an available needy ground vehicle.
         vehicle = target;
         if (vehicle.isReservedForMaintenance()) {
-            clearTask(vehicle.getName() + " already reserved for EVA maintenance");
+            clearTask(vehicle.getName() + " already reserved for EVA maintenance.");
             checkLocation();
             return;
         }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MaintainGarageVehicle.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/MaintainGarageVehicle.java
@@ -119,7 +119,7 @@ public class MaintainGarageVehicle extends Task {
 
 		// End task if vehicle or garage not available.
 		if (garage == null) {
-			clearTask(vehicle.getName() + " Can not find available garage for maintenance");
+			clearTask(vehicle.getName() + " Can not find available garage for maintenance.");
 		}
 
 		logger.log(worker, Level.FINER, 0, "Starting maintainGarageVehicle task on " + vehicle.getName());
@@ -181,7 +181,7 @@ public class MaintainGarageVehicle extends Task {
 		
 		int shortfall = manager.transferMaintenanceParts(settlement);
 		if (shortfall == -1) {
-			clearTask("No spare parts for maintenance");
+			clearTask("No spare parts for maintenance.");
 			return time;
 		}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/TendGreenhouse.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/TendGreenhouse.java
@@ -153,7 +153,7 @@ public class TendGreenhouse extends Task {
 	}
 
 	/**
-	 * Select a suitable sub-task in the greenhouse
+	 * Selects a suitable sub-task in the greenhouse.s
 	 */
 	private void selectTask() {
 		if (greenhouse.getNumCrops2Plant() > 0) {
@@ -280,9 +280,9 @@ public class TendGreenhouse extends Task {
 		double mod = 0;
 		
 		if (worker.getUnitType() == UnitType.PERSON)
-			mod = 1;
+			mod = 1.2;
 		else
-			mod = .25 * RandomUtil.getRandomDouble(.85, 1.15);
+			mod = .3 * RandomUtil.getRandomDouble(.85, 1.15);
 		
 		// Determine amount of effective work time based on "Botany" skill
 		int greenhouseSkill = getEffectiveSkillLevel();
@@ -377,7 +377,7 @@ public class TendGreenhouse extends Task {
 	}
 
 	/**
-	 * Grows the tissue culture.
+	 * Grows tissue culture.
 	 * 
 	 * @param time
 	 * @return

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ToggleResourceProcess.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/ToggleResourceProcess.java
@@ -68,11 +68,11 @@ public class ToggleResourceProcess extends Task {
 		super(NAME, worker, true, false, STRESS_MODIFIER, SkillType.MECHANICS, 100D, 20D);
 
 		if (process.isFlagged()) {
-			clearTask("Process toggle already active with someone else");
+			clearTask("Process toggle already active with someone else.");
 			return;
 		}
 		else if (!process.isToggleAvailable()) {
-			clearTask("Process already completed toggled");
+			clearTask("Process already completed toggled.");
 			return;
 		}
 
@@ -153,7 +153,7 @@ public class ToggleResourceProcess extends Task {
 			if (perf == 0D) {
 				// reset it to 10% so that he can walk inside
 				person.getPhysicalCondition().setPerformanceFactor(.1);
-				clearTask(": poor performance in " + process.getProcessName());
+				clearTask(": poor performance in " + process.getProcessName() + ".");
 			}
 
 		} else {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/UnloadVehicleGarage.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/UnloadVehicleGarage.java
@@ -92,17 +92,17 @@ public class UnloadVehicleGarage extends Task {
 		settlement = worker.getSettlement();
 
 		if (isFullyUnloaded(vehicle)) {
-			clearTask(vehicle.getName() + " already unloaded");
+			clearTask(vehicle.getName() + " already unloaded.");
 			return;
 		}
-		logger.log(worker, Level.FINER, 0, "Going to unload " + vehicle.getName());
+		logger.log(worker, Level.FINER, 0, "Going to unload " + vehicle.getName() + ".");
 
 		// Add the vehicle to a garage if possible
 		Building garage = settlement.getBuildingManager().addToGarageBuilding(vehicle);
 
 		// End task if vehicle or garage not available
 		if (garage == null) {
-			clearTask(vehicle.getName() + " no garage found");
+			clearTask(vehicle.getName() + " no garage found.");
 			return;
 		}
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/DigLocalIceMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/DigLocalIceMeta.java
@@ -41,14 +41,16 @@ public class DigLocalIceMeta extends DigLocalMeta {
 
     @Override
     public double getProbability(Person person) {
-    	if (!unitManager.isSettlement(person.getCoordinates())) {
-    		return 0;
-    	}
     	
-    	Settlement settlement = unitManager.findSettlement(person.getCoordinates());
-    	double rate = settlement.getIceCollectionRate();
-    	if (rate <= 0D) {
-    		return 0D;
+    	Settlement settlement = person.getSettlement();
+    	double rate = 0;
+    	
+    	if (settlement != null) {
+    		
+    		rate = settlement.getIceCollectionRate();
+	    	if (rate <= 0D) {
+	    		return 0D;
+	    	}
     	}
     	
         // Check if settlement has DIG_LOCAL_ICE override flag set.

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/DigLocalRegolithMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/DigLocalRegolithMeta.java
@@ -20,7 +20,7 @@ import org.mars_sim.msp.core.structure.Settlement;
  */
 public class DigLocalRegolithMeta extends DigLocalMeta {
     
-	// can add back private static SimLogger logger = SimLogger.getLogger(DigLocalRegolithMeta.class.getName())
+	// May add back private static SimLogger logger = SimLogger.getLogger(DigLocalRegolithMeta.class.getName())
 	
 	private static final int THRESHOLD_AMOUNT = 50;
 	
@@ -39,14 +39,16 @@ public class DigLocalRegolithMeta extends DigLocalMeta {
 
     @Override
     public double getProbability(Person person) {
-    	if (!unitManager.isSettlement(person.getCoordinates())) {
-    		return 0;
-    	}
     	
-    	Settlement settlement = unitManager.findSettlement(person.getCoordinates());
-    	double rate = settlement.getRegolithCollectionRate();
-    	if (rate <= 0D) {
-    		return 0D;
+    	Settlement settlement = person.getSettlement();
+    	double rate = 0;
+    	
+    	if (settlement != null) {
+    		
+    		rate = settlement.getIceCollectionRate();
+	    	if (rate <= 0D) {
+	    		return 0D;
+	    	}
     	}
     	
         // Check if settlement has DIG_LOCAL_REGOLITH override flag set.
@@ -62,7 +64,7 @@ public class DigLocalRegolithMeta extends DigLocalMeta {
     	double result = getProbability(ResourceUtil.regolithID, settlement, 
     			person, rate * settlement.getRegolithProbabilityValue());
     	
-//    	logger.info(settlement, 20_000, "rate: " + Math.round(settlement.getRegolithCollectionRate() * 100.0)/100.0 
+//    	logger.info(settlement, 20_000, "DigLocalMeta - rate: " + Math.round(settlement.getRegolithCollectionRate() * 100.0)/100.0 
 //    			+ "  Final regolith: " + Math.round(result* 100.0)/100.0);
         
         return result;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskManager.java
@@ -44,6 +44,7 @@ public abstract class TaskManager implements Serializable {
 	private static final String SLEEPING = "Sleeping";
 	private static final String EVA = "EVA";
 	private static final String AIRLOCK = "Airlock";
+	private static final String DIG = "Digging";
 	
 	/*
 	 * This class represents a record of a given activity (task or mission)
@@ -674,7 +675,8 @@ public abstract class TaskManager implements Serializable {
 			// Note: make sure robot's 'Sleep Mode' won't return false
 			if (currentDes.contains(SLEEPING)
 				|| currentDes.contains(EVA)
-				|| taskName.contains(AIRLOCK))
+				|| taskName.contains(AIRLOCK)
+				|| taskName.contains(DIG))
 				return false;
 			
 			if (newTask.getDescription().equalsIgnoreCase(currentDes))
@@ -760,7 +762,7 @@ public abstract class TaskManager implements Serializable {
 			currentTask.setDuration(newDuration);
 			
 			logger.info(worker, "Updating current task '" + currentTask.getName() 
-				+ "''s duration: " + oldDuration + " -> " + Math.round(newDuration * 10.0)/10.0 + "'.");
+				+ "''s duration: " + oldDuration + " -> " + Math.round(newDuration * 10.0)/10.0 + ".");
 		}
 		
 		// Potential ClassCast but only temp. measure

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/Shift.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/Shift.java
@@ -144,4 +144,15 @@ public class Shift implements ScheduledEventHandler {
         }
         return duration;
     }
+    
+    public boolean isOnDuty(int time) {
+    	int start0 = start;
+    	int end0 = end;
+    	if (start0 > end0)
+    		end0 = end0 + 1000;
+    	if (time > start0 && time < end0)
+    		return true;
+    	
+    	return false;
+    }
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/ShiftManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/ShiftManager.java
@@ -1,3 +1,9 @@
+/*
+ * Mars Simulation Project
+ * ShiftManager.java
+ * @date 2023-09-01
+ * @author Barry Evans
+ */
 package org.mars_sim.msp.core.structure;
 
 import java.io.Serializable;
@@ -82,7 +88,7 @@ public class ShiftManager implements Serializable {
         if (shiftDefinition.getShifts().isEmpty()) {
             throw new  IllegalArgumentException("No shift defined in " + shiftDefinition.getName());
         }
-        for(ShiftSpec ss : shiftDefinition.getShifts()) {
+        for (ShiftSpec ss : shiftDefinition.getShifts()) {
             Shift s = new Shift(ss, offset);
             shifts.add(s);
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/ShiftSlot.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/ShiftSlot.java
@@ -1,7 +1,7 @@
 /*
  * Mars Simulation Project
  * ShiftSlot.java
- * @date 2022-11-19
+ * @date 2023-09-01
  * @author Barry Evans
  */
 package org.mars_sim.msp.core.structure;
@@ -21,7 +21,26 @@ public class ShiftSlot implements ScheduledEventHandler {
      * The work status of this slot.
      */
     public enum WorkStatus {
-        ON_DUTY, OFF_DUTY, ON_CALL, ON_LEAVE;
+        ON_DUTY ("On Duty"), 
+        OFF_DUTY ("Off Duty"), 
+        ON_CALL ("On Call"), 
+        ON_LEAVE ("On Leave");
+
+    	private String name;
+
+		/** hidden constructor. */
+		private WorkStatus(String name) {
+			this.name = name;
+		}
+		
+		public final String getName() {
+			return this.name;
+		}
+
+		@Override
+		public final String toString() {
+			return getName();
+		}
     }
 
     private boolean onCall = false;

--- a/mars-sim-headless/src/deb/changelog
+++ b/mars-sim-headless/src/deb/changelog
@@ -2,7 +2,7 @@
  -- By  									        ___, __ ___ 2023 00:00:00 -0700
  
   * Version 3.6.2 debian package release.
- -- By Manny Kung 									Wed, 30 Aug 2023 00:00:00 -0700
+ -- By Manny Kung 									Fri, 01 Sep 2023 00:00:00 -0700
  
   * Version 3.6.1 debian package release.
  -- By Barry Evans	 						        Fri, 25 Aug 2023 00:00:00 -0700

--- a/mars-sim-main/src/deb/changelog
+++ b/mars-sim-main/src/deb/changelog
@@ -2,7 +2,7 @@
  -- By  									        ___, __ ___ 2023 00:00:00 -0700 
  
   * Version 3.6.2 debian package release.
- -- By Manny Kung 									Wed, 30 Aug 2023 00:00:00 -0700 
+ -- By Manny Kung 									Fri, 01 Sep 2023 00:00:00 -0700 
  
   * Version 3.6.1 debian package release.
  -- By Barry Evans	 						        Fri, 25 Aug 2023 00:00:00 -0700 

--- a/mars-sim-ui/src/main/resources/docs/help/version_history.html
+++ b/mars-sim-ui/src/main/resources/docs/help/version_history.html
@@ -29,7 +29,7 @@
 
 <br>
 
-<H3> Version 3.6.2 (30 Aug 2023) </H3>
+<H3> Version 3.6.2 (01 Sep 2023) </H3>
 <H4> A. CORE ENGINE IMPROVEMENTS :</H4>
 <OL>
   <LI>Crop: allow changing growing area per crop in Farming.</LI>
@@ -44,6 +44,7 @@
 <H4> C. FIXES :</H4>
 <OL>
   <LI>Computing: rework work time related to consuming computing resources when analyzing map data.</LI>
+  <LI>Digging Local: correct not being able to start digging ice and regolith on its own.</LI> 
   <LI>Equipment: correct transferring container back to settlement after digging regolith/ice.</LI>  
   <LI>Food Production: correct potato typo.</LI>
   <LI>Map: correct magnification and zooming issues.</LI>

--- a/mars-sim-ui/src/main/resources/docs/help/whatsnew.html
+++ b/mars-sim-ui/src/main/resources/docs/help/whatsnew.html
@@ -27,7 +27,7 @@
 
 <br>
 
-<H3> Version 3.6.2 (30 Aug 2023) </H3>
+<H3> Version 3.6.2 (01 Sep 2023) </H3>
 <H4> A. CORE ENGINE IMPROVEMENTS :</H4>
 <OL>
   <LI>Crop: allow changing growing area per crop in Farming.</LI>
@@ -42,6 +42,7 @@
 <H4> C. FIXES :</H4>
 <OL>
   <LI>Computing: rework work time related to consuming computing resources when analyzing map data.</LI>
+  <LI>Digging Local: correct not being able to start digging ice and regolith on its own.</LI> 
   <LI>Equipment: correct transferring container back to settlement after digging regolith/ice.</LI> 
   <LI>Food Production: correct potato typo.</LI>
   <LI>Map: correct magnification and zooming issues.</LI>


### PR DESCRIPTION
09.01.2023

- new: add AIRLOCK_OPERATION_OFFSET in Settlement
- fix: correct how ice/regolith collection rate is calculated in DigLocalIceMeta and DigLocalRegolithMeta
- change: avoid airlock congestion by reworking setAppointedTask() in Settlement to set up EVA start time in groups of 4 for each airlock select only personnel on duty and without a mission
- change: avoid replacing digging task in TaskManager's checkAndReplaceTask()

Relates to #141, #511, #637, #857, #910