### PR TITLE
Ignore dependabot branches from SonarCloud analysis

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,11 +1,14 @@
 name: SonarQube Analysis
 on:
-  # Trigger analysis when pushing in master 
+  # Trigger analysis when pushing in master
   push:
     branches:
       - master
+  # Trigger analysis when creating a PR but ignore dependabot branches
   pull_request:
     types: [opened, synchronize, reopened]
+    branches-ignore:    
+      - 'dependabot/**'
 jobs:
   sonarqube:
     name: SonarQube Trigger


### PR DESCRIPTION
Dependabot is not allowed access to the organisation secrets so analysis fails on it's branches. Secondly, dependabot never changes code so the analysis is redundant.

This adds the dependabot branches to the ignore list.