### PR TITLE
Fix Issue1127

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/tool/Conversion.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/tool/Conversion.java
@@ -150,51 +150,6 @@ public class Conversion {
 			return null;
 	}
 
-	/**
-	 * Obtains the two-letter initial of the input phase.
-	 * 
-	 * @param input The input phase
-	 * @return The initials
-	 */
-	public static String getTwoLetterInitial(String input) {
-		if (input != null) {
-			StringBuilder titleCase = new StringBuilder();
-			boolean hasSpace = input.contains(" ");
-			
-			if (hasSpace) {
-				String[] inputs = input.split(" "); 
-				titleCase.append(inputs[0].charAt(0));
-				titleCase.append(inputs[1].charAt(0));
-			}
-			else {
-				boolean firstInitial = true;
-				boolean secondInitial = true;
-			
-				for (char c : input.toCharArray()) {
-					if (Character.isSpaceChar(c) || c == '(') {
-						if (titleCase.toString().length() == 2) 
-							return titleCase.toString();
-						firstInitial = true;
-					} else if (firstInitial) {
-						if (titleCase.toString().length() == 2) 
-							return titleCase.toString();
-						c = Character.toTitleCase(c);
-						titleCase.append(c);
-						firstInitial = false;
-					} else if (secondInitial) {
-						if (titleCase.toString().length() == 2) 
-							return titleCase.toString();
-						c = Character.toTitleCase(c);
-						titleCase.append(c);
-						secondInitial = false;
-					}
-				}
-			}
-
-			return titleCase.toString();
-		} else
-			return null;
-	}
 	
 	/**
 	 * Is this character an integer ?

--- a/mars-sim-core/src/test/java/com/mars_sim/core/AbstractMarsSimUnitTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/AbstractMarsSimUnitTest.java
@@ -130,7 +130,11 @@ public abstract class AbstractMarsSimUnitTest extends TestCase {
 	}
 
 	protected Settlement buildSettlement() {
-		Settlement settlement = new MockSettlement();
+		return buildSettlement(MockSettlement.DEFAULT_NAME);
+	}
+
+	protected Settlement buildSettlement(String name) {
+		Settlement settlement = new MockSettlement(name);
 		unitManager.addUnit(settlement);
 
 		return settlement;

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/MetaTaskUtilTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/MetaTaskUtilTest.java
@@ -49,15 +49,15 @@ extends AbstractMarsSimUnitTest {
 		assertMetaTask(eatDrink, "Eating");
 	}
 
-//	public void testLoadVehicleGarage() throws Exception {
-//		LoadVehicleGarage evaLoad = new LoadVehicleGarage(person, buildMission(settlement, person));
-//		assertMetaTask(evaLoad, "Loading Vehicle");
-//	}
+	public void testLoadVehicleGarage() throws Exception {
+		LoadVehicleGarage evaLoad = new LoadVehicleGarage(person, buildMission(settlement, person));
+		assertMetaTask(evaLoad, "Loading Vehicle");
+	}
 
-//	public void testLoadVehicleEVA() throws Exception {
-//		LoadVehicleEVA evaLoad = new LoadVehicleEVA(person, buildMission(settlement, person));
-//		assertMetaTask(evaLoad, "Loading Vehicle");
-//	}
+	public void testLoadVehicleEVA() throws Exception {
+		LoadVehicleEVA evaLoad = new LoadVehicleEVA(person, buildMission(settlement, person));
+		assertMetaTask(evaLoad, "Loading Vehicle");
+	}
 
 	public void testUnloadVehicleGarage() throws Exception {
 		Vehicle vehicle = buildRover(settlement, "loader", null);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/MockSettlement.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/MockSettlement.java
@@ -12,17 +12,24 @@ import com.mars_sim.mapdata.location.Coordinates;
 @SuppressWarnings("serial")
 public class MockSettlement extends Settlement {
 
+	/**
+	 *
+	 */
+	public static final String DEFAULT_NAME = "Mock Settlement";
+
 	/* default logger. */
 	private static final Logger logger = Logger.getLogger(MockSettlement.class.getName());
 	
 	private Simulation sim = Simulation.instance();
 
-	/**
-	 * Constructor
-	 */
+
 	public MockSettlement()  {
+		this(DEFAULT_NAME);
+	}
+
+	public MockSettlement(String name) {
 		// Use Settlement constructor.
-		super("Mock Settlement", 0, new Coordinates(Math.PI / 2D, 0));
+		super(name, 0, new Coordinates(Math.PI / 2D, 0));
 		
 		if (sim == null)
 			logger.severe("sim is null");
@@ -34,7 +41,7 @@ public class MockSettlement extends Settlement {
 		getEquipmentInventory().addCargoCapacity(Double.MAX_VALUE);
 
         // Initialize building manager
-        buildingManager = new BuildingManager(this, "Mock Settlement");
+        buildingManager = new BuildingManager(this, DEFAULT_NAME);
 
         // Initialize building connector manager.
         buildingConnectorManager = new BuildingConnectorManager(this,
@@ -45,11 +52,5 @@ public class MockSettlement extends Settlement {
 
         // Initialize power grid
         powerGrid = new PowerGrid(this);
-	}
-	
-	@Override
-	public String toString() {
-		return getName();
-	}
-	
+	}	
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/SettlementCodeTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/SettlementCodeTest.java
@@ -1,0 +1,53 @@
+/*
+ * Mars Simulation Project
+ * SettlementCodeTest.java
+ * @date 2023-11-11
+ * @author Barry Evans
+ */
+package com.mars_sim.core.structure;
+
+import com.mars_sim.core.AbstractMarsSimUnitTest;
+
+/**
+ * Test the intenrals of the SHiftMansger
+ */
+public class SettlementCodeTest extends AbstractMarsSimUnitTest {
+
+    /**
+     * Test the code logic
+     */
+    public void testSingleSettlement() {
+        Settlement settlement = buildSettlement("First Second");
+        assertEquals("Single Settlement code", "FS", settlement.getSettlementCode());
+    }
+
+    /**
+     * Test the code logic based on words
+     */
+    public void testWordSettlement() {
+        buildSettlement("First Second");
+        Settlement settlement2 = buildSettlement("First Second Forth");
+
+        assertEquals("Second Settlement code", "FF", settlement2.getSettlementCode());
+    }
+
+    /**
+     * Test the code logic based on words
+     */
+    public void testLettersSettlement() {
+        buildSettlement("First Second");
+        Settlement settlement2 = buildSettlement("First Sx");
+
+        assertEquals("Second Settlement code", "FI", settlement2.getSettlementCode());
+    }
+
+    /**
+     * Test the code logic based on letters with puncutation
+     */
+    public void testLettersPuncSettlement() {
+        buildSettlement("First Second");
+        Settlement settlement2 = buildSettlement("F#-rst Sx");
+
+        assertEquals("Second Settlement code", "FR", settlement2.getSettlementCode());
+    }
+}


### PR DESCRIPTION
The issue relates to the Settlement Code potentially going into an infinite loop if no unique entry can be found.

This changes the logic to find a unique code:

1. Use the first letter of each word in the name
2. The first letter and then any other letter in the name
3. A default of 'ZZ' if no code can be found but this should never happen unless there is a duplicate Settlement Name

close #1127 