### PR TITLE
Change the bed allocation logic

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/person/BedCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/person/BedCommand.java
@@ -32,11 +32,9 @@ public class BedCommand extends AbstractPersonCommand {
 			ActivitySpot bedSpot = bed.getAllocated();
 			StringBuilder responseText = new StringBuilder();
 			responseText.append("My designated quarters is ");
-			responseText.append(bedSpot.getName() + " at ");
+			responseText.append(bed.getSpotDescription() + " (");
 			responseText.append(bedSpot.getPos().getShortFormat());
-			responseText.append(" in ");
-			responseText.append(bed.getOwner());
-			responseText.append(" at ");
+			responseText.append(") at ");
 			responseText.append(person.getAssociatedSettlement());
 
 			context.println(responseText.toString());

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
@@ -289,6 +289,7 @@ public class Person extends Unit implements Worker, Temporal, Researcher {
 		// Set the person's status of death
 		isBuried = false;
 
+
 		// Add this person as a citizen
 		settlement.addACitizen(this);
 		// Set the container unit
@@ -344,9 +345,9 @@ public class Person extends Unit implements Worker, Temporal, Researcher {
 		eVATaskTime = new SolMetricDataLogger<>(MAX_NUM_SOLS);
 		// Create a set of collaborative studies
 		collabStudies = new HashSet<>();
+
 		// Construct the EquipmentInventory instance.
 		eqmInventory = new EquipmentInventory(this, carryingCapacity);
-		
 		eqmInventory.setResourceCapacity(ResourceUtil.foodID, CARRYING_CAPACITY_FOOD);
 	}
 
@@ -2443,7 +2444,8 @@ public class Person extends Unit implements Worker, Temporal, Researcher {
 	 */
 	@Override
 	public void setActivitySpot(AllocatedSpot newSpot) {
-		if (spot != null) {
+		// Check the spot is really chnging and not just a reallocation
+		if ((spot != null) && !spot.equals(newSpot)) {
 			spot.leave(this, false);
 		}
 		spot = newSpot;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/BudgetResources.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/BudgetResources.java
@@ -79,6 +79,7 @@ public class BudgetResources extends Task {
 					office.addStaff();
 					// Walk to the office building.
 					walkToTaskSpecificActivitySpotInBuilding(officeBuilding, FunctionType.ADMINISTRATION, true);
+					building = officeBuilding;
 				}
 			}
 
@@ -87,6 +88,7 @@ public class BudgetResources extends Task {
 				if (managementBuilding != null) {
 					// Walk to the management building.
 					walkToTaskSpecificActivitySpotInBuilding(managementBuilding, FunctionType.MANAGEMENT, true);
+					building = managementBuilding;
 				}
 				else {	
 					Building dining = BuildingManager.getAvailableDiningBuilding(person, false);
@@ -94,6 +96,7 @@ public class BudgetResources extends Task {
 					if (dining != null) {
 						// Walk to the dining building.
 						walkToTaskSpecificActivitySpotInBuilding(dining, FunctionType.DINING, true);
+						building = dining;
 					}
 				}
 			}
@@ -129,9 +132,6 @@ public class BudgetResources extends Task {
 	 * @return the amount of time (millisols) left over after performing the phase.
 	 */
 	private double reviewingPhase(double time) {
-		
-		if (building == null)
-			building = BuildingManager.getRandomQuarter(person);
 	
 		if (getTimeCompleted() > .9 * getDuration()) {
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/Walk.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/Walk.java
@@ -218,9 +218,6 @@ public class Walk extends Task {
 		addPhase(CLIMB_DOWN_LADDER);
 
 		setPhase(getWalkingStepPhase());
-
-		// Release any starting actvity spot
-		worker.setActivitySpot(null);
 	}
 
 	public Walk(Robot robot, WalkingSteps walkingSteps) {
@@ -235,9 +232,6 @@ public class Walk extends Task {
 		addPhase(WALKING_SETTLEMENT_INTERIOR);
 
 		setPhase(getWalkingStepPhase());
-
-		// Release any starting actvity spot
-		worker.setActivitySpot(null);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/Task.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/Task.java
@@ -46,7 +46,6 @@ import com.mars_sim.core.structure.building.BuildingManager;
 import com.mars_sim.core.structure.building.function.Function;
 import com.mars_sim.core.structure.building.function.FunctionType;
 import com.mars_sim.core.structure.building.function.LifeSupport;
-import com.mars_sim.core.structure.building.function.LivingAccommodations;
 import com.mars_sim.core.structure.building.function.farming.CropConfig;
 import com.mars_sim.core.structure.construction.ConstructionConfig;
 import com.mars_sim.core.time.MarsTime;
@@ -1081,45 +1080,6 @@ public abstract class Task implements Serializable, Comparable<Task> {
 	}
 
 	/**
-	 * Walks to a guest bed.
-	 * 
-	 * @param building the building the bed is at
-	 * @param person the person who walks to the bed
-	 * @param allowFail true if allowing the walk task to fail
-	 */
-	protected boolean walkToGuestBed(Person person, boolean allowFail) {
-		LocalPosition bed = null;
-		Building target = null;
-		
-		Set<Building> set = person.getSettlement().getBuildingManager()
-				.getBuildingSet(FunctionType.LIVING_ACCOMMODATIONS);
-		
-		for (Building building : set) {
-			LivingAccommodations quarters = building.getLivingAccommodations();
-			bed = quarters.getEmptyGuestBed();
-			if (bed != null) {
-				target = building;
-				// Converts a settlement-wide bed location back to an activity spot within a building
-				Function f = building.getFunction(FunctionType.LIVING_ACCOMMODATIONS);
-				
-				// Create subtask for walking to destination.
-				boolean canWalk = createWalkingSubtask(target, bed, allowFail);
-				if (canWalk) {
-					// Register this person to use this guest bed
-					quarters.registerGuestBed(person.getIdentifier());
-					
-					// Add the person to this activity spot
-					f.claimActivitySpot(bed, person);
-					
-					return true;
-				}
-			}
-		}
-		
-		return false;
-	}
-	
-	/**
 	 * Walks to the bed previously assigned for this person.
 	 * 
 	 * @param person the person who walks to the bed
@@ -1136,7 +1096,8 @@ public abstract class Task implements Serializable, Comparable<Task> {
 		
 		// Check my own position
 		LocalPosition myLoc = person.getPosition();
-		
+		person.setActivitySpot(bed);
+
 		if (myLoc.equals(bed.getAllocated().getPos())) {
 			logger.info(person, 10_000L, "Already in my own bed.");
 			return canWalk;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -85,6 +85,7 @@ import com.mars_sim.core.structure.building.BuildingManager;
 import com.mars_sim.core.structure.building.connection.BuildingConnectorManager;
 import com.mars_sim.core.structure.building.function.EVA;
 import com.mars_sim.core.structure.building.function.FunctionType;
+import com.mars_sim.core.structure.building.function.LivingAccommodations;
 import com.mars_sim.core.structure.construction.ConstructionManager;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.MarsTime;
@@ -966,16 +967,6 @@ public class Settlement extends Structure implements Temporal,
 			iceProbabilityValue = computeIceProbability();
 
 			regolithProbabilityValue = computeRegolithProbability();
-			
-			// Future: should register a bed when calling addACitizen(() to 
-			// add this person as a citizen and not here
-			
-			for (Person p : citizens) {
-				// Register each settler with a bed
-				Building b = BuildingManager.getBestAvailableQuarters(p, false, true);
-				if (b != null)
-					b.getLivingAccommodations().registerSleeper(p, false);
-			}
 
 			// Initialize the goods manager
 			goodsManager.updateGoodValues();
@@ -1985,11 +1976,9 @@ public class Settlement extends Structure implements Temporal,
 			
 			p.setCoordinates(getCoordinates());
 
-			// Register each settler with a bed
-//			Building b = BuildingManager.getBestAvailableQuarters(p, true, true);
-//			if (b != null)
-//				b.getLivingAccommodations().registerSleeper(p, false);
-			
+			// Assign a permenant bed reservatinoif possible
+			LivingAccommodations.allocateBed(this, p, true);
+
 			// Update the numCtizens
 			numCitizens = citizens.size();
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingConfig.java
@@ -301,34 +301,9 @@ public class BuildingConfig {
 	private static BuildingCategory deriveCategory(Set<FunctionType> functions) {
 
 		// Get a set of categories
-		Set<BuildingCategory> cats = new HashSet<>();
-		for (FunctionType fType : functions) {
-			var bCat = switch(fType) {
-				case EARTH_RETURN -> BuildingCategory.ERV;
-				case EVA -> BuildingCategory.EVA_AIRLOCK;
-				case FARMING, FISHERY -> BuildingCategory.FARMING;
-				case BUILDING_CONNECTION -> BuildingCategory.HALLWAY;
-				case ASTRONOMICAL_OBSERVATION, FIELD_STUDY,
-					 RESEARCH, COMPUTATION -> BuildingCategory.LABORATORY;
-				case ADMINISTRATION, COMMUNICATION,
-				     MANAGEMENT -> BuildingCategory.COMMAND;
-				case COOKING, DINING, EXERCISE, FOOD_PRODUCTION,
-				     LIVING_ACCOMMODATIONS, PREPARING_DESSERT,
-					 RECREATION -> BuildingCategory.LIVING;
-				case STORAGE -> BuildingCategory.STORAGE;					
-				case MEDICAL_CARE -> BuildingCategory.MEDICAL;
-				case POWER_GENERATION, POWER_STORAGE,
-				     THERMAL_GENERATION -> BuildingCategory.POWER;
-				case RESOURCE_PROCESSING, WASTE_PROCESSING -> BuildingCategory.PROCESSING;
-				case VEHICLE_MAINTENANCE -> BuildingCategory.VEHICLE;
-				case MANUFACTURE -> BuildingCategory.WORKSHOP;
-				default -> null;
-			};
-
-			if (bCat != null) {
-				cats.add(bCat);
-			}
-		}
+		Set<BuildingCategory> cats = functions.stream()
+						.map(f -> f.getCategory())
+						.collect(Collectors.toSet());
 
 		BuildingCategory category = BuildingCategory.HALLWAY;
 		if (!cats.isEmpty()) {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingConfig.java
@@ -75,10 +75,8 @@ public class BuildingConfig {
 	private static final String CONVERSION = "thermal-conversion";
 	private static final String PERCENT_LOADING = "percent-loading";
 
-	private static final String ACCOMMODATIONS = "living-accommodations";
 	private static final String MEDICAL_CARE = "medical-care";
 	private static final String BEDS = "beds";
-	private static final String GUEST = "guest";
 	private static final String VEHICLE_MAINTENANCE = "vehicle-maintenance";
 	private static final String PARKING_LOCATION = "parking-location";
 	private static final String FLYER_LOCATION = "flyer-location";
@@ -268,13 +266,6 @@ public class BuildingConfig {
 		Element medicalElement = functionsElement.getChild(MEDICAL_CARE);
 		if (medicalElement != null) {
 			Set<LocalPosition> beds = parsePositions(medicalElement, BEDS, BED_LOCATION,
-												width, length);
-			newSpec.setBeds(beds);
-		}
-		
-		Element accommodationsElement = functionsElement.getChild(ACCOMMODATIONS);
-		if (accommodationsElement != null) {
-			Set<LocalPosition> beds = parsePositions(accommodationsElement, GUEST, ACTIVITY_SPOT,
 												width, length);
 			newSpec.setBeds(beds);
 		}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/FunctionSpec.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/FunctionSpec.java
@@ -20,7 +20,6 @@ public class FunctionSpec {
 	public static final String CAPACITY = "capacity";
 	private static final String AREA = "area";
 	private static final String DEPTH = "depth";
-	public static final String GUEST_BED = "guest";
 	public static final String BED = "bed";
 
 	// Name of the standard tech level property
@@ -73,13 +72,6 @@ public class FunctionSpec {
 	public double getDepth() {
 		return getDoubleProperty(DEPTH);
 	}
-	
-	/**
-	 * Gets the value of the standard bed property.
-	 */
-	public int getGuestBeds() {
-		return getIntegerProperty(GUEST_BED);
-	}
 
 	/**
 	 * Gets the value of the standard TechLevel property.
@@ -127,6 +119,23 @@ public class FunctionSpec {
 	}
 
 	/**
+	 * Gets a Function property as a boolean object.
+	 * 
+	 * @param propName
+	 * @return
+	 */
+    public boolean getBoolProperty(String propName, boolean defaultValue) {
+		Object value = props.get(propName);
+		if (value == null) {
+			return defaultValue;
+		}
+		if (value instanceof Boolean v) {
+			return v;
+		}
+		return Boolean.parseBoolean((String) value);
+    }
+
+	/**
 	 * Sets the building specs instance.
 	 * 
 	 * @param spec
@@ -143,4 +152,5 @@ public class FunctionSpec {
 	public BuildingSpec getBuildingSpec() {
 		return buildingSpec;
 	}
+
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/ActivitySpot.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/ActivitySpot.java
@@ -64,6 +64,41 @@ public final class ActivitySpot implements Serializable {
 		public Building getOwner() {
 			return owner;
 		}
+
+		/**
+		 * Get a description of the spot
+		 */
+        public String getSpotDescription() {
+            return spot.getName() + " @ " + owner.getName();
+        }
+		
+
+		@Override
+		public int hashCode() {
+			return owner.hashCode();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			AllocatedSpot other = (AllocatedSpot) obj;
+			if (spot == null) {
+				if (other.spot != null)
+					return false;
+			} else if (!spot.equals(other.spot))
+				return false;
+			if (owner == null) {
+				if (other.owner != null)
+					return false;
+			} else if (!owner.equals(other.owner))
+				return false;
+			return true;
+		}
 	}
 
 	private static final int EMPTY_ID = -1;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/FunctionType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/FunctionType.java
@@ -7,56 +7,63 @@
 package com.mars_sim.core.structure.building.function;
 
 import com.mars_sim.core.robot.RobotType;
+import com.mars_sim.core.structure.building.BuildingCategory;
 import com.mars_sim.tools.Msg;
 
 public enum FunctionType {
 
-    ADMINISTRATION              (Msg.getString("FunctionType.administration")), //$NON-NLS=1$
-	ALGAE_FARMING				(Msg.getString("FunctionType.algaeFarming")), //$NON-NLS-1$
-    ASTRONOMICAL_OBSERVATION	(Msg.getString("FunctionType.astronomicalObservations")), //$NON-NLS-1$
-	BUILDING_CONNECTION			(Msg.getString("FunctionType.buildingConnection")), //$NON-NLS-1$
-	COMMUNICATION				(Msg.getString("FunctionType.communication")), //$NON-NLS-1$
-	COMPUTATION					(Msg.getString("FunctionType.computation")), //$NON-NLS-1$
-	COOKING						(Msg.getString("FunctionType.cooking")), //$NON-NLS-1$
-	DINING						(Msg.getString("FunctionType.dining")), //$NON-NLS-1$
-	EARTH_RETURN				(Msg.getString("FunctionType.earthReturn")), //$NON-NLS-1$
-	EVA							(Msg.getString("FunctionType.eva")), //$NON-NLS-1$
-	EXERCISE					(Msg.getString("FunctionType.exercise")), //$NON-NLS-1$
-	FARMING						(Msg.getString("FunctionType.farming")), //$NON-NLS-1$
-	FISHERY						(Msg.getString("FunctionType.fishery")), //$NON-NLS-1$
-	FOOD_PRODUCTION  			(Msg.getString("FunctionType.foodProduction")), //$NON-NLS-1$	
-	VEHICLE_MAINTENANCE			(Msg.getString("FunctionType.vehicleMaintenance")), //$NON-NLS-1$
-	LIFE_SUPPORT				(Msg.getString("FunctionType.lifeSupport")), //$NON-NLS-1$
-	LIVING_ACCOMMODATIONS		(Msg.getString("FunctionType.livingAccommodations")), //$NON-NLS-1$
-	MANAGEMENT					(Msg.getString("FunctionType.management")), //$NON-NLS-1$
-	MANUFACTURE					(Msg.getString("FunctionType.manufacture")), //$NON-NLS-1$
-	MEDICAL_CARE				(Msg.getString("FunctionType.medicalCare")), //$NON-NLS-1$
-	POWER_GENERATION			(Msg.getString("FunctionType.powerGeneration")), //$NON-NLS-1$
-	POWER_STORAGE				(Msg.getString("FunctionType.powerStorage")), //$NON-NLS-1$
-	PREPARING_DESSERT			(Msg.getString("FunctionType.preparingDessert")),  //$NON-NLS-1$
-	RECREATION					(Msg.getString("FunctionType.recreation")), //$NON-NLS-1$
-	RESEARCH					(Msg.getString("FunctionType.research")), //$NON-NLS-1$
-	RESOURCE_PROCESSING			(Msg.getString("FunctionType.resourceProcessing")), //$NON-NLS-1$
-	ROBOTIC_STATION				(Msg.getString("FunctionType.roboticStation")), //$NON-NLS-1$
-	STORAGE						(Msg.getString("FunctionType.storage")),  //$NON-NLS-1$
-	THERMAL_GENERATION			(Msg.getString("FunctionType.thermalGeneration")), //$NON-NLS-1$
-	WASTE_PROCESSING			(Msg.getString("FunctionType.wasteProcessing")), //$NON-NLS-1$
-	FIELD_STUDY					(Msg.getString("FunctionType.fieldStudy")), //$NON-NLS-1$
-	UNKNOWN						(Msg.getString("FunctionType.unknown")) //$NON-NLS-1$
+    ADMINISTRATION              (BuildingCategory.COMMAND, Msg.getString("FunctionType.administration")), //$NON-NLS=1$
+	ALGAE_FARMING				(BuildingCategory.FARMING, Msg.getString("FunctionType.algaeFarming")), //$NON-NLS-1$
+    ASTRONOMICAL_OBSERVATION	(BuildingCategory.LABORATORY, Msg.getString("FunctionType.astronomicalObservations")), //$NON-NLS-1$
+	BUILDING_CONNECTION			(BuildingCategory.HALLWAY, Msg.getString("FunctionType.buildingConnection")), //$NON-NLS-1$
+	COMMUNICATION				(BuildingCategory.COMMAND,Msg.getString("FunctionType.communication")), //$NON-NLS-1$
+	COMPUTATION					(BuildingCategory.LABORATORY, Msg.getString("FunctionType.computation")), //$NON-NLS-1$
+	COOKING						(BuildingCategory.LIVING, Msg.getString("FunctionType.cooking")), //$NON-NLS-1$
+	DINING						(BuildingCategory.LIVING, Msg.getString("FunctionType.dining")), //$NON-NLS-1$
+	EARTH_RETURN				(BuildingCategory.ERV, Msg.getString("FunctionType.earthReturn")), //$NON-NLS-1$
+	EVA							(BuildingCategory.EVA_AIRLOCK, Msg.getString("FunctionType.eva")), //$NON-NLS-1$
+	EXERCISE					(BuildingCategory.LIVING, Msg.getString("FunctionType.exercise")), //$NON-NLS-1$
+	FARMING						(BuildingCategory.FARMING, Msg.getString("FunctionType.farming")), //$NON-NLS-1$
+	FISHERY						(BuildingCategory.FARMING, Msg.getString("FunctionType.fishery")), //$NON-NLS-1$
+	FOOD_PRODUCTION  			(BuildingCategory.LIVING, Msg.getString("FunctionType.foodProduction")), //$NON-NLS-1$	
+	VEHICLE_MAINTENANCE			(BuildingCategory.VEHICLE, Msg.getString("FunctionType.vehicleMaintenance")), //$NON-NLS-1$
+	LIFE_SUPPORT				(BuildingCategory.LIVING, Msg.getString("FunctionType.lifeSupport")), //$NON-NLS-1$
+	LIVING_ACCOMMODATIONS		(BuildingCategory.LIVING, Msg.getString("FunctionType.livingAccommodations")), //$NON-NLS-1$
+	MANAGEMENT					(BuildingCategory.COMMAND, Msg.getString("FunctionType.management")), //$NON-NLS-1$
+	MANUFACTURE					(BuildingCategory.WORKSHOP, Msg.getString("FunctionType.manufacture")), //$NON-NLS-1$
+	MEDICAL_CARE				(BuildingCategory.MEDICAL, Msg.getString("FunctionType.medicalCare")), //$NON-NLS-1$
+	POWER_GENERATION			(BuildingCategory.POWER, Msg.getString("FunctionType.powerGeneration")), //$NON-NLS-1$
+	POWER_STORAGE				(BuildingCategory.POWER, Msg.getString("FunctionType.powerStorage")), //$NON-NLS-1$
+	PREPARING_DESSERT			(BuildingCategory.LIVING, Msg.getString("FunctionType.preparingDessert")),  //$NON-NLS-1$
+	RECREATION					(BuildingCategory.LIVING, Msg.getString("FunctionType.recreation")), //$NON-NLS-1$
+	RESEARCH					(BuildingCategory.LABORATORY, Msg.getString("FunctionType.research")), //$NON-NLS-1$
+	RESOURCE_PROCESSING			(BuildingCategory.PROCESSING, Msg.getString("FunctionType.resourceProcessing")), //$NON-NLS-1$
+	ROBOTIC_STATION				(BuildingCategory.LIVING, Msg.getString("FunctionType.roboticStation")), //$NON-NLS-1$
+	STORAGE						(BuildingCategory.STORAGE, Msg.getString("FunctionType.storage")),  //$NON-NLS-1$
+	THERMAL_GENERATION			(BuildingCategory.POWER, Msg.getString("FunctionType.thermalGeneration")), //$NON-NLS-1$
+	WASTE_PROCESSING			(BuildingCategory.PROCESSING, Msg.getString("FunctionType.wasteProcessing")), //$NON-NLS-1$
+	FIELD_STUDY					(BuildingCategory.LABORATORY, Msg.getString("FunctionType.fieldStudy")), //$NON-NLS-1$
+	UNKNOWN						(BuildingCategory.LIVING, Msg.getString("FunctionType.unknown")) //$NON-NLS-1$
 	;
 
 	private String name;
+	private BuildingCategory category;
 
 
 	/** hidden constructor. */
-	private FunctionType(String name) {
+	private FunctionType(BuildingCategory category, String name) {
 		this.name = name;
+		this.category = category;
 	}
 
 	public String getName() {
 		return this.name;
 	}
 	
+	public BuildingCategory getCategory() {
+		return this.category;
+	}
+
 	/**
 	 * Gets the default Function for a Robot Type.
 	 * 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/LivingAccommodations.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/LivingAccommodations.java
@@ -7,13 +7,9 @@
 package com.mars_sim.core.structure.building.function;
 
 import java.util.Iterator;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
-import com.mars_sim.core.LocalAreaUtil;
 import com.mars_sim.core.data.SolSingleMetricDataLogger;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.person.Person;
@@ -23,7 +19,6 @@ import com.mars_sim.core.structure.building.BuildingException;
 import com.mars_sim.core.structure.building.FunctionSpec;
 import com.mars_sim.core.structure.building.function.ActivitySpot.AllocatedSpot;
 import com.mars_sim.core.time.ClockPulse;
-import com.mars_sim.mapdata.location.LocalPosition;
 import com.mars_sim.tools.util.RandomUtil;
 
 /**
@@ -48,10 +43,6 @@ public class LivingAccommodations extends Function {
 	
 	private static final String WASTE_NAME = "LivingAccomodation::generateWaste";
 	
-	/** max # of beds. */
-	private int maxNumBeds;
-	/** max # of guest beds. */
-	private int maxGuestBeds;
 	/** The average water used per person for washing (showers, washing clothes, hands, dishes, etc) [kg/sol].*/
 	private double washWaterUsage;
 	// private double wasteWaterProduced; // Waste water produced by
@@ -63,14 +54,14 @@ public class LivingAccommodations extends Function {
 	/** The estimated waste water produced. */
 	private double estimatedWasteWaterProduced;
 
-	/** The guest beds in this facility, using settlement-wide position. */
-	private Map<Integer, LocalPosition> guestBeds = new ConcurrentHashMap<>();
-	
 	/** The daily water usage in this facility [kg/sol]. */
 	private SolSingleMetricDataLogger dailyWaterUsage;
 	
 	/** The daily grey water generated in this facility [kg/sol]. */
 	private SolSingleMetricDataLogger greyWaterGen;
+
+	/** Can this be used as a bunk house for guests */
+	private boolean guesthouse;
 
 	/**
 	 * Constructor.
@@ -86,26 +77,15 @@ public class LivingAccommodations extends Function {
 		dailyWaterUsage = new SolSingleMetricDataLogger(MAX_NUM_SOLS);
 		
 		greyWaterGen = new SolSingleMetricDataLogger(MAX_NUM_SOLS);
-		// Loads the max # of regular beds available
-		maxNumBeds = spec.getCapacity();
-		
-		Set<LocalPosition> bedSet = spec.getBuildingSpec().getBeds();
-		
-		for (LocalPosition loc: bedSet) {
-			// Convert to settlement position
-			LocalPosition bedLoc = LocalAreaUtil.getLocalRelativePosition(loc, building);
-			guestBeds.put(-1, bedLoc);
-		}
-		
-		// Loads the max # of guest beds available
-		maxGuestBeds = bedSet.size();
-		
+
 		// Loads the wash water usage kg/sol
 		washWaterUsage = personConfig.getWaterUsageRate();
 		// Loads the grey to black water ratio
 		double grey2BlackWaterRatio = personConfig.getGrey2BlackWaterRatio();
 		// Calculate the grey water fraction
 		greyWaterFraction = grey2BlackWaterRatio / (grey2BlackWaterRatio + 1);
+
+		guesthouse = spec.getBoolProperty("guesthouse", false);
 	}
 
 	/**
@@ -131,7 +111,7 @@ public class LivingAccommodations extends Function {
 				removedBuilding = true;
 			} else {
 				double wearModifier = (building.getMalfunctionManager().getWearCondition() / 100D) * .75D + .25D;
-				supply += building.getLivingAccommodations().getTotalBeds() * wearModifier;
+				supply += building.getLivingAccommodations().getBedCap() * wearModifier;
 			}
 		}
 
@@ -146,27 +126,8 @@ public class LivingAccommodations extends Function {
 	 * @return
 	 */
 	public int getBedCap() {
-		return maxNumBeds;
+		return getActivitySpots().size();
 	}
-
-	/**
-	 * Gets the max number of guest beds in the living accommodations.
-	 *
-	 * @return
-	 */
-	public int getMaxGuestBeds() {
-		return maxGuestBeds;
-	}
-	
-	/**
-	 * Gets the total number of beds (regular and guest) in the living accommodations.
-	 *
-	 * @return
-	 */
-	public int getTotalBeds() {
-		return maxNumBeds + maxGuestBeds;
-	}
-
 	
 	/**
 	 * Gets the number of assigned beds in this building.
@@ -178,14 +139,6 @@ public class LivingAccommodations extends Function {
 	}
 
 	/**
-	 * Gets the total number of guest beds in this building.
-	 *
-	 * @return total number of guest beds
-	 */
-	public int getTotalGuestBeds() {
-		return guestBeds.size();
-	}
-	/**
 	 * Gets the number of people registered to sleep in this building.
 	 *
 	 * @return number of registered sleepers
@@ -195,78 +148,34 @@ public class LivingAccommodations extends Function {
 	}
 
 	/**
-	 * Assigns standard living necessity.
-	 */
-	public void	assignStandardNecessity(Person person) {
-
-		// Obtain a standard set of clothing items
-		person.wearGarment(building.getSettlement());
-
-		// Assign thermal bottle
-		person.assignThermalBottle();
-	}
-	
-	/**
-	 * Registers a sleeper with a bed.
-	 *
-	 * @param person
-	 * @param isAGuest is this person a guest (not inhabitant) of this settlement
-	 * @return Successful with the registeration
-	 */
-	public boolean registerSleeper(Person person, boolean isAGuest) {
-		// Assign standard necessity
-		assignStandardNecessity(person);	
-		
-		if (person.getBed() != null) {
-			return true;
-		}
-
-		// Find a bed
-		if (getNumEmptyActivitySpots() > 0) {
-			LocalPosition bed = designateABed(person, isAGuest);
-			if (bed != null) {
-				return true;
-			}
-		}
-		
-		logger.log(building, person, Level.WARNING, 2000,
-								"Could not find a temporary bed.", null);
-		return false;
-	}
-
-	/**
 	 * Assigns/designates an available bed to a person.
 	 *
 	 * @param person
 	 * @return
 	 */
-	private LocalPosition designateABed(Person person, boolean guest) {
-		LocalPosition bedLoc = null;
+	private AllocatedSpot assignBed(Person person, boolean permanent) {		
 
-		int numDesignated = getNumAssignedBeds();
-		if (numDesignated >= maxNumBeds) {
-			return null;
-		}
-		
 		// Note: guest beds are reserved for temporary use and 
 		// are not assigned here for use here
 		Set<ActivitySpot> spots = getActivitySpots();
 		for (var sp : spots) {
 			if (sp.isEmpty()) {
-				if (!guest) {
-					// Claim the bed permanently
-					AllocatedSpot bed = sp.claim(person, true, building);
+				// Claim the bed
+				AllocatedSpot bed = sp.claim(person, permanent, building);
+				if (permanent) {
 					person.setBed(bed);
 				}
-				logger.log(building, person, Level.INFO, 0, "Given a bed ("
+				
+				logger.log(building, person, Level.INFO, 0, "Given a "
+							+ (permanent ? "permanent" : "temporary")
+							+ " bed at " + sp.getPos() + "("
 							+ sp.getName() + ").");
 				
-				bedLoc = sp.getPos();
-				break;
+				return bed;
 			}
 		}
 
-		return bedLoc;
+		return null;
 	}
 
 	/**
@@ -397,85 +306,75 @@ public class LivingAccommodations extends Function {
 		return new double[] {estimatedWaterUsed, estimatedWasteWaterProduced};
 	}
 
-	/*
-	 * Checks if an unmarked or unassigned bed is available
-	 */
-	public boolean hasAnUnmarkedBed() {
-        return getNumAssignedBeds() < maxNumBeds || hasEmptyGuestBed();
+	@Override
+	public double getMaintenanceTime() {
+		return getActivitySpots().size() * 7D;
 	}
 
 	/**
-	 * Checks if there is an empty guest bed.
-	 *  
-	 * @return
+	 * Allocate a bed for sleeping
+	 * @param settlement
+	 * @param p
+	 * @param permenant Looking to make the allocate fixed
 	 */
-	public boolean hasEmptyGuestBed() {
-		for (int i: guestBeds.keySet()) {
-			if (i == -1) 
-				return true;
+	public static AllocatedSpot allocateBed(Settlement settlement, Person p, boolean permanent) {
+		boolean guest = (!settlement.equals(p.getAssociatedSettlement()));
+		if (guest) {
+			permanent = false;
 		}
-		return false;
-	}
-	
-	/**
-	 * Gets an empty guest bed.
-	 * 
-	 * @return
-	 */
-	public LocalPosition getEmptyGuestBed() {
-		for (Entry<Integer, LocalPosition> i: guestBeds.entrySet()) {
-			if (i.getKey() == -1) 
-				return i.getValue();
+
+		var blgManager = settlement.getBuildingManager();
+		Set<Building> dorms = blgManager.getBuildingSet(FunctionType.LIVING_ACCOMMODATIONS);
+		if (dorms.isEmpty()) {
+			return null;
 		}
-		return null;
-	}
-	
-	/**
-	 * Registers a guest bed.
-	 * 
-	 * @param id
-	 * @return
-	 */
-	public LocalPosition registerGuestBed(int id) {
-		for (Entry<Integer, LocalPosition> entry: guestBeds.entrySet()) {
-			int oldID = entry.getKey();
-			if (oldID == -1) {
-				LocalPosition p = entry.getValue();
-				guestBeds.put(id, p);
-				return p;
+
+		LivingAccommodations guestHouse = null;
+		for(Building b : dorms) {
+			// If looking for permanent then find an unassigned ActivitySpot
+			LivingAccommodations lvi = b.getLivingAccommodations();
+			if ((lvi.getNumEmptyActivitySpots() > 0)
+				&& (permanent || (guest && lvi.isGuestHouse()))) {
+				return lvi.assignBed(p, permanent);
+			}
+
+			if (lvi.isGuestHouse()) {
+				guestHouse = lvi;
 			}
 		}
-		return null;
-	}
-	
-	/**
-	 * Deregisters a guest bed.
-	 * 
-	 * @param id
-	 */
-	public void deRegisterGuestBed(int id) {
-		for (Entry<Integer, LocalPosition> entry: guestBeds.entrySet()) {
-			int oldID = entry.getKey();
-			if (oldID == id) {
-				LocalPosition p = entry.getValue();
-				guestBeds.put(-1, p);
+
+		// No bed found
+		if (guestHouse == null) {
+			if (guest) {
+				logger.warning(p, "No guest bunk provided");
+				return null;
 			}
+			guestHouse = RandomUtil.getARandSet(dorms).getLivingAccommodations();
 		}
+
+		// Looking for a citizen with no capacity
+		logger.warning(p, "All beds are allocated");
+
+		// Pick a random bed in the guesthouse; unoikely to arrive here
+		return RandomUtil.getARandSet(guestHouse.getActivitySpots()).claim(p, false,
+									  guestHouse.getBuilding());
 	}
-	
-	
-	@Override
-	public double getMaintenanceTime() {
-		return maxNumBeds * 7D;
+
+	/**
+	 * Can guest sstay here and squat on allocated beds
+	 * @return
+	 */
+	public boolean isGuestHouse() {
+		return guesthouse;
 	}
 
 	@Override
 	public void destroy() {
 		building = null;
-		guestBeds.clear();
-		guestBeds = null;
 		dailyWaterUsage = null;
 
 		super.destroy();
 	}
+
+
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/construction/SalvageValues.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/construction/SalvageValues.java
@@ -256,7 +256,7 @@ implements Serializable {
 			int popSize = settlement.getNumCitizens();
 			int popCapacity = settlement.getPopulationCapacity();
 			LivingAccommodations livingAccommodations = building.getLivingAccommodations();
-			int buildingPopCapacity = livingAccommodations.getTotalBeds();
+			int buildingPopCapacity = livingAccommodations.getBedCap();
 			if ((popCapacity - buildingPopCapacity) < popSize) {
 				result = 0D;
 			}

--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -160,11 +160,9 @@ BuildingPanelInhabitable.number   = # of Occupants
 BuildingPanelInhabitable.title    = Occupancy
 
 BuildingPanelLiving.title 				= Accommodation
-BuildingPanelLiving.beds.capacity 		= Regular Bed Capacity
-BuildingPanelLiving.guestBeds.capacity 	= Guest Bed Capacity
-BuildingPanelLiving.beds.assigned 		= # Regular Beds Assigned
-BuildingPanelLiving.beds.occupied 		= # Regular Beds Occupied
-BuildingPanelLiving.beds.empty	 		= # Regular Beds Empty 
+BuildingPanelLiving.beds.capacity 		= Bed Capacity
+BuildingPanelLiving.beds.assigned 		= # Beds Assigned
+BuildingPanelLiving.guesthouse           = Supports Guest?
 
 MaintenanceTabPanel.title					= Maintenance
 MaintenanceTabPanel.tooltip                 = Display maintenance details

--- a/mars-sim-core/src/main/resources/xml/buildings.xml
+++ b/mars-sim-core/src/main/resources/xml/buildings.xml
@@ -80,8 +80,9 @@
 	<!ELEMENT life-support EMPTY>
 	<!ATTLIST life-support capacity CDATA #REQUIRED>
 	<!ATTLIST life-support power-required CDATA #REQUIRED>
-	<!ELEMENT living-accommodations (activity?, guest?)>
+	<!ELEMENT living-accommodations (activity)>
 	<!ATTLIST living-accommodations capacity CDATA #REQUIRED>
+	<!ATTLIST living-accommodations guesthouse CDATA #IMPLIED>
 	<!ELEMENT management (activity?)>
 	<!ATTLIST management capacity CDATA #REQUIRED>
 	<!ELEMENT manufacture (activity?)>
@@ -142,7 +143,6 @@
 	<!ATTLIST resource-initial amount CDATA #REQUIRED>
 
 	<!ELEMENT activity (activity-spot+)>
-	<!ELEMENT guest (activity-spot+)>
 	<!ELEMENT activity-spot EMPTY>
 	<!ATTLIST activity-spot xloc CDATA #REQUIRED>
 	<!ATTLIST activity-spot yloc CDATA #REQUIRED>
@@ -265,9 +265,6 @@ http://www.uss-hornet.org/groups/pdf/SEMB_MarsHabitat.pdf
 					<activity-spot xloc="-3.3" yloc="0.9" />
 					<activity-spot xloc="-3.17" yloc="-1.08" />
 				</activity>
-				<guest>
-					<activity-spot xloc="-1.97" yloc="1.83" />
-				</guest>
 			</living-accommodations>
 
 			<!-- The building provides command and control for the population. -->
@@ -1531,7 +1528,7 @@ http://www.uss-hornet.org/groups/pdf/SEMB_MarsHabitat.pdf
 
 		<functions>
 			<life-support capacity="16" power-required="0.8" />
-			<living-accommodations capacity="11">
+			<living-accommodations capacity="11" guesthouse="true">
 				<activity>
 					<activity-spot xloc="2.2" yloc="3.2" />
 					<activity-spot xloc="2.2" yloc="1.8" />
@@ -1547,9 +1544,6 @@ http://www.uss-hornet.org/groups/pdf/SEMB_MarsHabitat.pdf
 					<activity-spot xloc="-2.2" yloc="-2.0" />
 					<activity-spot xloc="-2.2" yloc="-3.4" />
 				</activity>
-				<guest>
-					<activity-spot xloc="0" yloc="0" />
-				</guest>
 			</living-accommodations>
 			<power-generation>
 				<power-source type="Fuel Power Source" toggle="false" power="5.0"
@@ -2603,15 +2597,6 @@ http://www.uss-hornet.org/groups/pdf/SEMB_MarsHabitat.pdf
 			</dining>
 			
 			<life-support capacity="8" power-required="0.4" />
-				
-			<living-accommodations capacity="0">
-				<guest>
-					<activity-spot xloc="-1.2" yloc="2.9" />
-					<activity-spot xloc="1.2" yloc="-2.95" />
-					<activity-spot xloc="-1.9" yloc="-2.35" />
-					<activity-spot xloc="-1.9" yloc="-2.35" />					
-				</guest>
-			</living-accommodations>
 
 			<power-storage capacity="40"  discharge-rate="1.25"/>
 			<research tech-level="4" capacity="3">
@@ -2765,10 +2750,7 @@ http://www.uss-hornet.org/groups/pdf/SEMB_MarsHabitat.pdf
 					<activity-spot xloc="2.89" yloc="0.31" />
 					<activity-spot xloc="2.67" yloc="-0.92" />
 					<activity-spot xloc="-0.18" yloc="-2.97" />
-				</activity>
-				<guest>
-					<activity-spot xloc="-2.82" yloc="-1.14" />
-				</guest>				
+				</activity>			
 			</living-accommodations>
 			<power-generation>
 				<power-source type="Solar Power Source" power="5.0" />
@@ -3212,13 +3194,11 @@ http://www.uss-hornet.org/groups/pdf/SEMB_MarsHabitat.pdf
 
 		<functions>
 			<life-support capacity="4" power-required="0.2" />
-			<living-accommodations capacity="1">
+			<living-accommodations capacity="2" guesthouse="true">
 				<activity>
 					<activity-spot xloc="1.35" yloc="-1.35" />
-				</activity>
-				<guest>
 					<activity-spot xloc="-1.35" yloc="-1.35" />
-				</guest>
+				</activity>
 			</living-accommodations>
 			<power-generation>
 				<power-source type="Solar Power Source" power="5.0" />

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/LocationTabPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/LocationTabPanel.java
@@ -459,7 +459,7 @@ public class LocationTabPanel extends TabPanel implements ActionListener{
 		if (unit instanceof Worker w) {
 			var allocated = w.getActivitySpot();
 			if (allocated != null) {
-				n5 = allocated.getAllocated().getName() + " @ " + allocated.getOwner().getName();
+				n5 = allocated.getSpotDescription();
 			}
 		}
 		

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelHealth.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelHealth.java
@@ -575,7 +575,7 @@ extends TabPanel {
 		String bedText = "";
 		var allocatedBed = person.getBed();
 		if (allocatedBed != null) {
-			bedText = allocatedBed.getAllocated().getName() + " @ " + allocatedBed.getOwner().getName();
+			bedText = allocatedBed.getSpotDescription();
 		}
  		bedTF.setText(bedText);
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/building/ActivitySpotModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/building/ActivitySpotModel.java
@@ -50,15 +50,18 @@ public class ActivitySpotModel extends AbstractTableModel implements UnitModel {
         ActivitySpot sp = spots.get(rowIndex);
         String result = null;
         switch(columnIndex) {
-            case NAME_COL: result = sp.getName(); break;
-            case POS_COL: result = sp.getPos().getShortFormat(); break;
+            case NAME_COL: result = sp.getName();
+                        break;
+            case POS_COL: result = sp.getPos().getShortFormat(); 
+                        break;
             case WORK_COL: {
                 Unit u = getAssociatedUnit(rowIndex);
                 if (u != null) {
                     result = u.getName();
                 }
             } break;
-            default: break;
+            default:
+                break;
         }
 
         return result;

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/building/ActivitySpotModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/building/ActivitySpotModel.java
@@ -1,0 +1,92 @@
+/*
+ * Mars Simulation Project
+ * ActivitySpotModel.java
+ * @date 2023-12-17
+ * @author Barry Evans
+ */
+package com.mars_sim.ui.swing.unit_window.structure.building;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import javax.swing.table.AbstractTableModel;
+
+import com.mars_sim.core.Unit;
+import com.mars_sim.core.UnitManager;
+import com.mars_sim.core.structure.building.function.ActivitySpot;
+import com.mars_sim.ui.swing.utils.UnitModel;
+
+/**
+ * Is a table model for a collection of activity spots. Renders the name, position and assignment.
+ * Can also be used to launcher the entity launcher.
+ */
+public class ActivitySpotModel extends AbstractTableModel implements UnitModel {
+
+    private static final int NAME_COL = 0;
+    private static final int POS_COL = 1;
+    private static final int WORK_COL = 2;
+    
+    private UnitManager um;
+    private List<ActivitySpot> spots;
+
+    public ActivitySpotModel(Set<ActivitySpot> activitySpots, UnitManager unitManager) {
+        spots = new ArrayList<>(activitySpots);
+        this.um = unitManager;
+    }
+
+    @Override
+    public int getRowCount() {
+        return spots.size();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return 3;
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        ActivitySpot sp = spots.get(rowIndex);
+        String result = null;
+        switch(columnIndex) {
+            case NAME_COL: result = sp.getName(); break;
+            case POS_COL: result = sp.getPos().getShortFormat(); break;
+            case WORK_COL: {
+                Unit u = getAssociatedUnit(rowIndex);
+                if (u != null) {
+                    result = u.getName();
+                }
+            } break;
+            default: break;
+        }
+
+        return result;
+    }
+
+    @Override
+    public Class<?> getColumnClass(int columnIndex) {
+        return String.class;
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        return switch(column) {
+            case NAME_COL -> "Name";
+            case POS_COL -> "Position";
+            case WORK_COL -> "Allocation";
+            default -> "";
+        };
+    }
+
+    @Override
+    public Unit getAssociatedUnit(int row) {
+        ActivitySpot sp = spots.get(row);
+        int id = sp.getID();
+        if (id >= 0) {
+            return um.getUnitByID(id);
+        }
+        return null;
+    }
+
+}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/building/BuildingPanelLiving.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/building/BuildingPanelLiving.java
@@ -8,15 +8,20 @@
 package com.mars_sim.ui.swing.unit_window.structure.building;
 
 import java.awt.BorderLayout;
+import java.awt.Dimension;
 
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
 
 import com.mars_sim.core.structure.building.function.LivingAccommodations;
 import com.mars_sim.tools.Msg;
 import com.mars_sim.ui.swing.ImageLoader;
 import com.mars_sim.ui.swing.MainDesktopPane;
+import com.mars_sim.ui.swing.StyleManager;
 import com.mars_sim.ui.swing.utils.AttributePanel;
+import com.mars_sim.ui.swing.utils.UnitTableLauncher;
 
 
 /**
@@ -29,18 +34,14 @@ public class BuildingPanelLiving extends BuildingFunctionPanel {
 	private static final String BED_ICON = "bed";
 
 	private int bedCapCache;
-	private int guestBedCapCache;
-	private int bedAssignedCache;
 	private int bedOccupiedCache;
-	private int bedEmptyCache;
 
 	private JLabel bedCapLabel;
-	private JLabel guestBedCapLabel;
-	private JLabel bedAssignsLabel;
 	private JLabel bedOccupiedLabel;
-	private JLabel bedEmptyLabel;
 
 	private LivingAccommodations living;
+
+	
 
 	/**
 	 * Constructor.
@@ -69,31 +70,44 @@ public class BuildingPanelLiving extends BuildingFunctionPanel {
 	 */
 	@Override
 	protected void buildUI(JPanel center) {
+  		ActivitySpotModel bedTableModel;
 
 		// Create label panel
-		AttributePanel labelPanel = new AttributePanel(5);
+		AttributePanel labelPanel = new AttributePanel(3);
 		center.add(labelPanel, BorderLayout.NORTH);
 
 		// Create bed capacity label
 		bedCapLabel = labelPanel.addTextField(Msg.getString("BuildingPanelLiving.beds.capacity"),
 									Integer.toString(living.getBedCap()), "Max number of beds available");
 
-		// Create # of assigned bed label
-		bedAssignsLabel = labelPanel.addTextField(Msg.getString("BuildingPanelLiving.beds.assigned"),
-									Integer.toString(living.getNumAssignedBeds()), "Number of beds already assigned");
-
 		// Create bedOccupiedLabel
-		bedOccupiedLabel = labelPanel.addTextField(Msg.getString("BuildingPanelLiving.beds.occupied"),
+		bedOccupiedLabel = labelPanel.addTextField(Msg.getString("BuildingPanelLiving.beds.assigned"),
 									Integer.toString(living.getNumOccupiedActivitySpots()), "Number of beds already occupied");
 
-		// Create bedEmptyLabel
-		bedEmptyLabel = labelPanel.addTextField(Msg.getString("BuildingPanelLiving.beds.empty"),
-									 Integer.toString(living.getNumEmptyActivitySpots()), "Number of empty beds available");
-	
 		// Create guest bed capacity label
-		guestBedCapLabel = labelPanel.addTextField(Msg.getString("BuildingPanelLiving.guestBeds.capacity"),
-									Integer.toString(living.getMaxGuestBeds()), "Max number of guest beds available");
+		labelPanel.addTextField(Msg.getString("BuildingPanelLiving.guesthouse"),
+									Boolean.toString(living.isGuestHouse()), "Max number of guest beds available");
+		
+		// Create scroll panel for beds
+		JScrollPane scrollPanel = new JScrollPane();
+		scrollPanel.setPreferredSize(new Dimension(160, 120));
 
+		center.add(scrollPanel, BorderLayout.CENTER);
+	    scrollPanel.getViewport().setOpaque(false);
+	    scrollPanel.setOpaque(false);
+		scrollPanel.setBorder(StyleManager.createLabelBorder("Beds"));
+
+		// Prepare medical table model
+		bedTableModel = new ActivitySpotModel(living.getActivitySpots(),
+											  getDesktop().getSimulation().getUnitManager());
+
+		// Prepare medical table
+		JTable table = new JTable(bedTableModel);
+		table.setCellSelectionEnabled(false);
+		table.setRowSelectionAllowed(true);
+		table.addMouseListener(new UnitTableLauncher(getDesktop()));
+
+		scrollPanel.setViewportView(table);
 	}
 
 	@Override
@@ -104,28 +118,10 @@ public class BuildingPanelLiving extends BuildingFunctionPanel {
 			bedCapLabel.setText(Integer.toString(bedCapCache));
 		}
 
-		// Update guestBedCapLabel
-		if (guestBedCapCache != living.getMaxGuestBeds()) {
-			guestBedCapCache = living.getMaxGuestBeds();
-			guestBedCapLabel.setText(Integer.toString(guestBedCapCache));
-		}
-			
-		// Update bedAssignsLabel
-		if (bedAssignedCache != living.getNumAssignedBeds()) {
-			bedAssignedCache = living.getNumAssignedBeds();
-			bedAssignsLabel.setText(Integer.toString(bedAssignedCache));
-		}
-
 		// Update bedOccupiedLabel
 		if (bedOccupiedCache != living.getNumOccupiedActivitySpots()) {
 			bedOccupiedCache = living.getNumOccupiedActivitySpots();
 			bedOccupiedLabel.setText(Integer.toString(bedOccupiedCache));
-		}
-
-		// Update bedEmptyLabel
-		if (bedEmptyCache != living.getNumEmptyActivitySpots()) {
-			bedEmptyCache = living.getNumEmptyActivitySpots();
-			bedEmptyLabel.setText(Integer.toString(bedEmptyCache));
 		}
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/UnitTableLauncher.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/UnitTableLauncher.java
@@ -49,9 +49,10 @@ public class UnitTableLauncher extends MouseInputAdapter {
             RowSorter<? extends TableModel> sorter = table.getRowSorter();
             if (sorter != null && r >= 0) {
                 r = sorter.convertRowIndexToModel(r);
-                UnitModel model = (UnitModel)table.getModel();
-                desktop.showDetails(model.getAssociatedUnit(r));
             }
+
+            UnitModel model = (UnitModel)table.getModel();
+            desktop.showDetails(model.getAssociatedUnit(r));
         }
     }
 }


### PR DESCRIPTION
Changes:
- LivingAccommodations handles the allocation bed logic instead of Settlements & BuildingManager
- Logic allows guest/temporary allocation to use exsiting Bed but these are not permanently assigned
- Supports a sleep rough ability of there are no free beds; finds a spot anywhere
- Person claim a bed when they become a citizen and removing the need to do allocation from the first pulse
- Person gets sleeping essentials, e.g garment, when starting Sleep task
- Bed tab in the Settlement window now has a table of the beds and their allocations which can double click to Person window
- New table model to model ActivitySpot lists
- Remove the guest bed conception from FunctionSpec and BuildingConfig
- Add guesthouse property to the Living Accomodation function when gues can use the beds
- building.xml updated to remove <guest-beds> and mark some Building as guest house
- Clean up BuildingManager to remove bed related logic

Part of #1166