### PR TITLE
SettlementMetaTask conversation to Ratings 

### DIFF
--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/data/RatingLog.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/data/RatingLog.java
@@ -140,8 +140,13 @@ public class RatingLog {
     private static String ratingToJsonLines(RatingScore r) {
         StringBuilder output = new StringBuilder();
 
-        output.append("{\"score\":").append(SCORE_FORMAT.format(r.getScore()))
-                .append(",\"base\":").append(SCORE_FORMAT.format(r.getBase()));
+        output.append("{\"score\":").append(SCORE_FORMAT.format(r.getScore()));
+        output.append(",\"bases\":{");
+        output.append(r.getBases().entrySet().stream()
+                        .map(entry -> "\"" + entry.getKey() + "\":"
+                                    + SCORE_FORMAT.format(entry.getValue()))
+                        .collect(Collectors.joining(",")));
+        output.append('}');
 
         var modifiers = r.getModifiers();     
         if (!modifiers.isEmpty()) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/FieldStudyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/mission/meta/FieldStudyMeta.java
@@ -6,7 +6,6 @@
  */
 package org.mars_sim.msp.core.person.ai.mission.meta;
 
-import java.util.Iterator;
 import java.util.Set;
 
 import org.mars_sim.msp.core.data.RatingScore;
@@ -23,7 +22,12 @@ import org.mars_sim.msp.core.vehicle.Rover;
 
 public class FieldStudyMeta extends AbstractMetaMission {
 
-    private static final double WEIGHT = 10D;
+	private static final Set<RoleType> PREFERRED_ROLES = Set.of(RoleType.CHIEF_OF_SCIENCE,
+							RoleType.MISSION_SPECIALIST, RoleType.CHIEF_OF_MISSION_PLANNING,
+							RoleType.SCIENCE_SPECIALIST, RoleType.COMMANDER,
+							RoleType.SUB_COMMANDER);
+	private static final String STUDY_BASE = "study";
+	private static final double WEIGHT = 10D;
 	private ScienceType science;
 
 	public FieldStudyMeta(MissionType type, Set<JobType> preferredLeaderJob,
@@ -35,76 +39,64 @@ public class FieldStudyMeta extends AbstractMetaMission {
 	@Override
 	public RatingScore getProbability(Person person) {
 
-		if (FieldStudyMission.determineStudy(science, person) == null) {
+		RoleType roleType = person.getRole().getType();
+		JobType jobType = person.getMind().getJob();
+
+		if ((FieldStudyMission.determineStudy(science, person) == null)
+			|| !person.isInSettlement()
+			|| (!getPreferredLeaderJob().contains(jobType)
+					&& !PREFERRED_ROLES.contains(roleType))) {
 			return RatingScore.ZERO_RATING;
 		}
 
-	    RatingScore missionProbability = RatingScore.ZERO_RATING;
+		Settlement settlement = person.getSettlement();
 
-	    if (person.isInSettlement()) {
-	    	Settlement settlement = person.getSettlement();
+		RatingScore missionProbability = new RatingScore(STUDY_BASE, 1D);
+			
+		// Get available rover.
+		Rover rover = RoverMission.getVehicleWithGreatestRange(settlement, false);
+		if (rover != null) {
+			double newBase = 0;
 
-	        RoleType roleType = person.getRole().getType();
-			JobType jobType = person.getMind().getJob();
+			// Add probability for researcher's primary study (if any).
+			ScientificStudy primaryStudy = person.getStudy();
+			if ((primaryStudy != null) && ScientificStudy.RESEARCH_PHASE.equals(primaryStudy.getPhase())
+					&& !primaryStudy.isPrimaryResearchCompleted()
+					&& (science == primaryStudy.getScience())) {
+				newBase += WEIGHT;
+			}
 
-			if (getPreferredLeaderJob().contains(jobType)
-					|| RoleType.CHIEF_OF_SCIENCE == roleType
-					|| RoleType.MISSION_SPECIALIST == roleType
-					|| RoleType.CHIEF_OF_MISSION_PLANNING == roleType
-					|| RoleType.SCIENCE_SPECIALIST == roleType
-					|| RoleType.COMMANDER == roleType
-					|| RoleType.SUB_COMMANDER == roleType
-					) {
-				missionProbability = new RatingScore(1D);
-				
-				// Get available rover.
-				Rover rover = (Rover) RoverMission.getVehicleWithGreatestRange(settlement, false);
-				if (rover != null) {
-					double newBase = 0;
-
-					// Add probability for researcher's primary study (if any).
-					ScientificStudy primaryStudy = person.getStudy();
-					if ((primaryStudy != null) && ScientificStudy.RESEARCH_PHASE.equals(primaryStudy.getPhase())
-							&& !primaryStudy.isPrimaryResearchCompleted()
-							&& (science == primaryStudy.getScience())) {
-						newBase += WEIGHT;
-					}
-
-					// Add probability for each study researcher is collaborating on.
-					Iterator<ScientificStudy> i = person.getCollabStudies().iterator();
-					while (i.hasNext()) {
-						ScientificStudy collabStudy = i.next();
-						if (ScientificStudy.RESEARCH_PHASE.equals(collabStudy.getPhase())
-								&& !collabStudy.isCollaborativeResearchCompleted(person)
-								&& (science == collabStudy.getContribution(person))) {
-							newBase += WEIGHT/2D;
-						}
-					}
-
-					missionProbability.setBase(newBase);
+			// Add probability for each study researcher is collaborating on.
+			for(ScientificStudy collabStudy : person.getCollabStudies()) {
+				if (ScientificStudy.RESEARCH_PHASE.equals(collabStudy.getPhase())
+						&& !collabStudy.isCollaborativeResearchCompleted(person)
+						&& (science == collabStudy.getContribution(person))) {
+					newBase += WEIGHT/2D;
 				}
+			}
 
-				missionProbability.addModifier(SETTLEMENT_POPULATION,
-								getSettlementPopModifier(settlement, 4));
+			missionProbability.addBase(STUDY_BASE, newBase);
+		}
 
-	            // Crowding modifier
-	            int crowding = settlement.getIndoorPeopleCount() - settlement.getPopulationCapacity();
-	            if (crowding > 0) missionProbability.addModifier(OVER_CROWDING, crowding + 1);
+		missionProbability.addModifier(SETTLEMENT_POPULATION,
+						getSettlementPopModifier(settlement, 4));
 
-	            // Job modifier.
-	            missionProbability.addModifier(LEADER, getLeaderSuitability(person));
-	            missionProbability.addModifier(GOODS, (settlement.getGoodsManager().getTourismFactor()
-	                    + settlement.getGoodsManager().getResearchFactor())/1.5);
+		// Crowding modifier
+		int crowding = settlement.getIndoorPeopleCount() - settlement.getPopulationCapacity();
+		if (crowding > 0) missionProbability.addModifier(OVER_CROWDING, crowding + 1);
 
-				// if introvert, score  0 to  50 --> -2 to 0
-				// if extrovert, score 50 to 100 -->  0 to 2
-				// Reduce probability if introvert
-				int extrovert = person.getExtrovertmodifier();
-				missionProbability.addModifier(PERSON_EXTROVERT, (1 + extrovert/2.0));
+		// Job modifier.
+		missionProbability.addModifier(LEADER, getLeaderSuitability(person));
+		missionProbability.addModifier(GOODS, (settlement.getGoodsManager().getTourismFactor()
+				+ settlement.getGoodsManager().getResearchFactor())/1.5);
 
-				missionProbability.applyRange(0, LIMIT);
-	        }
-	    }
+		// if introvert, score  0 to  50 --> -2 to 0
+		// if extrovert, score 50 to 100 -->  0 to 2
+		// Reduce probability if introvert
+		int extrovert = person.getExtrovertmodifier();
+		missionProbability.addModifier(PERSON_EXTROVERT, (1 + extrovert/2.0));
+
+		missionProbability.applyRange(0, LIMIT);
 
 	    return missionProbability;
 	}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ConsolidateContainersMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ConsolidateContainersMeta.java
@@ -38,7 +38,7 @@ public class ConsolidateContainersMeta extends FactoryMetaTask implements Settle
 		
 		private static final long serialVersionUID = 1L;
 
-		public ConsolidateTaskJob(SettlementMetaTask owner, double score) {
+		public ConsolidateTaskJob(SettlementMetaTask owner, RatingScore score) {
 			super(owner, "Consolidate Containers", null, score);
 		}
 
@@ -81,7 +81,9 @@ public class ConsolidateContainersMeta extends FactoryMetaTask implements Settle
                         needsConsolidation(person.getVehicle(), false)) {
             // Create a real list
             result = new ArrayList<>();
-            result.add(new ConsolidateTaskJob(this, DEFAULT_SCORE * getPersonModifier(person)));
+            RatingScore score = new RatingScore(DEFAULT_SCORE);
+            assessPersonSuitability(score, person);
+            result.add(new ConsolidateTaskJob(this, score));
         }
         return result;
 	}
@@ -108,7 +110,7 @@ public class ConsolidateContainersMeta extends FactoryMetaTask implements Settle
         if (needsConsolidation(settlement, true)) {
             // Create a real list
             result = new ArrayList<>();
-            result.add(new ConsolidateTaskJob(this, DEFAULT_SCORE));
+            result.add(new ConsolidateTaskJob(this, new RatingScore(DEFAULT_SCORE)));
         }
         return result;
     }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ExamineBodyMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ExamineBodyMeta.java
@@ -39,7 +39,7 @@ public class ExamineBodyMeta  extends MetaTask implements SettlementMetaTask {
 
         private DeathInfo patient;
 
-        public ExamineBodyJob(SettlementMetaTask owner, DeathInfo patient, double score) {
+        public ExamineBodyJob(SettlementMetaTask owner, DeathInfo patient, RatingScore score) {
 			super(owner, "Examine Body", patient.getPerson(), score);
             this.patient = patient;
         }
@@ -107,8 +107,9 @@ public class ExamineBodyMeta  extends MetaTask implements SettlementMetaTask {
 		if (!deaths.isEmpty() && hasNeedyMedicalAidsAtSettlement(settlement)) {
 			for(DeathInfo pm : deaths) {
 				if (!pm.getExamDone()) {
-					double score = DEFAULT_SCORE +
-							((getMarsTime().getMissionSol() - pm.getTimeOfDeath().getMissionSol()) * SOL_SCORE);
+					RatingScore score = new RatingScore(DEFAULT_SCORE);
+					score.addBase("due",
+							(getMarsTime().getMissionSol() - pm.getTimeOfDeath().getMissionSol()) * SOL_SCORE);
 					tasks.add(new ExamineBodyJob(this, pm, score));
 				}
 			}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/MaintainBuildingMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/MaintainBuildingMeta.java
@@ -152,7 +152,7 @@ public class MaintainBuildingMeta extends MetaTask implements SettlementMetaTask
 			// the standard inspection/maintenance due
 			|| hasPartsInStore) {
 			// Score is based on condition plus %age overdue
-			score = new RatingScore(100 - condition);
+			score = new RatingScore("condition", 100 - condition);
 			score.addModifier("due", 1D +
 								((effectiveTime - minMaintenance) / minMaintenance));
 			if (hasPartsInStore) {

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/MaintainBuildingMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/MaintainBuildingMeta.java
@@ -44,7 +44,7 @@ public class MaintainBuildingMeta extends MetaTask implements SettlementMetaTask
 		private static final long serialVersionUID = 1L;
 
 
-        public MaintainTaskJob(SettlementMetaTask owner, Building target, boolean eva, double score) {
+        public MaintainTaskJob(SettlementMetaTask owner, Building target, boolean eva, RatingScore score) {
 			super(owner, "Building Maintenance " + (eva ? "via EVA " : ""), target, score);
 			setEVA(eva);
         }
@@ -114,9 +114,9 @@ public class MaintainBuildingMeta extends MetaTask implements SettlementMetaTask
 		List<SettlementTask> tasks = new ArrayList<>();
 	
 		for (Building building: settlement.getBuildingManager().getBuildingSet()) {
-			double score = scoreMaintenance(building);
+			RatingScore score = scoreMaintenance(building);
 
-			if (score > 0) {
+			if (score.getScore() > 0) {
 				boolean habitableBuilding = building.hasFunction(FunctionType.LIFE_SUPPORT);
 				tasks.add(new MaintainTaskJob(this, building, !habitableBuilding, score));
 			}
@@ -132,12 +132,12 @@ public class MaintainBuildingMeta extends MetaTask implements SettlementMetaTask
 	 * @param entity
 	 * @return A score on the need for maintenance
 	 */
-	public static double scoreMaintenance(Malfunctionable entity) {
+	public static RatingScore scoreMaintenance(Malfunctionable entity) {
 		MalfunctionManager manager = entity.getMalfunctionManager();
 		boolean hasNoMalfunction = !manager.hasMalfunction();
 		boolean hasPartsInStore = manager.hasMaintenancePartsInStorage(entity.getAssociatedSettlement());
 
-		double score = 0D;
+		RatingScore score = RatingScore.ZERO_RATING;
 		double condition = manager.getAdjustedCondition();
 		double effectiveTime = manager.getEffectiveTimeSinceLastMaintenance();
 		double minMaintenance = manager.getMaintenancePeriod();
@@ -152,13 +152,15 @@ public class MaintainBuildingMeta extends MetaTask implements SettlementMetaTask
 			// the standard inspection/maintenance due
 			|| hasPartsInStore) {
 			// Score is based on condition plus %age overdue
-			score = (100 - condition) + (effectiveTime - minMaintenance) * 100D / minMaintenance;
+			score = new RatingScore(100 - condition);
+			score.addModifier("due", 1D +
+								((effectiveTime - minMaintenance) / minMaintenance));
 			if (hasPartsInStore) {
 				// If needed parts are available, double up the speed of the maintenance
-				score = score * 2;
+				score.addModifier("parts", 2);
 			}
 		}
-
+ 
 		return score;
 	}
 }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/MaintainVehicleMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/MaintainVehicleMeta.java
@@ -37,7 +37,7 @@ public class MaintainVehicleMeta extends MetaTask implements SettlementMetaTask 
 
 		private static final long serialVersionUID = 1L;
 
-        public VehicleMaintenanceJob(SettlementMetaTask owner, Vehicle target, boolean eva, double score) {
+        public VehicleMaintenanceJob(SettlementMetaTask owner, Vehicle target, boolean eva, RatingScore score) {
             super(owner, "Vehicle Maintenance " + (eva ? "via EVA " : ""), target, score);
 			setEVA(eva);
         }
@@ -101,10 +101,10 @@ public class MaintainVehicleMeta extends MetaTask implements SettlementMetaTask 
 		boolean insideTasks = getGarageSpaces(settlement) > 0;
 
 		for (Vehicle vehicle : getAllVehicleCandidates(settlement, false)) {
-			double score = MaintainBuildingMeta.scoreMaintenance(vehicle);
+			RatingScore score = MaintainBuildingMeta.scoreMaintenance(vehicle);
 
 			// Vehicle in need of maintenance
-			if (score > 0) {
+			if (score.getScore() > 0) {
 				tasks.add(new VehicleMaintenanceJob(this, vehicle, !insideTasks, score));
 			}
 		}

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/PlanMissionMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/PlanMissionMeta.java
@@ -33,7 +33,7 @@ public class PlanMissionMeta extends MetaTask implements SettlementMetaTask {
 		
 		private static final long serialVersionUID = 1L;
 
-        public PlanTaskJob(SettlementMetaTask owner, double score) {
+        public PlanTaskJob(SettlementMetaTask owner, RatingScore score) {
             super(owner, "Plan Mission", null, score);
         }
 
@@ -71,7 +71,7 @@ public class PlanMissionMeta extends MetaTask implements SettlementMetaTask {
         int optimalMissions = (int) settlement.getPreferenceModifier(Settlement.MISSION_LIMIT);
         int shortfall = optimalMissions - settlementMissions;
         if (shortfall > 0) {
-            results.add(new PlanTaskJob(this, 1.0 * shortfall * START_FACTOR));
+            results.add(new PlanTaskJob(this, new RatingScore(shortfall * START_FACTOR)));
         }
         return results;
     }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/TendAlgaePondMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/TendAlgaePondMeta.java
@@ -42,7 +42,7 @@ public class TendAlgaePondMeta extends MetaTask implements SettlementMetaTask {
 
         private AlgaeFarming pond;
 
-        public AlgaeTaskJob(SettlementMetaTask owner, AlgaeFarming pond, double score) {
+        public AlgaeTaskJob(SettlementMetaTask owner, AlgaeFarming pond, RatingScore score) {
             super(owner, "Tend Algae Pond", pond.getBuilding(), score);
             this.pond = pond;
         }
@@ -118,26 +118,27 @@ public class TendAlgaePondMeta extends MetaTask implements SettlementMetaTask {
 
         for(Building building : settlement.getBuildingManager().getBuildingSet(FunctionType.ALGAE_FARMING)) {
             AlgaeFarming pond = building.getAlgae();
-            double result = (pond.getUncleaned().size() + pond.getUninspected().size()) * 3D;
+            RatingScore result = new RatingScore("maintenance",
+                        (pond.getUncleaned().size() + pond.getUninspected().size()) * 3D);
 
             double ratio = pond.getSurplusRatio();
             		
-            result += ((1 - ratio) * 10D);
+            result.addBase("surplus", (1 - ratio) * 10D);
             
             double foodDemand = pond.getFoodDemand();
          
-            result += foodDemand * 10;
+            result.addBase("goods", foodDemand * 10);
             
             double foodMass = pond.getFoodMass();
             double algaeMass = pond.getCurrentAlgae();
             
             if (foodMass < 0)
             	// Need to 
-            	result += Math.exp(2 * (1 - foodMass));
+            	result.addBase("ratio", Math.exp(2 * (1 - foodMass)));
             else
-            	result += algaeMass / foodMass / 5;
+            	result.addBase("ratio", algaeMass / foodMass / 5);
             
-            if (result > 0) {
+            if (result.getScore() > 0) {
                 tasks.add(new AlgaeTaskJob(this, pond, result));
             }
         }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/TendFishTankMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/TendFishTankMeta.java
@@ -42,7 +42,7 @@ public class TendFishTankMeta extends MetaTask implements SettlementMetaTask {
 
         private Fishery tank;
 
-        public FishTaskJob(SettlementMetaTask owner, Fishery tank, double score) {
+        public FishTaskJob(SettlementMetaTask owner, Fishery tank, RatingScore score) {
             super(owner, "Tend Fish Tank", tank.getBuilding(), score);
             this.tank = tank;
         }
@@ -118,12 +118,13 @@ public class TendFishTankMeta extends MetaTask implements SettlementMetaTask {
 
         for(Building building : settlement.getBuildingManager().getBuildingSet(FunctionType.FISHERY)) {
             Fishery fishTank = building.getFishery();
-            double result = (fishTank.getUncleaned().size() + fishTank.getUninspected().size()) *3D;
+            RatingScore result = new RatingScore("maintenance", 
+                    (fishTank.getUncleaned().size() + fishTank.getUninspected().size()) *3D);
 
-            result += (fishTank.getSurplusStock() * 10D);
-            result += fishTank.getWeedDemand();
+            result.addBase("surplus", (fishTank.getSurplusStock() * 10D));
+            result.addBase("fish.weeds", fishTank.getWeedDemand());
             
-            if (result > 0) {
+            if (result.getScore() > 0) {
                 tasks.add(new FishTaskJob(this, fishTank, result));
             }
         }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/TendGreenhouseMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/TendGreenhouseMeta.java
@@ -40,7 +40,7 @@ public class TendGreenhouseMeta extends MetaTask implements SettlementMetaTask {
 
         private Farming farm;
 
-        public CropTaskJob(SettlementMetaTask owner, Farming farm, int demand, double score) {
+        public CropTaskJob(SettlementMetaTask owner, Farming farm, int demand, RatingScore score) {
             super(owner, "Tend crop", farm.getBuilding(), score);
             this.farm = farm;
 
@@ -88,7 +88,7 @@ public class TendGreenhouseMeta extends MetaTask implements SettlementMetaTask {
 
             if (farm.getFarmerNum() <= 2 * ls.getOccupantCapacity()) {
     			factor = super.assessPersonSuitability(t, p);
-                if (factor.getScore() == 0) {
+                if (factor.getScore() <= 0) {
                     return factor;
                 }
 
@@ -125,12 +125,12 @@ public class TendGreenhouseMeta extends MetaTask implements SettlementMetaTask {
         for (Building b : settlement.getBuildingManager().getFarmsNeedingWork()) {
             Farming farm = b.getFarming();
 
-            double score = farm.getTendingScore();
+            RatingScore score = new RatingScore(farm.getTendingScore());
 
             // Settlement factors
-            score *= goodsFactor ;
+            score.addModifier(GOODS_MODIFIER, goodsFactor);
 
-            if (score > 0) {
+            if (score.getScore() > 0) {
                 int workTask = farm.getNumNeedTending() / 2; // Each farmer can do 2 crop per visit
                 workTask = Math.min(workTask, b.getLifeSupport().getAvailableOccupancy());
                 workTask = Math.max(1, workTask);

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ToggleFuelPowerSourceMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ToggleFuelPowerSourceMeta.java
@@ -44,7 +44,7 @@ public class ToggleFuelPowerSourceMeta extends MetaTask implements SettlementMet
 		private FuelPowerSource powerSource;
 
         public PowerTaskJob(SettlementMetaTask owner, Building building, FuelPowerSource powerSource,
-                                    double score) {
+                                    RatingScore score) {
             super(owner, "Toggle " + powerSource.getType().getName(), building, score);
 			this.powerSource = powerSource;
 		}
@@ -135,8 +135,7 @@ public class ToggleFuelPowerSourceMeta extends MetaTask implements SettlementMet
             FuelPowerSource bestSource = null;
             PowerGeneration powerGeneration = building.getPowerGeneration();
             for(PowerSource powerSource : powerGeneration.getPowerSources()) {
-                if (powerSource instanceof FuelPowerSource) {
-                    FuelPowerSource fuelSource = (FuelPowerSource) powerSource;
+                if (powerSource instanceof FuelPowerSource fuelSource) {
                     double diff = scorePowerSource(settlement, fuelSource);
                     if (diff > bestDiff) {
                         bestDiff = diff;
@@ -145,8 +144,9 @@ public class ToggleFuelPowerSourceMeta extends MetaTask implements SettlementMet
                 }
             }
 
-            double score = bestDiff * FACTOR;
-            if (score > 0) {
+            if (bestDiff > 0) {
+                RatingScore score = new RatingScore(FACTOR);
+                score.addModifier("best", bestDiff);
                 tasks.add(new PowerTaskJob(this, building, bestSource, score));
             }
         }

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ToggleResourceProcessMeta.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/meta/ToggleResourceProcessMeta.java
@@ -44,7 +44,8 @@ public class ToggleResourceProcessMeta extends MetaTask implements SettlementMet
 
 		private ResourceProcess process;
 
-        public ToggleProcessJob(SettlementMetaTask mt, Building processBuilding, ResourceProcess process, double score) {
+        public ToggleProcessJob(SettlementMetaTask mt, Building processBuilding, ResourceProcess process,
+						RatingScore score) {
 			super(mt, "Toggle " + process.getProcessName(), processBuilding, score);
 			this.process = process;
         }
@@ -274,7 +275,7 @@ public class ToggleResourceProcessMeta extends MetaTask implements SettlementMet
 		}
 
 		if (bestProcess != null) {
-			return new ToggleProcessJob(this, building, bestProcess, bestScore);
+			return new ToggleProcessJob(this, building, bestProcess, new RatingScore(bestScore));
 		}
 
 		return null;

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/MetaTask.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/MetaTask.java
@@ -45,13 +45,12 @@ public abstract class MetaTask {
 		ANY_HOUR, WORK_HOUR, NONWORK_HOUR
 	}
 	
-	protected static final String PERSON_MODIFIER = "person";
 	protected static final String BUILDING_MODIFIER = "building";
 	private static final String EVA_MODIFIER = "eva";
-	private static final String RADIATION_MODIFIER = "radiation";
+	protected static final String GARAGED_MODIFIER = "garaged";
 	protected static final String GOODS_MODIFIER = "goods";
-
-
+	protected static final String PERSON_MODIFIER = "person";
+	private static final String RADIATION_MODIFIER = "radiation";
 
 	// Traits used to identify non-effort tasks
 	private static final Set<TaskTrait> PASSIVE_TRAITS

--- a/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/SettlementTask.java
+++ b/mars-sim-core/src/main/java/org/mars_sim/msp/core/person/ai/task/util/SettlementTask.java
@@ -25,18 +25,6 @@ public abstract class SettlementTask extends AbstractTaskJob {
     private boolean needsEVA = false;
 
     /**
-     * Old approach where a single double is used for scoring
-     * @param parent
-     * @param description
-     * @param focus
-     * @param score
-     * deprecated Use {@link #SettlementTask(SettlementMetaTask, String, Entity, RatingScore)}
-     */
-    protected SettlementTask(SettlementMetaTask parent, String description, Entity focus, double score) {
-        this(parent, description, focus, new RatingScore(score));
-    }
-
-    /**
      * Create an abstract Settlement task for the backlog that relates to an Entity within a Settlement
      * that can be executed by any Citizen.
      * @param parent The metatask that defines the eventual Task.

--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -990,20 +990,25 @@ RandomUtil.log.ceilingMustBePositive  = ceiling must be positive:
 RandomUtil.log.ceilingMustGreaterBase = ceiling must be greater than base.
 RandomUtil.log.weightMapIsNull        = weightedMap is null
 
-RatingScore.reviewer = Reviewer
+RatingScore.building = Building Suitability
 RatingScore.citizens = Citizens Count
 RatingScore.crowding = Overcrowding
-RatingScore.robot.expert = Robot Expertise
-RatingScore.leader = Leader
-RatingScore.extrovert = Person Extrovert
-RatingScore.building = Building Suitability
-RatingScore.medical = Medical Skill
+RatingScore.due = Overdue
 RatingScore.eva = EVA Weight
-RatingScore.radiation = Radiation Exposure
-RatingScore.building = Building
+RatingScore.extrovert = Person Extrovert
+RatingScore.favourite = Favourite Task
+RatingScore.goods = Goods
+RatingScore.job = Job
+RatingScore.leader = Leader
+RatingScore.medical = Medical Skill
+RatingScore.part = Parts Available
 RatingScore.performance = Performance
 RatingScore.person = Person
-
+RatingScore.radiation = Radiation Exposure
+RatingScore.review.age = Plan Age
+RatingScore.reviewer = Reviewer
+RatingScore.robot.expert = Robot Expertise
+RatingScore.settlement = Settlement Preference
 
 ResupplyMissionEditingPanel.error.duplicatedSol 		= Invalid entry in 'Sols Until Arrival' since sol {0} has already been chosen in another resupply mission.
 

--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -990,16 +990,23 @@ RandomUtil.log.ceilingMustBePositive  = ceiling must be positive:
 RandomUtil.log.ceilingMustGreaterBase = ceiling must be greater than base.
 RandomUtil.log.weightMapIsNull        = weightedMap is null
 
+RatingScore.base = Base
+RatingScore.best = Best Choice
 RatingScore.building = Building Suitability
 RatingScore.citizens = Citizens Count
+RatingScore.condition = Condition of unit
 RatingScore.crowding = Overcrowding
 RatingScore.due = Overdue
+RatingScore.effort = Effort
 RatingScore.eva = EVA Weight
 RatingScore.extrovert = Person Extrovert
 RatingScore.favourite = Favourite Task
+RatingScore.fish.weeds = Weeds
+RatingScore.garaged = Garaged
 RatingScore.goods = Goods
 RatingScore.job = Job
 RatingScore.leader = Leader
+RatingScore.maintenance = Maintenance
 RatingScore.medical = Medical Skill
 RatingScore.part = Parts Available
 RatingScore.performance = Performance
@@ -1009,6 +1016,10 @@ RatingScore.review.age = Plan Age
 RatingScore.reviewer = Reviewer
 RatingScore.robot.expert = Robot Expertise
 RatingScore.settlement = Settlement Preference
+RatingScore.study = Study
+RatingScore.surplus = Surplus Stock
+RatingScore.vehicle = Vehicle
+
 
 ResupplyMissionEditingPanel.error.duplicatedSol 		= Invalid entry in 'Sols Until Arrival' since sol {0} has already been chosen in another resupply mission.
 

--- a/mars-sim-core/src/test/java/org/mars_sim/msp/core/data/RatingTest.java
+++ b/mars-sim-core/src/test/java/org/mars_sim/msp/core/data/RatingTest.java
@@ -17,7 +17,10 @@ public class RatingTest extends TestCase {
     public void testAddModifier() {
         RatingScore r = new RatingScore(BASE);
         assertEquals("Only base", BASE, r.getScore());
-        assertEquals("Base", BASE, r.getBase());
+        var b = r.getBases();
+        assertEquals("Bases present", 1, b.size());
+        assertEquals("1st Base", BASE, b.get(RatingScore.BASE));
+
 
         r.addModifier(MOD1, MOD1_VALUE);
         assertEquals("Apply " + MOD1, BASE * MOD1_VALUE, r.getScore());
@@ -32,10 +35,19 @@ public class RatingTest extends TestCase {
     }
 
     public void testSetBase() {
-        RatingScore r = new RatingScore(BASE);
+        RatingScore r = new RatingScore("test", BASE);
         r.addModifier(MOD1, MOD1_VALUE);
 
-        r.setBase(BASE2);
+        r.addBase("test", BASE2);
         assertEquals("Set base " + MOD1, BASE2 * MOD1_VALUE, r.getScore());
+    }
+
+    
+    public void testAddBase() {
+        RatingScore r = new RatingScore("test", BASE);
+        r.addModifier(MOD1, MOD1_VALUE);
+
+        r.addBase("tests", BASE2);
+        assertEquals("Set base " + MOD1, (BASE + BASE2) * MOD1_VALUE, r.getScore());
     }
 }


### PR DESCRIPTION
This PR completes the conversion of ```SettlementMetaTask``` to use the rating approach. This involves changing the scores into the composite parts so the user can understand the reason behind choices.

This includes expanding RatingScore to support multiple base components for complex MetaTasks, e.g. tending fish tank.

The MetaTasks use a new approach to assessing the suitability of a Person or Robot. Instead of a simple double, a Rating Score is used allowing the individual modifiers to be recorded.

Close #1070 