### PR TITLE
Allow tables in the Console to wrap cells contents

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/StructuredResponse.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/StructuredResponse.java
@@ -9,6 +9,7 @@ package com.mars_sim.console.chat.simcommand;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -18,6 +19,11 @@ import com.google.common.primitives.Ints;
  * A buffer holding structured output similar to a table.
  */
 public class StructuredResponse {
+
+	private static record SplitString(String left, String right) {}
+
+	private static final Pattern SPLIT_CHARS = Pattern.compile("[ ,-]");
+
 
 	// Formats
 	private static final String HEADING_FORMAT = " %s%n";
@@ -30,6 +36,7 @@ public class StructuredResponse {
 	
 	private StringBuilder buffer = new StringBuilder();
 	private int[] columnsWidth;
+	private boolean wrapTableCells;
 	
 	/**
 	 * Adda free text"
@@ -108,13 +115,28 @@ public class StructuredResponse {
 	 * columns the table contains. Table must have at least 2 columns including the 1st fixed one.
 	 * The headings columns contains String to define the columns; if a String is followed by an integer
 	 * then the int specifies the width of that column. 
+	 * This has no cell wrapping.
 	 * @param heading1 1st column heading
 	 * @param width Width of 1st column
 	 * @param headings A variab le list of heading defining the columns
 	 */
 	public void appendTableHeading(String heading1, int width, Object ... headings) {
+		appendTableHeading(false, heading1, width, headings);
+	}
+
+	/**
+	 * Add a table heading and prepares for table. The number of heading strings defines how many
+	 * columns the table contains. Table must have at least 2 columns including the 1st fixed one.
+	 * The headings columns contains String to define the columns; if a String is followed by an integer
+	 * then the int specifies the width of that column. 
+	 * @param wrapContents Wrap the conents of the cells to fit in the column width
+	 * @param heading1 1st column heading
+	 * @param width Width of 1st column
+	 * @param headings A variab le list of heading defining the columns
+	 */
+	public void appendTableHeading(boolean wrapContents, String heading1, int width, Object ... headings) {
 		List<Integer> widths = new ArrayList<>();
-		
+		wrapTableCells = wrapContents;
 		int firstWidth = Math.max(width, heading1.length()); 
 		StringBuilder fmt  = new StringBuilder();
 		fmt.append("%");
@@ -172,17 +194,40 @@ public class StructuredResponse {
 					+ ") does not match the defined columns " + columnsWidth.length);
 		}
 		
-		StringBuilder headFmt = new StringBuilder("%").append(columnsWidth[0]).append("s");
-		buffer.append(String.format(headFmt.toString(), label));
+		outputTableRow(buffer, label, values);
+	}
+
+	private void outputTableRow(StringBuilder tableBody, String label, Object [] values) {
+		String nextLabel = "";
+		Object [] nextValues = new Object[values.length];
+		boolean nextRow = false;
+
+		int labelWidth = columnsWidth[0];
+		StringBuilder headFmt = new StringBuilder("%").append(labelWidth).append("s");
+		var labSplit = splitText(label, labelWidth);
+		if (labSplit != null) {
+			nextRow = true;
+			nextLabel = labSplit.right();
+			label = labSplit.left();
+		}
+		tableBody.append(String.format(headFmt.toString(), label));
 		
 		for(int i = 0; i < values.length; i++) {
 			StringBuilder fmt = new StringBuilder();
 			fmt.append(" | %");
 			int w = columnsWidth[i + 1];
 			Object value = values[i];
-			if (value instanceof String) {
+			if (value instanceof String str) {
 				fmt.append(w);
 				fmt.append('s');
+
+				// Can wrap String cells
+				var split = splitText(str, w);
+				if (split != null) {
+					nextRow = true;
+					nextValues[i] = split.right();
+					value = split.left();
+				}
 			}
 			else if (value instanceof Double) {
 				fmt.append(w);
@@ -192,10 +237,10 @@ public class StructuredResponse {
 				fmt.append(w);
 				fmt.append('d');			
 			}
-			else if (value instanceof Boolean) {
+			else if (value instanceof Boolean b) {
 				fmt.append(w);
 				fmt.append('s');			
-				value = ((Boolean)value).booleanValue() ? "Yes" : "No";
+				value = b.booleanValue() ? "Yes" : "No";
 			}
 			else if (value != null) {
 				fmt.append(w);
@@ -207,11 +252,47 @@ public class StructuredResponse {
 				fmt.append('s');
 				value = "";				
 			}
-			buffer.append(String.format(fmt.toString(), value));
+			tableBody.append(String.format(fmt.toString(), value));
 		}
-		buffer.append(LF);		
+		tableBody.append(LF);	
+		
+		// Output another row?
+		if (nextRow) {
+			outputTableRow(tableBody, nextLabel, nextValues);
+		}
 	}
 
+	/**
+	 * Split a string into 2 parts where the first is no bigger than the width.
+	 * If the source string is less than the width then a null is returned as no
+	 * split is needed.
+	 * 
+	 * @param source String to be split
+	 * @param width Maximum size of lefthand string
+	 * @return
+	 */
+	private SplitString splitText(String source, int width) {
+		SplitString result = null;
+		int w = Math.abs(width);
+
+		if (wrapTableCells & source.length() > w) {
+			int splitIdx = w;
+
+			var match = SPLIT_CHARS.matcher(source);
+			while(match.find()) {
+				if (match.end() < w) {
+					splitIdx = match.end();
+				}
+				else {
+					// Gone too far
+					break;
+				}
+			}
+			result = new SplitString(source.substring(0, splitIdx),
+									 source.substring(splitIdx).trim());
+		}
+		return result;
+	}
 
 	/**
 	 * Write a line of text

--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/BacklogCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/BacklogCommand.java
@@ -37,8 +37,8 @@ class BacklogCommand extends AbstractSettlementCommand {
 
         List<SettlementTask> tasks = stm.getAvailableTasks();
         if (tasks != null) {
-            response.appendTableHeading("Tasks", CommandHelper.TASK_WIDTH, "Subject", CommandHelper.BUILIDNG_WIDTH,
-                            "#", 3, "Score");
+            response.appendTableHeading(true, "Tasks", 35, "Subject", CommandHelper.BUILIDNG_WIDTH,
+                            "#", 3, "Score", -30);
             for(SettlementTask t : tasks) {
                 String subjectName = null;
                 Entity subject = t.getFocus();

--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/unit/WorkerWorkCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/unit/WorkerWorkCommand.java
@@ -53,8 +53,8 @@ public class WorkerWorkCommand extends AbstractUnitCommand {
 		// List pending tasks first
 		var pending = tm.getPendingTasks();
 		if (!pending.isEmpty()) {
-			response.appendTableHeading("Pending Task", 45, 
-							"When", 9);
+			response.appendTableHeading(true, "Pending Task", 45, 
+							"When", -CommandHelper.TIMESTAMP_TRUNCATED_WIDTH);
 			for (PendingTask item : pending) {
 				response.appendTableRow(item.job().getName(), item.when().getTruncatedDateTimeStamp());
 			}
@@ -74,8 +74,8 @@ public class WorkerWorkCommand extends AbstractUnitCommand {
 			}
 
 			double sum = tasks.getTotal();
-			response.appendTableHeading("Potential Task", CommandHelper.TASK_WIDTH, "P %", 6,
-										"P Score", 20);
+			response.appendTableHeading(true, "Potential Task", 30, "P %", 6,
+										"P Score", -60);
 
 			// Display the last selected as 1st entry
 			TaskJob lastSelected = tasks.getLastSelected();


### PR DESCRIPTION
There is now appendTableHeading method that takes a boolean to allow cell contents to be wrapped on word and punctuation boundaries.

Changes:
- StructuredResponse has new table heading method allowing cell wrapping
- New private method to create a single table row
- Backlog & work commands wrap cell contents

@mokun I have implemented wrapping of the cell contents in the Console. You can add it to selected tables now.