### PR TITLE
Fix problem with copy failure on incremental builds

### DIFF
--- a/mars-sim-headless/pom.xml
+++ b/mars-sim-headless/pom.xml
@@ -39,7 +39,6 @@
 		</dependency>	
 	</dependencies>	
 	<build>
-		<defaultGoal>clean package install</defaultGoal>
 		<plugins>
 			<!-- Package into an executable JAR file -->
 			<plugin>
@@ -79,7 +78,7 @@
                         <id>copy-file</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>rename</goal>
+                            <goal>copy</goal>
                         </goals>
                         <configuration>
                             <sourceFile>${project.build.directory}/${project.build.finalName}-jar-with-dependencies.jar</sourceFile>

--- a/mars-sim-main/pom.xml
+++ b/mars-sim-main/pom.xml
@@ -88,7 +88,6 @@
   </profiles>
   
 	<build>
-		<defaultGoal>clean package install</defaultGoal>
 		<plugins>
 			<!-- Build the executable JAR file -->
 			<plugin>
@@ -129,7 +128,7 @@
                         <id>copy-file</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>rename</goal>
+                            <goal>copy</goal>
                         </goals>
                         <configuration>
                             <sourceFile>${project.build.directory}/${project.build.finalName}-jar-with-dependencies.jar</sourceFile>


### PR DESCRIPTION
Changes:
- Remove the default build target
- Change the rename to a copy operation

relates to #1017