### PR TITLE
Clean up MonitorModel part 2

### DIFF
--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/BacklogTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/BacklogTableModel.java
@@ -25,7 +25,6 @@ import org.mars_sim.msp.core.structure.Settlement;
  * This class models how SettlementTasks are organized and displayed
  * within the Monitor Window for a settlement.
  */
-@SuppressWarnings("serial")
 public class BacklogTableModel extends AbstractMonitorModel
 					implements UnitListener {
 
@@ -41,10 +40,10 @@ public class BacklogTableModel extends AbstractMonitorModel
 		COLUMNS = new ColumnSpec[SCORE_COL+1];
 		COLUMNS[ENTITY_COL] = new ColumnSpec("Entity", String.class);
 		COLUMNS[DESC_COL] = new ColumnSpec("Description", String.class);
-		COLUMNS[DEMAND_COL]  = new ColumnSpec("Demand", String.class);
+		COLUMNS[DEMAND_COL]  = new ColumnSpec("Demand", Integer.class);
 		COLUMNS[EVA_COL]  = new ColumnSpec("EVA", String.class);
 		COLUMNS[SCORE_COL] = new ColumnSpec("Score", Double.class);
-	};
+	}
 
 	private Settlement selectedSettlement;
 	private boolean monitorSettlement = false;
@@ -76,14 +75,6 @@ public class BacklogTableModel extends AbstractMonitorModel
 		}
 	}
 
-	/**
-	 * Has this model got a natural order that the model conforms to ?
-	 * If true, then it implies that the user should not be allowed to order.
-	 */
-	public boolean getOrdered() {
-		return false;
-	}
-    
 	/**
 	 * The Object 
 	 */
@@ -232,7 +223,7 @@ public class BacklogTableModel extends AbstractMonitorModel
 			case DESC_COL:
 				return selectedTask.getShortName();
 			case EVA_COL:
-				return selectedTask.isEVA();
+				return (selectedTask.isEVA() ? "Yes" : "No");
 			case DEMAND_COL:
 				return selectedTask.getDemand();
 			case SCORE_COL:

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/BuildingTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/BuildingTableModel.java
@@ -19,7 +19,6 @@ import org.mars_sim.msp.core.structure.building.BuildingManager;
  * The BuildingTableModel maintains a list of Building objects. By defaults the source
  * of the list is the Unit Manager. 
  */
