### PR TITLE
ActivitySpots are allocatable to a Worker

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
@@ -76,8 +76,9 @@ import com.mars_sim.core.science.ScientificStudy;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.building.Building;
 import com.mars_sim.core.structure.building.BuildingManager;
-import com.mars_sim.core.structure.building.function.Function;
+import com.mars_sim.core.structure.building.function.ActivitySpot;
 import com.mars_sim.core.structure.building.function.FunctionType;
+import com.mars_sim.core.structure.building.function.ActivitySpot.AllocatedSpot;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.Temporal;
 import com.mars_sim.core.vehicle.Crewable;
@@ -176,8 +177,8 @@ public class Person extends Unit implements Worker, Temporal, ResearcherInterfac
 
 	/** Settlement position (meters) from settlement center. */
 	private LocalPosition position;
-	/** The Function the person is actively participating. */
-	private Function function;
+	/** The spot owned by this Person */
+	private AllocatedSpot spot;
 	/** The gender of the person (male or female). */
 	private GenderType gender = GenderType.MALE;
 
@@ -2444,22 +2445,21 @@ public class Person extends Unit implements Worker, Temporal, ResearcherInterfac
 		return inviteeId;
 	}
 	
-	/**
-	 * Gets the function the person is actively participating.
-	 * 
-	 * @return
-	 */
-	public Function getFunction() {
-		return function;
+	public ActivitySpot getActivitySpot() {
+		return (spot != null ? spot.getAllocated() : null);
 	}
 	
 	/**
-	 * Sets the function.
+	 * Sets the activity spot allocated.
 	 * 
-	 * @param function
+	 * @param newSpot Can be null if no spot assigned
 	 */
-	public void setFunction(Function function) {
-		this.function = function;
+	@Override
+	public void setActivitySpot(AllocatedSpot newSpot) {
+		if (spot != null) {
+			spot.release(this);
+		}
+		spot = newSpot;
 	}
 	
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/EatDrink.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/EatDrink.java
@@ -393,8 +393,17 @@ public class EatDrink extends Task {
 	 * @param allowFail true if walking is allowed to fail.
 	 */
 	protected void walkToDiningLoc(Building building, boolean allowFail) {
-
-		LocalPosition loc = findLocalDiningSpot(building);
+		// Find a free spot in the building
+		Function f = building.getFunction(FunctionType.DINING);
+		LocalPosition loc = f.getAvailableActivitySpot();
+		if (loc == null) {
+			// Find another spot in the smae building
+			f = building.getEmptyActivitySpotFunction();
+			if (f == null) {
+				return;
+			}
+			loc = f.getAvailableActivitySpot();
+		}
 
 		// Create subtask for walking to destination.
 		if (loc != null) {
@@ -407,40 +416,10 @@ public class EatDrink extends Task {
 				// Set the new position
 				person.setPosition(sLoc);
 						
-				Function f = building.getFunction(FunctionType.DINING);
 				// Add the person to this activity spot
-				f.addActivitySpot(loc, person.getIdentifier());
-				// Remove the person from the previous activity spot
-				if (person.getFunction() != null) {
-					person.getFunction().removeFromActivitySpot(person.getIdentifier());
-				}
-				// Set the new function type
-				person.setFunction(f);
+				f.claimActivitySpot(loc, person);
 			}
 		}
-	}
-
-	/**
-	 * Finds a local dining spot in this building.
-	 * 
-	 * @param building
-	 * @return
-	 */
-	private LocalPosition findLocalDiningSpot(Building building) {
-
-		LocalPosition loc = building.getFunction(FunctionType.DINING).getAvailableActivitySpot();
-		
-		if (loc != null) {
-			return loc;
-		}
-		
-		Function f = building.getEmptyActivitySpotFunction();
-		if (f == null) {
-			return null;
-		}
-		
-		// Find available activity spot in building.
-		return f.getAvailableActivitySpot();
 	}
 
 	private void goForWater() {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/EnterAirlock.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/EnterAirlock.java
@@ -56,7 +56,6 @@ public class EnterAirlock extends Task {
 	private static final TaskPhase LEAVE_AIRLOCK = new TaskPhase(Msg.getString("Task.phase.leaveAirlock")); //$NON-NLS-1$
 
 	private static final String CHAMBER_FULL = "All chambers are occupied in ";
-	private static final String NOT_IN_RIGHT_AIRLOCK_MODE = "Airlock is not in ingress mode.";
 	
 	// Static members
 	/** The standard time for doffing the EVA suit. */
@@ -181,9 +180,9 @@ public class EnterAirlock extends Task {
 		// The previous zone # has a higher numeric #
 		int previousZone = newZone + 1;
 		LocalPosition newPos = fetchNewPos(newZone);
-		if (newPos != null && airlock.occupy(newZone, newPos, id)) {
+		if (newPos != null && airlock.occupy(newZone, newPos, person)) {
 			if (previousZone <= 4) {
-				if (airlock.vacate(previousZone, id)) {
+				if (airlock.vacate(previousZone, person)) {
 					return moveThere(newPos, newZone);
 				}
 				else
@@ -942,7 +941,7 @@ public class EnterAirlock extends Task {
 			accumulatedTime -= STANDARD_TIME * time;
 			
 			// Remove the position at zone 0 before ending the task
-			airlock.vacate(0, id);
+			airlock.vacate(0, person);
 			
 			// Add experience
 			addExperience(time);
@@ -1003,10 +1002,10 @@ public class EnterAirlock extends Task {
 			}
 			
 			if (inSettlement) {
-				((BuildingAirlock)airlock).removeFromActivitySpot(id);
+				((BuildingAirlock)airlock).removeFromActivitySpot(person);
 			}
 			
-			airlock.removeID(id);
+			airlock.remove(person);
 			
 			if (airlock.isEmpty())
 				airlock.setAirlockMode(AirlockMode.NOT_IN_USE);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/ExitAirlock.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/ExitAirlock.java
@@ -67,7 +67,6 @@ public class ExitAirlock extends Task {
 	private static final String SUPER_UNFIT = "Super unfit";
 	private static final String INNER_DOOR_LOCKED = "Inner door was locked.";
 	private static final String CHAMBER_FULL = "All chambers are occupied.";
-	private static final String NOT_IN_RIGHT_AIRLOCK_MODE = "Airlock is not in egress mode.";
 	
     /** The minimum performance needed. */
 	private static final double MIN_PERFORMANCE = 0.05;
@@ -216,9 +215,9 @@ public class ExitAirlock extends Task {
 		// the previous zone #  a lower numeric #
 		int previousZone = newZone - 1;
 		LocalPosition newPos = fetchNewPos(newZone);
-		if (newPos != null && airlock.occupy(newZone, newPos, id)) {
+		if (newPos != null && airlock.occupy(newZone, newPos, person)) {
 			if (previousZone >= 0) {
-				if (airlock.vacate(previousZone, id)) {
+				if (airlock.vacate(previousZone, person)) {
 					return moveThere(newPos, newZone);
 				}
 				else
@@ -1279,7 +1278,7 @@ public class ExitAirlock extends Task {
 			
 			if (inSettlement) {
 				// Remove the position at zone 4 before ending the task
-				if (airlock.vacate(4, id)) {
+				if (airlock.vacate(4, person)) {
 					// Add experience
 			 		addExperience(time);
 		
@@ -1469,10 +1468,10 @@ public class ExitAirlock extends Task {
 			}
 			
 			if (inSettlement) {
-				((BuildingAirlock)airlock).removeFromActivitySpot(id);
+				((BuildingAirlock)airlock).removeFromActivitySpot(person);
 			}
 			
-			airlock.removeID(id);
+			airlock.remove(person);
 			
 			if (airlock.isEmpty())
 				airlock.setAirlockMode(AirlockMode.NOT_IN_USE);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/Walk.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/Walk.java
@@ -96,9 +96,6 @@ public class Walk extends Task {
 	public Walk(Person person) {
 		super(NAME, person, false, false, STRESS_MODIFIER, null, 100D);
 
-		if (unitManager == null)
-			unitManager = Simulation.instance().getUnitManager();
-
 		LocalBoundedObject targetObject = null;
 		if (person.isInSettlement()) {
 			// Walk to random inhabitable building at settlement.
@@ -221,6 +218,9 @@ public class Walk extends Task {
 		addPhase(CLIMB_DOWN_LADDER);
 
 		setPhase(getWalkingStepPhase());
+
+		// Release any starting actvity spot
+		worker.setActivitySpot(null);
 	}
 
 	public Walk(Robot robot, WalkingSteps walkingSteps) {
@@ -235,6 +235,9 @@ public class Walk extends Task {
 		addPhase(WALKING_SETTLEMENT_INTERIOR);
 
 		setPhase(getWalkingStepPhase());
+
+		// Release any starting actvity spot
+		worker.setActivitySpot(null);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/Task.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/Task.java
@@ -222,10 +222,10 @@ public abstract class Task implements Serializable, Comparable<Task> {
 		}
 		this.worker = worker;
 
-		if (worker instanceof Person person) {
-			this.person = person;
-			this.id = person.getIdentifier();
-			this.eventTarget = person;
+		if (worker instanceof Person p) {
+			this.person = p;
+			this.id = p.getIdentifier();
+			this.eventTarget = p;
 		}
 
 		else {
@@ -249,11 +249,6 @@ public abstract class Task implements Serializable, Comparable<Task> {
 			subTask.setPhase(null);
 			subTask = null;
 		}
-		
-		// Set standard pulse time to a quarter of the value of the current pulse width
-		if (masterClock == null)
-			masterClock = Simulation.instance().getMasterClock();
-		standardPulseTime = Math.min(MAX_PULSE_WIDTH, masterClock.getNextPulseTime());
 	}
 
 	/**
@@ -461,15 +456,15 @@ public abstract class Task implements Serializable, Comparable<Task> {
 	 * Sets the task's description.
 	 * 
 	 * @param des the task description.
-	 * @param record true if wanting to record
+	 * @param recordTask true if wanting to record
 	 */
-	protected void setDescription(String des, boolean record) {
+	protected void setDescription(String des, boolean recordTask) {
 		description = des;
 		eventTarget.fireUnitUpdate(UnitEventType.TASK_DESCRIPTION_EVENT, des);
 		
 		if (!des.equals("") && worker.getTaskManager().getTask() != null
 			// Record the activity
-			&& record && canRecord()) {
+			&& recordTask && canRecord()) {
 				Mission ms = worker.getMission();
 				worker.getTaskManager().recordTask(this, ms);
 		}
@@ -737,6 +732,7 @@ public abstract class Task implements Serializable, Comparable<Task> {
 	 * @return integer comparison of the two objects.
 	 * @throws ClassCastException if the object in not of a Task.
 	 */
+	@Override
 	public int compareTo(Task other) {
 		return name.compareTo(other.name);
 	}
@@ -803,19 +799,6 @@ public abstract class Task implements Serializable, Comparable<Task> {
 				modifier /= ((double) newOverCrowding + 2);
 			}
 		}
-
-		return modifier;
-	}
-
-	/**
-	 * Gets the crowding probability modifier.
-	 * 
-	 * @param robot
-	 * @param newBuilding
-	 * @return
-	 */
-	protected static double getCrowdingProbabilityModifier(Robot robot, Building newBuilding) {
-		double modifier = 1D;
 
 		return modifier;
 	}
@@ -900,7 +883,7 @@ public abstract class Task implements Serializable, Comparable<Task> {
 			int learningModifier = worker.getNaturalAttributeManager()
 					.getAttribute(NaturalAttributeType.ACADEMIC_APTITUDE);
 
-			result += (double) (teachingModifier + learningModifier) / 100D;
+			result += (teachingModifier + learningModifier) / 100D;
 		}
 
 		return result;
@@ -955,7 +938,7 @@ public abstract class Task implements Serializable, Comparable<Task> {
 			double newPoints = time / experienceRatio;
 			int experienceAptitude = worker.getNaturalAttributeManager().getAttribute(experienceAttribute);
 
-			newPoints += newPoints * ((double) experienceAptitude - 50D) / 100D;
+			newPoints += newPoints * (experienceAptitude - 50D) / 100D;
 			newPoints *= getTeachingExperienceModifier();
 
 			SkillManager sm = worker.getSkillManager();
@@ -1113,17 +1096,9 @@ public abstract class Task implements Serializable, Comparable<Task> {
 				if (canWalk) {
 					// Register this person to use this guest bed
 					quarters.registerGuestBed(person.getIdentifier());
-					// Set this quarters
-//					person.setQuarters(building);
 					
 					// Add the person to this activity spot
-					f.addActivitySpot(loc, person.getIdentifier());
-					// Remove the person from the previous activity spot
-					if (person.getFunction() != null) {
-						person.getFunction().removeFromActivitySpot(person.getIdentifier());
-					}
-					// Set the new function type
-					person.setFunction(f);
+					f.claimActivitySpot(loc, person);
 					
 					return true;
 				}
@@ -1150,22 +1125,23 @@ public abstract class Task implements Serializable, Comparable<Task> {
 		}
 		
 		// Converts a settlement-wide bed location back to an activity spot within a building
-		LocalPosition loc = LocalAreaUtil.getObjectRelativePosition(bed, building);
+		LocalPosition relBedLoc = LocalAreaUtil.getObjectRelativePosition(bed, building);
 		// Check my own position
 		LocalPosition myLoc = person.getPosition();
-		
-		boolean empty = building.getLivingAccommodations().isActivitySpotEmpty(loc);
-		
-		if (!empty) {
-			 if (myLoc.equals(bed))
-				 logger.info(person, "I'm already in my own bed at " + bed + ".");		
-			 else
+		var livingAccom = building.getLivingAccommodations();
+		var bedSpot = livingAccom.findActivitySpot(relBedLoc);
+		if (bedSpot == null) {
+			logger.warning(person, "Can not find my bed " + relBedLoc + "in " + building.getName()
+					+ ", quarters is " + person.getQuarters().getName());		
+			return true;
+		}
+		else if (!bedSpot.isEmpty()) {
+			 if (!myLoc.equals(bed))
 				 logger.warning(person, "Someone is using my bed at " + bed + ".");		
 			 
 			 return true;
 		}
-		
-		if (!myLoc.equals(bed) && empty && bed != null) {		
+		else if (!myLoc.equals(bed)) {		
 			// Create subtask for walking to destination.
 			canWalk = createWalkingSubtask(building, bed, allowFail);
 			
@@ -1173,15 +1149,8 @@ public abstract class Task implements Serializable, Comparable<Task> {
 				// Put the person there
 				person.setPosition(bed);
 				
-				Function f = building.getFunction(FunctionType.LIVING_ACCOMMODATIONS);
 				// Add the worker to this activity spot
-				f.addActivitySpot(loc, worker.getIdentifier());
-				// Remove the worker from the previous activity spot
-				if (worker.getFunction() != null) {
-					worker.getFunction().removeFromActivitySpot(worker.getIdentifier());
-				}
-				// Set the new function type
-				worker.setFunction(f);
+				livingAccom.claimActivitySpot(relBedLoc, worker);
 			}
 		}
 		
@@ -1218,13 +1187,7 @@ public abstract class Task implements Serializable, Comparable<Task> {
 				// Set the new position
 				worker.setPosition(sLoc);
 				// Add to this activity spot
-				f.addActivitySpot(loc, worker.getIdentifier());
-				// Remove the previous activity spot
-				if (worker.getFunction() != null) {
-					worker.getFunction().removeFromActivitySpot(worker.getIdentifier());
-				}
-				// Set the new function type
-				worker.setFunction(f);
+				f.claimActivitySpot(loc, worker);
 			}
 		}
 
@@ -1253,13 +1216,7 @@ public abstract class Task implements Serializable, Comparable<Task> {
 				// Set the new position
 				worker.setPosition(sLoc);
 				// Add to this activity spot
-				f.addActivitySpot(loc, worker.getIdentifier());
-				// Remove the previous activity spot
-				if (worker.getFunction() != null) {
-					worker.getFunction().removeFromActivitySpot(worker.getIdentifier());
-				}
-				// Set the new function type
-				worker.setFunction(f);
+				f.claimActivitySpot(loc, worker);
 					
 				return loc;
 			}
@@ -1296,13 +1253,7 @@ public abstract class Task implements Serializable, Comparable<Task> {
 				// Set the new position
 				worker.setPosition(sLoc);
 				// Add to this activity spot
-				f.addActivitySpot(loc, worker.getIdentifier());
-				// Remove the previous activity spot
-				if (worker.getFunction() != null) {
-					worker.getFunction().removeFromActivitySpot(worker.getIdentifier());
-				}
-				// Set the new function type
-				worker.setFunction(f);
+				f.claimActivitySpot(loc, worker);
 			}
 		} 
 
@@ -1399,28 +1350,18 @@ public abstract class Task implements Serializable, Comparable<Task> {
 
 		if (person != null) {
 			// Check all crew members other than person doing task.
-			Iterator<Person> i = rover.getCrew().iterator();
-			while (i.hasNext()) {
-				Person crewmember = i.next();
-				if (!crewmember.equals(person)) {
-
-					// Check if crew member's position is very close to settlementLoc
-					if (settlementLoc.isClose(crewmember.getPosition())) {
-						result = false;
-					}
+			for(Person crewmember: rover.getCrew()) {
+				// Check if crew member's position is very close to settlementLoc
+				if (!crewmember.equals(person) && settlementLoc.isClose(crewmember.getPosition())) {
+					result = false;
 				}
 			}
 		} else {
 			// Check all crew members other than robot doing task.
-			Iterator<Robot> i = rover.getRobotCrew().iterator();
-			while (i.hasNext()) {
-				Robot crewmember = i.next();
-				if (!crewmember.equals(robot)) {
-
-					// Check if crew member's position is very close to settlementLoc
-					if (settlementLoc.isClose(crewmember.getPosition())) {
+			for(Robot crewmember : rover.getRobotCrew()) {
+				// Check if crew member's position is very close to settlementLoc
+				if (!crewmember.equals(robot) && settlementLoc.isClose(crewmember.getPosition())) {
 						result = false;
-					}
 				}
 			}
 		}
@@ -1475,24 +1416,17 @@ public abstract class Task implements Serializable, Comparable<Task> {
 			if (s != null) {
 				Set<Building> buildingList = s.getBuildingManager()
 						.getBuildingsWithoutFctNotAstro(FunctionType.EVA);
-
-				if (!buildingList.isEmpty()) {
-					for (Building b : buildingList) {
-						FunctionType ft = b.getEmptyActivitySpotFunctionType();
-						if (ft != null) {
-							walkToEmptyActivitySpotInBuilding(b, allowFail);
-							return;
-						}
+				for (Building b : buildingList) {
+					FunctionType ft = b.getEmptyActivitySpotFunctionType();
+					if (ft != null) {
+						walkToEmptyActivitySpotInBuilding(b, allowFail);
+						return;
 					}
 				}
 			}
 			// If person is in a vehicle, walk to random location within vehicle.
-			else if (person.isInVehicle()) {
-
-				// Walk to a random location within rover if possible.
-				if (person.getVehicle() instanceof Rover rover) {
-					walkToRandomLocInRover(rover, allowFail);
-				}
+			else if (person.isInVehicle() && (person.getVehicle() instanceof Rover rover)) {
+				walkToRandomLocInRover(rover, allowFail);
 			}
 		} 
 		else {
@@ -1546,7 +1480,6 @@ public abstract class Task implements Serializable, Comparable<Task> {
 	 */
 	protected boolean walkToRoboticStation(Robot robot, boolean allowFail) {
 		boolean canWalk = false;
-		Building destination = null;
 		
 		if (robot.isInSettlement()) {
 			Building currentBuilding = BuildingManager.getBuilding(robot);
@@ -1557,8 +1490,7 @@ public abstract class Task implements Serializable, Comparable<Task> {
 				canWalk = walkToActivitySpotInBuilding(currentBuilding, functionType, allowFail);
 	
 				if (canWalk) {
-					destination = currentBuilding;
-					BuildingManager.addRobotToRoboticStation(robot, destination, functionType);
+					BuildingManager.addRobotToRoboticStation(robot, currentBuilding, functionType);
 				}
 			}
 			else {
@@ -1573,9 +1505,6 @@ public abstract class Task implements Serializable, Comparable<Task> {
 					if (!robot.getSettlement().getAdjacentBuildings(building).isEmpty()) {
 						logger.log(robot, Level.FINER, 5000, "Walking toward " + building.getNickName());
 						canWalk = walkToActivitySpotInBuilding(building, functionType, allowFail);
-						
-						if (canWalk)
-							destination = building;
 					}
 				}
 			}
@@ -1702,6 +1631,10 @@ public abstract class Task implements Serializable, Comparable<Task> {
 	static void initializeInstances(Simulation s, PersonConfig pc) {
 		sim = s;
 		masterClock = s.getMasterClock();
+				
+		// Set standard pulse time to a quarter of the value of the current pulse width
+		standardPulseTime = Math.min(MAX_PULSE_WIDTH, masterClock.getNextPulseTime());
+		
 		eventManager = s.getEventManager();
 		unitManager = s.getUnitManager();
 		scientificStudyManager = s.getScientificStudyManager();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/Worker.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/Worker.java
@@ -7,8 +7,6 @@
 
 package com.mars_sim.core.person.ai.task.util;
 
-import java.io.Serializable;
-
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitIdentifer;
 import com.mars_sim.core.UnitListener;
@@ -20,12 +18,13 @@ import com.mars_sim.core.person.ai.SkillManager;
 import com.mars_sim.core.person.ai.mission.Mission;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.building.Building;
-import com.mars_sim.core.structure.building.function.Function;
+import com.mars_sim.core.structure.building.function.ActivitySpot;
+import com.mars_sim.core.structure.building.function.ActivitySpot.AllocatedSpot;
 import com.mars_sim.core.vehicle.Vehicle;
 import com.mars_sim.mapdata.location.Coordinates;
 import com.mars_sim.mapdata.location.LocalPosition;
 
-public interface Worker extends Loggable, Serializable, UnitIdentifer, EquipmentOwner {
+public interface Worker extends Loggable, UnitIdentifer, EquipmentOwner {
 
 	/**
 	 * Returns a reference to the Worker natural attribute manager
@@ -204,16 +203,11 @@ public interface Worker extends Loggable, Serializable, UnitIdentifer, Equipment
 	public UnitType getUnitType();
 	
 	/**
-	 * Gets the function type the person is actively participating.
-	 * 
-	 * @return
+	 * An activity spot has been assigned to a Worker.
+	 * This should release any activity spot already assigned
+	 * @param spot Owned spot
+	 * @see ActivitySpot#claim(Worker)
+	 * @see ActivitySpot#release(Worker)
 	 */
-	public Function getFunction();
-	
-	/**
-	 * Sets the function type.
-	 * 
-	 * @param functionType
-	 */
-	public void setFunction(Function function);
+    public void setActivitySpot(AllocatedSpot spot);
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/robot/Robot.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/robot/Robot.java
@@ -45,10 +45,10 @@ import com.mars_sim.core.science.ScienceType;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.building.Building;
 import com.mars_sim.core.structure.building.BuildingManager;
-import com.mars_sim.core.structure.building.function.Function;
 import com.mars_sim.core.structure.building.function.FunctionType;
 import com.mars_sim.core.structure.building.function.RoboticStation;
 import com.mars_sim.core.structure.building.function.SystemType;
+import com.mars_sim.core.structure.building.function.ActivitySpot.AllocatedSpot;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.Temporal;
 import com.mars_sim.core.vehicle.Crewable;
@@ -104,8 +104,8 @@ public class Robot extends Unit implements Salvagable, Temporal, Malfunctionable
 
 	private String model;
 	
-	/** The Function the robot's is actively participating. */
-	private Function function;
+	/** The spot assigned to the Robot */
+	private AllocatedSpot spot;
 	/** The year of birth of this robot. */
 	private LocalDate birthDate;
 	/** Settlement position (meters) from settlement center. */
@@ -1287,21 +1287,16 @@ public class Robot extends Unit implements Salvagable, Temporal, Malfunctionable
 	}
 	
 	/**
-	 * Gets the function the person is actively participating.
+	 * Sets the activity spot assigned.
 	 * 
-	 * @return
+	 * @param newSpot Can be null if no spot assigned
 	 */
-	public Function getFunction() {
-		return function;
-	}
-	
-	/**
-	 * Sets the function.
-	 * 
-	 * @param functionType
-	 */
-	public void setFunction(Function function) {
-		this.function = function;
+	@Override
+	public void setActivitySpot(AllocatedSpot newSpot) {
+		if (spot != null) {
+			spot.release(this);
+		}
+		spot = newSpot;
 	}
 	
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Airlock.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Airlock.java
@@ -425,17 +425,15 @@ public abstract class Airlock implements Serializable {
 	}
 
 	/**
-	 * Removes the id of a person.
+	 * Removes the person.
 	 *
-	 * @param id the person's id
+	 * @param p Person   removed
 	 */
-	public void removeID(Integer id) {
-//		if (getAirlockType() == AirlockType.BUILDING_AIRLOCK) {
-			for (int i=0; i<5; i++) {
-				// Remove this person from all zone maps
-				vacate(i, id);
-			}
-//		}
+	public void remove(Person p) {
+		int id = p.getIdentifier();
+		for (int i=0; i<5; i++) {
+			vacate(i, p);
+		}
 
 		if (operatorID.equals(id)) {;
 			operatorID = Integer.valueOf(-1);
@@ -1005,9 +1003,9 @@ public abstract class Airlock implements Serializable {
 	 */
 	public abstract LocalPosition getAvailableAirlockPosition();
 
-    public abstract boolean occupy(int zone, LocalPosition p, Integer id);
+    public abstract boolean occupy(int zone, LocalPosition pos, Person p);
 
-	public abstract boolean vacate(int zone, Integer id);
+	public abstract boolean vacate(int zone, Person p);
 
 	public abstract boolean isInZone(Person p, int zone);
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingManager.java
@@ -1681,13 +1681,7 @@ public class BuildingManager implements Serializable {
 				person.setPosition(settlementLoc);
 				
 				// Add the person to this activity spot
-				f.addActivitySpot(loc, person.getIdentifier());
-				// Remove the person from the previous activity spot
-				if (person.getFunction() != null) {
-					person.getFunction().removeFromActivitySpot(person.getIdentifier());
-				}
-				// Set the new function type
-				person.setFunction(f);
+				f.claimActivitySpot(loc, person);
 				
 				result = true;
 			}
@@ -1752,13 +1746,7 @@ public class BuildingManager implements Serializable {
 				robot.setPosition(settlementLoc);
 
 				// Add the robot to this activity spot
-				f.addActivitySpot(loc, robot.getIdentifier());
-				// Remove the robot from the previous activity spot
-				if (robot.getFunction() != null) {
-					robot.getFunction().removeFromActivitySpot(robot.getIdentifier());
-				}
-				// Set the new function type
-				robot.setFunction(f);
+				f.claimActivitySpot(loc, robot);
 
 				result = true;
 			}	

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/ActivitySpot.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/ActivitySpot.java
@@ -9,24 +9,96 @@ package com.mars_sim.core.structure.building.function;
 
 import java.io.Serializable;
 
+import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.mapdata.location.LocalPosition;
 
+/**
+ * Represents an activity spotthat can be claimed by a Worker.
+ */
 public final class ActivitySpot implements Serializable {
+
+	/**
+	 * This provides a binding to an allocated ActivitySpot. Only an Allocated spot
+	 * can be released.
+	 */
+	public static class AllocatedSpot implements Serializable {
+		private ActivitySpot spot;
+
+		private AllocatedSpot(ActivitySpot spot) {
+			this.spot = spot;
+		}
+
+		/**
+		 * Release a previously allocated activity spot.
+		 * @param w Worker releasing
+		 */
+		public void release(Worker w) {
+			spot.release(w);
+			spot = null;
+		}
+
+		/**
+		 * Spot allocated to a Worker.
+		 */
+		public ActivitySpot getAllocated() {
+			return spot;
+		}
+	}
+
+	private static final int EMPTY_ID = -1;
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
-	/** default logger. */
-	// May add back private static SimLogger logger = SimLogger.getLogger(ActivitySpot.class.getName())
+
 
 	private int id;
 
 	private LocalPosition pos;
 	
-	public ActivitySpot(LocalPosition pos, int id) {
+	ActivitySpot(LocalPosition pos) {
 		this.pos = pos;
-		this.id = id;
+		this.id = EMPTY_ID;
 	}
 	
+	/**
+	 * A Worker claims this spot. The claim is ignored if the spot if not available.
+	 * Can only be claimed by a Function and not directly.
+	 * Returns a callback instance to allow the spot to be released in the future.
+
+	 * @param w Worker claiming
+	 * @return Allocation reference or null if it is already allocated
+	 */
+	AllocatedSpot claim(Worker w) {
+		if (id == EMPTY_ID) {
+			id = w.getIdentifier();
+			return new AllocatedSpot(this);
+		}
+		return null;
+	}
+
+	/**
+	 * Release this spot for the given worker. Release is ignored if the worker
+	 * does not own the spot.
+	 * @param w Worker doing the release.
+	 */
+	private void release(Worker w) {
+		// Only release it if still allocaetd to the worker
+		if (id == w.getIdentifier()) {
+			id = EMPTY_ID;
+		}
+	}
+
+	/**
+	 * Is the spot empty and not claimed
+	 * @return is unallocated
+	 */
+	public boolean isEmpty() {
+		return id == EMPTY_ID;
+	}
+
+	/**
+	 * Identifier ot the Worker allocated
+	 */
 	public int getID() {
 		return id;
 	}
@@ -41,7 +113,11 @@ public final class ActivitySpot implements Serializable {
 		if (obj == null) return false;
 		if (this.getClass() != obj.getClass()) return false;
 		LocalPosition p = ((ActivitySpot) obj).getPos();
-		int d = ((ActivitySpot)obj).getID();
-		return p.equals(pos) && id == d;
+		return p.equals(pos);
+	}
+
+	@Override
+	public int hashCode() {
+		return pos.hashCode();
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/EVA.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/EVA.java
@@ -31,7 +31,7 @@ public class EVA extends Function {
 	
 	private int airlockCapacity;
 	
-	private Airlock airlock;
+	private BuildingAirlock airlock;
 
 	/**
 	 * Constructor.
@@ -49,10 +49,8 @@ public class EVA extends Function {
 		LocalPosition airlockInteriorLoc = spec.getPositionProperty(INTERIOR_POSITION);
 		LocalPosition airlockExteriorLoc = spec.getPositionProperty(EXTERIOR_POSITION);
 
-		airlock = new BuildingAirlock(building, airlockCapacity, airlockLoc, 
+		airlock = new BuildingAirlock(building, this, airlockCapacity, airlockLoc, 
 											airlockInteriorLoc, airlockExteriorLoc);
-		
-		((BuildingAirlock)airlock).setEVA(this);
 	}
 
 	/**
@@ -90,10 +88,6 @@ public class EVA extends Function {
 		return airlockCapacity * airlockCapacityValue;
 	}
 
-	public int getAirlockCapacity() {
-		return airlockCapacity;
-	}
-	
 	/**
 	 * Gets the building's airlock.
 	 * 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/LivingAccommodations.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/LivingAccommodations.java
@@ -293,10 +293,10 @@ public class LivingAccommodations extends Function {
 		// Note: guest beds are reserved for temporary use and 
 		// are not assigned here for use here
 		
-		Set<LocalPosition> locs = getActivitySpots();
-		for (LocalPosition loc : locs) {
+		Set<ActivitySpot> spots = getActivitySpots();
+		for (var sp : spots) {
 			// Convert the activity spot (the bed location) to the settlement reference coordinate
-			bedLoc = LocalAreaUtil.getLocalRelativePosition(loc, building);
+			bedLoc = LocalAreaUtil.getLocalRelativePosition(sp.getPos(), building);
 	
 			if (!assignedBeds.containsValue(bedLoc)) {
 				if (!guest) {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/VehicleAirlock.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/VehicleAirlock.java
@@ -348,22 +348,20 @@ extends Airlock {
      * Vacate the person from a particular zone
      *
      * @param zone the zone of interest
-     * @param id the person's id
+     * @param p the person
 	 * @return true if the person has been successfully vacated
      */
 	@Override
-	public boolean vacate(int zone, Integer id) {
+	public boolean vacate(int zone, Person p) {
+		int id = p.getIdentifier();
 	 	if (zone == 0) {
     		LocalPosition oldPos = getOldPos(airlockInteriorPosMap, id);
     		if (oldPos == null)
     			return false;
-//    		for (int i=0; i<2; i++) {
-//    			LocalPosition pp = outsideInteriorList.get(i);
     			if (airlockInteriorPosMap.get(oldPos).equals(id)) {
     				airlockInteriorPosMap.put(oldPos, -1);
     				return true;
     			}
-//    		}
     	}
 
 	   	else if (zone == 1 || zone == 3) {
@@ -378,20 +376,17 @@ extends Airlock {
 				airlockInsidePosMap.put(oldPos, -1);
 				return true;
 			}
-//    		return true;
     	}
 
     	else if (zone == 4) {
     		LocalPosition oldPos = getOldPos(airlockExteriorPosMap, id);
     		if (oldPos == null)
     			return false;
-//    		for (int i=0; i<2; i++) {
-//    			LocalPosition pp = outsideExteriorList.get(i);
-    			if (airlockExteriorPosMap.get(oldPos).equals(id)) {
-    				airlockExteriorPosMap.put(oldPos, -1);
-    				return true;
-    			}
-//    		}
+
+			if (airlockExteriorPosMap.get(oldPos).equals(id)) {
+				airlockExteriorPosMap.put(oldPos, -1);
+				return true;
+			}
     	}
     	return false;
     }
@@ -447,10 +442,11 @@ extends Airlock {
      * 
      * @param zone
      * @param p
-     * @param id
+     * @param person
      */
     @Override
-    public boolean occupy(int zone, LocalPosition p, Integer id) {
+    public boolean occupy(int zone, LocalPosition p, Person per) {
+		int id = per.getIdentifier();
     	if (zone == 0) {
     		// Do not allow the same person who has already occupied a position to take another position
     		if (airlockInteriorPosMap.values().contains(id))

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/VehicleAirlock.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/VehicleAirlock.java
@@ -358,10 +358,10 @@ extends Airlock {
     		LocalPosition oldPos = getOldPos(airlockInteriorPosMap, id);
     		if (oldPos == null)
     			return false;
-    			if (airlockInteriorPosMap.get(oldPos).equals(id)) {
-    				airlockInteriorPosMap.put(oldPos, -1);
-    				return true;
-    			}
+			if (airlockInteriorPosMap.get(oldPos).equals(id)) {
+				airlockInteriorPosMap.put(oldPos, -1);
+				return true;
+			}
     	}
 
 	   	else if (zone == 1 || zone == 3) {

--- a/mars-sim-core/src/test/java/com/mars_sim/core/AbstractMarsSimUnitTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/AbstractMarsSimUnitTest.java
@@ -19,12 +19,12 @@ import com.mars_sim.core.structure.MockSettlement;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.building.Building;
 import com.mars_sim.core.structure.building.BuildingManager;
-import com.mars_sim.core.structure.building.FunctionSpec;
 import com.mars_sim.core.structure.building.MockBuilding;
 import com.mars_sim.core.structure.building.function.EVA;
 import com.mars_sim.core.structure.building.function.Function;
 import com.mars_sim.core.structure.building.function.FunctionType;
 import com.mars_sim.core.structure.building.function.LivingAccommodations;
+import com.mars_sim.core.structure.building.function.Recreation;
 import com.mars_sim.core.structure.building.function.VehicleGarage;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.MarsTime;
@@ -43,8 +43,6 @@ public abstract class AbstractMarsSimUnitTest extends TestCase {
 	protected UnitManager unitManager;
 	protected MarsSurface surface;
 	protected Simulation sim;
-	private FunctionSpec evaSpec;
-	private FunctionSpec quartersSpec;
 	protected SimulationConfig simConfig;
 	private int pulseID = 1;
 
@@ -76,10 +74,7 @@ public abstract class AbstractMarsSimUnitTest extends TestCase {
 	    							 simConfig.getPersonConfig(), simConfig.getCropConfiguration(), sim.getSurfaceFeatures(),
 	    							 sim.getWeather(), unitManager);
 	    
-	    surface = unitManager.getMarsSurface();
-		evaSpec = simConfig.getBuildingConfiguration().getFunctionSpec("EVA Airlock", FunctionType.EVA);
-		quartersSpec = simConfig.getBuildingConfiguration().getFunctionSpec("Residential Quarters", FunctionType.LIVING_ACCOMMODATIONS);
-		
+	    surface = unitManager.getMarsSurface();		
 	}
 
 	
@@ -96,9 +91,8 @@ public abstract class AbstractMarsSimUnitTest extends TestCase {
 	protected VehicleGarage buildGarage(BuildingManager buildingManager, LocalPosition pos, double facing, int id) {
 	
 		MockBuilding building0 = buildBuilding(buildingManager, pos, facing, id);
-
-//	    building0.addFunction(new EVA(building0, evaSpec));
 	
+		// TODO this should be built off a FunctionSpec
 	    LocalPosition parkingLocation = LocalPosition.DEFAULT_POSITION;
 	    VehicleGarage garage = new VehicleGarage(building0,
 	            new LocalPosition[] { parkingLocation });
@@ -126,9 +120,19 @@ public abstract class AbstractMarsSimUnitTest extends TestCase {
 	    return building0;
 	}
 
+	protected Building buildRecreation(BuildingManager buildingManager, LocalPosition pos, double facing, int id) {
+		MockBuilding building0 = buildBuilding(buildingManager, pos, facing, id);
+
+		var spec = simConfig.getBuildingConfiguration().getFunctionSpec("Lander Hab", FunctionType.LIVING_ACCOMMODATIONS);
+
+	    building0.addFunction(new Recreation(building0, spec));
+	    return building0;
+	}
+
 	protected Building buildEVA(BuildingManager buildingManager, LocalPosition pos, double facing, int id) {
 		MockBuilding building0 = buildBuilding(buildingManager, pos, facing, id);
 
+		var evaSpec = simConfig.getBuildingConfiguration().getFunctionSpec("EVA Airlock", FunctionType.EVA);
 	    building0.addFunction(new EVA(building0, evaSpec));
 	    return building0;
 	}
@@ -136,6 +140,8 @@ public abstract class AbstractMarsSimUnitTest extends TestCase {
 	protected Building buildAccommodation(BuildingManager buildingManager, LocalPosition pos, double facing, int id) {
 		MockBuilding building0 = buildBuilding(buildingManager, pos, facing, id);
 		// Need to rework to allow maven to test this
+		var quartersSpec = simConfig.getBuildingConfiguration().getFunctionSpec("Residential Quarters", FunctionType.LIVING_ACCOMMODATIONS);
+
 	    building0.addFunction(new LivingAccommodations(building0, quartersSpec));
 	    return building0;
 	}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/function/FunctionTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/function/FunctionTest.java
@@ -1,0 +1,91 @@
+package com.mars_sim.core.structure.building.function;
+
+
+import java.util.ArrayList;
+
+import com.mars_sim.core.AbstractMarsSimUnitTest;
+import com.mars_sim.core.person.Person;
+
+public class FunctionTest extends AbstractMarsSimUnitTest {
+
+    public void testBuildActivitySpot() {
+        var home = buildSettlement("Test");
+        var building = buildRecreation(home.getBuildingManager(), null, 0D, 0);
+        var b = building.getRecreation();
+
+        var spots = b.getActivitySpots();
+        assertFalse("Has Activity spots", spots.isEmpty());
+        assertEquals("Unoccupied count", spots.size(), b.getNumEmptyActivitySpots());
+        assertEquals("Occupied count", 0, b.getNumOccupiedActivitySpots());
+
+        for(var as : spots) {
+            var as1 = b.findActivitySpot(as.getPos());
+            assertEquals("Found Activity spot", as, as1);
+        }
+
+    }
+
+    public void testClaimActivitySpot() {
+        var home = buildSettlement("Test");
+        var building = buildRecreation(home.getBuildingManager(), null, 0D, 0);
+        var b = building.getRecreation();
+
+        Person p = buildPerson("Worker", home);
+
+        var spots = b.getActivitySpots();
+        var as = (new ArrayList<ActivitySpot>(spots)).get(0); // Bad code
+        b.claimActivitySpot(as.getPos(), p);
+
+        ActivitySpot claimed = p.getActivitySpot();
+        assertNotNull("Activity spot owned", claimed);
+        assertEquals("Correct activity spot", as, claimed);
+        assertFalse("Activity spot empty", claimed.isEmpty());
+        assertEquals("Activity spot owned by Person", p.getIdentifier(), claimed.getID());
+        assertEquals("Unoccupied count", spots.size()-1, b.getNumEmptyActivitySpots());
+        assertEquals("Occupied count", 1, b.getNumOccupiedActivitySpots());
+    }
+
+    public void testReleaseActivitySpot() {
+        var home = buildSettlement("Test");
+        var building = buildRecreation(home.getBuildingManager(), null, 0D, 0);
+        var b = building.getRecreation();
+
+        Person p = buildPerson("Worker", home);
+
+        var spots = b.getActivitySpots();
+        var as = (new ArrayList<ActivitySpot>(spots)).get(0); // Bad code
+        b.claimActivitySpot(as.getPos(), p);
+
+        ActivitySpot claimed = p.getActivitySpot();
+        p.setActivitySpot(null);
+        assertNull("No activity spot allocated", p.getActivitySpot());
+        assertTrue("Activity spot released", claimed.isEmpty());
+        assertEquals("Unoccupied count", spots.size(), b.getNumEmptyActivitySpots());
+        assertEquals("Occupied count", 0, b.getNumOccupiedActivitySpots());
+    }
+
+    public void testReassignActivitySpot() {
+        var home = buildSettlement("Test");
+        var building = buildRecreation(home.getBuildingManager(), null, 0D, 0);
+        var b1 = building.getRecreation();
+        var building2 = buildRecreation(home.getBuildingManager(), null, 0D, 1);
+        var b2 = building2.getRecreation();
+        Person p = buildPerson("Worker", home);
+
+        // Assign spot in 1st building
+        var as1 = (new ArrayList<ActivitySpot>(b1.getActivitySpots())).get(0); // Bad code
+        b1.claimActivitySpot(as1.getPos(), p);
+
+        // Claim spot in 2nd building
+        var as2 = (new ArrayList<ActivitySpot>(b2.getActivitySpots())).get(0); // Bad code
+        b2.claimActivitySpot(as2.getPos(), p);
+
+        assertTrue("Previous spot released", as1.isEmpty());
+        assertEquals("Previous spots all empty", 0, b1.getNumOccupiedActivitySpots());
+
+        ActivitySpot claimed = p.getActivitySpot();
+        assertNotNull("2nd activity spot allocated", claimed);
+        assertEquals("Person owns correct 2nd spot", as2, claimed);
+        assertEquals("Occupied spots in 2nd building", 1, b2.getNumOccupiedActivitySpots());
+    }
+}

--- a/mars-sim-mapdata/src/main/java/com/mars_sim/mapdata/location/LocalPosition.java
+++ b/mars-sim-mapdata/src/main/java/com/mars_sim/mapdata/location/LocalPosition.java
@@ -24,7 +24,7 @@ public class LocalPosition implements Serializable {
     public static final LocalPosition DEFAULT_POSITION = new LocalPosition(0D, 0D);
 
 	/** A very small distance (meters) for measuring how close two positions are. */
-	private static final double VERY_SMALL_DISTANCE = .01; // within a centimeter
+	private static final double ONE_CENTIMETER = .01; // within a centimeter
 	
 	private double x;
 	private double y;
@@ -120,7 +120,7 @@ public class LocalPosition implements Serializable {
 	 * @return
 	 */
 	public boolean isClose(LocalPosition other) {
-		return getDistanceTo(other) < VERY_SMALL_DISTANCE;
+		return getDistanceTo(other) < ONE_CENTIMETER;
 	}
 
 	/**
@@ -155,11 +155,11 @@ public class LocalPosition implements Serializable {
 		if (getClass() != obj.getClass())
 			return false;
 		LocalPosition other = (LocalPosition) obj;
-		if (Double.doubleToLongBits(x) != Double.doubleToLongBits(other.x))
+		double xdiff = x - other.x;
+		if (Math.abs(xdiff) > ONE_CENTIMETER)
 			return false;
-		if (Double.doubleToLongBits(y) != Double.doubleToLongBits(other.y))
-			return false;
-		return true;
+		double ydiff = y - other.y;
+		return (Math.abs(ydiff) < ONE_CENTIMETER);
 	}
 
 	/**


### PR DESCRIPTION
This changes how ActivitySpots are allocated. They are now created as part of a Function constructor. An ActivitySpot now remembers which Worker it is assigned to as it is explcitly allocated to the Worker. Once allocated, the Worker receives a dedicated AllocatedActivitySpot which allows them to release it once completed. Only position that have activity spots created can be allocated; this is another different from the previous implementation which was a loose binding. This has highlighted the complexity in using 2 different coordinate frames (Settlement & local Building); Activity Spots currently are in the Building coordinate frame.

Changes:
- ActivitySpot remembers the Worker assigned; this can later be released by the AllocatedActivitySpot object.
- Function is responsable for creating the required Activity Spots.
- Worker no longer remembers the Function but just the AllocatedActivtySpot.
- A Worker releases any old ActivitySpot when a new one is assigned.
- Arrival and claiming of an ActivitySpot has been changed in many places.
- Corrected a problem with allocating an ActivitySpot for Dining; old approach could assign the wrong Function.
- Airlock has been converted to use ActivitySpot for the main airlock location.
- Airlock methods are now based on Person instead of identifier; internally identifer is still heavily used :-(
- Task walk to bed corrected as previous it could use the wrong coordinate frame to find the Activity Spot.
- At the start of a Walk task, any activity spot is released.
- Changed LocalPosition equals method to have a 1 centimeter tolerance. This is a precision problem with using double and converting between the 2 coordinate frames.
- New Function unit test to check ActivitySpot logic.

Part of #1143