### PR TITLE
Process Override controlled by Settlement Preferences

### DIFF
--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionManager.java
@@ -26,6 +26,7 @@ import org.mars_sim.msp.core.person.ai.mission.meta.MetaMission;
 import org.mars_sim.msp.core.person.ai.mission.meta.MetaMissionUtil;
 import org.mars_sim.msp.core.person.ai.task.EVAOperation;
 import org.mars_sim.msp.core.reportingAuthority.PreferenceKey;
+import org.mars_sim.msp.core.reportingAuthority.PreferenceCategory;
 import org.mars_sim.msp.core.structure.Settlement;
 
 /**
@@ -203,7 +204,7 @@ public class MissionManager implements Serializable {
 				if (baseProb.getScore() > 0D) {
 					// Get any overriding ratio
 					double settlementRatio = startingSettlement.getPreferenceModifier(
-										new PreferenceKey(PreferenceKey.Type.MISSION_WEIGHT,
+										new PreferenceKey(PreferenceCategory.MISSION_WEIGHT,
 														metaMission.getType().name()));
 					baseProb.addModifier("settlementratio", settlementRatio);
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionManager.java
@@ -203,7 +203,7 @@ public class MissionManager implements Serializable {
 				if (baseProb.getScore() > 0D) {
 					// Get any overriding ratio
 					double settlementRatio = startingSettlement.getPreferenceModifier(
-										new PreferenceKey(PreferenceKey.Type.MISSION,
+										new PreferenceKey(PreferenceKey.Type.MISSION_WEIGHT,
 														metaMission.getType().name()));
 					baseProb.addModifier("settlementratio", settlementRatio);
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionType.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/MissionType.java
@@ -6,37 +6,33 @@
  */
 package org.mars_sim.msp.core.person.ai.mission;
 