-@SuppressWarnings("serial")
 public class BuildingTableModel extends UnitTableModel<Building> {
 
 	// Column indexes
@@ -35,7 +34,7 @@ public class BuildingTableModel extends UnitTableModel<Building> {
 	private static final int COLUMNCOUNT = 8;
 
 	/** Names of Columns. */
-	private static ColumnSpec[] COLUMNS;
+	private static final ColumnSpec[] COLUMNS;
 
 	/**
 	 * The static initializer creates the name & type arrays.

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/CropTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/CropTableModel.java
@@ -24,7 +24,6 @@ import org.mars_sim.msp.core.structure.building.function.farming.Farming;
 /**
  * The CropTableModel keeps track of the quantity of the growing crops in each greenhouse by categories.
  */
-@SuppressWarnings("serial")
 public class CropTableModel extends UnitTableModel<Building> {
 
 	// Column indexes

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/FoodInventoryTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/FoodInventoryTableModel.java
@@ -22,7 +22,6 @@ import org.mars_sim.msp.core.structure.Settlement;
  * This class model how food data is organized and displayed
  * within the Monitor Window for a settlement.
  */
-@SuppressWarnings("serial")
 public class FoodInventoryTableModel extends EntityTableModel<Food>
 implements UnitListener {
 	
@@ -54,7 +53,7 @@ implements UnitListener {
 		COLUMNS[NATIONAL_VP_COL] = new ColumnSpec("National VP", Double.class);
 		COLUMNS[COST_COL] = new ColumnSpec("Cost [$]", Double.class);
 		COLUMNS[PRICE_COL] = new ColumnSpec("Price [$]", Double.class);
-	};
+	}
 
 	private Settlement selectedSettlement;
 	private boolean monitorSettlement = false;
@@ -87,14 +86,7 @@ implements UnitListener {
 		}
 	}
 
-	/**
-	 * Has this model got a natural order that the model conforms to. If this value
-	 * is true, then it implies that the user should not be allowed to order.
-	 */
-	public boolean getOrdered() {
-		return false;
-	}
-
+	@Override
 	protected Object getEntityValue(Food selectedFood, int columnIndex) {
 		switch(columnIndex) {
 			case 0:

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/MissionTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/MissionTableModel.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.SwingUtilities;
-import javax.swing.table.AbstractTableModel;
 
 import org.mars.sim.tools.Msg;
 import org.mars_sim.msp.core.GameManager;
@@ -35,9 +34,8 @@ import org.mars_sim.msp.core.vehicle.Vehicle;
  * This class model how mission data is organized and displayed
  * within the Monitor Window for all settlements.
  */
-@SuppressWarnings("serial")
-public class MissionTableModel extends AbstractTableModel
-		implements MonitorModel, MissionManagerListener, MissionListener {
+public class MissionTableModel extends AbstractMonitorModel
+		implements MissionManagerListener, MissionListener {
 
 	// Column indexes
 	/** Date filed column. */
@@ -73,9 +71,8 @@ public class MissionTableModel extends AbstractTableModel
 	/** The number of Columns. */
 	private static final int COLUMNCOUNT = 15;
 	/** Names of Columns. */
-	private static String[] columnNames;
-	/** Types of Columns. */
-	private static Class<?>[] columnTypes;
+	private static final ColumnSpec[] COLUMNS;
+
 
 	private GameMode mode = GameManager.getGameMode();
 	
@@ -88,44 +85,29 @@ public class MissionTableModel extends AbstractTableModel
 	private MissionManager missionManager;
 
 	static {
-		columnNames = new String[COLUMNCOUNT];
-		columnTypes = new Class[COLUMNCOUNT];
-		columnNames[DATE_FILED] = Msg.getString("MissionTableModel.column.filed"); //$NON-NLS-1$
-		columnTypes[DATE_FILED] = MarsTime.class;
-		columnNames[DATE_EMBARKED] = Msg.getString("MissionTableModel.column.embarked"); //$NON-NLS-1$
-		columnTypes[DATE_EMBARKED] = MarsTime.class;
-		columnNames[DATE_RETURNED] = Msg.getString("MissionTableModel.column.returned"); //$NON-NLS-1$
-		columnTypes[DATE_RETURNED] = MarsTime.class;
-		columnNames[STARTING_MEMBER] = Msg.getString("MissionTableModel.column.name"); //$NON-NLS-1$
-		columnTypes[STARTING_MEMBER] = String.class;
-		columnNames[TYPE_ID] = Msg.getString("MissionTableModel.column.typeID"); //$NON-NLS-1$
-		columnTypes[TYPE_ID] = String.class;
-		columnNames[DESIGNATION] = Msg.getString("MissionTableModel.column.designation"); //$NON-NLS-1$
-		columnTypes[DESIGNATION] = String.class;
-		columnNames[PHASE] = Msg.getString("MissionTableModel.column.phase"); //$NON-NLS-1$
-		columnTypes[PHASE] = String.class;
-		columnNames[STARTING_SETTLEMENT] = Msg.getString("MissionTableModel.column.startingSettlement"); //$NON-NLS-1$
-		columnTypes[STARTING_SETTLEMENT] = String.class;
-		columnNames[VEHICLE] = Msg.getString("MissionTableModel.column.vehicle"); //$NON-NLS-1$
-		columnTypes[VEHICLE] = String.class;
-		columnNames[MEMBER_NUM] = Msg.getString("MissionTableModel.column.members"); //$NON-NLS-1$
-		columnTypes[MEMBER_NUM] = Integer.class;
-		columnNames[NAVPOINT_NUM] = Msg.getString("MissionTableModel.column.navpoints"); //$NON-NLS-1$
-		columnTypes[NAVPOINT_NUM] = Integer.class;
-		columnNames[TRAVELLED_DISTANCE] = Msg.getString("MissionTableModel.column.distanceTravelled"); //$NON-NLS-1$
-		columnTypes[TRAVELLED_DISTANCE] = Integer.class;
-		columnNames[TOTAL_REMAINING_DISTANCE] = Msg.getString("MissionTableModel.column.totalRemaining"); //$NON-NLS-1$
-		columnTypes[TOTAL_REMAINING_DISTANCE] = Integer.class;
-		columnNames[REMAINING_DISTANCE_TO_NEXT_NAVPOINT] = Msg.getString("MissionTableModel.column.legRemaining"); //$NON-NLS-1$
-		columnTypes[REMAINING_DISTANCE_TO_NEXT_NAVPOINT] = Integer.class;		
-		columnNames[PROPOSED_ROUTE_DISTANCE] = Msg.getString("MissionTableModel.column.proposedDistance"); //$NON-NLS-1$
-		columnTypes[PROPOSED_ROUTE_DISTANCE] = Integer.class;
+		COLUMNS = new ColumnSpec[COLUMNCOUNT];
+		COLUMNS[DATE_FILED] = new ColumnSpec(Msg.getString("MissionTableModel.column.filed"), MarsTime.class);
+		COLUMNS[DATE_EMBARKED] = new ColumnSpec(Msg.getString("MissionTableModel.column.embarked"), MarsTime.class);
+		COLUMNS[DATE_RETURNED] = new ColumnSpec(Msg.getString("MissionTableModel.column.returned"), MarsTime.class);
+		COLUMNS[STARTING_MEMBER] = new ColumnSpec(Msg.getString("MissionTableModel.column.name"), String.class);
+		COLUMNS[TYPE_ID] = new ColumnSpec(Msg.getString("MissionTableModel.column.typeID"), String.class);
+		COLUMNS[DESIGNATION] = new ColumnSpec(Msg.getString("MissionTableModel.column.designation"), String.class);
+		COLUMNS[PHASE] = new ColumnSpec(Msg.getString("MissionTableModel.column.phase"), String.class);
+		COLUMNS[STARTING_SETTLEMENT] = new ColumnSpec(Msg.getString("MissionTableModel.column.startingSettlement"), String.class);
+		COLUMNS[VEHICLE] = new ColumnSpec(Msg.getString("MissionTableModel.column.vehicle"), String.class);
+		COLUMNS[MEMBER_NUM] = new ColumnSpec(Msg.getString("MissionTableModel.column.members"), Integer.class);
+		COLUMNS[NAVPOINT_NUM] = new ColumnSpec(Msg.getString("MissionTableModel.column.navpoints"), Integer.class);
+		COLUMNS[TRAVELLED_DISTANCE] = new ColumnSpec(Msg.getString("MissionTableModel.column.distanceTravelled"), Integer.class);
+		COLUMNS[TOTAL_REMAINING_DISTANCE] = new ColumnSpec(Msg.getString("MissionTableModel.column.totalRemaining"), Integer.class);
+		COLUMNS[REMAINING_DISTANCE_TO_NEXT_NAVPOINT] = new ColumnSpec(Msg.getString("MissionTableModel.column.legRemaining"), Integer.class);		
+		COLUMNS[PROPOSED_ROUTE_DISTANCE] = new ColumnSpec(Msg.getString("MissionTableModel.column.proposedDistance"), Integer.class);
 	}
 
 	/**
 	 * Constructor.
 	 */
 	public MissionTableModel(Simulation sim) {
+		super(Msg.getString("MissionTableModel.tabName"), "MissionTableModel.numberOfMissions", COLUMNS);
 
 		missionManager = sim.getMissionManager();
 		if (mode == GameMode.COMMAND) {
@@ -173,17 +155,6 @@ public class MissionTableModel extends AbstractTableModel
 	public boolean setSettlementFilter(Settlement filter) {
 		// Mission doesn't support filtering ???
 		return false;
-	}
-
-	/**
-	 * Gets the name of this model. The name will be a description helping the user
-	 * understand the contents.
-	 *
-	 * @return Descriptive name.
-	 */
-	@Override
-	public String getName() {
-		return Msg.getString("MissionTableModel.tabName"); //$NON-NLS-1$
 	}
 
 	/**
@@ -235,34 +206,6 @@ public class MissionTableModel extends AbstractTableModel
 	}
 
 	/**
-	 * Returns the type of the column requested.
-	 *
-	 * @param columnIndex Index of column.
-	 * @return Class of specified column.
-	 */
-	@Override
-	public Class<?> getColumnClass(int columnIndex) {
-		if ((columnIndex >= 0) && (columnIndex < columnTypes.length)) {
-			return columnTypes[columnIndex];
-		}
-		return Object.class;
-	}
-
-	/**
-	 * Returns the name of the column requested.
-	 *
-	 * @param columnIndex Index of column.
-	 * @return name of specified column.
-	 */
-	@Override
-	public String getColumnName(int columnIndex) {
-		if ((columnIndex >= 0) && (columnIndex < columnNames.length)) {
-			return columnNames[columnIndex];
-		}
-		return Msg.getString("unknown"); //$NON-NLS-1$
-	}
-
-	/**
 	 * Returns the object at the specified row indexes.
 	 *
 	 * @param row Index of the row object.
@@ -271,23 +214,6 @@ public class MissionTableModel extends AbstractTableModel
 	@Override
 	public Object getObject(int row) {
 		return missionCache.get(row);
-	}
-
-	/**
-	 * Has this model got a natural order that the model conforms to. If this value
-	 * is true, then it implies that the user should not be allowed to order.
-	 */
-	public boolean getOrdered() {
-		return false;
-	}
-
-	/**
-	 * Gets the model count string.
-	 */
-	@Override
-	public String getCountString() {
-		return "  " + Msg.getString("MissionTableModel.numberOfMissions", //$NON-NLS-2$
-				missionCache.size());
 	}
 
 	/**
@@ -301,66 +227,46 @@ public class MissionTableModel extends AbstractTableModel
 		int index = missionCache.indexOf(event.getSource());
 
 		if (index > -1) {
+			List<Integer> columnsToUpdate = new ArrayList<>();
 			MissionEventType eventType = event.getType();
-
-			int column0 = -1;
-
-			if (eventType == MissionEventType.VEHICLE_EVENT)
-				column0 = VEHICLE;
-			else if (eventType == MissionEventType.STARTING_SETTLEMENT_EVENT)
-				column0 = STARTING_SETTLEMENT;
-			else if (eventType == MissionEventType.TYPE_ID_EVENT)
-				column0 = TYPE_ID;
-			else if (eventType == MissionEventType.DESIGNATION_EVENT)
-				column0 = DESIGNATION;
-			else if (eventType == MissionEventType.ADD_MEMBER_EVENT
-					|| eventType == MissionEventType.REMOVE_MEMBER_EVENT)
-				column0 = MEMBER_NUM;
-			else if (eventType == MissionEventType.DATE_EVENT)
-				column0 = DATE_FILED;
-			else if (eventType == MissionEventType.NAME_EVENT)
-				column0 = STARTING_MEMBER;
+			int column0 = switch (eventType) {
+				case VEHICLE_EVENT -> VEHICLE;
+				case STARTING_SETTLEMENT_EVENT -> STARTING_SETTLEMENT;
+				case TYPE_ID_EVENT -> TYPE_ID;
+				case DESIGNATION_EVENT ->DESIGNATION;
+				case ADD_MEMBER_EVENT, REMOVE_MEMBER_EVENT -> MEMBER_NUM;
+				case DATE_EVENT -> DATE_FILED;
+				case NAME_EVENT ->STARTING_MEMBER;
+				default -> -1;
+			};
 
 			if (column0 > -1)
-				SwingUtilities.invokeLater(new MissionTableCellUpdater(index, column0));
+				columnsToUpdate.add(column0);
 
-			if (event.getSource() instanceof VehicleMission) {
+			if (event.getSource() instanceof VehicleMission) {	
+				switch(eventType) {
 
-				int column1 = -1;
-				int column2 = -1;
-				int column3 = -1;
-				int column4 = -1;
-				int column5 = -1;
-				int column6 = -1;
-				
-				if (eventType == MissionEventType.DISTANCE_EVENT) {
-					column1 = TRAVELLED_DISTANCE;
-					column2 = TOTAL_REMAINING_DISTANCE;
-					column3 = REMAINING_DISTANCE_TO_NEXT_NAVPOINT;
-					column4 = PROPOSED_ROUTE_DISTANCE;
+					case DISTANCE_EVENT: {
+						columnsToUpdate.add(TRAVELLED_DISTANCE);
+						columnsToUpdate.add(TOTAL_REMAINING_DISTANCE);
+						columnsToUpdate.add(REMAINING_DISTANCE_TO_NEXT_NAVPOINT);
+						columnsToUpdate.add(PROPOSED_ROUTE_DISTANCE);
+					} break;
+
+					case NAVPOINTS_EVENT:
+						columnsToUpdate.add(NAVPOINT_NUM);
+						break;
+
+					case PHASE_EVENT, PHASE_DESCRIPTION_EVENT:
+						columnsToUpdate.add(PHASE);
+						break;
+					default:
+						break;
 				}
-
-				if (eventType == MissionEventType.NAVPOINTS_EVENT)
-					column5 = NAVPOINT_NUM;
-
-				if (eventType == MissionEventType.PHASE_EVENT
-						|| eventType == MissionEventType.PHASE_DESCRIPTION_EVENT)
-					column6 = PHASE;
-
-				// TODO THis is pretty bad. Shoudl rework to only fire a single invokeLater uisng a columns range
-				if (column0 > -1)
-					SwingUtilities.invokeLater(new MissionTableCellUpdater(index, column1));
-				if (column1 > -1)
-					SwingUtilities.invokeLater(new MissionTableCellUpdater(index, column2));
-				if (column2 > -1)
-					SwingUtilities.invokeLater(new MissionTableCellUpdater(index, column3));
-				if (column3 > -1)
-					SwingUtilities.invokeLater(new MissionTableCellUpdater(index, column4));
-				if (column4 > -1)
-					SwingUtilities.invokeLater(new MissionTableCellUpdater(index, column5));
-				if (column5 > -1)
-					SwingUtilities.invokeLater(new MissionTableCellUpdater(index, column6));
 			}
+
+			if (!columnsToUpdate.isEmpty())
+				SwingUtilities.invokeLater(new MissionTableCellUpdater(index, columnsToUpdate));
 		}
 	}
 
@@ -368,27 +274,6 @@ public class MissionTableModel extends AbstractTableModel
 	public int getRowCount() {
 		return missionCache.size();
 	}
-
-	/**
-	 * Return the number of columns
-	 *
-	 * @return column count.
-	 */
-	@Override
-	public int getColumnCount() {
-		return COLUMNCOUNT;
-	}
-
-	/**
-     * Default implementation return null as no tooltips are supported by default
-     * @param rowIndex Row index of cell
-     * @param columnIndex Column index of cell
-     * @return Return null by default
-     */
-    @Override
-    public String getToolTipAt(int rowIndex, int columnIndex) {
-        return null;
-    }
 
 	/**
 	 * Returns the value of a Cell.
@@ -544,6 +429,7 @@ public class MissionTableModel extends AbstractTableModel
 		}
 
 		missionManager.removeListener(this);
+		super.destroy();
 	}
 
 	/**
@@ -552,16 +438,20 @@ public class MissionTableModel extends AbstractTableModel
 	private class MissionTableCellUpdater implements Runnable {
 
 		private int row;
-		private int column;
+		private List<Integer> columns;
 
-		private MissionTableCellUpdater(int row, int column) {
+		private MissionTableCellUpdater(int row, List<Integer>columns) {
 			this.row = row;
-			this.column = column;
+			this.columns = columns;
 		}
 
 		public void run() {
-			if ((row < getRowCount()) && (column < getColumnCount()))
-				fireTableCellUpdated(row, column);
+			if (row < getRowCount()) {
+				for(int column : columns) {
+					if (column < getColumnCount())
+						fireTableCellUpdated(row, column);
+				}
+			}
 		}
 	}
 

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/MonitorModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/MonitorModel.java
@@ -35,13 +35,6 @@ interface MonitorModel extends TableModel {
 	public Object getObject(int row);
 
 	/**
-	 * Has this model got a natural order that the model conforms to. If this
-	 * value is true, then it implies that the user should not be allowed to
-	 * order.
-	 */
-	public boolean getOrdered();
-
-	/**
 	 * Prepares the model for deletion.
 	 */
 	public void destroy();

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/PieChartTab.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/PieChartTab.java
@@ -184,7 +184,7 @@ class PieChartTab extends MonitorTab {
                 int count = 0;
                 Iterator<String> i = keys.iterator();
                 while (i.hasNext()) {
-                    if (key == i.next()) result = count;
+                    if (key.equals(i.next())) result = count;
                     else count++;
                 }
             }

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/RobotTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/RobotTableModel.java
@@ -33,7 +33,6 @@ import org.mars_sim.msp.core.vehicle.Crewable;
  * of the list is the Unit Manager. It maps key attributes of the Robot into
  * Columns.
  */
-@SuppressWarnings("serial")
 public class RobotTableModel extends UnitTableModel<Robot> {
 
 	/**
@@ -281,9 +280,9 @@ public class RobotTableModel extends UnitTableModel<Robot> {
 				break;
 
 			case MISSION_COL: 
-				Mission mission = robot.getBotMind().getMission();
-				if (mission != null) {
-					result = mission.getName();
+				Mission m = robot.getBotMind().getMission();
+				if (m != null) {
+					result = m.getName();
 				}
 				break;
 		

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/SettlementTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/SettlementTableModel.java
@@ -28,7 +28,6 @@ import org.mars_sim.msp.core.vehicle.Vehicle;
  * The SettlementTableModel that maintains a list of Settlement objects. It maps
  * key attributes of the Settlement into Columns.
  */
-@SuppressWarnings("serial")
 public class SettlementTableModel extends UnitTableModel<Settlement> {
 
 	// Column indexes

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/TableTab.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/TableTab.java
@@ -93,12 +93,10 @@ abstract class TableTab extends MonitorTab {
 			}
 		});
 
-		// If the model is not fixed ordered then allow user to select order
-		if (!model.getOrdered()) {
-			TableRowSorter<TableModel> sorter = new TableRowSorter<TableModel>(model);
-			table.setRowSorter(sorter);
-			sorter.setSortsOnUpdates(true);
-		}
+		// Allow orderring
+		TableRowSorter<TableModel> sorter = new TableRowSorter<>(model);
+		table.setRowSorter(sorter);
+		sorter.setSortsOnUpdates(true);
 
 		// Set single selection mode if necessary.
 		if (singleSelection)

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/TradeTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/TradeTableModel.java
@@ -26,7 +26,6 @@ import org.mars_sim.msp.core.structure.Settlement;
 import org.mars_sim.msp.core.vehicle.VehicleType;
 
 
-@SuppressWarnings("serial")
 public class TradeTableModel extends EntityTableModel<Good>
 implements UnitListener {
 
@@ -140,19 +139,11 @@ implements UnitListener {
 	}
 
 	/**
-	 * Has this model got a natural order that the model conforms to ?
-	 *
-	 * @return If true, it implies that the user should not be allowed to order.
-	 */
-	public boolean getOrdered() {
-		return false;
-	}
-
-	/**
 	 * get the value for a Good property
 	 * @param selectedGood Good selected
 	 * @param columnIndex COlumn to get
 	 */
+	@Override
 	protected  Object getEntityValue(Good selectedGood, int columnIndex) {
 		switch(columnIndex) {
 			case 0:

--- a/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/UnitTableModel.java
+++ b/mars-sim-ui/src/main/java/org/mars_sim/msp/ui/swing/tool/monitor/UnitTableModel.java
@@ -18,7 +18,6 @@ import org.mars_sim.msp.core.UnitType;
  * The UnitTableModel that maintains a table model of Units objects. It is only
  * a partial implementation of the TableModel interface.
  */
-@SuppressWarnings("serial")
 public abstract class UnitTableModel<T extends Unit> extends EntityTableModel<T>
 		implements UnitListener {
 
@@ -125,17 +124,6 @@ public abstract class UnitTableModel<T extends Unit> extends EntityTableModel<T>
 		oldUnit.removeUnitListener(this);
 	}
 
-	/**
-	 * Is this model already ordered according to some external criteria.
-	 *
-	 * @return FALSE as the Units have no natural order.
-	 */
-	@Override
-	public boolean getOrdered() {
-		return false;
-	}
-
-	
 	/**
 	 * Prepares the model for deletion.
 	 */


### PR DESCRIPTION
Goal is to clean-up code and remove duplicates

Changes:
- MissionTableModel, BacklogModel & EventTableModel now use the new AbstractMonitorModel
- Allow user to sort on any monitor table column; all column types can be correctly ordered now since the delivery of MarsTime
- Optimise MissionTableModel to effeciently update multiple columns in response to Unit event
- Fix problem in BarChartTab & PieChartTab so it handles values correctly that are null
- Cleaned up BarChartTab & PieChartTab
- Fix sorting problem on BacklogModel due to incorrect column types confusing sorter