### PR TITLE
Reduce frozen tasks

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/ObserveAstronomicalObjects.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/ObserveAstronomicalObjects.java
@@ -85,7 +85,10 @@ public class ObserveAstronomicalObjects extends Task implements ResearchScientif
 			// Walk to observatory building.
 			walkToTaskSpecificActivitySpotInBuilding(observatory.getBuilding(),
 													FunctionType.ASTRONOMICAL_OBSERVATION, false);
-			observatory.addObserver();
+			if (!observatory.addObserver()) {
+				endTask();
+				return;
+			}
 			isActiveObserver = true;
 			
 			// Initialize phase

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/ConverseMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/ConverseMeta.java
@@ -39,6 +39,11 @@ public class ConverseMeta extends FactoryMetaTask {
 
     @Override
     public double getProbability(Person person) {
+        // Avoid chatting when outside        
+        if (person.isOutside()) {
+            return 0D;
+        }
+
     	double result = RandomUtil.getRandomDouble(person.getNaturalAttributeManager()
     			.getAttribute(NaturalAttributeType.CONVERSATION))/20;
  

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/AstronomicalObservation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/AstronomicalObservation.java
@@ -65,15 +65,16 @@ public class AstronomicalObservation extends Function {
 	/**
 	 * Adds a new observer to the observatory.
 	 * 
-	 * @throws Exception if observatory is already at capacity.
+	 * @return If there is space
 	 */
-	public void addObserver() {
+	public boolean addObserver() {
 		observerNum++;
 		if (observerNum > observatoryCapacity) {
 			observerNum = observatoryCapacity;
 			logger.log(Level.SEVERE, "addObserver(): " + "Observatory is already full of observers.");
-			throw new IllegalStateException("Observatory is already full of observers.");
+			return false;
 		}
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
It may not be the root cause BUT Persons are starting Conversations when outside on EVA.

Changes:
- Stop conversations starting if the Person is outside. This appears to be causing a problem with frozen People
- Handle when the Observatory becomes full with people

Part of #1146