### PR TITLE
Clean up Skills Manager

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/unit/WorkerSkillsCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/unit/WorkerSkillsCommand.java
@@ -1,20 +1,19 @@
 /**
  * Mars Simulation Project
  * WorkerSkillsCommand.java
- * @version 3.1.2 2020-12-30
+ * @date 2023-10-31
  * @author Barry Evans
  */
 
 package com.mars_sim.console.chat.simcommand.unit;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import com.mars_sim.console.chat.Conversation;
 import com.mars_sim.console.chat.simcommand.CommandHelper;
 import com.mars_sim.console.chat.simcommand.StructuredResponse;
 import com.mars_sim.core.Unit;
+import com.mars_sim.core.person.ai.Skill;
 import com.mars_sim.core.person.ai.SkillManager;
 import com.mars_sim.core.person.ai.task.util.Worker;
 
@@ -34,8 +33,8 @@ public class WorkerSkillsCommand extends AbstractUnitCommand {
 	protected boolean execute(Conversation context, String input, Unit target) {
 
 		SkillManager skillManager = null;
-		if (target instanceof Worker) {
-			skillManager = ((Worker)target).getSkillManager();
+		if (target instanceof Worker w) {
+			skillManager = w.getSkillManager();
 		}
 		else {
 			context.println("Sorry I am not a Worker");
@@ -47,15 +46,13 @@ public class WorkerSkillsCommand extends AbstractUnitCommand {
 			StructuredResponse responseText = new StructuredResponse();
 			responseText.appendTableHeading("Type of Skill", CommandHelper.TASK_WIDTH, "Level", "Exp. Needed", "Labor Time [sols]");
 
-			Map<String, Integer> levels = skillManager.getSkillLevelMap();
-			Map<String, Integer> exps = skillManager.getSkillDeltaExpMap();
-			Map<String, Integer> times = skillManager.getSkillTimeMap();
-			List<String> skillNames = skillManager.getKeyStrings();
-			Collections.sort(skillNames);
+			List<Skill> skills = skillManager.getSkills();
 
-			for (String n : skillNames) {
-				responseText.appendTableRow(n, levels.get(n), exps.get(n),
-											Math.round(100.0 * times.get(n))/100000.0);	
+			for (Skill n : skills) {
+				responseText.appendTableRow(n.getType().getName(), n.getLevel(),
+											n.getNeededExp(),
+											String.format(CommandHelper.DOUBLE_FORMAT,
+														n.getTime()/1000D));	
 			}
 			context.println(responseText.getOutput());
 			

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/Skill.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/Skill.java
@@ -19,7 +19,7 @@ public class Skill implements Serializable {
 	private static final long serialVersionUID = 1L;
 	
 	/** The base factor. */
-	static final int BASE = 75;
+	public static final int BASE = 75;
 	
 	// Data members
 	/** The skill level (0 to infinity). */
@@ -33,15 +33,15 @@ public class Skill implements Serializable {
 	private double time;
 	
 	/** The unique (for each person) skill. */
-	private SkillType skill;
+	private SkillType sType;
 
 	/**
 	 * Constructor, starting at level 0.
 	 * 
 	 * @param skill {@link SkillType}
 	 */
-	public Skill(SkillType skill) {
-		this.skill = skill;
+	Skill(SkillType skill) {
+		this.sType = skill;
 		level = 0;
 		experiencePoints = 0D;
 		threshold = BASE;
@@ -53,18 +53,18 @@ public class Skill implements Serializable {
 	 * @param skill {@link SkillType} the skill's name.
 	 * @param level the skill's initial level.
 	 */
-	public Skill(SkillType skill, int level) {
+	Skill(SkillType skill, int level) {
 		this(skill);
 		setLevel(level);
 	}
 
 	/**
-	 * Returns the name of the skill.
+	 * Returns the skilltype associated with this skill
 	 * 
-	 * @return the skill's name
+	 * @return the skill type
 	 */
-	public SkillType getSkill() {
-		return skill;
+	public SkillType getType() {
+		return sType;
 	}
 
 	/**
@@ -154,5 +154,29 @@ public class Skill implements Serializable {
 	 */
 	void addTime(double time) {
 		this.time += time; 
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		return prime * level + sType.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Skill other = (Skill) obj;
+		if (level != other.level)
+			return false;
+		if (Double.doubleToLongBits(experiencePoints) != Double.doubleToLongBits(other.experiencePoints))
+			return false;
+		if (Double.doubleToLongBits(time) != Double.doubleToLongBits(other.time))
+			return false;
+		return (sType == other.sType);
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/robot/Robot.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/robot/Robot.java
@@ -158,7 +158,7 @@ public class Robot extends Unit implements Salvagable, Temporal, Malfunctionable
 		// Construct the SkillManager instance.
 		skillManager = new SkillManager(this);
 		for(Entry<SkillType, Integer> e : spec.getSkillMap().entrySet()) {
-			skillManager.addNewSkillNExperience(e.getKey(), e.getValue());
+			skillManager.addNewSkill(e.getKey(), e.getValue());
 		}
 
 		// Construct the RoboticAttributeManager instance.

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/SkillManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/SkillManagerTest.java
@@ -1,0 +1,43 @@
+package com.mars_sim.core.person.ai;
+
+import com.mars_sim.core.AbstractMarsSimUnitTest;
+import com.mars_sim.core.person.Person;
+
+
+public class SkillManagerTest  extends AbstractMarsSimUnitTest   {
+    public void testAddNewSkillNExperience() {
+        Person p = buildPerson("Skill", buildSettlement());
+
+        SkillManager sm = p.getSkillManager();
+
+        assertSkillExperience(sm, SkillType.BOTANY, 10);
+        assertSkillExperience(sm, SkillType.MANAGEMENT, 15);
+    }
+
+    private void assertSkillExperience(SkillManager sm, SkillType type, int level) {
+        sm.addNewSkill(type, level);
+        Skill b = sm.getSkill(type);
+
+        double expLevel = Skill.BASE * Math.pow(2D, level);
+
+        assertEquals(type.name() + " Skill level", level, b.getLevel());
+        assertEquals(type.name() + " time", 0D, b.getTime());
+        assertEquals(type.name() + " experience needed", expLevel - b.getExperience(), b.getNeededExp());
+    }
+
+    public void testAddExperience() {
+        Person p = buildPerson("Skill", buildSettlement());
+
+        SkillManager sm = p.getSkillManager();
+
+        int startLevel = 2;
+        sm.addNewSkill(SkillType.CHEMISTRY, startLevel);
+        Skill c = sm.getSkill(SkillType.CHEMISTRY);
+        double expNeeded = c.getNeededExp();
+        sm.addExperience(SkillType.CHEMISTRY, expNeeded, 10D);
+
+        assertEquals("Next level", startLevel + 1, c.getLevel());
+        assertEquals("No experience", 0D, c.getExperience());
+        assertEquals("Experience needed", Skill.BASE * Math.pow(2D, startLevel+1), c.getNeededExp());
+    }
+}


### PR DESCRIPTION
Changes:
- SkillsManager reworked to improve code quality and remove code smells.
- SkillsManager is based on Worker instead of both Person & Robot
- Created a new unit test for SkillsManager
- SkillsManager returns a list of known Skills instead of seperate methods for each individual Skill attribute
- Skill class implements equals/hashCode methods
- Only a single method to add new Skill called ```addNewSkill``` that at a certian level with random experience.
- Update Robot for new add method
- Skills model in TabPanelSkill is simplified to use the list of Skills returned from SkillsManager
- PersonBuilderImpl is now responsible for deciding what skills the intiial Person has