### PR TITLE
SettlementTask modifiers use RatingScore

### DIFF
--- a/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/BacklogCommand.java
+++ b/mars-sim-console/src/main/java/org/mars/sim/console/chat/simcommand/settlement/BacklogCommand.java
@@ -45,7 +45,7 @@ class BacklogCommand extends AbstractSettlementCommand {
                 if (subject != null) {
                     subjectName = subject.getName();
                 }
-                response.appendTableRow(t.getName(), subjectName,
+                response.appendTableRow(t.getShortName(), subjectName,
                                 t.getDemand(),
                                 t.getScore().getOutput());
             }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/data/RatingScore.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/data/RatingScore.java
@@ -13,11 +13,18 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.mars.sim.tools.Msg;
+
 /**
  * A class to represent a score Rating. Consists of a base value and a set
  * of modifiers that are applied to create a final score.
  */
 public class RatingScore implements Serializable {
+    /**
+     * Prefix to the key in the message bundle
+     */
+    private static final String RATING_KEY = "RatingScore.";
+
     private static final DecimalFormat SCORE_FORMAT = new DecimalFormat("0.###");
 
     /**
@@ -129,6 +136,27 @@ public class RatingScore implements Serializable {
                                 .map(entry -> entry.getKey() + ":" + SCORE_FORMAT.format(entry.getValue()))
                                 .collect(Collectors.joining(",")));
         output.append(")");
+        return output.toString();
+    }
+
+    /**
+     * Produce a structure output of this rating. This s not ideal being in this class
+     * @return HTML formatted string localised.
+     */
+    public String getHTMLOutput() {
+        
+        StringBuilder output = new StringBuilder();
+        output.append("<html>");
+        output.append("<b>Score: ").append(SCORE_FORMAT.format(score)).append("</b><br>");
+        output.append("Base: ").append(SCORE_FORMAT.format(base));
+        if (!modifiers.isEmpty()) {
+            output.append("<br>");
+        }
+        output.append(modifiers.entrySet().stream()
+                                .map(entry -> Msg.getString(RATING_KEY + entry.getKey())
+                                                    + ": " + SCORE_FORMAT.format(entry.getValue()))
+                                .collect(Collectors.joining("<br>")));
+        output.append("</html>");
         return output.toString();
     }
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/data/RatingScore.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/data/RatingScore.java
@@ -121,7 +121,10 @@ public class RatingScore implements Serializable {
         
         StringBuilder output = new StringBuilder();
         output.append("Score:").append(SCORE_FORMAT.format(score)).append(" (");
-        output.append("base:").append(SCORE_FORMAT.format(base)).append(',');
+        output.append("base:").append(SCORE_FORMAT.format(base));
+        if (!modifiers.isEmpty()) {
+            output.append(',');
+        }
         output.append(modifiers.entrySet().stream()
                                 .map(entry -> entry.getKey() + ":" + SCORE_FORMAT.format(entry.getValue()))
                                 .collect(Collectors.joining(",")));

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ConsolidateContainersMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ConsolidateContainersMeta.java
@@ -23,6 +23,7 @@ import org.mars_sim.msp.core.person.ai.task.util.SettlementMetaTask;
 import org.mars_sim.msp.core.person.ai.task.util.SettlementTask;
 import org.mars_sim.msp.core.person.ai.task.util.Task;
 import org.mars_sim.msp.core.person.ai.task.util.TaskJob;
+import org.mars_sim.msp.core.person.ai.task.util.TaskProbabilityUtil;
 import org.mars_sim.msp.core.person.ai.task.util.TaskTrait;
 import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.robot.RobotType;
@@ -93,7 +94,7 @@ public class ConsolidateContainersMeta extends FactoryMetaTask implements Settle
 	 */
     @Override
     public List<TaskJob> getTaskJobs(Robot robot) {
-		return null;
+		return Collections.emptyList();
 	}
 	
     /**
@@ -112,21 +113,12 @@ public class ConsolidateContainersMeta extends FactoryMetaTask implements Settle
         return result;
     }
 
-    @Override
-    public RatingScore assessPersonSuitability(SettlementTask t, Person p) {
-        var factor = new RatingScore(t.getScore());
-        factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
-        return factor;
-    }
-
     /**
      * Score modifier for a Robot is based on it's performance rating
      */
     @Override
     public RatingScore assessRobotSuitability(SettlementTask t, Robot r) {
-        var factor = new RatingScore(t.getScore());
-        factor.addModifier(ROBOT_PERF_MODIFIER, r.getPerformanceRating());
-        return factor;
+        return TaskProbabilityUtil.assessRobot(t, r);
     }
 
     /**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ConsolidateContainersMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ConsolidateContainersMeta.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.mars.sim.tools.Msg;
+import org.mars_sim.msp.core.data.RatingScore;
 import org.mars_sim.msp.core.equipment.Container;
 import org.mars_sim.msp.core.equipment.Equipment;
 import org.mars_sim.msp.core.equipment.EquipmentOwner;
@@ -112,16 +113,20 @@ public class ConsolidateContainersMeta extends FactoryMetaTask implements Settle
     }
 
     @Override
-    public double getPersonSettlementModifier(SettlementTask t, Person p) {
-        return getPersonModifier(p);
+    public RatingScore assessPersonSuitability(SettlementTask t, Person p) {
+        var factor = new RatingScore(t.getScore());
+        factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
+        return factor;
     }
 
     /**
      * Score modifier for a Robot is based on it's performance rating
      */
     @Override
-    public double getRobotSettlementModifier(SettlementTask t, Robot r) {
-        return r.getPerformanceRating();
+    public RatingScore assessRobotSuitability(SettlementTask t, Robot r) {
+        var factor = new RatingScore(t.getScore());
+        factor.addModifier(ROBOT_PERF_MODIFIER, r.getPerformanceRating());
+        return factor;
     }
 
     /**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/DigLocalMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/DigLocalMeta.java
@@ -14,6 +14,7 @@ import org.mars_sim.msp.core.person.ai.fav.FavoriteType;
 import org.mars_sim.msp.core.person.ai.task.EVAOperation;
 import org.mars_sim.msp.core.person.ai.task.Walk;
 import org.mars_sim.msp.core.person.ai.task.util.FactoryMetaTask;
+import org.mars_sim.msp.core.person.ai.task.util.TaskProbabilityUtil;
 import org.mars_sim.msp.core.person.ai.task.util.TaskTrait;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.structure.Shift;
@@ -31,7 +32,7 @@ public abstract class DigLocalMeta extends FactoryMetaTask {
 	
 	private EquipmentType containerType;
 
-    public DigLocalMeta(String name, EquipmentType containerType) {
+    protected DigLocalMeta(String name, EquipmentType containerType) {
 		super(name, WorkerType.PERSON, TaskScope.WORK_HOUR);
 		setFavorite(FavoriteType.OPERATION);
 		setTrait(TaskTrait.STRENGTH);
@@ -42,6 +43,7 @@ public abstract class DigLocalMeta extends FactoryMetaTask {
     /**
      * Computes the probability of doing this task.
      * 
+     * @param resourceId The id of the resource being dug
      * @param settlement
      * @param person
      * @param collectionProbability
@@ -82,9 +84,7 @@ public abstract class DigLocalMeta extends FactoryMetaTask {
         
         if (result > MAX)
         	result = MAX;
-      
-//        logger.info(settlement, 10_000, "1. DigLocalMeta - " + ResourceUtil.findAmountResourceName(resourceId) + ": " + (int)result);
-        
+              
         // Checks if the person's settlement is at meal time and is hungry
         if (EVAOperation.isHungryAtMealTime(person))
         	result *= .5;
@@ -98,13 +98,11 @@ public abstract class DigLocalMeta extends FactoryMetaTask {
         double exerciseMillisols = person.getCircadianClock().getTodayExerciseTime();
         
         result = result - stress * 2 - fatigue/2 - hunger/2 - exerciseMillisols;
-
-//        logger.info(settlement, 10_000, "2. DigLocalMeta - " + ResourceUtil.findAmountResourceName(resourceId) + ": " + (int)result);
         
         if (result <= 0)
         	return 0;
         
-        result *= getRadiationModifier(settlement);
+        result *= TaskProbabilityUtil.getRadiationModifier(settlement);
 
 	    int indoor = settlement.getIndoorPeopleCount(); 
 	    int citizen = settlement.getNumCitizens();
@@ -138,7 +136,6 @@ public abstract class DigLocalMeta extends FactoryMetaTask {
         if (result > CAP)
         	result = CAP;
 
-//        logger.info(settlement, 10_000, "3. DigLocalMeta - " + ResourceUtil.findAmountResourceName(resourceId) + ": " + (int)result);
         return result;
     }
 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ExamineBodyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ExamineBodyMeta.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.mars.sim.tools.Msg;
+import org.mars_sim.msp.core.data.RatingScore;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.SkillType;
 import org.mars_sim.msp.core.person.ai.job.util.JobType;
@@ -21,7 +22,6 @@ import org.mars_sim.msp.core.person.ai.task.util.Task;
 import org.mars_sim.msp.core.person.ai.task.util.TaskTrait;
 import org.mars_sim.msp.core.person.health.DeathInfo;
 import org.mars_sim.msp.core.person.health.MedicalManager;
-import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.structure.building.Building;
 import org.mars_sim.msp.core.structure.building.function.FunctionType;
@@ -75,18 +75,19 @@ public class ExamineBodyMeta  extends MetaTask implements SettlementMetaTask {
 	 * @return The factor to adjust task score; 0 means task is not applicable
      */
     @Override
-	public double getPersonSettlementModifier(SettlementTask t, Person p) {
-        double factor = 0D;
+	public RatingScore assessPersonSuitability(SettlementTask t, Person p) {
+        RatingScore factor = RatingScore.ZERO_RATING;
         if (p.isInSettlement() &&
 				p.getPhysicalCondition().isFitByLevel(1000, 70, 1000)) {
 
 			// Effort-driven task modifier.
-			factor = getPersonModifier(p);
+			factor = new RatingScore(t.getScore());
+			factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
 
 			double skill = p.getSkillManager().getEffectiveSkillLevel(SkillType.MEDICINE);
 			if (skill == 0)
 				skill = 0.01D;
-			factor *= skill;
+			factor.addModifier("medical", skill);
 		}
 		return factor;
 	}
@@ -132,14 +133,6 @@ public class ExamineBodyMeta  extends MetaTask implements SettlementMetaTask {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Robots 
-	 */
-	@Override
-	public double getRobotSettlementModifier(SettlementTask t, Robot r) {
-		return 0;
 	}
 
 	public static void initialiseInstances(MedicalManager mm) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ExamineBodyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ExamineBodyMeta.java
@@ -81,8 +81,10 @@ public class ExamineBodyMeta  extends MetaTask implements SettlementMetaTask {
 				p.getPhysicalCondition().isFitByLevel(1000, 70, 1000)) {
 
 			// Effort-driven task modifier.
-			factor = new RatingScore(t.getScore());
-			factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
+			factor = super.assessPersonSuitability(t, p);
+			if (factor.getScore() == 0) {
+				return factor;
+			}
 
 			double skill = p.getSkillManager().getEffectiveSkillLevel(SkillType.MEDICINE);
 			if (skill == 0)

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/LoadVehicleMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/LoadVehicleMeta.java
@@ -26,6 +26,7 @@ import org.mars_sim.msp.core.person.ai.task.util.SettlementMetaTask;
 import org.mars_sim.msp.core.person.ai.task.util.SettlementTask;
 import org.mars_sim.msp.core.person.ai.task.util.Task;
 import org.mars_sim.msp.core.person.ai.task.util.TaskJob;
+import org.mars_sim.msp.core.person.ai.task.util.TaskProbabilityUtil;
 import org.mars_sim.msp.core.person.ai.task.util.TaskTrait;
 import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.robot.RobotType;
@@ -42,11 +43,9 @@ public class LoadVehicleMeta extends MetaTask
 
 		private static final long serialVersionUID = 1L;
 
-        private boolean eva;
-
         private LoadJob(SettlementMetaTask owner, VehicleMission target, boolean eva, double score) {
             super(owner, "Load " + (eva ? "via EVA " : ""), target, score);
-            this.eva = eva;
+            setEVA(eva);
         }
 
         private VehicleMission getMission() {
@@ -57,7 +56,7 @@ public class LoadVehicleMeta extends MetaTask
         public Task createTask(Person person) {
             if (!person.isInSettlement())
             	return null;
-            if (eva) {
+            if (isEVA()) {
                 return new LoadVehicleEVA(person, getMission());
             }
             return new LoadVehicleGarage(person, getMission());
@@ -65,7 +64,7 @@ public class LoadVehicleMeta extends MetaTask
 
         @Override
         public Task createTask(Robot robot) {
-            if (eva) {
+            if (isEVA()) {
 				// Should not happen
 				throw new IllegalStateException("Robots can not do EVA load vehicle");
 			}
@@ -91,28 +90,6 @@ public class LoadVehicleMeta extends MetaTask
 		setPreferredJob(JobType.LOADERS);
         addPreferredRobot(RobotType.DELIVERYBOT);
 	}
-    
-    /**
-     * Gets the score for a Settlement task for a person. If EVA is needed, considers radiation.
-     * 
-	 * @param t Task being scored
-	 * @param p Person requesting work.
-	 * @return The factor to adjust task score; 0 means task is not applicable
-     */
-    @Override
-	public RatingScore assessPersonSuitability(SettlementTask t, Person p) {
-        RatingScore factor = RatingScore.ZERO_RATING;
-        if (p.isInSettlement()) {
-			LoadJob mtj = (LoadJob) t;
-
-			factor = new RatingScore(t.getScore());
-			factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
-			if (mtj.eva) {
-				factor = applyEVASuitability(factor, p);
-			}
-		}
-		return factor;
-	}
 
     /**
      * Gets the score for a Settlement task for a robot. Note that robots can not do EVA.
@@ -123,15 +100,7 @@ public class LoadVehicleMeta extends MetaTask
      */
 	@Override
 	public RatingScore assessRobotSuitability(SettlementTask t, Robot r)  {
-        LoadJob mtj = (LoadJob) t;
-        if (mtj.eva) {
-            return RatingScore.ZERO_RATING;
-        }
-
-        var factor = new RatingScore(t.getScore());
-        factor.addModifier(ROBOT_PERF_MODIFIER, r.getPerformanceRating());
-
-        return factor;
+        return TaskProbabilityUtil.assessRobot(t, r);
     }
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/MaintainBuildingMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/MaintainBuildingMeta.java
@@ -100,7 +100,7 @@ public class MaintainBuildingMeta extends MetaTask implements SettlementMetaTask
 	public RatingScore assessRobotSuitability(SettlementTask t, Robot r)  {
         var factor = TaskProbabilityUtil.assessRobot(t, r);
 		if (factor.getScore() > 0)
-			factor.addModifier("robot.maintain", ROBOT_FACTOR);
+			factor.addModifier("robot.expert", ROBOT_FACTOR);
         return factor;
     }
 	

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/PlanMissionMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/PlanMissionMeta.java
@@ -93,8 +93,10 @@ public class PlanMissionMeta extends MetaTask implements SettlementMetaTask {
         if (fatigue > 1000 || stress > 75 || hunger > 750)
             return RatingScore.ZERO_RATING;
             
-        var factor = new RatingScore(t.getScore());
-        factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
+        var factor = super.assessPersonSuitability(t, p);
+        if (factor.getScore() == 0) {
+            return factor;
+        }
 
         double roleFactor = switch (p.getRole().getType()) {
             case CHIEF_OF_MISSION_PLANNING  -> 2.0;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ReviewMissionPlanMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ReviewMissionPlanMeta.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.mars.sim.tools.Msg;
+import org.mars_sim.msp.core.data.RatingScore;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
 import org.mars_sim.msp.core.person.ai.mission.MissionManager;
@@ -74,8 +75,8 @@ public class ReviewMissionPlanMeta extends MetaTask implements SettlementMetaTas
 	 * @return The factor to adjust task score; 0 means task is not applicable
      */
     @Override
-	public double getPersonSettlementModifier(SettlementTask t, Person p) {
-        double factor = 0D;
+	public RatingScore assessPersonSuitability(SettlementTask t, Person p) {
+        RatingScore factor = RatingScore.ZERO_RATING;
         if (p.isInSettlement() && p.getPhysicalCondition().isFitByLevel(1000, 70, 1000)) {
 			MissionPlanning mp = ((ReviewMissionPlanJob)t).plan;
 			Mission m = mp.getMission();			
@@ -83,20 +84,19 @@ public class ReviewMissionPlanMeta extends MetaTask implements SettlementMetaTas
 
 			// Is this Person allowed to review this Mission
 			if (!p.equals(m.getStartingPerson()) && mp.isReviewerValid(p.getName(), pop)) {
-				// This reviewer is valid
-				factor = 1D;
+				factor = new RatingScore(t.getScore());
+				factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
 
-				RoleType roleType = p.getRole().getType();   	
-				if (RoleType.MISSION_SPECIALIST == roleType)
-					factor *= 1.5;
-				else if (RoleType.CHIEF_OF_MISSION_PLANNING == roleType)
-					factor *= 3;
-				else if (RoleType.SUB_COMMANDER == roleType)
-					factor *= 4.5;
-				else if (RoleType.COMMANDER == roleType)
-					factor *= 6;
-				
-				factor *= getPersonModifier(p);
+				// This reviewer is valid
+				RoleType roleType = p.getRole().getType();  
+				double reviewer = switch(roleType) {
+					case MISSION_SPECIALIST -> 1.5;
+					case CHIEF_OF_MISSION_PLANNING -> 3;
+					case SUB_COMMANDER -> 4.5;
+					case COMMANDER -> 6;
+					default -> 1;
+				};
+				factor.addModifier("reviewer", reviewer);
 			}
 		}
 		return factor;
@@ -139,17 +139,6 @@ public class ReviewMissionPlanMeta extends MetaTask implements SettlementMetaTas
 	
         return tasks;
     }
-
-	/**
-	 * Robots can not do review missions.
-	 * 
-	 * @param t Task to be reviewed
-	 * @param r Robot asking
-	 */
-	@Override
-	public double getRobotSettlementModifier(SettlementTask t, Robot r) {
-		return 0;
-	}
 
 	public static void initialiseInstances(MissionManager mm) {
 		missionManager = mm;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ReviewMissionPlanMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ReviewMissionPlanMeta.java
@@ -23,7 +23,6 @@ import org.mars_sim.msp.core.person.ai.task.util.SettlementMetaTask;
 import org.mars_sim.msp.core.person.ai.task.util.SettlementTask;
 import org.mars_sim.msp.core.person.ai.task.util.Task;
 import org.mars_sim.msp.core.person.ai.task.util.TaskTrait;
-import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.structure.Settlement;
 
 /**
@@ -84,8 +83,10 @@ public class ReviewMissionPlanMeta extends MetaTask implements SettlementMetaTas
 
 			// Is this Person allowed to review this Mission
 			if (!p.equals(m.getStartingPerson()) && mp.isReviewerValid(p.getName(), pop)) {
-				factor = new RatingScore(t.getScore());
-				factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
+				factor = super.assessPersonSuitability(t, p);
+				if (factor.getScore() == 0) {
+					return factor;
+				}
 
 				// This reviewer is valid
 				RoleType roleType = p.getRole().getType();  

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/TendFishTankMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/TendFishTankMeta.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.mars.sim.tools.Msg;
+import org.mars_sim.msp.core.data.RatingScore;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.fav.FavoriteType;
 import org.mars_sim.msp.core.person.ai.job.util.JobType;
@@ -77,16 +78,15 @@ public class TendFishTankMeta extends MetaTask implements SettlementMetaTask {
 	 * @return The factor to adjust task score; 0 means task is not applicable
      */
     @Override
-	public double getPersonSettlementModifier(SettlementTask t, Person p) {
-        double factor = 0D;
+	public RatingScore assessPersonSuitability(SettlementTask t, Person p) {
+        RatingScore factor = RatingScore.ZERO_RATING;
         if (p.isInSettlement()) {
-            factor = 1D;
-            Building b = ((FishTaskJob)t).tank.getBuilding();
-
+			factor = new RatingScore(t.getScore());
+			factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
+            
             // Crowding modifier.
-            factor *= getBuildingModifier(b, p);
-
-            factor *= (1 + getPersonModifier(p));
+            Building b = ((FishTaskJob)t).tank.getBuilding();
+            factor.addModifier(BUILDING_MODIFIER, getBuildingModifier(b, p));
 		}
 		return factor;
 	}
@@ -96,11 +96,10 @@ public class TendFishTankMeta extends MetaTask implements SettlementMetaTask {
 	 * @return The factor to adjust task score; 0 means task is not applicable
      */
 	@Override
-	public double getRobotSettlementModifier(SettlementTask t, Robot r) {
-        
-        // Crowding modifier.
-        return r.getPerformanceRating();
-
+	public RatingScore assessRobotSuitability(SettlementTask t, Robot r)  {
+        var factor = new RatingScore(t.getScore());
+        factor.addModifier(ROBOT_PERF_MODIFIER, r.getPerformanceRating());
+        return factor;
     }
 
     /**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/TendFishTankMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/TendFishTankMeta.java
@@ -19,6 +19,7 @@ import org.mars_sim.msp.core.person.ai.task.util.MetaTask;
 import org.mars_sim.msp.core.person.ai.task.util.SettlementMetaTask;
 import org.mars_sim.msp.core.person.ai.task.util.SettlementTask;
 import org.mars_sim.msp.core.person.ai.task.util.Task;
+import org.mars_sim.msp.core.person.ai.task.util.TaskProbabilityUtil;
 import org.mars_sim.msp.core.person.ai.task.util.TaskTrait;
 import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.robot.RobotType;
@@ -81,8 +82,10 @@ public class TendFishTankMeta extends MetaTask implements SettlementMetaTask {
 	public RatingScore assessPersonSuitability(SettlementTask t, Person p) {
         RatingScore factor = RatingScore.ZERO_RATING;
         if (p.isInSettlement()) {
-			factor = new RatingScore(t.getScore());
-			factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
+			factor = super.assessPersonSuitability(t, p);
+            if (factor.getScore() == 0) {
+                return factor;
+            }
             
             // Crowding modifier.
             Building b = ((FishTaskJob)t).tank.getBuilding();
@@ -97,9 +100,7 @@ public class TendFishTankMeta extends MetaTask implements SettlementMetaTask {
      */
 	@Override
 	public RatingScore assessRobotSuitability(SettlementTask t, Robot r)  {
-        var factor = new RatingScore(t.getScore());
-        factor.addModifier(ROBOT_PERF_MODIFIER, r.getPerformanceRating());
-        return factor;
+        return TaskProbabilityUtil.assessRobot(t, r);
     }
 
     /**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/TendGreenhouseMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/TendGreenhouseMeta.java
@@ -87,8 +87,10 @@ public class TendGreenhouseMeta extends MetaTask implements SettlementMetaTask {
             LifeSupport ls = b.getLifeSupport();
 
             if (farm.getFarmerNum() <= 2 * ls.getOccupantCapacity()) {
-    			factor = new RatingScore(t.getScore());
-			    factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
+    			factor = super.assessPersonSuitability(t, p);
+                if (factor.getScore() == 0) {
+                    return factor;
+                }
 
                 // Crowding modifier.
                 factor.addModifier(BUILDING_MODIFIER, getBuildingModifier(b, p));                                    
@@ -104,9 +106,7 @@ public class TendGreenhouseMeta extends MetaTask implements SettlementMetaTask {
      */
 	@Override
 	public RatingScore assessRobotSuitability(SettlementTask t, Robot r)  {
-        var factor = new RatingScore(t.getScore());
-        factor.addModifier(ROBOT_PERF_MODIFIER, r.getPerformanceRating());
-        return factor;
+        return TaskProbabilityUtil.assessRobot(t, r);
     }
     
     /**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ToggleFuelPowerSourceMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ToggleFuelPowerSourceMeta.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.mars.sim.tools.Msg;
+import org.mars_sim.msp.core.data.RatingScore;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.fav.FavoriteType;
 import org.mars_sim.msp.core.person.ai.job.util.JobType;
@@ -99,8 +100,8 @@ public class ToggleFuelPowerSourceMeta extends MetaTask implements SettlementMet
 	 * @return The factor to adjust task score; 0 means task is not applicable
      */
     @Override
-	public double getPersonSettlementModifier(SettlementTask t, Person p) {
-        double factor = 0D;
+	public RatingScore assessPersonSuitability(SettlementTask t, Person p) {
+        RatingScore factor = RatingScore.ZERO_RATING;
         if (p.isInSettlement()) {
             Building building = ((PowerTaskJob)t).getBuilding();
       
@@ -109,14 +110,15 @@ public class ToggleFuelPowerSourceMeta extends MetaTask implements SettlementMet
                     &&     // Checks if the person is physically fit for heavy EVA tasks
                     !EVAOperation.isEVAFit(p)) {
                 // Probability affected by the person's stress, hunger, thirst and fatigue.
-                return 0D;
+                return factor;
             }
-	                      
+	          
+			factor = new RatingScore(t.getScore());
+			factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
             if (building.hasFunction(FunctionType.LIFE_SUPPORT)) {
                 // Factor in building crowding and relationship factors.
-                factor *= getBuildingModifier(building, p);
+                factor.addModifier(BUILDING_MODIFIER, getBuildingModifier(building, p));
             }
-            factor *= getPersonModifier(p);
 		}
 		return factor;
 	}
@@ -227,11 +229,5 @@ public class ToggleFuelPowerSourceMeta extends MetaTask implements SettlementMet
         }
 
         return result;
-    }
-
-    @Override
-    public double getRobotSettlementModifier(SettlementTask t, Robot r) {
-        // TODO Auto-generated method stub
-        return 0;
     }
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ToggleFuelPowerSourceMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ToggleFuelPowerSourceMeta.java
@@ -20,7 +20,6 @@ import org.mars_sim.msp.core.person.ai.task.util.MetaTask;
 import org.mars_sim.msp.core.person.ai.task.util.SettlementMetaTask;
 import org.mars_sim.msp.core.person.ai.task.util.SettlementTask;
 import org.mars_sim.msp.core.person.ai.task.util.Task;
-import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.structure.building.Building;
 import org.mars_sim.msp.core.structure.building.BuildingCategory;
@@ -113,9 +112,8 @@ public class ToggleFuelPowerSourceMeta extends MetaTask implements SettlementMet
                 return factor;
             }
 	          
-			factor = new RatingScore(t.getScore());
-			factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
-            if (building.hasFunction(FunctionType.LIFE_SUPPORT)) {
+			factor = super.assessPersonSuitability(t, p);
+            if ((factor.getScore() > 0) && building.hasFunction(FunctionType.LIFE_SUPPORT)) {
                 // Factor in building crowding and relationship factors.
                 factor.addModifier(BUILDING_MODIFIER, getBuildingModifier(building, p));
             }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ToggleResourceProcessMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ToggleResourceProcessMeta.java
@@ -20,6 +20,7 @@ import org.mars_sim.msp.core.person.ai.task.util.MetaTask;
 import org.mars_sim.msp.core.person.ai.task.util.SettlementMetaTask;
 import org.mars_sim.msp.core.person.ai.task.util.SettlementTask;
 import org.mars_sim.msp.core.person.ai.task.util.Task;
+import org.mars_sim.msp.core.person.ai.task.util.TaskProbabilityUtil;
 import org.mars_sim.msp.core.resource.ResourceUtil;
 import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.robot.RobotType;
@@ -103,26 +104,8 @@ public class ToggleResourceProcessMeta extends MetaTask implements SettlementMet
 	 */
 	@Override
 	public RatingScore assessRobotSuitability(SettlementTask t, Robot r)  {
-        var factor = new RatingScore(t.getScore());
-        factor.addModifier(ROBOT_PERF_MODIFIER, r.getPerformanceRating());
-        return factor;
+        return TaskProbabilityUtil.assessRobot(t, r);
     }
-
-	/**
-	 * Evaluates if a Person can do a Settlement task, based on in settlement.
-	 * 
-	 * @param t Task 
-	 * @param p Person making the request
-	 */
-    @Override
-	public RatingScore assessPersonSuitability(SettlementTask t, Person p) {
-        RatingScore factor = RatingScore.ZERO_RATING;
-		if (p.isInSettlement()) {
-			factor = new RatingScore(t.getScore());
-			factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
-		}
-		return factor;
-	}
 
 	/**
 	 * Builds a list of TaskJob covering the most suitable Resource Processes to toggle.

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ToggleResourceProcessMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ToggleResourceProcessMeta.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.mars.sim.tools.Msg;
+import org.mars_sim.msp.core.data.RatingScore;
 import org.mars_sim.msp.core.goods.GoodsManager;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.fav.FavoriteType;
@@ -101,9 +102,11 @@ public class ToggleResourceProcessMeta extends MetaTask implements SettlementMet
 	 * @param r Robot making the request
 	 */
 	@Override
-	public double getRobotSettlementModifier(SettlementTask t, Robot r) {
-		return 1D;
-	}
+	public RatingScore assessRobotSuitability(SettlementTask t, Robot r)  {
+        var factor = new RatingScore(t.getScore());
+        factor.addModifier(ROBOT_PERF_MODIFIER, r.getPerformanceRating());
+        return factor;
+    }
 
 	/**
 	 * Evaluates if a Person can do a Settlement task, based on in settlement.
@@ -111,12 +114,14 @@ public class ToggleResourceProcessMeta extends MetaTask implements SettlementMet
 	 * @param t Task 
 	 * @param p Person making the request
 	 */
-	@Override
-	public double getPersonSettlementModifier(SettlementTask t, Person p) {
+    @Override
+	public RatingScore assessPersonSuitability(SettlementTask t, Person p) {
+        RatingScore factor = RatingScore.ZERO_RATING;
 		if (p.isInSettlement()) {
-			return getPersonModifier(p);
+			factor = new RatingScore(t.getScore());
+			factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
 		}
-		return 0D;
+		return factor;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/UnloadVehicleMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/UnloadVehicleMeta.java
@@ -27,6 +27,7 @@ import org.mars_sim.msp.core.person.ai.task.util.SettlementMetaTask;
 import org.mars_sim.msp.core.person.ai.task.util.SettlementTask;
 import org.mars_sim.msp.core.person.ai.task.util.Task;
 import org.mars_sim.msp.core.person.ai.task.util.TaskJob;
+import org.mars_sim.msp.core.person.ai.task.util.TaskProbabilityUtil;
 import org.mars_sim.msp.core.person.ai.task.util.TaskTrait;
 import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.robot.RobotType;
@@ -41,11 +42,9 @@ public class UnloadVehicleMeta extends MetaTask implements SettlementMetaTask {
 
 		private static final long serialVersionUID = 1L;
 
-        private boolean eva;
-
         public UnloadJob(SettlementMetaTask owner, Vehicle target, boolean eva, double score) {
             super(owner, "Unload " + (eva ? "via EVA " : "") + "@ " + target.getName(), target, score);
-            this.eva = eva;
+            setEVA(eva);
         }
 
         /**
@@ -57,7 +56,7 @@ public class UnloadVehicleMeta extends MetaTask implements SettlementMetaTask {
 
         @Override
         public Task createTask(Person person) {
-            if (eva) {
+            if (isEVA()) {
                 return new UnloadVehicleEVA(person, getVehicle());
             }
             return new UnloadVehicleGarage(person, getVehicle());
@@ -65,7 +64,7 @@ public class UnloadVehicleMeta extends MetaTask implements SettlementMetaTask {
 
         @Override
         public Task createTask(Robot robot) {
-            if (eva) {
+            if (isEVA()) {
 				// Should not happen
 				throw new IllegalStateException("Robots can not do EVA unload vehicle");
 			}
@@ -88,29 +87,6 @@ public class UnloadVehicleMeta extends MetaTask implements SettlementMetaTask {
         addPreferredRobot(RobotType.DELIVERYBOT);
 	}
 
-       
-    /**
-     * Gets the score for a Settlement task for a person. This considers and EVA factor for eva maintenance.
-     * 
-	 * @param t Task being scored
-	 * @param p Person requesting work
-	 * @return The factor to adjust task score; 0 means task is not applicable
-     */
-    @Override
-	public RatingScore assessPersonSuitability(SettlementTask t, Person p) {
-        RatingScore factor = RatingScore.ZERO_RATING;
-        if (p.isInSettlement()) {
-			UnloadJob mtj = (UnloadJob) t;
-
-			factor = new RatingScore(t.getScore());
-			factor.addModifier(PERSON_MODIFIER, getPersonModifier(p));
-			if (mtj.eva) {
-				factor = applyEVASuitability(factor, p);
-			}
-		}
-		return factor;
-	}
-
     /**
      * For a robot can not do EVA tasks so will return a zero factor in this case.
      * 
@@ -120,14 +96,7 @@ public class UnloadVehicleMeta extends MetaTask implements SettlementMetaTask {
      */
     @Override
 	public RatingScore assessRobotSuitability(SettlementTask t, Robot r)  {
-        UnloadJob mtj = (UnloadJob) t;
-        if (mtj.eva) {
-            return RatingScore.ZERO_RATING;
-        }
-
-        var factor = new RatingScore(t.getScore());
-        factor.addModifier(ROBOT_PERF_MODIFIER, r.getPerformanceRating());
-        return factor;
+        return TaskProbabilityUtil.assessRobot(t, r);
     }
 
 	/**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/FactoryMetaTask.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/FactoryMetaTask.java
@@ -7,6 +7,7 @@
 package org.mars_sim.msp.core.person.ai.task.util;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.mars_sim.msp.core.Simulation;
@@ -116,7 +117,7 @@ public abstract class FactoryMetaTask extends MetaTask {
 	private List<TaskJob> createTaskJob(double score, int duration) {
 		// This is to avoid a massive rework in the subclasses.
 		if (score <= 0) {
-			return null;
+			return Collections.emptyList();
 		}
 
 		List<TaskJob> result = new ArrayList<>(1);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/MetaTask.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/MetaTask.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.mars_sim.msp.core.Simulation;
+import org.mars_sim.msp.core.data.RatingScore;
 import org.mars_sim.msp.core.environment.SurfaceFeatures;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.person.ai.fav.FavoriteType;
@@ -47,6 +48,13 @@ public abstract class MetaTask {
 		ANY_HOUR, WORK_HOUR, NONWORK_HOUR
 	}
 	
+	protected static final String PERSON_MODIFIER = "person";
+	protected static final String ROBOT_PERF_MODIFIER = "robot-perf";
+	protected static final String BUILDING_MODIFIER = "building";
+	private static final String EVA_MODIFIER = "eva";
+	private static final String RADIATION_MODIFIER = "radiation";
+
+
 	// Traits used to identify non-effort tasks
 	private static final Set<TaskTrait> PASSIVE_TRAITS
 		= Set.of(TaskTrait.RELAXATION, 
@@ -343,7 +351,21 @@ public abstract class MetaTask {
 		return 1D;
 	}
 
-	
+	/**
+	 * Apply the suitability of a Person to do an EVA.
+	 * @param factor Current rating
+	 * @param p Person to assess
+	 * @return Update rating
+	 */
+	protected static RatingScore applyEVASuitability(RatingScore factor, Person p) {
+
+		// EVA factor is the radiation and the EVA modifiers applied extra
+		factor.addModifier(RADIATION_MODIFIER, getRadiationModifier(p.getSettlement()));
+		factor.addModifier(EVA_MODIFIER, getEVAModifier(p));
+
+		return factor;
+	}
+
 	/**
 	 * Gets the modifier for a Person using a building.
 	 * 

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/SettlementMetaTask.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/SettlementMetaTask.java
@@ -9,6 +9,7 @@ package org.mars_sim.msp.core.person.ai.task.util;
 import java.util.List;
 import java.util.Set;
 
+import org.mars_sim.msp.core.data.RatingScore;
 import org.mars_sim.msp.core.person.Person;
 import org.mars_sim.msp.core.robot.Robot;
 import org.mars_sim.msp.core.robot.RobotType;
@@ -38,20 +39,23 @@ public interface SettlementMetaTask {
     List<SettlementTask> getSettlementTasks(Settlement settlement);
 
     /**
-     * Gets the Person applicable modifiers for this  Meta Task.
+     * Assess a Person for a specific SettlementTask of this type.
      * 
      * @param t The Settlement task being evaluated
      * @param p Person in question
-     * @return Default returns 0 being no applicable Task
+     * @return A new rating score applying the Person's modifiers
      */
-    double getPersonSettlementModifier(SettlementTask t, Person p);
+    RatingScore assessPersonSuitability(SettlementTask t, Person p);
 
     /**
-     * Gets the Robot applicable modifiers for this  Meta Task.
+     * Assess a Robot for a specific SettlementTask of this type.
+     * Default implementation return Robot is not suitable.
      * 
      * @param t The Settlement task being evaluated
      * @param r Robot in question
-     * @return Default returns 0 
+     * @return A new rating score applying the Robot's modifiers
      */
-    double getRobotSettlementModifier(SettlementTask t, Robot r);
+    default RatingScore assessRobotSuitability(SettlementTask t, Robot r) {
+        return RatingScore.ZERO_RATING;
+    }
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/SettlementTask.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/SettlementTask.java
@@ -21,6 +21,7 @@ public abstract class SettlementTask extends AbstractTaskJob {
     
     private SettlementMetaTask metaTask;
     private Entity focus;
+    private String shortName;
 
     /**
      * Old approach where a single double is used for scoring
@@ -43,10 +44,19 @@ public abstract class SettlementTask extends AbstractTaskJob {
      * @param score The Rating score for this work
      */
     protected SettlementTask(SettlementMetaTask parent, String name, Entity focus, RatingScore score) {
-        super(name, score);
+        super(name + (focus != null ? " @ " + focus.getName() : ""), score);
         this.metaTask = parent;
         this.demand = 1;
         this.focus = focus;
+        this.shortName = name;
+    }
+
+    /**
+     * Get a short name that does not include the Entity reference.
+     * @return
+     */
+    public String getShortName() {
+        return shortName;
     }
 
     /**

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/SettlementTask.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/SettlementTask.java
@@ -22,6 +22,7 @@ public abstract class SettlementTask extends AbstractTaskJob {
     private SettlementMetaTask metaTask;
     private Entity focus;
     private String shortName;
+    private boolean needsEVA = false;
 
     /**
      * Old approach where a single double is used for scoring
@@ -59,6 +60,17 @@ public abstract class SettlementTask extends AbstractTaskJob {
         return shortName;
     }
 
+    /**
+     * Does this task need a an EVA activity
+     */
+    public boolean isEVA() {
+        return needsEVA;
+    }
+
+    protected void setEVA(boolean eva) {
+        needsEVA = eva;
+    }
+    
     /**
      * Sets a specific level of demand for this job.
      * 
@@ -128,6 +140,8 @@ public abstract class SettlementTask extends AbstractTaskJob {
             if (other.metaTask != null)
                 return false;
         } else if (!metaTask.equals(other.metaTask))
+            return false;
+        if (needsEVA != other.needsEVA)
             return false;
         if (focus == null) {
             if (other.focus != null)

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/SettlementTaskManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/SettlementTaskManager.java
@@ -131,10 +131,8 @@ public class SettlementTaskManager implements Serializable {
 
             // Check this type of Robot can do the Job
             if (mt.getPreferredRobot().contains(r.getRobotType())) {
-                double factor = mt.getRobotSettlementModifier(st,r);
-                if (factor > 0) {
-                    RatingScore score = new RatingScore(st.getScore());
-                    score.addModifier("robot", factor);
+                RatingScore score = mt.assessRobotSuitability(st, r);
+                if (score.getScore() > 0) {
                     result.add(new SettlementTaskProxy(this, st, score));
                 }
             }
@@ -148,16 +146,14 @@ public class SettlementTaskManager implements Serializable {
      * to the particular worker by applying their personal modifier. 
      * 
      * @return Custom list of jobs applicable
-     * @see SettlementMetaTask#getPersonSettlementModifier(Person)
+     * @see SettlementMetaTask#assessPersonSuitability(SettlementTask, Person)
      */
     public List<TaskJob> getTasks(Person p) {
         List<TaskJob> result = new ArrayList<>();
         for(SettlementTask st : getTasks()) {
             SettlementMetaTask mt = st.getMeta();
-            double factor = mt.getPersonSettlementModifier(st, p);
-            if (factor > 0) {
-                RatingScore score = new RatingScore(st.getScore());
-                score.addModifier("person", factor);
+            RatingScore score = mt.assessPersonSuitability(st, p);
+            if (score.getScore() > 0) {
                 result.add(new SettlementTaskProxy(this, st, score));
             }
         }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskManager.java
@@ -19,6 +19,7 @@ import org.mars_sim.msp.core.Unit;
 import org.mars_sim.msp.core.UnitEventType;
 import org.mars_sim.msp.core.data.History;
 import org.mars_sim.msp.core.data.RatingLog;
+import org.mars_sim.msp.core.data.RatingScore;
 import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
 import org.mars_sim.msp.core.person.ai.task.Walk;
@@ -145,6 +146,8 @@ public abstract class TaskManager implements Serializable {
 	protected transient Unit worker;
 	/** The current task the worker is doing. */
 	protected Task currentTask;
+	private RatingScore currentScore;
+
 	/** The last task the person was doing. */
 	private Task lastTask;
 
@@ -211,6 +214,14 @@ public abstract class TaskManager implements Serializable {
 			return "";
 		}
 	}
+
+	/**
+	 * Get the score of the current Task if it was choosen at random. 
+	 * @return Will be null if task has been preselected.
+	 */
+    public RatingScore getScore() {
+        return currentScore;
+    }
 
 	/**
 	 * Gets the bottom-most real-time task. 
@@ -633,6 +644,7 @@ public abstract class TaskManager implements Serializable {
 
 			// Start this newly selected task
 			replaceTask(selectedTask);
+			currentScore = selectedJob.getScore();
 		}
 	}
 
@@ -704,6 +716,7 @@ public abstract class TaskManager implements Serializable {
 			
 			// Make the new task as the current task
 			currentTask = newTask;
+			currentScore = null;
 			
 			// Send out the task event
 			worker.fireUnitUpdate(UnitEventType.TASK_EVENT, newTask);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskProbabilityUtil.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/TaskProbabilityUtil.java
@@ -138,7 +138,7 @@ public class TaskProbabilityUtil {
         }
 
         var factor = new RatingScore(t.getScore());
-        factor.addModifier("robot.perf", r.getPerformanceRating());
+        factor.addModifier("performance", r.getPerformanceRating());
 
         return factor;
     }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/robot/ai/task/BotTaskManager.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/robot/ai/task/BotTaskManager.java
@@ -193,7 +193,7 @@ public class BotTaskManager extends TaskManager {
 		for (FactoryMetaTask mt : potentials) {
 			List<TaskJob> job = mt.getTaskJobs(robot);
 	
-			if (job != null) {
+			if (!job.isEmpty()) {
 				newCache.add(job);
 			}
 		}

--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -981,6 +981,21 @@ RandomUtil.log.ceilingMustBePositive  = ceiling must be positive:
 RandomUtil.log.ceilingMustGreaterBase = ceiling must be greater than base.
 RandomUtil.log.weightMapIsNull        = weightedMap is null
 
+RatingScore.reviewer = Reviewer
+RatingScore.citizens = Citizens Count
+RatingScore.crowding = Overcrowding
+RatingScore.robot.expert = Robot Expertise
+RatingScore.leader = Leader
+RatingScore.extrovert = Person Extrovert
+RatingScore.building = Building Suitability
+RatingScore.medical = Medical Skill
+RatingScore.eva = EVA Weight
+RatingScore.radiation = Radiation Exposure
+RatingScore.building = Building
+RatingScore.performance = Performance
+RatingScore.person = Person
+
+
 ResupplyMissionEditingPanel.error.duplicatedSol 		= Invalid entry in 'Sols Until Arrival' since sol {0} has already been chosen in another resupply mission.
 
 RobotTableModel.bots   		              = Bots

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/StyleManager.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/StyleManager.java
@@ -128,6 +128,10 @@ public class StyleManager {
         styles.put(LAF_STYLE, lafProps);
     }
 
+    private StyleManager() {
+        // Stop instatiation
+    }
+    
     /**
      * Gets available LAF.
      */

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/BacklogTab.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/BacklogTab.java
@@ -32,6 +32,6 @@ public class BacklogTab extends TableTab {
 		TableColumnModel m = table.getColumnModel();
 		m.getColumn(BacklogTableModel.SCORE_COL).setCellRenderer(DIGIT2_RENDERER);
 			  
-		super.adjustColumnWidth(table);
+		adjustColumnWidth(table);
 	}
 }

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/BacklogTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/BacklogTableModel.java
@@ -223,7 +223,7 @@ public class BacklogTableModel extends AbstractTableModel
 		if ((columnIndex == SCORE_COL) && (rowIndex < tasks.size())) {
 			SettlementTask selectedTask = tasks.get(rowIndex);
 
-			result = selectedTask.getScore().getOutput();
+			result = selectedTask.getScore().getHTMLOutput();
 		}
         return result;
     }

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/BacklogTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/BacklogTableModel.java
@@ -223,7 +223,7 @@ public class BacklogTableModel extends AbstractTableModel
 					return des.getName();
 				return null;
 			case DESC_COL:
-				return selectedTask.getName();
+				return selectedTask.getShortName();
 			case DEMAND_COL:
 				return selectedTask.getDemand();
 			case SCORE_COL:

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/BacklogTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/BacklogTableModel.java
@@ -211,6 +211,29 @@ public class BacklogTableModel extends AbstractTableModel
 		};
 	}
 
+    /**
+     * Default implementation return null as no tooltips are supported by default
+     * @param rowIndex Row index of cell
+     * @param columnIndex Column index of cell
+     * @return Return null by default
+     */
+    @Override
+    public String getToolTipAt(int rowIndex, int columnIndex) {
+		String result = null;
+		if ((columnIndex == SCORE_COL) && (rowIndex < tasks.size())) {
+			SettlementTask selectedTask = tasks.get(rowIndex);
+
+			result = selectedTask.getScore().getOutput();
+		}
+        return result;
+    }
+
+	/**
+	 * Get the value of a cell of a SettlementTask
+     * @param rowIndex Row index of cell
+     * @param columnIndex Column index of cell
+     * @return Object value of the cell
+	 */
 	@Override
 	public Object getValueAt(int rowIndex, int columnIndex) {
 		if (tasks.size() <= rowIndex) {

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/BacklogTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/BacklogTableModel.java
@@ -34,8 +34,9 @@ public class BacklogTableModel extends AbstractTableModel
 	
 	private static final int DESC_COL = 0;
 	private static final int ENTITY_COL = 1;
-	private static final int DEMAND_COL = 2;
-	static final int SCORE_COL = 3;
+	private static final int EVA_COL = 2;
+	private static final int DEMAND_COL = 3;
+	static final int SCORE_COL = 4;
 
 	private String name = null;
 	private Settlement selectedSettlement;
@@ -192,6 +193,7 @@ public class BacklogTableModel extends AbstractTableModel
 			case ENTITY_COL -> "Entity";
 			case DESC_COL -> "Description";
 			case DEMAND_COL -> "Demand";
+			case EVA_COL -> "EVA";
 			case SCORE_COL -> "Score";
 			default -> throw new IllegalArgumentException("Unexpected value: " + index);
 		};
@@ -203,6 +205,7 @@ public class BacklogTableModel extends AbstractTableModel
 			case ENTITY_COL ->  String.class;
 			case DESC_COL ->  String.class;
 			case DEMAND_COL ->  Integer.class;
+			case EVA_COL -> String.class;
 			case SCORE_COL ->  Double.class;
 			default -> throw new IllegalArgumentException("Unexpected value: " + index);
 		};
@@ -224,6 +227,8 @@ public class BacklogTableModel extends AbstractTableModel
 				return null;
 			case DESC_COL:
 				return selectedTask.getShortName();
+			case EVA_COL:
+				return selectedTask.isEVA();
 			case DEMAND_COL:
 				return selectedTask.getDemand();
 			case SCORE_COL:

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/EntityTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/EntityTableModel.java
@@ -244,6 +244,17 @@ public abstract class EntityTableModel<T> extends AbstractTableModel
 	}
 
     /**
+     * Default implementation return null as no tooltips are supported by default
+     * @param rowIndex Row index of cell
+     * @param columnIndex Column index of cell
+     * @return Return null by default
+     */
+    @Override
+    public String getToolTipAt(int rowIndex, int columnIndex) {
+        return null;
+    }
+
+    /**
      * Get a value for a particular cell. This may come from a cached value
      * if the column is one of the cached columns.
      * @param rowIndex

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/EventTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/EventTableModel.java
@@ -132,11 +132,7 @@ public class EventTableModel extends AbstractTableModel implements MonitorModel,
 		}
 
 		// Update all table listeners.
-		SwingUtilities.invokeLater(new Runnable() {
-			public void run() {
-				fireTableDataChanged();
-			}
-		});
+		SwingUtilities.invokeLater(this::fireTableDataChanged);
 
 	}
 
@@ -161,6 +157,7 @@ public class EventTableModel extends AbstractTableModel implements MonitorModel,
 	 * @param columnIndex Index of column.
 	 * @return Class of specified column.
 	 */
+	@Override
 	public Class<?> getColumnClass(int columnIndex) {
 		if ((columnIndex >= 0) && (columnIndex < columnTypes.length)) {
 			return columnTypes[columnIndex];
@@ -174,6 +171,7 @@ public class EventTableModel extends AbstractTableModel implements MonitorModel,
 	 * @param columnIndex Index of column.
 	 * @return name of specified column.
 	 */
+	@Override
 	public String getColumnName(int columnIndex) {
 		if ((columnIndex >= 0) && (columnIndex < columnNames.length)) {
 			return columnNames[columnIndex];
@@ -225,6 +223,17 @@ public class EventTableModel extends AbstractTableModel implements MonitorModel,
 	public boolean getOrdered() {
 		return true;
 	}
+
+    /**
+     * Default implementation return null as no tooltips are supported by default
+     * @param rowIndex Row index of cell
+     * @param columnIndex Column index of cell
+     * @return Return null by default
+     */
+    @Override
+    public String getToolTipAt(int rowIndex, int columnIndex) {
+        return null;
+    }
 
 	/**
 	 * Return the value of a Cell

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/FoodInventoryTab.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/FoodInventoryTab.java
@@ -16,7 +16,6 @@ import org.mars_sim.msp.ui.swing.tool.NumberRenderer;
  * This class represents an inventory of food at settlements displayed within
  * the Monitor Window.
  */
-@SuppressWarnings("serial")
 public class FoodInventoryTab extends TableTab {
 	private static final String FOOD_ICON = "food";
 
@@ -50,6 +49,6 @@ public class FoodInventoryTab extends TableTab {
 			m.getColumn(i).setCellRenderer(r);
 		}
 		
-		super.adjustColumnWidth(table);
+		adjustColumnWidth(table);
 	}
 }

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/MissionTab.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/MissionTab.java
@@ -26,7 +26,7 @@ public class MissionTab extends TableTab {
 		// Use TableTab constructor
 		super(window, new MissionTableModel(window.getDesktop().getSimulation()), true, true, MissionWindow.ICON);
 		
-		super.adjustColumnWidth(table);
+		adjustColumnWidth(table);
 
 		setEntityDriven(true);
 		setNavigatable(true);
@@ -37,6 +37,7 @@ public class MissionTab extends TableTab {
 	 * Get the Coordinates of the selected Mission
 	 * @return Cooridnates, maybe null
 	 */
+	@Override
     public Coordinates getSelectedCoordinates() {
 		List<?> rows = getSelection();
 		if (!rows.isEmpty() && (rows.get(0) instanceof Mission m)) {

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/MissionTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/MissionTableModel.java
@@ -380,6 +380,17 @@ public class MissionTableModel extends AbstractTableModel
 	}
 
 	/**
+     * Default implementation return null as no tooltips are supported by default
+     * @param rowIndex Row index of cell
+     * @param columnIndex Column index of cell
+     * @return Return null by default
+     */
+    @Override
+    public String getToolTipAt(int rowIndex, int columnIndex) {
+        return null;
+    }
+
+	/**
 	 * Returns the value of a Cell.
 	 *
 	 * @param rowIndex    Row index of the cell.

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/MonitorModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/MonitorModel.java
@@ -63,4 +63,12 @@ interface MonitorModel extends TableModel {
 	 * @param activate 
 	 */
     public void setMonitorEntites(boolean activate);
+
+	/**
+	 * Get a tooltip representation of a cell. Most cells with return null.
+	 * @param rowIndex
+	 * @param colIndex
+	 * @return
+	 */
+    public String getToolTipAt(int rowIndex, int colIndex);
 }

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/TableTab.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/TableTab.java
@@ -107,7 +107,7 @@ abstract class TableTab extends MonitorTab {
 		return table;
 	}
 
-	public static void adjustColumnWidth(JTable table) {
+	protected static void adjustColumnWidth(JTable table) {
 		// Gets max width for cells in column as the preferred width
 		TableColumnModel columnModel = table.getColumnModel();
 		for (int col = 0; col < table.getColumnCount(); col++) {

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/TradeTab.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/TradeTab.java
@@ -52,6 +52,6 @@ public class TradeTab extends TableTab {
 			m.getColumn(i).setCellRenderer(renderer);				
 		}
 		
-		super.adjustColumnWidth(table);
+		adjustColumnWidth(table);
 	}
 }

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/UnitTab.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/UnitTab.java
@@ -27,7 +27,7 @@ extends TableTab {
 		// Use TableTab constructor
 		super(window, model, mandatory, false, icon);
 
-		super.adjustColumnWidth(table);
+		adjustColumnWidth(table);
 
 		setEntityDriven(true);
 		setNavigatable(true);

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/UnitTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/UnitTableModel.java
@@ -131,10 +131,12 @@ public abstract class UnitTableModel<T extends Unit> extends EntityTableModel<T>
 	 *
 	 * @return FALSE as the Units have no natural order.
 	 */
+	@Override
 	public boolean getOrdered() {
 		return false;
 	}
 
+	
 	/**
 	 * Prepares the model for deletion.
 	 */

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/person/TabPanelActivity.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/unit_window/person/TabPanelActivity.java
@@ -18,6 +18,7 @@ import javax.swing.JPanel;
 
 import org.mars.sim.tools.Msg;
 import org.mars_sim.msp.core.Unit;
+import org.mars_sim.msp.core.data.RatingScore;
 import org.mars_sim.msp.core.logging.SimLogger;
 import org.mars_sim.msp.core.person.ai.mission.Mission;
 import org.mars_sim.msp.core.person.ai.task.util.TaskManager;
@@ -25,6 +26,7 @@ import org.mars_sim.msp.core.person.ai.task.util.TaskPhase;
 import org.mars_sim.msp.core.person.ai.task.util.Worker;
 import org.mars_sim.msp.ui.swing.ImageLoader;
 import org.mars_sim.msp.ui.swing.MainDesktopPane;
+import org.mars_sim.msp.ui.swing.StyleManager;
 import org.mars_sim.msp.ui.swing.tool.mission.MissionWindow;
 import org.mars_sim.msp.ui.swing.tool.monitor.MonitorWindow;
 import org.mars_sim.msp.ui.swing.tool.monitor.PersonTableModel;
@@ -70,6 +72,7 @@ public class TabPanelActivity extends TabPanel implements ActionListener {
 
 	private JLabel taskTextArea;
 	private JLabel taskPhaseArea;
+	private JLabel scoreTextArea;
 
 	private JLabel subTaskTextArea;
 	private JLabel subTaskPhaseArea;
@@ -139,13 +142,14 @@ public class TabPanelActivity extends TabPanel implements ActionListener {
 		missionButtonPanel.add(monitorButton);
 		
 		// Prepare activity panel
-		AttributePanel activityPanel = new AttributePanel(8);
+		AttributePanel activityPanel = new AttributePanel(9);
 		addBorder(activityPanel, "Task");
 		topPanel.add(activityPanel, BorderLayout.SOUTH);
 
 		// Prepare task labels. Create empty and then update
 		taskTextArea = activityPanel.addTextField(Msg.getString("TabPanelActivity.task"), "", null); //$NON-NLS-1$
 		taskPhaseArea = activityPanel.addTextField(Msg.getString("TabPanelActivity.taskPhase"), "", null); //$NON-NLS-1$
+		scoreTextArea = activityPanel.addTextField("Score", "", null);
 		subTaskTextArea = activityPanel.addTextField(Msg.getString("TabPanelActivity.subTask"), "", null); //$NON-NLS-1$
 		subTaskPhaseArea = activityPanel.addTextField(Msg.getString("TabPanelActivity.subTaskPhase"), "", null); //$NON-NLS-1$
 		subTask1TextArea = activityPanel.addTextField(Msg.getString("TabPanelActivity.subTask1"), "", null); //$NON-NLS-1$
@@ -202,6 +206,18 @@ public class TabPanelActivity extends TabPanel implements ActionListener {
 		if (!taskTextCache.equals(newTaskText)) {
 			taskTextCache = newTaskText;
 			updateLabel(taskTextArea, newTaskText);
+
+			// Task has changed so update the score
+			var scoreLabel = "";
+			String scoreTooltip = null; 
+			RatingScore score = taskManager.getScore();
+			if (score != null) {
+				scoreLabel = StyleManager.DECIMAL_PLACES2.format(score.getScore());
+				scoreTooltip = score.getHTMLOutput();
+			}
+
+			updateLabel(scoreTextArea, scoreLabel);
+			scoreTextArea.setToolTipText(scoreTooltip);
 		}
 
 		if (taskTextCache.equals(""))
@@ -279,7 +295,6 @@ public class TabPanelActivity extends TabPanel implements ActionListener {
 	}
 
 	private static void updateLabel(JLabel label, String text) {
-		label.setToolTipText(text);
 		if (text.length() > MAX_LABEL) {
 			text = text.substring(0, MAX_LABEL - EXTRA.length()) + EXTRA;
 		}


### PR DESCRIPTION
This PR starts to expose the the ```Rating``` concept to the user via 2 changes:

- Backlog table now shows a tooltip of the composite score for any Tasks.
- The Robot/Person Acitivity Panel displays the score and the composition as a tooltip.

Both of these will help explain why Tasks are chosen.

To deliver this the ```MonitorModel``` and table tab now support displaying tooltips for a cell. The Score column in the Backlog table utilises this new feature. The tooltip content is generated in HTML by the RatingScore class using new entries from the message.properties following a naming convention of 'RatingScore.<modifier key>'.

To ensure the Task Jobs have some composition the Person & Robot modifier logic has been reworked to breakdown the score according to more parts.

close #1060 