-import java.util.Map;
-
 import org.mars.sim.tools.Msg;
 
 public enum MissionType {
 
-	AREOLOGY				(Msg.getString("Mission.description.areologyFieldStudy")), //$NON-NLS-1$
-	BIOLOGY					(Msg.getString("Mission.description.biologyFieldStudy")), //$NON-NLS-1$
-	COLLECT_ICE				(Msg.getString("Mission.description.collectIce")), //$NON-NLS-1$
-	COLLECT_REGOLITH		(Msg.getString("Mission.description.collectRegolith")), //$NON-NLS-1$
-	DELIVERY				(Msg.getString("Mission.description.delivery")), //$NON-NLS-1$
+	AREOLOGY,
+	BIOLOGY,
+	COLLECT_ICE,
+	COLLECT_REGOLITH,
+	DELIVERY,
 
-	EMERGENCY_SUPPLY		(Msg.getString("Mission.description.emergencySupply")), //$NON-NLS-1$
-	EXPLORATION				(Msg.getString("Mission.description.exploration")), //$NON-NLS-1$
-	METEOROLOGY				(Msg.getString("Mission.description.meteorologyFieldStudy")), //$NON-NLS-1$
-	MINING					(Msg.getString("Mission.description.mining")), //$NON-NLS-1$
-	RESCUE_SALVAGE_VEHICLE	(Msg.getString("Mission.description.rescueSalvageVehicle")), //$NON-NLS-1$
+	EMERGENCY_SUPPLY,
+	EXPLORATION,
+	METEOROLOGY,
+	MINING,
+	RESCUE_SALVAGE_VEHICLE,
 
-	TRADE					(Msg.getString("Mission.description.trade")), //$NON-NLS-1$
-	TRAVEL_TO_SETTLEMENT	(Msg.getString("Mission.description.travelToSettlement")), //$NON-NLS-1$
-	CONSTRUCTION			(Msg.getString("Mission.description.construction")), //$NON-NLS-1$
-	SALVAGE					(Msg.getString("Mission.description.salvage")), //$NON-NLS-1$
+	TRADE,
+	TRAVEL_TO_SETTLEMENT,
+	CONSTRUCTION,
+	SALVAGE
 	;
 
 	private String name;
 
-	static Map<Integer, MissionType> lookup = null;
-
 	/** hidden constructor. */
-	private MissionType(String name) {
-		this.name = name;
+	private MissionType() {
+		this.name = Msg.getString("MissionType." + name().toLowerCase());
 	}
 
 	/** gives the internationalized name of this skill for display in user interface. */

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ProposeScientificStudyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ProposeScientificStudyMeta.java
@@ -17,6 +17,7 @@ import org.mars_sim.msp.core.person.ai.task.util.FactoryMetaTask;
 import org.mars_sim.msp.core.person.ai.task.util.Task;
 import org.mars_sim.msp.core.person.ai.task.util.TaskTrait;
 import org.mars_sim.msp.core.reportingAuthority.PreferenceKey;
+import org.mars_sim.msp.core.reportingAuthority.PreferenceCategory;
 import org.mars_sim.msp.core.science.ScienceType;
 import org.mars_sim.msp.core.science.ScientificStudy;
 import org.mars_sim.msp.core.structure.Settlement;
@@ -142,7 +143,7 @@ public class ProposeScientificStudyMeta extends FactoryMetaTask {
 
 				// Check the favourite research of the Reporting Authority
 				result *= settlement.getPreferenceModifier(
-								new PreferenceKey(PreferenceKey.Type.SCIENCE, science.name()));
+								new PreferenceKey(PreferenceCategory.SCIENCE, science.name()));
 	        }
 
 	        // Crowding modifier

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/MetaTask.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/MetaTask.java
@@ -19,6 +19,7 @@ import org.mars_sim.msp.core.person.ai.mission.MissionManager;
 import org.mars_sim.msp.core.person.ai.role.RoleType;
 import org.mars_sim.msp.core.person.ai.task.EVAOperation;
 import org.mars_sim.msp.core.reportingAuthority.PreferenceKey;
+import org.mars_sim.msp.core.reportingAuthority.PreferenceCategory;
 import org.mars_sim.msp.core.robot.RobotType;
 import org.mars_sim.msp.core.structure.RadiationStatus;
 import org.mars_sim.msp.core.structure.Settlement;
@@ -250,7 +251,7 @@ public abstract class MetaTask {
 
 		// Apply the home base modifier
 		score = score * person.getAssociatedSettlement().getPreferenceModifier(
-							new PreferenceKey(PreferenceKey.Type.TASK, getID()));
+							new PreferenceKey(PreferenceCategory.TASK_WEIGHT, getID()));
 
         if (score < 0) score = 0;
         return score;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/reportingAuthority/PreferenceCategory.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/reportingAuthority/PreferenceCategory.java
@@ -1,0 +1,39 @@
+ /*
+ * Mars Simulation Project
+ * PreferenceCategory.java
+ * @date 2023-09-03
+ * @author Barry Evans
+ */
+package org.mars_sim.msp.core.reportingAuthority;
+
+import org.mars.sim.tools.Msg;
+
+/**
+ * Category of a Preference
+ */
+public enum PreferenceCategory {
+    TASK_WEIGHT(PreferenceValueType.DOUBLE), MISSION_WEIGHT(PreferenceValueType.DOUBLE),
+    SCIENCE(PreferenceValueType.DOUBLE),
+    CONFIGURATION(PreferenceValueType.DOUBLE),
+    PROCESS_OVERRIDE(PreferenceValueType.BOOLEAN);
+
+    private String name;
+    private PreferenceValueType valueType;
+
+    PreferenceCategory(PreferenceValueType valueType) {
+        this.name = Msg.getString("PreferenceCategory." + name().toLowerCase());
+        this.valueType = valueType;
+    }
+
+    /** gives the internationalized name of this enum for display in user interface. */
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * What is the type of the value fr this category of preference
+     */
+    public PreferenceValueType getValueType() {
+        return valueType;
+    }
+}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/reportingAuthority/PreferenceKey.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/reportingAuthority/PreferenceKey.java
@@ -19,7 +19,7 @@ public class PreferenceKey implements Serializable {
      * Type of Preference
      */
     public enum Type {
-        TASK, MISSION, SCIENCE, CONFIGURATION
+        TASK, MISSION_WEIGHT, SCIENCE, CONFIGURATION, PROCESS_OVERRIDE
     };
 
     private Type type;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/reportingAuthority/PreferenceKey.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/reportingAuthority/PreferenceKey.java
@@ -15,22 +15,15 @@ public class PreferenceKey implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	/**
-     * Type of Preference
-     */
-    public enum Type {
-        TASK, MISSION_WEIGHT, SCIENCE, CONFIGURATION, PROCESS_OVERRIDE
-    };
-
-    private Type type;
+	private PreferenceCategory type;
     private String name;
     
-    public PreferenceKey(Type type, String name) {
+    public PreferenceKey(PreferenceCategory type, String name) {
         this.type = type;
         this.name = name;
     }
 
-    public Type getType() {
+    public PreferenceCategory getCategory() {
         return type;
     }
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/reportingAuthority/PreferenceValueType.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/reportingAuthority/PreferenceValueType.java
@@ -1,0 +1,8 @@
+package org.mars_sim.msp.core.reportingAuthority;
+
+/**
+ * The type of the expected preference value
+ */
+public enum PreferenceValueType {
+    DOUBLE, BOOLEAN;
+}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/reportingAuthority/ReportingAuthorityFactory.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/reportingAuthority/ReportingAuthorityFactory.java
@@ -90,12 +90,13 @@ public final class ReportingAuthorityFactory extends UserConfigurableConfig<Repo
 				for (Element preNode : subNode.getChildren(PERFERENCE_EL)) {
 					double value = Double.parseDouble(preNode.getAttributeValue(MODIFIER_ATTR));
 
-					// Backwar compatiable with the old naming scheme
+					// Backward compatiable with the old naming scheme
 					String pTypeValue = preNode.getAttributeValue(TYPE_ATTR);
-					if (pTypeValue.equals("MISSION")) {
-						pTypeValue = "MISSION_WEIGHT";
+					if (pTypeValue.equals("MISSION") || pTypeValue.equals("TASK")) {
+						pTypeValue = pTypeValue + "_WEIGHT";
 					}
-					PreferenceKey.Type pType = PreferenceKey.Type.valueOf(pTypeValue);
+
+					PreferenceCategory pType = PreferenceCategory.valueOf(pTypeValue);
 					String pName = preNode.getAttributeValue(NAME_ATTR).toUpperCase();
 
 					preferences.put(new PreferenceKey(pType, pName), value);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/reportingAuthority/ReportingAuthorityFactory.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/reportingAuthority/ReportingAuthorityFactory.java
@@ -89,7 +89,13 @@ public final class ReportingAuthorityFactory extends UserConfigurableConfig<Repo
 				Map<PreferenceKey, Double> preferences = new HashMap<>();	
 				for (Element preNode : subNode.getChildren(PERFERENCE_EL)) {
 					double value = Double.parseDouble(preNode.getAttributeValue(MODIFIER_ATTR));
-					PreferenceKey.Type pType = PreferenceKey.Type.valueOf(preNode.getAttributeValue(TYPE_ATTR));
+
+					// Backwar compatiable with the old naming scheme
+					String pTypeValue = preNode.getAttributeValue(TYPE_ATTR);
+					if (pTypeValue.equals("MISSION")) {
+						pTypeValue = "MISSION_WEIGHT";
+					}
+					PreferenceKey.Type pType = PreferenceKey.Type.valueOf(pTypeValue);
 					String pName = preNode.getAttributeValue(NAME_ATTR).toUpperCase();
 
 					preferences.put(new PreferenceKey(pType, pName), value);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/OverrideType.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/OverrideType.java
@@ -6,6 +6,8 @@
  */
 package org.mars_sim.msp.core.structure;
 
+import org.mars.sim.tools.Msg;
+
 public enum OverrideType {
 	CONSTRUCTION,
 	DIG_LOCAL_REGOLITH,
@@ -15,5 +17,16 @@ public enum OverrideType {
 	MISSION,
 	RESOURCE_PROCESS,
 	SALVAGE,
-	WASTE_PROCESSING
+	WASTE_PROCESSING;
+
+	private String name;
+
+	private OverrideType() {
+		this.name = Msg.getString("OverrideType." + name().toLowerCase());
+	}
+
+	/** gives the internationalized name of this enum for display in user interface. */
+	public String getName() {
+		return this.name;
+	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/SettlementBuilder.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/structure/SettlementBuilder.java
@@ -443,15 +443,13 @@ public final class SettlementBuilder {
 		if (crew == null) {
 			throw new IllegalArgumentException("No crew defined called " + crewName);
 		}
+		logger.config("Crew '" + crew.getName() + "' assigned to " + settlement.getName() + ".");
 
 		// Check for any duplicate full Name
 		Collection<Person> people = unitManager.getPeople();
 		
 		Set<String> existingfullnames = people.stream()
 				.map(Person::getName).collect(Collectors.toSet());
-		
-//		List<String> existingfullnames = people.stream()
-//				.map(Person::getName).collect(Collectors.toList());
 
 		Map<Person, Map<String, Integer>> addedCrew = new HashMap<>();
 
@@ -471,7 +469,6 @@ public final class SettlementBuilder {
 				if (existingfullnames.contains(name)) {
 					// Should not happen so a cheap fix in place
 					logger.warning("Person already called " + name + ".");
-//					name = crew.getName() + " Member" + settlement.getNumCitizens();
 					
 					// Choose the next gender based on the current ratio of M/F
 					GenderType gender;
@@ -489,7 +486,6 @@ public final class SettlementBuilder {
 					name = spec.generateName(gender, existingfullnames);
 					
 				}
-				logger.config(name + " from crew '" + crew.getName() + "' assigned to " + settlement.getName() + ".");
 				existingfullnames.add(name);
 
 				// Get person's gender or randomly determine it if not configured.

--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -626,32 +626,32 @@ MeteorologyStudyFieldMissionCustomInfoPanel.leadResearcher            = Lead Res
 MeteorologyStudyFieldMissionCustomInfoPanel.researchCompletion        = Study Research Completion:
 MeteorologyStudyFieldMissionCustomInfoPanel.tooltip.openInScienceTool = Open study in science tool.
 
-Mission.description.areologyFieldStudy        = Areology Field Study
-Mission.description.biologyFieldStudy        = Biology Field Study
-Mission.description.meteorologyFieldStudy     = Meteorology Field Study
+MissionType.areology            = Areology Field Study
+MissionType.biology             = Biology Field Study
+MissionType.meteorology         = Meteorology Field Study
 
-Mission.description.construction      				= Construction
-Mission.description.salvage							= Salvage
+MissionType.construction      	= Construction
+MissionType.salvage							= Salvage
 
-Mission.description.collectIce                       = Ice Prospecting
-Mission.description.collectRegolith                  = Regolith Prospecting
+MissionType.collect_ice                      = Ice Prospecting
+MissionType.collect_regolith                 = Regolith Prospecting
 
-Mission.description.delivery                         = Delivery
-Mission.description.delivery.detail                  = Delivery by {0}
+MissionType.delivery                         = Delivery
+Mission.description.delivery.detail          = Delivery by {0}
 
-Mission.description.emergencySupply          		 = Emergency Supply
-Mission.description.exploration                      = Mineral Exploration
-Mission.description.mining                           = Mining
+MissionType.emergency_supply          		 = Emergency Supply
+MissionType.exploration                      = Mineral Exploration
+MissionType.mining                           = Mining
 
-Mission.description.rescueSalvageVehicle             = Vehicle Rescue
+MissionType.rescue_salvage_vehicle                   = Vehicle Rescue
 Mission.description.rescueSalvageVehicle.rescue      = Rescuing {0}
 Mission.description.rescueSalvageVehicle.salvage     = Salvaging {0}
 
-Mission.description.travelToSettlement               = Traveling
-Mission.description.travelToSettlement.detail        = Travel to {0}
+MissionType.travel_to_settlement                = Traveling
+Mission.description.travelToSettlement.detail   = Travel to {0}
 
-Mission.description.trade                            = Trading
-Mission.description.trade.detail                     = Trading by {0}
+MissionType.trade                               = Trading
+Mission.description.trade.detail                = Trading by {0}
 
 Mission.phase.reviewing                              = Reviewing
 Mission.phase.reviewing.description					 = Review Pending
@@ -844,6 +844,16 @@ OngoingStudyListPanel.column.researcher        = Pri Researcher
 OngoingStudyListPanel.column.settlement        = Settlement
 OngoingStudyListPanel.title 				   = Ongoing Scientific Studies
 
+OverrideType.construction       = Construction
+OverrideType.dig_local_regolith = Dig Regolith
+OverrideType.dig_local_ice      = Dig Ice
+OverrideType.food_production    = Food Production
+OverrideType.manufacture        = Manufacturing
+OverrideType.mission            = Start new Mission
+OverrideType.resource_process	= Resource Processing
+OverrideType.salvage            = Salvage Missions
+OverrideType.waste_processing   = Waste Processing
+
 Part.error.nameIsNull = name is null
 
 PersonGender.female = Female
@@ -952,6 +962,13 @@ PowerSourceType.solarThermalPower			= Solar Thermal Power Source
 PowerSourceType.thermionicNuclearPower		= Thermionic Nuclear Power Source
 PowerSourceType.windPower					= Wind Power Source
 	
+
+PreferenceCategory.task_weight = Task Weighting
+PreferenceCategory.mission_weight = Mission Weighting
+PreferenceCategory.science = Science Weighting
+PreferenceCategory.configuration = Configuration limit
+PreferenceCategory.process_override = Only manual process
+
 RandomMineralMap.image.crater			= TopographyCrater.png
 RandomMineralMap.image.volcanic			= TopographyVolcanic.png
 RandomMineralMap.image.sedimentary		= TopographySedimentary.png

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelConstruction.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelConstruction.java
@@ -9,8 +9,6 @@ package org.mars_sim.msp.ui.swing.unit_window.structure;
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.GridLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 import javax.swing.JCheckBox;
 import javax.swing.JPanel;
@@ -67,11 +65,8 @@ extends TabPanel {
 		// Create override check box.
 		overrideCheckbox = new JCheckBox(Msg.getString("TabPanelConstruction.checkbox.overrideConstructionAndSalvage")); //$NON-NLS-1$
 		overrideCheckbox.setToolTipText(Msg.getString("TabPanelConstruction.tooltip.overrideConstructionAndSalvage")); //$NON-NLS-1$
-		overrideCheckbox.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent arg0) {
-				setConstructionOverride(overrideCheckbox.isSelected());
-			}
-		});
+		overrideCheckbox.addActionListener(a -> 
+				setConstructionOverride(overrideCheckbox.isSelected()));
 		overrideCheckbox.setSelected(settlement.getProcessOverride(OverrideType.CONSTRUCTION));
 		overridePanel.add(overrideCheckbox);
 		

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelPreferences.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/structure/TabPanelPreferences.java
@@ -7,6 +7,7 @@
 package org.mars_sim.msp.ui.swing.unit_window.structure;
 
 import java.awt.BorderLayout;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -16,9 +17,11 @@ import java.util.Map;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
+import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
+import javax.swing.plaf.basic.BasicComboBoxRenderer;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 
@@ -27,17 +30,15 @@ import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.person.ai.mission.MissionType;
 import org.mars_sim.msp.core.person.ai.task.util.MetaTaskUtil;
 import org.mars_sim.msp.core.reportingAuthority.PreferenceKey;
-import org.mars_sim.msp.core.reportingAuthority.PreferenceKey.Type;
+import org.mars_sim.msp.core.reportingAuthority.PreferenceCategory;
 import org.mars_sim.msp.core.science.ScienceType;
 import org.mars_sim.msp.core.structure.OverrideType;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.ui.swing.ImageLoader;
 import org.mars_sim.msp.ui.swing.MainDesktopPane;
-import org.mars_sim.msp.ui.swing.NumberCellRenderer;
 import org.mars_sim.msp.ui.swing.StyleManager;
 import org.mars_sim.msp.ui.swing.unit_window.TabPanel;
 
-@SuppressWarnings("serial")
 public class TabPanelPreferences extends TabPanel {
 
 	/** Default logger. */
@@ -59,7 +60,7 @@ public class TabPanelPreferences extends TabPanel {
 	// Maintains a cache of preferences already having a renderable equivalent
 	private static Map<PreferenceKey,RenderableKey> keys = new HashMap<>();
 	private PreferenceTableModel tableModel;
-	private JComboBox<PreferenceKey.Type> typeCombo;
+	private JComboBox<PreferenceCategory> typeCombo;
 	private JComboBox<RenderableKey> nameCombo;
 
 	/**
@@ -114,15 +115,16 @@ public class TabPanelPreferences extends TabPanel {
 		newPanel.setBorder(StyleManager.createLabelBorder("Add new Preference"));
 		topPanel.add(newPanel, BorderLayout.NORTH);
 
-		typeCombo = new JComboBox<>(PreferenceKey.Type.values());
-		typeCombo.addItemListener(i -> {populateNameCombo(); });
+		typeCombo = new JComboBox<>(PreferenceCategory.values());
+		typeCombo.addItemListener(i -> populateNameCombo());
+		typeCombo.setRenderer(new PreferenceCategoryRenderer());
 		newPanel.add(typeCombo);
 
 		nameCombo = new JComboBox<>();
 		newPanel.add(nameCombo);
 
 		JButton add = new JButton(ImageLoader.getIconByName("action/add"));
-		add.addActionListener(i -> {addEntry();});
+		add.addActionListener(i -> addEntry());
 		newPanel.add(add);
 
 		// Add an explanation
@@ -138,21 +140,26 @@ public class TabPanelPreferences extends TabPanel {
 	 * Adds a new entry to the settlement.
 	 */
 	private void addEntry() {
-		tableModel.addEntry((RenderableKey) nameCombo.getSelectedItem(), 1D);
+		RenderableKey key = (RenderableKey) nameCombo.getSelectedItem();
+		Object newValue = switch(key.key().getCategory().getValueType()) {
+			case BOOLEAN -> Boolean.TRUE;
+			case DOUBLE -> Double.valueOf(1D);
+		};
+		tableModel.addEntry(key, newValue);
 	}
 
 	/**
 	 * Populates the name combo based on the type of preference.
 	 */
 	private void populateNameCombo() {
-		PreferenceKey.Type selectedType = (Type) typeCombo.getSelectedItem();
+		PreferenceCategory selectedType = (PreferenceCategory) typeCombo.getSelectedItem();
 		nameCombo.removeAllItems();
 
 		List<RenderableKey> newItems = null;
 		switch(selectedType) {
-			case TASK: {
+			case TASK_WEIGHT: {
 				newItems = MetaTaskUtil.getAllMetaTasks().stream()
-									.map(mt -> getRendered(new PreferenceKey(Type.TASK, mt.getID())))
+									.map(mt -> getRendered(new PreferenceKey(PreferenceCategory.TASK_WEIGHT, mt.getID())))
 									.sorted((v1, v2) -> v1.label().compareTo(v2.label()))
 									.toList();
 				}
@@ -161,20 +168,20 @@ public class TabPanelPreferences extends TabPanel {
 			case MISSION_WEIGHT:
 				newItems = new ArrayList<>();
 				for(MissionType mt : MissionType.values()) {
-					newItems.add(getRendered(new PreferenceKey(Type.MISSION_WEIGHT, mt.name())));
+					newItems.add(getRendered(new PreferenceKey(PreferenceCategory.MISSION_WEIGHT, mt.name())));
 				}
 				break;
 
 			case SCIENCE:
 				newItems = ScienceType.valuesList().stream()
-									.map(mt -> getRendered(new PreferenceKey(Type.SCIENCE, mt.name())))
+									.map(mt -> getRendered(new PreferenceKey(PreferenceCategory.SCIENCE, mt.name())))
 									.toList();
 				break;
 
 			case PROCESS_OVERRIDE:
 				newItems = new ArrayList<>();
 				for(OverrideType mt : OverrideType.values()) {
-					newItems.add(getRendered(new PreferenceKey(Type.PROCESS_OVERRIDE, mt.name())));
+					newItems.add(getRendered(new PreferenceKey(PreferenceCategory.PROCESS_OVERRIDE, mt.name())));
 				}
 				break;
 			default:
@@ -198,18 +205,20 @@ public class TabPanelPreferences extends TabPanel {
 			return keys.get(key);
 		}
 
-		// Create a better readable number of the user
+		// Create a better readable version for the user
 		String label = "?";
 		try {
-			label = switch (key.getType()) {
-				case TASK -> MetaTaskUtil.getMetaTask(key.getName()).getName();
+			label = switch (key.getCategory()) {
+				case TASK_WEIGHT -> MetaTaskUtil.getMetaTask(key.getName()).getName();
 				case SCIENCE -> ScienceType.valueOf(key.getName()).getName();
 				case MISSION_WEIGHT -> MissionType.valueOf(key.getName()).getName();
+				case PROCESS_OVERRIDE -> OverrideType.valueOf(key.getName()).getName();
+
 				default -> key.getName();
 			};
 		}
 		catch (RuntimeException e) {
-			// Problem with the specifc user value not matching any known item
+			// Problem with the specfic user value not matching any known item
 		}
 		RenderableKey result = new RenderableKey(key, label);
 		keys.put(key, result);
@@ -223,8 +232,8 @@ public class TabPanelPreferences extends TabPanel {
 				extends AbstractTableModel {
 
 		private Settlement manager;
-		private List<RenderableKey> items;
-		private Map<PreferenceKey,Object> target;
+		private transient List<RenderableKey> items;
+		private transient Map<PreferenceKey,Object> target;
 
 		private PreferenceTableModel(Settlement manager) {
 			this.manager = manager;
@@ -239,7 +248,7 @@ public class TabPanelPreferences extends TabPanel {
 		public void addEntry(RenderableKey preference, Object value) {
 			if (!items.contains(preference)) {
 				items.add(preference);
-				target.put(preference.key(), value);
+				manager.setPreference(preference.key(), value);
 				int newRow = items.size()-1;
 				fireTableRowsInserted(newRow, newRow);
 				
@@ -271,7 +280,7 @@ public class TabPanelPreferences extends TabPanel {
 		@Override
 		public String getColumnName(int columnIndex) {
 			return switch(columnIndex) {
-				case 0 -> "Type";
+				case 0 -> "Category";
 				case 1 -> "Name";
 				case 2 -> "Modifier";
 				default -> throw new IllegalArgumentException("Unexpected column name index: " + columnIndex);
@@ -283,7 +292,7 @@ public class TabPanelPreferences extends TabPanel {
 			if (row < getRowCount()) {
 				RenderableKey entry = items.get(row);
 				return switch(column) {
-					case 0 -> entry.key().getType();
+					case 0 -> entry.key().getCategory().getName();
 					case 1 -> entry.label();
 					case 2 -> target.get(entry.key());
 					default -> throw new IllegalArgumentException("Unexpected value: " + column);
@@ -301,8 +310,28 @@ public class TabPanelPreferences extends TabPanel {
 		public void setValueAt(Object value, int row, int col) {
 			if (col == 2) {
 				PreferenceKey key = items.get(row).key();
-				target.put(key, value);
+				Object newValue = switch(key.getCategory().getValueType()) {
+					case BOOLEAN -> Boolean.parseBoolean((String)value);
+					case DOUBLE -> Double.parseDouble((String)value);
+				};
+				manager.setPreference(key, newValue);
 			}
+		}
+	}
+
+	/**
+	 * Renderer for preference category items
+	 */
+	private static class PreferenceCategoryRenderer extends BasicComboBoxRenderer {
+		@Override
+		public Component getListCellRendererComponent(JList list, Object value,
+					int index, boolean isSelected, boolean cellHasFocus) {
+			super.getListCellRendererComponent(list, value, index, isSelected,
+				cellHasFocus);
+
+			PreferenceCategory item = (PreferenceCategory) value;
+			setText(item.getName());
+			return this;
 		}
 	}
 }


### PR DESCRIPTION
This PR expands the Settlement Preference logic to replace the specialised Process Override logic. The latter is now a new ```PreferenceCategory`` and hence editable from the Settlement Preference panel.

The Preference now supports boolean values as well as the existing double. The preference value type is defined by the PreferenceCategory such that all preferences of the same category have the same type.

In addition, a simplification of the labelling for MissionType has been applied that relies on the enum name  to lookup the name in the message properties.

close #963