### PR TITLE
Show multiple Settlements in the Monitor Window

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/authority/Authority.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/authority/Authority.java
@@ -6,12 +6,12 @@
  */
 package com.mars_sim.core.authority;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.mars_sim.core.Entity;
 import com.mars_sim.core.configuration.UserConfigurable;
 import com.mars_sim.core.person.NationSpecConfig;
 import com.mars_sim.core.person.ai.task.util.Worker;
@@ -21,7 +21,7 @@ import com.mars_sim.tools.util.RandomUtil;
  * Represents a sponsor that owns units such as people, settlement, lunar colonies, etc..
  */
 public class Authority
-implements UserConfigurable, Serializable {
+implements Entity, UserConfigurable {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
@@ -130,6 +130,7 @@ implements UserConfigurable, Serializable {
 	 * 
 	 * @return
 	 */
+	@Override
 	public String getDescription() {
 		return fullName;
 	}
@@ -154,10 +155,7 @@ implements UserConfigurable, Serializable {
 	 * @return
 	 */
 	public boolean isOneCountry() {
-		if (countries.size() == 1)
-			return true;
-		else
-			return false;
+		return (countries.size() == 1);
 	}
 	
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/AbstractMonitorModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/AbstractMonitorModel.java
@@ -22,11 +22,12 @@ public abstract class AbstractMonitorModel extends AbstractTableModel
     /**
      * Helper class to define the specification of a column.
      */
-    protected record ColumnSpec (String name, Class<?> type) implements Serializable {};
+    protected record ColumnSpec (String name, Class<?> type) implements Serializable {}
 
     private String name;
     private String countingMsgKey;
     private ColumnSpec[] columns;
+	private int settlementColumn = -1;
 
     protected AbstractMonitorModel(String name, String countingMsgKey, ColumnSpec[] columns) {
         this.name = name;
@@ -34,6 +35,24 @@ public abstract class AbstractMonitorModel extends AbstractTableModel
         this.columns = columns;
     }
 
+	/**
+	 * This model as a Settlement column. This is a special column that can be visbile/hidden according
+	 * to the selection.
+	 * @param settlementColumn
+	 */
+	protected void setSettlementColumn(int settlementColumn) {
+		this.settlementColumn = settlementColumn;
+	}
+
+	/**
+	 * Get the index of the Settlement column if defined. This is a special column that can be visbile/hidden according
+	 * to the selection.
+	 * @return
+	 */
+	@Override
+	public int getSettlementColumn() {
+		return settlementColumn;
+	}	
 
     /**
 	 * Returns the number of columns.

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BacklogTab.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BacklogTab.java
@@ -6,11 +6,7 @@
  */
 package com.mars_sim.ui.swing.tool.monitor;
 
-import java.util.Set;
-
 import javax.swing.table.TableColumnModel;
-
-import com.mars_sim.core.structure.Settlement;
 
 /**
  * This class displays the backlog of SettlementTasks at settlement displayed within
@@ -26,9 +22,9 @@ public class BacklogTab extends TableTab {
 	 * @param selectedSettlement
 	 * @param window {@link MonitorWindow} the containing window.
 	 */
-	public BacklogTab(Set<Settlement> selectedSettlement, final MonitorWindow window) {
+	public BacklogTab(final MonitorWindow window) {
 		// Use TableTab constructor
-		super(window, new BacklogTableModel(selectedSettlement), true, false,
+		super(window, new BacklogTableModel(), true, false,
 			  TASK_ICON);
 
 		TableColumnModel m = table.getColumnModel();

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BacklogTab.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BacklogTab.java
@@ -6,6 +6,8 @@
  */
 package com.mars_sim.ui.swing.tool.monitor;
 
+import java.util.Set;
+
 import javax.swing.table.TableColumnModel;
 
 import com.mars_sim.core.structure.Settlement;
@@ -24,7 +26,7 @@ public class BacklogTab extends TableTab {
 	 * @param selectedSettlement
 	 * @param window {@link MonitorWindow} the containing window.
 	 */
-	public BacklogTab(Settlement selectedSettlement, final MonitorWindow window) {
+	public BacklogTab(Set<Settlement> selectedSettlement, final MonitorWindow window) {
 		// Use TableTab constructor
 		super(window, new BacklogTableModel(selectedSettlement), true, false,
 			  TASK_ICON);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BacklogTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BacklogTableModel.java
@@ -47,17 +47,15 @@ public class BacklogTableModel extends AbstractMonitorModel
 
 	private Set<Settlement> selectedSettlements = Collections.emptySet();
 	private boolean monitorSettlement = false;
-	private List<SettlementTask> tasks;
+	private List<SettlementTask> tasks = Collections.emptyList();
 
 	/**
 	 * Constructor.
 	 */
-	public BacklogTableModel(Set<Settlement> filter) {
+	public BacklogTableModel() {
 		super(Msg.getString("BacklogTableModel.tabName"),
 							"BacklogTableModel.counting",
-							COLUMNS);
-		
-		setSettlementFilter(filter);
+							COLUMNS);		
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BacklogTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BacklogTableModel.java
@@ -6,10 +6,12 @@
  */
 package com.mars_sim.ui.swing.tool.monitor;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
+
+import javax.swing.SwingUtilities;
 
 import com.mars_sim.core.Entity;
 import com.mars_sim.core.Unit;
@@ -27,18 +29,22 @@ import com.mars_sim.tools.Msg;
 @SuppressWarnings("serial")
 public class BacklogTableModel extends AbstractMonitorModel
 					implements UnitListener {
+	// Represents a row in the table
+	private record BacklogEntry(Settlement owner, SettlementTask task) implements Serializable {}
 
 	private static final ColumnSpec[] COLUMNS;
 
 	private static final int DESC_COL = 0;
-	private static final int ENTITY_COL = 1;
-	private static final int EVA_COL = 2;
-	private static final int DEMAND_COL = 3;
-	static final int SCORE_COL = 4;
+	private static final int SETTLEMENT_COL = DESC_COL+1;
+	private static final int ENTITY_COL = SETTLEMENT_COL+1;
+	private static final int EVA_COL = ENTITY_COL+1;
+	private static final int DEMAND_COL = EVA_COL+1;
+	static final int SCORE_COL = DEMAND_COL+1;
 
 	static {
 		COLUMNS = new ColumnSpec[SCORE_COL+1];
 		COLUMNS[ENTITY_COL] = new ColumnSpec("Entity", String.class);
+		COLUMNS[SETTLEMENT_COL] = new ColumnSpec("Settlement", String.class);
 		COLUMNS[DESC_COL] = new ColumnSpec("Description", String.class);
 		COLUMNS[DEMAND_COL]  = new ColumnSpec("Demand", Integer.class);
 		COLUMNS[EVA_COL]  = new ColumnSpec("EVA", String.class);
@@ -47,7 +53,7 @@ public class BacklogTableModel extends AbstractMonitorModel
 
 	private Set<Settlement> selectedSettlements = Collections.emptySet();
 	private boolean monitorSettlement = false;
-	private List<SettlementTask> tasks = Collections.emptyList();
+	private List<BacklogEntry> tasks = Collections.emptyList();
 
 	/**
 	 * Constructor.
@@ -55,7 +61,8 @@ public class BacklogTableModel extends AbstractMonitorModel
 	public BacklogTableModel() {
 		super(Msg.getString("BacklogTableModel.tabName"),
 							"BacklogTableModel.counting",
-							COLUMNS);		
+							COLUMNS);	
+		setSettlementColumn(SETTLEMENT_COL);	
 	}
 
 	/**
@@ -68,8 +75,10 @@ public class BacklogTableModel extends AbstractMonitorModel
 		Unit unit = (Unit) event.getSource();
 		UnitEventType eventType = event.getType();
 		if ((eventType == UnitEventType.BACKLOG_EVENT) && selectedSettlements.contains(unit)) {
-			// Reset the Tasks
-			resetTasks();
+			var newTasks = getTasks();
+
+			// Reset the Tasks asynchronously in teh Swing Dispatcher to avoid sorting clashes
+			SwingUtilities.invokeLater(() -> resetTasks(newTasks));
 		}
 	}
 
@@ -78,7 +87,7 @@ public class BacklogTableModel extends AbstractMonitorModel
 	 */
 	@Override
 	public Object getObject(int row) {
-		return tasks.get(row).getFocus();
+		return tasks.get(row).task().getFocus();
 	}
 
 	/**
@@ -135,39 +144,34 @@ public class BacklogTableModel extends AbstractMonitorModel
 		return true;
     }
 
-	private List<SettlementTask> getTasks() {
+	/**
+	 * Create a list od backlog entries for all the monitored settlements.
+	 * The SettlementTask does holdthe Settlement refernece so this is record in
+	 * the artifical BacklogEntry record.
+	 */
+	private List<BacklogEntry> getTasks() {
 		return selectedSettlements.stream()
-					.flatMap(s -> s.getTaskManager().getAvailableTasks().stream())
+					.flatMap(s -> s.getTaskManager().getAvailableTasks().stream()
+									.map(e -> new BacklogEntry(s, e)))
 					.toList();
 	}
 
     /**
      * Resets tasks.
      */
-	private void resetTasks() {
-		List<SettlementTask> oldTasks = tasks;
-		tasks = getTasks();
+	private void resetTasks(List<BacklogEntry> newTasks) {
+		List<BacklogEntry> oldTasks = tasks;
+		tasks = newTasks;
 
-		Set<SettlementTask> common = tasks.stream()
-						.filter(oldTasks::contains)
-						.collect(Collectors.toSet());
-		
-		// CHeck for deleted Task
-		int i = 0;
-		for(SettlementTask old : oldTasks) {
-			if (!common.contains(old)) {
-				fireTableRowsDeleted(i, i);
-			}
-			else {
-				i++;
-			}
+		// Find out how many rows have been added/deleted
+		int delta = tasks.size() - oldTasks.size();
+		if (delta < 0) {
+			// Row deleted
+			fireTableRowsDeleted(tasks.size(), oldTasks.size()-1);
 		}
-		i = 0;
-		for(SettlementTask newTask : tasks) {
-			if (!common.contains(newTask)) {
-				fireTableRowsInserted(i, i);
-			}
-			i++;
+		else if (delta > 0) {
+			// Rows added
+			fireTableRowsInserted(oldTasks.size(), tasks.size()-1);
 		}
 
 		if (!tasks.isEmpty())
@@ -189,7 +193,7 @@ public class BacklogTableModel extends AbstractMonitorModel
     public String getToolTipAt(int rowIndex, int columnIndex) {
 		String result = null;
 		if ((columnIndex == SCORE_COL) && (rowIndex < tasks.size())) {
-			SettlementTask selectedTask = tasks.get(rowIndex);
+			SettlementTask selectedTask = tasks.get(rowIndex).task;
 
 			result = selectedTask.getScore().getHTMLOutput();
 		}
@@ -210,13 +214,16 @@ public class BacklogTableModel extends AbstractMonitorModel
 			return null;
 		}
 
-		SettlementTask selectedTask = tasks.get(rowIndex);
+		var selectedRow = tasks.get(rowIndex);
+		var selectedTask = selectedRow.task;
 		switch(columnIndex) {
 			case ENTITY_COL:
 				Entity des = selectedTask.getFocus();
 				if (des != null)
 					return des.getName();
 				return null;
+			case SETTLEMENT_COL:
+				return selectedRow.owner.getName();
 			case DESC_COL:
 				return selectedTask.getShortName();
 			case EVA_COL:

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BuildingTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BuildingTableModel.java
@@ -23,15 +23,16 @@ public class BuildingTableModel extends UnitTableModel<Building> {
 
 	// Column indexes
 	private static final int NAME = 0;
-	private static final int TYPE = 1;
-	private static final int CATEGORY = 2;
-	private static final int POWER_MODE = 3;
-	private static final int POWER_REQUIRED = 4;
-	private static final int POWER_GEN = 5;
-	private static final int HEAT_MODE = 6;
-	private static final int TEMPERATURE = 7;
+	private static final int SETTLEMENT = NAME+1;
+	private static final int TYPE = SETTLEMENT+1;
+	private static final int CATEGORY = TYPE+1;
+	private static final int POWER_MODE = CATEGORY+1;
+	private static final int POWER_REQUIRED = POWER_MODE+1;
+	private static final int POWER_GEN = POWER_REQUIRED+1;
+	private static final int HEAT_MODE = POWER_GEN+1;
+	private static final int TEMPERATURE = HEAT_MODE+1;
 	
-	private static final int COLUMNCOUNT = 8;
+	private static final int COLUMNCOUNT = TEMPERATURE+1;
 
 	/** Names of Columns. */
 	private static final ColumnSpec[] COLUMNS;
@@ -42,6 +43,7 @@ public class BuildingTableModel extends UnitTableModel<Building> {
 	static {
 		COLUMNS = new ColumnSpec[COLUMNCOUNT];
 		COLUMNS[NAME] = new ColumnSpec(Msg.getString("BuildingTableModel.column.name"), String.class);
+		COLUMNS[SETTLEMENT] = new ColumnSpec("Settlement", String.class);
 		COLUMNS[TYPE] = new ColumnSpec(Msg.getString("BuildingTableModel.column.type"), String.class);
 		COLUMNS[CATEGORY] = new ColumnSpec(Msg.getString("BuildingTableModel.column.category"), String.class);	
 		COLUMNS[POWER_MODE] = new ColumnSpec(Msg.getString("BuildingTableModel.column.powerMode"), String.class);		
@@ -60,7 +62,9 @@ public class BuildingTableModel extends UnitTableModel<Building> {
 	public BuildingTableModel() {
 		super(UnitType.BUILDING, Msg.getString("BuildingTableModel.nameBuildings", ""),
 				"BuildingTableModel.countingBuilding", //$NON-NLS-1$
-				COLUMNS);		
+				COLUMNS);	
+		
+		setSettlementColumn(SETTLEMENT);
 	}
 
 	@Override
@@ -89,6 +93,9 @@ public class BuildingTableModel extends UnitTableModel<Building> {
 
 		case NAME: 
 			result = building.getName();
+			break;
+		case SETTLEMENT: 
+			result = building.getSettlement().getName();
 			break;
 
 		case TYPE: 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BuildingTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BuildingTableModel.java
@@ -57,12 +57,10 @@ public class BuildingTableModel extends UnitTableModel<Building> {
 	 * @param settlement
 	 * @throws Exception
 	 */
-	public BuildingTableModel(Set<Settlement> settlement) {
+	public BuildingTableModel() {
 		super(UnitType.BUILDING, Msg.getString("BuildingTableModel.nameBuildings", ""),
 				"BuildingTableModel.countingBuilding", //$NON-NLS-1$
-				COLUMNS);
-		
-		setSettlementFilter(settlement);
+				COLUMNS);		
 	}
 
 	@Override

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/CategoryKey.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/CategoryKey.java
@@ -1,0 +1,59 @@
+/*
+ * Mars Simulation Project
+ * CategoryKey.java
+ * @date 2023-12-27
+ * @author Barry Evans
+ */
+package com.mars_sim.ui.swing.tool.monitor;
+
+import com.mars_sim.core.structure.Settlement;
+
+/**
+ * This represents the unique identifiers of a row in the CategoryTableModel.
+ */
+class CategoryKey<T> {
+    private Settlement host;
+    private T category;
+
+    public CategoryKey(Settlement host, T category) {
+        this.host = host;
+        this.category = category;
+    }
+
+    public Settlement getSettlement() {
+        return host;
+    }
+    public T getCategory() {
+        return category;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        var other = (CategoryKey<T>) obj;
+        if (host == null) {
+            if (other.host != null)
+                return false;
+        } else if (!host.equals(other.host))
+            return false;
+        if (category == null) {
+            if (other.category != null)
+                return false;
+        } else if (!category.equals(other.category))
+            return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((category == null) ? 0 : category.hashCode());
+        return result;
+    }
+}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/CategoryTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/CategoryTableModel.java
@@ -1,0 +1,88 @@
+/*
+ * Mars Simulation Project
+ * CategoryTableModel.java
+ * @date 2023-12-27
+ * @author Barry Evans
+ */
+package com.mars_sim.ui.swing.tool.monitor;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import com.mars_sim.core.UnitListener;
+import com.mars_sim.core.structure.Settlement;
+
+/**
+ * A table model that displays a list of categories in a table. The categories are
+ * entities that are independent of a Settlement. This model creates one row per Category per Settlement.
+ * The row has a unique key as CategoryKey.
+ */
+public abstract class CategoryTableModel<T> extends EntityTableModel<CategoryKey<T>>
+            implements UnitListener {
+
+    private Set<Settlement> selectedSettlements = Collections.emptySet();
+	private boolean monitorSettlement = false;
+    private List<T> categories;
+
+    protected CategoryTableModel(String name, String countingMsgKey, ColumnSpec[] names, List<T> cats) {
+        super(name, countingMsgKey, names);
+        this.categories = cats;
+    }
+
+        
+	/**
+	 * Set whether the changes to the Entities should be monitor for change. Set up the 
+	 * Unitlisteners for the selected Settlement where Food comes from for the table.
+	 * @param activate 
+	 */
+    public void setMonitorEntites(boolean activate) {
+		if (activate != monitorSettlement) {
+			if (activate) {
+				selectedSettlements.forEach(s ->s.addUnitListener(this));
+			}
+			else {
+				selectedSettlements.forEach(s ->s.removeUnitListener(this));
+			}
+			monitorSettlement = activate;
+		}
+	}
+
+	/**
+	 * Prepares the model for deletion.
+	 */
+	@Override
+	public void destroy() {
+		selectedSettlements.forEach(s ->s.removeUnitListener(this));
+		super.destroy();
+	}
+
+	/**
+	 * Set the Settlement filter
+	 * @param filter Settlement
+	 */
+    public boolean setSettlementFilter(Set<Settlement> filter) {
+		selectedSettlements.forEach(s ->s.removeUnitListener(this));
+
+		// Initialize settlements.
+		selectedSettlements = filter;	
+
+        // Create a new row key for each combination of Settlement and Catogory
+		Collection<CategoryKey<T>> newRows = new ArrayList<>();
+        for(var s : filter) {
+            newRows.addAll(categories.stream().map(c -> new CategoryKey<>(s, c)).toList());
+        }
+
+        // Initialize goods list.
+		resetEntities(newRows);
+			
+		// Add table as listener to each settlement.
+		if (monitorSettlement) {
+			selectedSettlements.forEach(s ->s.addUnitListener(this));
+		}
+
+		return true;
+    }
+}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/CropTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/CropTableModel.java
@@ -69,6 +69,7 @@ public class CropTableModel extends UnitTableModel<Building> {
 
 		// Cache all crop categories
 		setCachedColumns(INITIAL_COLS, FIRST_CROP_CAT + CropCategory.values().length);
+		setSettlementColumn(SETTLEMENT_NAME);
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/CropTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/CropTableModel.java
@@ -8,6 +8,8 @@ package com.mars_sim.ui.swing.tool.monitor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitEvent;
@@ -28,7 +30,8 @@ public class CropTableModel extends UnitTableModel<Building> {
 
 	// Column indexes
 	private static final int GREENHOUSE_NAME = 0;
-	private static final int INITIAL_COLS = 1;
+	private static final int SETTLEMENT_NAME = 1;
+	private static final int INITIAL_COLS = 2;
 
 	private static final int FIRST_CROP_CAT = INITIAL_COLS + 1;
 	
@@ -43,7 +46,8 @@ public class CropTableModel extends UnitTableModel<Building> {
 
 	static {
 		COLUMNS = new ColumnSpec[columnCount];
-		COLUMNS[GREENHOUSE_NAME] = new ColumnSpec("Name of Greenhouse", String.class);
+		COLUMNS[GREENHOUSE_NAME] = new ColumnSpec("Greenhouse", String.class);
+		COLUMNS[SETTLEMENT_NAME] = new ColumnSpec("Settlement", String.class);
 		COLUMNS[INITIAL_COLS] = new ColumnSpec("# Crops", Integer.class);
 
 		for (CropCategory cat : CropCategory.values()) {
@@ -58,7 +62,7 @@ public class CropTableModel extends UnitTableModel<Building> {
 	 */
 	private List<CropCategory> cropCategoryList;
 
-	public CropTableModel(Settlement settlement) {
+	public CropTableModel(Set<Settlement> settlement) {
 		super (UnitType.BUILDING, Msg.getString("CropTableModel.tabName"), //$NON-NLS-1$
 				"CropTableModel.countingCrops", COLUMNS);
 		cropCategoryList = new ArrayList<>(List.of(CropCategory.values()));
@@ -66,16 +70,16 @@ public class CropTableModel extends UnitTableModel<Building> {
 		// Cache all crop categories
 		setCachedColumns(INITIAL_COLS, FIRST_CROP_CAT + CropCategory.values().length);
 		setSettlementFilter(settlement);
-
-		listenForUnits();
 	}
 
 	/**
 	 * Filter the Greenhouses according to a Settlement
 	 */
 	@Override
-	public boolean setSettlementFilter(Settlement filter) {
-		resetEntities(filter.getBuildingManager().getBuildingSet(FunctionType.FARMING));
+	public boolean setSettlementFilter(Set<Settlement> filter) {
+		resetEntities(filter.stream()
+				.flatMap(s -> s.getBuildingManager().getBuildingSet(FunctionType.FARMING).stream())
+				.collect(Collectors.toSet()));
 
 		return true;
 	}
@@ -120,7 +124,10 @@ public class CropTableModel extends UnitTableModel<Building> {
 
 		switch (columnIndex) {
 			case GREENHOUSE_NAME: 
-				result = greenhouse.getNickName();
+				result = greenhouse.getName();
+				break;
+			case SETTLEMENT_NAME: 
+				result = greenhouse.getSettlement().getName();
 				break;
 			case INITIAL_COLS: 
 				result = getTotalNumOfAllCrops(greenhouse);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/CropTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/CropTableModel.java
@@ -54,7 +54,7 @@ public class CropTableModel extends UnitTableModel<Building> {
 			int idx = FIRST_CROP_CAT + cat.ordinal();
 			COLUMNS[idx] = new ColumnSpec(cat.getName(), Integer.class);
 		}
-	};
+	}
 
 	// Data members
 	/**
@@ -62,14 +62,13 @@ public class CropTableModel extends UnitTableModel<Building> {
 	 */
 	private List<CropCategory> cropCategoryList;
 
-	public CropTableModel(Set<Settlement> settlement) {
+	public CropTableModel() {
 		super (UnitType.BUILDING, Msg.getString("CropTableModel.tabName"), //$NON-NLS-1$
 				"CropTableModel.countingCrops", COLUMNS);
 		cropCategoryList = new ArrayList<>(List.of(CropCategory.values()));
 
 		// Cache all crop categories
 		setCachedColumns(INITIAL_COLS, FIRST_CROP_CAT + CropCategory.values().length);
-		setSettlementFilter(settlement);
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/EventTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/EventTableModel.java
@@ -103,7 +103,7 @@ public class EventTableModel extends AbstractMonitorModel implements HistoricalE
 	}
 
 	@Override
-	public boolean setSettlementFilter(Settlement filter) {
+	public boolean setSettlementFilter(Set<Settlement> filter) {
 		// Events do not support filtering
 		return false;
 	}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/FoodInventoryTab.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/FoodInventoryTab.java
@@ -6,6 +6,8 @@
  */
 package com.mars_sim.ui.swing.tool.monitor;
 
+import java.util.Set;
+
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
 
@@ -25,7 +27,7 @@ public class FoodInventoryTab extends TableTab {
 	 * @param selectedSettlement
 	 * @param window {@link MonitorWindow} the containing window.
 	 */
-	public FoodInventoryTab(Settlement selectedSettlement, final MonitorWindow window) {
+	public FoodInventoryTab(Set<Settlement> selectedSettlement, final MonitorWindow window) {
 		// Use TableTab constructor
 		super(window, new FoodInventoryTableModel(selectedSettlement), true, false, FOOD_ICON);
 	

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/FoodInventoryTab.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/FoodInventoryTab.java
@@ -6,12 +6,9 @@
  */
 package com.mars_sim.ui.swing.tool.monitor;
 
-import java.util.Set;
-
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
 
-import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.ui.swing.tool.NumberRenderer;
 
 /**
@@ -24,12 +21,11 @@ public class FoodInventoryTab extends TableTab {
 	/**
 	 * constructor.
 	 *
-	 * @param selectedSettlement
 	 * @param window {@link MonitorWindow} the containing window.
 	 */
-	public FoodInventoryTab(Set<Settlement> selectedSettlement, final MonitorWindow window) {
+	public FoodInventoryTab(final MonitorWindow window) {
 		// Use TableTab constructor
-		super(window, new FoodInventoryTableModel(selectedSettlement), true, false, FOOD_ICON);
+		super(window, new FoodInventoryTableModel(), true, false, FOOD_ICON);
 	
 		TableColumnModel m = table.getColumnModel();
 		for (int i= FoodInventoryTableModel.NUM_INITIAL_COLUMNS; i < m.getColumnCount(); i++) {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/FoodInventoryTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/FoodInventoryTableModel.java
@@ -23,13 +23,17 @@ import com.mars_sim.tools.Msg;
 public class FoodInventoryTableModel extends CategoryTableModel<Food>
  {
 
-	protected static final int NUM_INITIAL_COLUMNS = 3;
 	protected static final int NUM_DATA_COL = 7;
 
 	/** Names of Columns. */
 	private static final ColumnSpec[] COLUMNS;
 
-	private static final int DEMAND_COL = NUM_INITIAL_COLUMNS;
+	private static final int FOOD_COL = 0;
+	private static final int TYPE_COL = FOOD_COL+1;
+	private static final int SETTLEMENT_COL = TYPE_COL+1;
+	protected static final int NUM_INITIAL_COLUMNS = SETTLEMENT_COL+1;
+
+	private static final int DEMAND_COL = SETTLEMENT_COL+1;
 	private static final int SUPPLY_COL = DEMAND_COL+1;
 	static final int MASS_COL = SUPPLY_COL+1;
 	private static final int LOCAL_VP_COL = MASS_COL+1;
@@ -39,9 +43,9 @@ public class FoodInventoryTableModel extends CategoryTableModel<Food>
 	static {
 		COLUMNS = new ColumnSpec[NUM_INITIAL_COLUMNS + NUM_DATA_COL];
 
-		COLUMNS[0] = new ColumnSpec("Food", String.class);
-		COLUMNS[1] =  new ColumnSpec("Type", String.class);
-		COLUMNS[2] =  new ColumnSpec("Settlement", String.class);
+		COLUMNS[FOOD_COL] = new ColumnSpec("Food", String.class);
+		COLUMNS[TYPE_COL] =  new ColumnSpec("Type", String.class);
+		COLUMNS[SETTLEMENT_COL] =  new ColumnSpec("Settlement", String.class);
 
 		COLUMNS[DEMAND_COL] = new ColumnSpec("Demand", Double.class);
 		COLUMNS[SUPPLY_COL] = new ColumnSpec("Supply", Double.class);
@@ -60,6 +64,7 @@ public class FoodInventoryTableModel extends CategoryTableModel<Food>
 					COLUMNS, FoodUtil.getFoodList());
 		
 		setCachedColumns(DEMAND_COL, PRICE_COL);
+		setSettlementColumn(SETTLEMENT_COL);
 	}
 
 	/**
@@ -85,11 +90,11 @@ public class FoodInventoryTableModel extends CategoryTableModel<Food>
 		Settlement selectedSettlement = selectedRow.getSettlement();
 
 		switch(columnIndex) {
-			case 0:
+			case FOOD_COL:
 				return selectedFood.getName();
-			case 1:
+			case TYPE_COL:
 				return selectedFood.getType();
-			case 2:
+			case SETTLEMENT_COL:
 				return selectedSettlement.getName();
 			
 			case DEMAND_COL:

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/FoodInventoryTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/FoodInventoryTableModel.java
@@ -6,8 +6,6 @@
  */
 package com.mars_sim.ui.swing.tool.monitor;
 
-import java.util.Set;
-
 import com.mars_sim.core.UnitEvent;
 import com.mars_sim.core.UnitEventType;
 import com.mars_sim.core.food.Food;
@@ -57,13 +55,11 @@ public class FoodInventoryTableModel extends CategoryTableModel<Food>
 	/**
 	 * Constructor.
 	 */
-	public FoodInventoryTableModel(Set<Settlement> selectedSettlement2) {
+	public FoodInventoryTableModel() {
 		super(Msg.getString("FoodInventoryTableModel.tabName"), "FoodInventoryTabModel.foodCounting",
 					COLUMNS, FoodUtil.getFoodList());
 		
 		setCachedColumns(DEMAND_COL, PRICE_COL);
-
-		setSettlementFilter(selectedSettlement2);
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MissionTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MissionTableModel.java
@@ -8,6 +8,7 @@ package com.mars_sim.ui.swing.tool.monitor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import javax.swing.SwingUtilities;
 
@@ -153,7 +154,7 @@ public class MissionTableModel extends AbstractMonitorModel
 	 * Cannot filter missions by Settlement although is should be possible.
 	 */
 	@Override
-	public boolean setSettlementFilter(Settlement filter) {
+	public boolean setSettlementFilter(Set<Settlement> filter) {
 		// Mission doesn't support filtering ???
 		return false;
 	}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorModel.java
@@ -63,6 +63,13 @@ interface MonitorModel extends TableModel {
     public void setMonitorEntites(boolean activate);
 
 	/**
+	 * Get the index of the Settlement column if defined. This is a special column that can be visbile/hidden according
+	 * to the selection.
+	 * @return
+	 */
+	public int getSettlementColumn();
+
+	/**
 	 * Gets a tooltip representation of a cell. Most cells with return null.
 	 * 
 	 * @param rowIndex

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorModel.java
@@ -7,6 +7,8 @@
 
 package com.mars_sim.ui.swing.tool.monitor;
 
+import java.util.Set;
+
 import javax.swing.table.TableModel;
 
 import com.mars_sim.core.structure.Settlement;
@@ -48,10 +50,10 @@ interface MonitorModel extends TableModel {
 	/**
 	 * Sets the Settlement as a filter.
 	 * 
-	 * @param filter Settlement
+	 * @param selectedSettlement Settlement
 	 * @return 
 	 */
-	public boolean setSettlementFilter(Settlement filter);
+	public boolean setSettlementFilter(Set<Settlement> selectedSettlement);
 
 	/**
 	 * Sets whether the changes to the Entities should be monitor for change.

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorWindow.java
@@ -219,10 +219,10 @@ public class MonitorWindow extends ToolWindow
 
 		// Add tabs into the table	
 		if (choices.size() > 1) {
-			newTabs.add(new UnitTab(this, new SettlementTableModel(), true, MARS_ICON));
+			newTabs.add(new UnitTab(this, new SettlementTableModel(true), true, MARS_ICON));
 		}
 		
-		newTabs.add(new UnitTab(this, new SettlementTableModel(), true, COLONY_ICON));
+		newTabs.add(new UnitTab(this, new SettlementTableModel(false), true, COLONY_ICON));
 		newTabs.add(new UnitTab(this, new PersonTableModel(), true, PEOPLE_ICON));
 		newTabs.add(new UnitTab(this, new RobotTableModel(), true, BOT_ICON));
 		newTabs.add(new UnitTab(this, new BuildingTableModel(), true, BUILDING_ICON));
@@ -513,14 +513,14 @@ public class MonitorWindow extends ToolWindow
 		boolean enableMap = selectedTab.isNavigatable();
 		boolean enableDetails = selectedTab.isEntityDriven();
 		boolean enableFilter = selectedTab.isFilterable();
-		boolean enableSettlement = tabTableModel.setSettlementFilter(currentSelection);
+		boolean enableSettlement = false;
 
 		boolean enableBar = false;
 		boolean enablePie = false;
 		if (selectedTab instanceof TableTab tt) {
 			enableBar = true;
 			enablePie = true;
-			tt.autoAdjustWidths();
+			enableSettlement = tt.setSettlementFilter(currentSelection);
 		}
 
 		// Configure the listeners

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/PersonTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/PersonTableModel.java
@@ -45,27 +45,28 @@ public class PersonTableModel extends UnitTableModel<Person> {
 
 	// Column indexes
 	private static final int NAME = 0;
-	private static final int TASK_DESC = 1;
-	private static final int MISSION_COL = 2;
-	private static final int JOB = 3;
-	private static final int ROLE = 4;
-	private static final int SHIFT = 5;
-	private static final int LOCATION = 6;
-	private static final int LOCALE = 7;
-	private static final int HEALTH = 8;
-	private static final int FATIGUE = 9;
-	private static final int ENERGY = 10;
-	private static final int WATER = 11;
-	private static final int STRESS = 12;
-	private static final int PERFORMANCE = 13;
-	private static final int EMOTION = 14;
+	private static final int SETTLEMENT = NAME+1;
+	private static final int TASK_DESC = SETTLEMENT+1;
+	private static final int MISSION_COL = TASK_DESC+1;
+	private static final int JOB = MISSION_COL+1;
+	private static final int ROLE = JOB+1;
+	private static final int SHIFT = ROLE+1;
+	private static final int LOCATION = SHIFT+1;
+	private static final int LOCALE = LOCATION+1;
+	private static final int HEALTH = LOCALE+1;
+	private static final int FATIGUE = HEALTH+1;
+	private static final int ENERGY = FATIGUE+1;
+	private static final int WATER = ENERGY+1;
+	private static final int STRESS = WATER+1;
+	private static final int PERFORMANCE = STRESS+1;
+	private static final int EMOTION = PERFORMANCE+1;
 
 	/** The number of Columns. */
-	private static final int COLUMNCOUNT = 15;
+	private static final int COLUMNCOUNT = EMOTION+1;
 	/** Names of Columns. */
 	private static final ColumnSpec[] COLUMNS;
 
-	private static Map<UnitEventType, Integer> eventColumnMapping;
+	private static final Map<UnitEventType, Integer> EVENT_COLUMN_MAPPING;
 
 	private static final String DEHYDRATED = "Dehydrated";
 	private static final String STARVING = "Starving";
@@ -76,6 +77,7 @@ public class PersonTableModel extends UnitTableModel<Person> {
 	static {
 		COLUMNS = new ColumnSpec[COLUMNCOUNT];
 		COLUMNS[NAME] = new ColumnSpec(Msg.getString("PersonTableModel.column.name"), String.class);
+		COLUMNS[SETTLEMENT] = new ColumnSpec("Settlement", String.class);
 		COLUMNS[HEALTH] = new ColumnSpec(Msg.getString("PersonTableModel.column.health"), String.class);
 		COLUMNS[ENERGY] = new ColumnSpec(Msg.getString("PersonTableModel.column.energy"), String.class);
 		COLUMNS[WATER] = new ColumnSpec(Msg.getString("PersonTableModel.column.water"), String.class);
@@ -91,27 +93,27 @@ public class PersonTableModel extends UnitTableModel<Person> {
 		COLUMNS[MISSION_COL] = new ColumnSpec(Msg.getString("PersonTableModel.column.mission"), String.class);
 		COLUMNS[TASK_DESC] = new ColumnSpec(Msg.getString("PersonTableModel.column.task"), String.class);
 
-		eventColumnMapping = new EnumMap<>(UnitEventType.class);
-		eventColumnMapping.put(UnitEventType.NAME_EVENT, NAME);
-		eventColumnMapping.put(UnitEventType.LOCATION_EVENT, LOCATION);
-		eventColumnMapping.put(UnitEventType.HUNGER_EVENT, ENERGY);
-		eventColumnMapping.put(UnitEventType.THIRST_EVENT, ENERGY);
-		eventColumnMapping.put(UnitEventType.FATIGUE_EVENT, FATIGUE);
-		eventColumnMapping.put(UnitEventType.STRESS_EVENT, STRESS);
-		eventColumnMapping.put(UnitEventType.EMOTION_EVENT, EMOTION);
-		eventColumnMapping.put(UnitEventType.PERFORMANCE_EVENT, PERFORMANCE);
-		eventColumnMapping.put(UnitEventType.JOB_EVENT, JOB);
-		eventColumnMapping.put(UnitEventType.ROLE_EVENT, ROLE);
-		eventColumnMapping.put(UnitEventType.SHIFT_EVENT, SHIFT);
-		eventColumnMapping.put(UnitEventType.TASK_EVENT, TASK_DESC);
-		eventColumnMapping.put(UnitEventType.TASK_NAME_EVENT, TASK_DESC);
-		eventColumnMapping.put(UnitEventType.TASK_DESCRIPTION_EVENT, TASK_DESC);
-		eventColumnMapping.put(UnitEventType.TASK_ENDED_EVENT, TASK_DESC);
-		eventColumnMapping.put(UnitEventType.MISSION_EVENT, MISSION_COL);
-		eventColumnMapping.put(UnitEventType.ILLNESS_EVENT, HEALTH);
-		eventColumnMapping.put(UnitEventType.DEATH_EVENT, HEALTH);
-		eventColumnMapping.put(UnitEventType.BURIAL_EVENT, HEALTH);
-		eventColumnMapping.put(UnitEventType.REVIVED_EVENT, HEALTH);
+		EVENT_COLUMN_MAPPING = new EnumMap<>(UnitEventType.class);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.NAME_EVENT, NAME);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.LOCATION_EVENT, LOCATION);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.HUNGER_EVENT, ENERGY);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.THIRST_EVENT, ENERGY);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.FATIGUE_EVENT, FATIGUE);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.STRESS_EVENT, STRESS);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.EMOTION_EVENT, EMOTION);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.PERFORMANCE_EVENT, PERFORMANCE);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.JOB_EVENT, JOB);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.ROLE_EVENT, ROLE);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.SHIFT_EVENT, SHIFT);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.TASK_EVENT, TASK_DESC);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.TASK_NAME_EVENT, TASK_DESC);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.TASK_DESCRIPTION_EVENT, TASK_DESC);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.TASK_ENDED_EVENT, TASK_DESC);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.MISSION_EVENT, MISSION_COL);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.ILLNESS_EVENT, HEALTH);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.DEATH_EVENT, HEALTH);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.BURIAL_EVENT, HEALTH);
+		EVENT_COLUMN_MAPPING.put(UnitEventType.REVIVED_EVENT, HEALTH);
 	}
 
 	/** 
@@ -165,6 +167,8 @@ public class PersonTableModel extends UnitTableModel<Person> {
 		super (UnitType.PERSON, Msg.getString("PersonTableModel.nameAllCitizens"),
 				"PersonTableModel.countingCitizens", COLUMNS);
 		setupCache();
+		setSettlementColumn(SETTLEMENT);
+
 		sourceType = ValidSourceType.SETTLEMENT_ALL_ASSOCIATED_PEOPLE;
 	}
 
@@ -261,7 +265,7 @@ public class PersonTableModel extends UnitTableModel<Person> {
 	public void unitUpdate(UnitEvent event) {
 		UnitEventType eventType = event.getType();
 
-		Integer column = eventColumnMapping.get(eventType);
+		Integer column = EVENT_COLUMN_MAPPING.get(eventType);
 
 		if (column != null && column > -1) {
 			Person unit = (Person) event.getSource();
@@ -298,6 +302,10 @@ public class PersonTableModel extends UnitTableModel<Person> {
 
 			case NAME:
 				result = person.getName();
+			break;
+
+			case SETTLEMENT:
+				result = person.getAssociatedSettlement().getName();
 			break;
 
 			case ENERGY: {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/PersonTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/PersonTableModel.java
@@ -160,15 +160,12 @@ public class PersonTableModel extends UnitTableModel<Person> {
 	 * Constructs a PersonTableModel that displays residents are all associated
 	 * people with a specified settlement.
 	 *
-	 * @param settlement    the settlement to check.
 	 */
-	public PersonTableModel(Set<Settlement> settlement)  {
+	public PersonTableModel()  {
 		super (UnitType.PERSON, Msg.getString("PersonTableModel.nameAllCitizens"),
 				"PersonTableModel.countingCitizens", COLUMNS);
 		setupCache();
 		sourceType = ValidSourceType.SETTLEMENT_ALL_ASSOCIATED_PEOPLE;
-
-		setSettlementFilter(settlement);
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/RobotTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/RobotTableModel.java
@@ -44,29 +44,18 @@ public class RobotTableModel extends UnitTableModel<Robot> {
 	private static final String NAME_ROBOTS_KEY = "RobotTableModel.nameRobots";
 
 	// Column indexes
-	/** Robot name column. */
 	private static final int NAME = 0;
-	/** Gender column. */
-	private static final int TYPE = 1;
-	/** Location column. */
-	private static final int LOCATION = 2;
-	/** Health column. */
-	private static final int HEALTH = 3;
-	/** Hunger column. */
-	private static final int BATTERY = 4;
+	private static final int TYPE = NAME+1;
+	private static final int LOCATION = TYPE+1;
+	private static final int SETTLEMENT = LOCATION+1;
+	private static final int HEALTH = SETTLEMENT+1;
+	private static final int BATTERY = HEALTH+1;
+	private static final int PERFORMANCE = BATTERY+1;
+	private static final int JOB = PERFORMANCE+1;
+	private static final int TASK = JOB+1;
+	private static final int MISSION_COL = TASK+1;
 
-	/** Performance column. */
-	private static final int PERFORMANCE = 5;
-	/** Job column. */
-	private static final int JOB = 6;
-	/** Task column. */
-	private static final int TASK = 7;
-	/** Mission column. */
-	private static final int MISSION_COL = 8;
-
-	/** The number of Columns. */
-	private static final int COLUMNCOUNT = 9;
-	/** Names of Columns. */
+	private static final int COLUMNCOUNT = MISSION_COL+1;
 	private static final ColumnSpec[] COLUMNS;
 
 	private static final Map<UnitEventType, Integer> eventColumnMapping;
@@ -78,6 +67,7 @@ public class RobotTableModel extends UnitTableModel<Robot> {
 		COLUMNS = new ColumnSpec[COLUMNCOUNT];
 		COLUMNS[NAME] = new ColumnSpec(Msg.getString("RobotTableModel.column.name"), String.class);
 		COLUMNS[TYPE] = new ColumnSpec(Msg.getString("RobotTableModel.column.type"), String.class);
+		COLUMNS[SETTLEMENT] = new ColumnSpec("Settlement", String.class);
 		COLUMNS[HEALTH] = new ColumnSpec(Msg.getString("RobotTableModel.column.health"), String.class);
 		COLUMNS[BATTERY] = new ColumnSpec(Msg.getString("RobotTableModel.column.battery"), String.class);
 		COLUMNS[PERFORMANCE] = new ColumnSpec(Msg.getString("RobotTableModel.column.performance"), String.class);
@@ -149,6 +139,7 @@ public class RobotTableModel extends UnitTableModel<Robot> {
 				COUNTING_ROBOTS_KEY, COLUMNS);
 
 		this.allAssociated = true;
+		setSettlementColumn(SETTLEMENT);
 	}
 
 	/**
@@ -248,6 +239,10 @@ public class RobotTableModel extends UnitTableModel<Robot> {
 
 			case TYPE: 
 				result = robot.getRobotType().getName();
+				break;
+
+			case SETTLEMENT: 
+				result = robot.getAssociatedSettlement().getName();
 				break;
 
 			case BATTERY: 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/RobotTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/RobotTableModel.java
@@ -144,12 +144,11 @@ public class RobotTableModel extends UnitTableModel<Robot> {
 	 * @param settlement    the settlement to check.
 
 	 */
-	public RobotTableModel(Set<Settlement> settlement) {
+	public RobotTableModel() {
 		super (UnitType.ROBOT, Msg.getString("RobotTableModel.nameAssociatedRobots"),
 				COUNTING_ROBOTS_KEY, COLUMNS);
 
 		this.allAssociated = true;
-		setSettlementFilter(settlement);
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/SettlementTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/SettlementTableModel.java
@@ -6,11 +6,10 @@
  */
 package com.mars_sim.ui.swing.tool.monitor;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitEvent;
@@ -142,7 +141,7 @@ public class SettlementTableModel extends UnitTableModel<Settlement> {
 		}
 	}
 
-	private boolean singleSettlement;
+	private boolean allSettlements;
 
 	/**
 	 * Constructs a SettlementTableModel model that displays all Settlements in the
@@ -151,7 +150,7 @@ public class SettlementTableModel extends UnitTableModel<Settlement> {
 	public SettlementTableModel() {
 		super(UnitType.SETTLEMENT, "Mars", "SettlementTableModel.countingSettlements",
 				COLUMNS);
-		singleSettlement = false;
+		allSettlements = true;
 
 		setupCaches();
 		resetEntities(unitManager.getSettlements());
@@ -169,11 +168,11 @@ public class SettlementTableModel extends UnitTableModel<Settlement> {
 	 *
 	 * @param settlement
 	 */
-	public SettlementTableModel(Settlement settlement) {
+	public SettlementTableModel(Set<Settlement> settlement) {
 		super(UnitType.SETTLEMENT, Msg.getString("SettlementTableModel.tabName"), //$NON-NLS-2$
 				"SettlementTableModel.countingSettlements", 
 				COLUMNS);
-		singleSettlement = true;
+		allSettlements = false;
 		setupCaches();
 
 		setSettlementFilter(settlement);
@@ -185,14 +184,12 @@ public class SettlementTableModel extends UnitTableModel<Settlement> {
 	 * @param filter
 	 */
 	@Override
-	public boolean setSettlementFilter(Settlement filter) {
+	public boolean setSettlementFilter(Set<Settlement> filter) {
 
-		if (singleSettlement) {
-			List<Settlement> sList = new ArrayList<>();
-			sList.add(filter);
-			resetEntities(sList);
+		if (!allSettlements) {
+			resetEntities(filter);
 		}
-		return singleSettlement;
+		return !allSettlements;
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/SettlementTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/SettlementTableModel.java
@@ -21,7 +21,6 @@ import com.mars_sim.core.resource.AmountResource;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.vehicle.Vehicle;
-import com.mars_sim.tools.Msg;
 
 /**
  * The SettlementTableModel that maintains a list of Settlement objects. It maps
@@ -147,35 +146,20 @@ public class SettlementTableModel extends UnitTableModel<Settlement> {
 	 * Constructs a SettlementTableModel model that displays all Settlements in the
 	 * simulation.
 	 */
-	public SettlementTableModel() {
-		super(UnitType.SETTLEMENT, "Mars", "SettlementTableModel.countingSettlements",
+	public SettlementTableModel(boolean allSettlements) {
+		super(UnitType.SETTLEMENT, (allSettlements ? "Mars" : "Settlement"), "SettlementTableModel.countingSettlements",
 				COLUMNS);
-		allSettlements = true;
+		this.allSettlements = allSettlements;
 
 		setupCaches();
-		resetEntities(unitManager.getSettlements());
-			
-		listenForUnits();
+		if (allSettlements) {
+			resetEntities(unitManager.getSettlements());
+			listenForUnits();
+		}
 	}
 
 	private void setupCaches() {
 		setCachedColumns(OXYGEN_COL, MINERALS_COL);
-	}
-
-	/**
-	 * Constructs a SettlementTableModel model that displays a specific settlement in the
-	 * simulation.
-	 *
-	 * @param settlement
-	 */
-	public SettlementTableModel(Set<Settlement> settlement) {
-		super(UnitType.SETTLEMENT, Msg.getString("SettlementTableModel.tabName"), //$NON-NLS-2$
-				"SettlementTableModel.countingSettlements", 
-				COLUMNS);
-		allSettlements = false;
-		setupCaches();
-
-		setSettlementFilter(settlement);
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TableTab.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TableTab.java
@@ -13,6 +13,7 @@ import java.awt.event.MouseEvent;
 import java.beans.PropertyVetoException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
@@ -25,6 +26,7 @@ import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
 
+import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.time.MarsTime;
 import com.mars_sim.ui.swing.ImageLoader;
 import com.mars_sim.ui.swing.MainDesktopPane;
@@ -49,6 +51,8 @@ abstract class TableTab extends MonitorTab {
 	/** Table component. */
 	protected JTable table;
 	private boolean widthAdjusted = false;
+	private int settlementColumnId;
+	private TableColumn savedSettlementColumn;
 	
 	/**
 	 * Creates a table within a tab displaying the specified model.
@@ -62,6 +66,8 @@ abstract class TableTab extends MonitorTab {
 			String iconname) {
 		super(model, mandatory, true, ImageLoader.getIconByName(iconname));
 
+		settlementColumnId = model.getSettlementColumn();
+		
 		// Simple WebTable
 		this.table = new JTable(model) {
             @Override
@@ -119,16 +125,6 @@ abstract class TableTab extends MonitorTab {
 
 	public JTable getTable() {
 		return table;
-	}
-
-	/**
-	 * Automatically adjust the width when a significant data change
-	 */
-	public void autoAdjustWidths() {
-		if (!widthAdjusted) {
-			widthAdjusted = true;
-			adjustColumnWidth(table);
-		}
 	}
 
 	protected static void adjustColumnWidth(JTable table) {
@@ -224,6 +220,38 @@ abstract class TableTab extends MonitorTab {
 	public void removeTab() {
 		super.removeTab();
 		table = null;
+	}
+
+	protected void setSettlementColumnIndex(int idx) {
+		settlementColumnId = idx;
+	}
+
+	public boolean setSettlementFilter(Set<Settlement> currentSelection) {
+		if (settlementColumnId > 0) {
+			boolean showSettlement = (currentSelection.size() > 1);
+			if (showSettlement && (savedSettlementColumn != null)) {
+				// SHow Settlement but it is hidden
+				var tc = table.getColumnModel();
+				tc.addColumn(savedSettlementColumn);
+				tc.moveColumn(tc.getColumnCount()-1, settlementColumnId);
+				savedSettlementColumn = null;
+			}
+			else if (!showSettlement && (savedSettlementColumn == null)) {
+				// No need for Settlement and is no display
+				var tc = table.getColumnModel();
+				savedSettlementColumn = tc.getColumn(settlementColumnId);
+				tc.removeColumn(savedSettlementColumn);
+			}
+		}
+		var accepted = getModel().setSettlementFilter(currentSelection);
+
+		// Automatically adjust the width when a significant data change
+		if (!widthAdjusted) {
+			widthAdjusted = true;
+			adjustColumnWidth(table);
+		}
+
+		return accepted;
 	}
 
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TableTab.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TableTab.java
@@ -48,7 +48,8 @@ abstract class TableTab extends MonitorTab {
 
 	/** Table component. */
 	protected JTable table;
-
+	private boolean widthAdjusted = false;
+	
 	/**
 	 * Creates a table within a tab displaying the specified model.
 	 *
@@ -118,6 +119,16 @@ abstract class TableTab extends MonitorTab {
 
 	public JTable getTable() {
 		return table;
+	}
+
+	/**
+	 * Automatically adjust the width when a significant data change
+	 */
+	public void autoAdjustWidths() {
+		if (!widthAdjusted) {
+			widthAdjusted = true;
+			adjustColumnWidth(table);
+		}
 	}
 
 	protected static void adjustColumnWidth(JTable table) {
@@ -214,4 +225,5 @@ abstract class TableTab extends MonitorTab {
 		super.removeTab();
 		table = null;
 	}
+
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTab.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTab.java
@@ -6,6 +6,8 @@
  */
 package com.mars_sim.ui.swing.tool.monitor;
 
+import java.util.Set;
+
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
 
@@ -26,7 +28,7 @@ public class TradeTab extends TableTab {
 	 * @param selectedSettlement
 	 * @param window {@link MonitorWindow} the containing window.
 	 */
-	public TradeTab(Settlement selectedSettlement, final MonitorWindow window) {
+	public TradeTab(Set<Settlement> selectedSettlement, final MonitorWindow window) {
 		// Use TableTab constructor
 		super(window, new TradeTableModel(selectedSettlement), true, false, TRADE_ICON);
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTab.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTab.java
@@ -6,12 +6,9 @@
  */
 package com.mars_sim.ui.swing.tool.monitor;
 
-import java.util.Set;
-
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
 
-import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.ui.swing.tool.NumberRenderer;
 
 /**
@@ -28,9 +25,9 @@ public class TradeTab extends TableTab {
 	 * @param selectedSettlement
 	 * @param window {@link MonitorWindow} the containing window.
 	 */
-	public TradeTab(Set<Settlement> selectedSettlement, final MonitorWindow window) {
+	public TradeTab(final MonitorWindow window) {
 		// Use TableTab constructor
-		super(window, new TradeTableModel(selectedSettlement), true, false, TRADE_ICON);
+		super(window, new TradeTableModel(), true, false, TRADE_ICON);
 
 		TableColumnModel m = table.getColumnModel();
 		for(int i = TradeTableModel.NUM_INITIAL_COLUMNS; i < m.getColumnCount(); i++) {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTableModel.java
@@ -6,8 +6,6 @@
  */
 package com.mars_sim.ui.swing.tool.monitor;
 
-import java.util.Set;
-
 import com.mars_sim.core.CollectionUtils;
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitEvent;
@@ -67,17 +65,13 @@ public class TradeTableModel extends CategoryTableModel<Good> {
 	/**
 	 * Constructor 2.
 	 * 
-	 * @param selectedSettlement2
-	 * @param window
 	 */
-	public TradeTableModel(Set<Settlement> filter) {
+	public TradeTableModel() {
 		super(Msg.getString("TradeTableModel.tabName"), "TradeTableModel.counting",COLUMNS,
 						GoodsUtil.getGoodsList());
 
 		// Cache the data columns
 		setCachedColumns(NUM_INITIAL_COLUMNS, COLUMNCOUNT-1);
-
-		setSettlementFilter(filter);
 	}
 	
 	

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTableModel.java
@@ -6,11 +6,12 @@
  */
 package com.mars_sim.ui.swing.tool.monitor;
 
+import java.util.Set;
+
 import com.mars_sim.core.CollectionUtils;
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitEvent;
 import com.mars_sim.core.UnitEventType;
-import com.mars_sim.core.UnitListener;
 import com.mars_sim.core.equipment.BinFactory;
 import com.mars_sim.core.equipment.BinType;
 import com.mars_sim.core.equipment.EquipmentFactory;
@@ -26,31 +27,32 @@ import com.mars_sim.core.vehicle.VehicleType;
 import com.mars_sim.tools.Msg;
 
 
-public class TradeTableModel extends EntityTableModel<Good>
-implements UnitListener {
-
-	static final int NUM_INITIAL_COLUMNS = 3;
-	private static final int NUM_DATA_COL = 8;
-	private static final int COLUMNCOUNT = NUM_INITIAL_COLUMNS + NUM_DATA_COL;
+public class TradeTableModel extends CategoryTableModel<Good> {
 
 	/** Names of Columns. */
 	private static final ColumnSpec[] COLUMNS;
+	private static final int GOOD_COL = 0;
+	private static final int CAT_COL = GOOD_COL+1;
+	private static final int TYPE_COL = CAT_COL+1;
+	private static final int SETTLEMENT_COL = TYPE_COL+1;
+	private static final int DEMAND_COL = SETTLEMENT_COL+1;
+	private static final int SUPPLY_COL = DEMAND_COL+1;
+	static final int QUANTITY_COL = SUPPLY_COL+1;
+	private static final int MASS_COL = QUANTITY_COL+1;
+	private static final int MARKET_COL = MASS_COL+1;
+	private static final int VALUE_COL = MARKET_COL+1;
+	static final int COST_COL = VALUE_COL+1;
+	static final int PRICE_COL = COST_COL+1;
 
-
-	private static final int DEMAND_COL = 3;
-	private static final int SUPPLY_COL = 4;
-	static final int QUANTITY_COL = 5;
-	private static final int MASS_COL = 6;
-	private static final int MARKET_COL = 7;
-	private static final int VALUE_COL = 8;
-	static final int COST_COL = 9;
-	static final int PRICE_COL = 10;
+	static final int NUM_INITIAL_COLUMNS = 4;
+	private static final int COLUMNCOUNT = PRICE_COL + 1;
 
 	static {
-		COLUMNS = new ColumnSpec[NUM_INITIAL_COLUMNS + NUM_DATA_COL];
-		COLUMNS[0] = new ColumnSpec ("Good", String.class);
-		COLUMNS[1] = new ColumnSpec ("Category", String.class);
-		COLUMNS[2] = new ColumnSpec ("Type", String.class);
+		COLUMNS = new ColumnSpec[COLUMNCOUNT];
+		COLUMNS[GOOD_COL] = new ColumnSpec ("Good", String.class);
+		COLUMNS[CAT_COL] = new ColumnSpec ("Category", String.class);
+		COLUMNS[TYPE_COL] = new ColumnSpec ("Type", String.class);
+		COLUMNS[SETTLEMENT_COL] = new ColumnSpec("Settlement", String.class);
 
 		COLUMNS[DEMAND_COL] = new ColumnSpec ("Demand", Double.class);
 		COLUMNS[SUPPLY_COL] = new ColumnSpec ("Supply", Double.class);
@@ -60,67 +62,25 @@ implements UnitListener {
 		COLUMNS[VALUE_COL] = new ColumnSpec ("Local VP", Double.class);
 		COLUMNS[COST_COL] = new ColumnSpec ("Cost [$]", Double.class);
 		COLUMNS[PRICE_COL] = new ColumnSpec ("Price [$]", Double.class);
-	};
-
-	// Data members
-	private Settlement selectedSettlement;
-	private boolean monitorSettlement = false;
+	}
 
 	/**
 	 * Constructor 2.
 	 * 
-	 * @param selectedSettlement
+	 * @param selectedSettlement2
 	 * @param window
 	 */
-	public TradeTableModel(Settlement selectedSettlement) {
-		super(Msg.getString("TradeTableModel.tabName"), "TradeTableModel.counting",COLUMNS);
+	public TradeTableModel(Set<Settlement> filter) {
+		super(Msg.getString("TradeTableModel.tabName"), "TradeTableModel.counting",COLUMNS,
+						GoodsUtil.getGoodsList());
 
 		// Cache the data columns
 		setCachedColumns(NUM_INITIAL_COLUMNS, COLUMNCOUNT-1);
 
-		this.selectedSettlement = selectedSettlement;
-
-		setSettlementFilter(selectedSettlement);
+		setSettlementFilter(filter);
 	}
 	
-	@Override
-	public boolean setSettlementFilter(Settlement filter) {
-		if (selectedSettlement != null) {
-			selectedSettlement.removeUnitListener(this);
-		}
-
-		// Initialize settlements.
-		selectedSettlement = filter;
-
-		// Initialize goods list.
-		resetEntities(GoodsUtil.getGoodsList());
-
-		// Add table as listener to each settlement.
-		if (monitorSettlement) {
-			selectedSettlement.addUnitListener(this);
-		}
-
-		return true;
-	}
 	
-	    
-	/**
-	 * Set whether the changes to the Entities should be monitor for change. Set up the 
-	 * Unitlisteners for the selected Settlement where Food comes from for the table.
-	 * @param activate 
-	 */
-    public void setMonitorEntites(boolean activate) {
-		if (activate != monitorSettlement) {
-			if (activate) {
-				selectedSettlement.addUnitListener(this);
-			}
-			else {
-				selectedSettlement.removeUnitListener(this);
-			}
-			monitorSettlement = activate;
-		}
-	}
-
 	/**
 	 * Catches unit update event.
 	 *
@@ -132,9 +92,9 @@ implements UnitListener {
 		UnitEventType eventType = event.getType();
 		if ((eventType == UnitEventType.GOODS_VALUE_EVENT
 			|| eventType == UnitEventType.FOOD_EVENT)
-			&& event.getTarget() instanceof Good 
-			&& unit.equals(selectedSettlement)) {
-				entityValueUpdated((Good)event.getTarget(), NUM_INITIAL_COLUMNS, COLUMNCOUNT-1);
+			&& event.getTarget() instanceof Good g
+			&& unit instanceof Settlement s) {
+				entityValueUpdated(new CategoryKey<>(s, g), NUM_INITIAL_COLUMNS, COLUMNCOUNT-1);
 			}
 	}
 
@@ -144,14 +104,19 @@ implements UnitListener {
 	 * @param columnIndex COlumn to get
 	 */
 	@Override
-	protected  Object getEntityValue(Good selectedGood, int columnIndex) {
+	protected  Object getEntityValue(CategoryKey<Good> row, int columnIndex) {
+		Good selectedGood = row.getCategory();
+		Settlement selectedSettlement = row.getSettlement();
+
 		switch(columnIndex) {
-			case 0:
+			case GOOD_COL:
 				return selectedGood.getName();
-			case 1:
+			case CAT_COL:
 				return getGoodCategoryName(selectedGood);
-			case 2:
+			case TYPE_COL:
 				return selectedGood.getGoodType().getName();
+			case SETTLEMENT_COL:
+				return selectedSettlement.getName();
 			case DEMAND_COL:
 				return selectedSettlement.getGoodsManager().getDemandValue(selectedGood);
 			case SUPPLY_COL:
@@ -268,18 +233,5 @@ implements UnitListener {
 	 */
 	private static String getGoodCategoryName(Good good) {
 		return good.getCategory().getMsgKey();
-	}
-
-	/**
-	 * Prepares the model for deletion.
-	 */
-	@Override
-	public void destroy() {
-		super.destroy();
-
-		// Remove as listener for all settlements.
-		selectedSettlement.removeUnitListener(this);
-
-		selectedSettlement = null;
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTableModel.java
@@ -69,9 +69,9 @@ public class TradeTableModel extends CategoryTableModel<Good> {
 	public TradeTableModel() {
 		super(Msg.getString("TradeTableModel.tabName"), "TradeTableModel.counting",COLUMNS,
 						GoodsUtil.getGoodsList());
-
 		// Cache the data columns
 		setCachedColumns(NUM_INITIAL_COLUMNS, COLUMNCOUNT-1);
+		setSettlementColumn(SETTLEMENT_COL);
 	}
 	
 	

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/VehicleTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/VehicleTableModel.java
@@ -27,7 +27,6 @@ import com.mars_sim.core.person.ai.mission.VehicleMission;
 import com.mars_sim.core.resource.AmountResource;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.structure.Settlement;
-import com.mars_sim.core.structure.building.function.cooking.PreparingDessert;
 import com.mars_sim.core.vehicle.Crewable;
 import com.mars_sim.core.vehicle.Vehicle;
 import com.mars_sim.mapdata.location.Coordinates;
@@ -46,32 +45,30 @@ public class VehicleTableModel extends UnitTableModel<Vehicle> {
 
 	// Column indexes
 	private static final int NAME = 0;
-	private static final int TYPE = 1;
-	private static final int LOCATION = 2;
-	private static final int DESTINATION = 3;
-	private static final int DESTDIST = 4;
-	private static final int MISSION = 5;
-	private static final int CREW = 6;
-	private static final int DRIVER = 7;
-	private static final int STATUS = 8;
-	private static final int BEACON = 9;
-	private static final int RESERVED = 10;
-	private static final int SPEED = 11;
-	private static final int MALFUNCTION = 12;
-	private static final int OXYGEN = 13;
-	private static final int METHANOL = 14;
-	private static final int WATER = 15;
-	private static final int FOOD = 16;
-	private static final int DESSERT = 17;
-	private static final int ROCK_SAMPLES = 18;
-	private static final int ICE = 19;
+	private static final int TYPE = NAME+1;
+	private static final int SETTLEMENT = TYPE+1;
+	private static final int LOCATION = SETTLEMENT+1;
+	private static final int DESTINATION = LOCATION+1;
+	private static final int DESTDIST = DESTINATION+1;
+	private static final int MISSION = DESTDIST+1;
+	private static final int CREW = MISSION+1;
+	private static final int DRIVER = CREW+1;
+	private static final int STATUS = DRIVER+1;
+	private static final int BEACON = STATUS+1;
+	private static final int RESERVED = BEACON+1;
+	private static final int SPEED = RESERVED+1;
+	private static final int MALFUNCTION = SPEED+1;
+	private static final int OXYGEN = MALFUNCTION+1;
+	private static final int METHANOL = OXYGEN+1;
+	private static final int WATER = METHANOL+1;
+	private static final int FOOD = WATER+1;
+	private static final int ROCK_SAMPLES = FOOD+1;
+	private static final int ICE = ROCK_SAMPLES+1;
 	/** The number of Columns. */
-	private static final int COLUMNCOUNT = 20;
+	private static final int COLUMNCOUNT = ICE+1;
 	/** Names of Columns. */
 	private static final ColumnSpec[] COLUMNS;
 	private static final Map<Integer,Integer> RESOURCE_TO_COL;
-
-	private static final int[] AVAILABLE_DESSERTS;
 
 	/**
 	 * Class initialiser creates the static names and classes.
@@ -80,6 +77,7 @@ public class VehicleTableModel extends UnitTableModel<Vehicle> {
 		COLUMNS = new ColumnSpec[COLUMNCOUNT];
 		COLUMNS[NAME] = new ColumnSpec("Name", String.class);
 		COLUMNS[TYPE] = new ColumnSpec("Type", String.class);
+		COLUMNS[SETTLEMENT] = new ColumnSpec("Settlement", String.class);
 		COLUMNS[LOCATION] = new ColumnSpec("Location", String.class);
 		COLUMNS[DESTINATION] = new ColumnSpec("Next Waypoint", Coordinates.class);
 		COLUMNS[DESTDIST] = new ColumnSpec("Dist. to next [km]", Double.class);
@@ -95,7 +93,6 @@ public class VehicleTableModel extends UnitTableModel<Vehicle> {
 		COLUMNS[METHANOL] = new ColumnSpec("Methanol", Double.class);
 		COLUMNS[WATER] = new ColumnSpec("Water", Double.class);
 		COLUMNS[FOOD] = new ColumnSpec("Food", Double.class);
-		COLUMNS[DESSERT] = new ColumnSpec("Dessert", Double.class);
 		COLUMNS[ROCK_SAMPLES] = new ColumnSpec("Rock Samples", Double.class);
 		COLUMNS[ICE] = new ColumnSpec("Ice", Double.class);
 
@@ -106,14 +103,6 @@ public class VehicleTableModel extends UnitTableModel<Vehicle> {
 		RESOURCE_TO_COL.put(ResourceUtil.waterID, WATER);
 		RESOURCE_TO_COL.put(ResourceUtil.rockSamplesID, ROCK_SAMPLES);
 		RESOURCE_TO_COL.put(ResourceUtil.iceID, ICE);
-
-		// Put together a list of available dessert
-		AVAILABLE_DESSERTS = new int[PreparingDessert.getArrayOfDessertsAR().length];
-		int i = 0;
-		for(AmountResource ar : PreparingDessert.getArrayOfDessertsAR()) {
-			RESOURCE_TO_COL.put(ar.getID(), DESSERT);
-			AVAILABLE_DESSERTS[i++] = ar.getID();
-		}
 	}
 
 	private static MissionManager missionManager = Simulation.instance().getMissionManager();
@@ -128,7 +117,7 @@ public class VehicleTableModel extends UnitTableModel<Vehicle> {
 		);
 
 		setCachedColumns(OXYGEN, ICE);
-
+		setSettlementColumn(SETTLEMENT);
 		missionManagerListener = new LocalMissionManagerListener();
 	}
 
@@ -155,6 +144,10 @@ public class VehicleTableModel extends UnitTableModel<Vehicle> {
 		switch (columnIndex) {
 			case NAME : 
 				result = vehicle.getName();
+				break;
+
+			case SETTLEMENT : 
+				result = vehicle.getAssociatedSettlement().getName();
 				break;
 
 			case TYPE :
@@ -234,10 +227,6 @@ public class VehicleTableModel extends UnitTableModel<Vehicle> {
 
 			case FOOD : 
 				result = vehicle.getAmountResourceStored(ResourceUtil.foodID);
-				break;
-
-			case DESSERT : 
-				result = SettlementTableModel.getTotalAmount(AVAILABLE_DESSERTS, vehicle);
 				break;
 
 			case OXYGEN : 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/VehicleTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/VehicleTableModel.java
@@ -9,7 +9,7 @@ package com.mars_sim.ui.swing.tool.monitor;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import java.util.Set;
 import com.mars_sim.core.Simulation;
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitEvent;
@@ -120,7 +120,7 @@ public class VehicleTableModel extends UnitTableModel<Vehicle> {
 
 	private transient LocalMissionManagerListener missionManagerListener;
 	
-	public VehicleTableModel(Settlement settlement) {
+	public VehicleTableModel(Set<Settlement> settlement) {
 		super(UnitType.VEHICLE,
 			Msg.getString("VehicleTableModel.tabName"),
 			"VehicleTableModel.countingVehicles", //$NON-NLS-1$
@@ -138,8 +138,8 @@ public class VehicleTableModel extends UnitTableModel<Vehicle> {
 	 * Filter the vehicles to a settlement
 	 */
 	@Override
-	public boolean setSettlementFilter(Settlement filter) {
-		resetEntities(filter.getAllAssociatedVehicles());
+	public boolean setSettlementFilter(Set<Settlement> filter) {
+		resetEntities(filter.stream().flatMap(s -> s.getAllAssociatedVehicles().stream()).toList());
 
 		return true;
 	}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/VehicleTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/VehicleTableModel.java
@@ -120,14 +120,12 @@ public class VehicleTableModel extends UnitTableModel<Vehicle> {
 
 	private transient LocalMissionManagerListener missionManagerListener;
 	
-	public VehicleTableModel(Set<Settlement> settlement) {
+	public VehicleTableModel() {
 		super(UnitType.VEHICLE,
 			Msg.getString("VehicleTableModel.tabName"),
 			"VehicleTableModel.countingVehicles", //$NON-NLS-1$
 			COLUMNS
 		);
-
-		setSettlementFilter(settlement);
 
 		setCachedColumns(OXYGEN, ICE);
 


### PR DESCRIPTION
This PR consists of changes to allow Reporting Authorities to be used in the Monitor window filter selection. The activity consists of a number of high level changes:
- Adding Authorities to the MonitorWindow combo with an indication of the number of owned Settlements. 
- When an Authority is selected; the Settlement names are shown in the toolbar of the window.
- MonitorModel converted so the selection filter is a Set of Settlements instead of a singe one
- Adding a Settlement column to most tables that is automatically shown/hidden depending on the number of Settlement being filtered.
- Category model, i.e. Food & Goods, now shown one entry per Category per Settlement

close #903 