### PR TITLE
Fix failed maven test in moderateTime()

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/LocalAreaUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/LocalAreaUtil.java
@@ -718,8 +718,8 @@ public class LocalAreaUtil {
 			if (pathBounds.intersects(obstacleBounds)) {
 				// If rectangles intersect, check for collision of path and obstacle areas
 				// (slower).
-//				Area pathArea = new Area(path);
-				result = !doAreasCollide(new Area(path), obstacleArea);
+				Area pathArea = new Area(path);
+				result = !doAreasCollide(pathArea, obstacleArea);
 			}
 		}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/Mind.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/Mind.java
@@ -169,10 +169,11 @@ public class Mind implements Serializable, Temporal {
 	 * @throws Exception if error during action.
 	 */
 	private void moderateTime(double time) {
+//		// Call takeAction to perform a task and consume the pulse time.
+//		takeAction(time);
 		double remainingTime = time;
-		double pulseTime = Task.getStandardPulseTime();
-		while (remainingTime > 0) {
-			double deltaTime = pulseTime;
+		double deltaTime = Task.getStandardPulseTime();
+		while (remainingTime > 0 && deltaTime > 0) {
 			if (remainingTime > deltaTime) {
 				// Call takeAction to perform a task and consume the pulse time.
 				takeAction(deltaTime);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/WalkOutside.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/WalkOutside.java
@@ -740,4 +740,12 @@ public class WalkOutside extends Task {
 	protected boolean canRecord() {
 		return false;
 	}
+	
+	@Override
+	public void destroy() {
+		start = null;
+		destination = null;
+		walkingPath.clear();
+		walkingPath = null;
+	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/robot/ai/BotMind.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/robot/ai/BotMind.java
@@ -103,10 +103,11 @@ public class BotMind implements Serializable, Temporal {
 	 * @throws Exception if error during action.
 	 */
 	private void moderateTime(double time) {
+//		// Call takeAction to perform a task and consume the pulse time.
+//		takeAction(time);
 		double remainingTime = time;
-		double pulseTime = Task.getStandardPulseTime();
-		while (remainingTime > 0) {
-			double deltaTime = pulseTime;
+		double deltaTime = Task.getStandardPulseTime();
+		while (remainingTime > 0 && deltaTime > 0) {
 			if (remainingTime > deltaTime) {
 				// Call takeAction to perform a task and consume the pulse time.
 				takeAction(deltaTime);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/Heating.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/Heating.java
@@ -914,10 +914,11 @@ public class Heating implements Serializable {
 	 * @throws Exception if error during action.
 	 */
 	private void moderateTime(double time) {
+//		// Call cycleThermalControl and consume the pulse time.
+//		cycleThermalControl(time);
 		double remainingTime = time;
-		double pulseTime = Task.getStandardPulseTime();
-		while (remainingTime > 0) {
-			double deltaTime = pulseTime;
+		double deltaTime = Task.getStandardPulseTime();
+		while (remainingTime > 0 && deltaTime > 0) {
 			if (remainingTime > deltaTime) {
 				// Call cycleThermalControl and consume the pulse time.
 				cycleThermalControl(deltaTime);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/time/MasterClock.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/time/MasterClock.java
@@ -658,8 +658,8 @@ public class MasterClock implements Serializable {
 					// Increase the optimal pulse width
 					nextPulse = nextPulse + (1 - ratio) * nextPulse / PULSE_STEPS / 2;
 					if (nextPulse > maxMilliSolPerPulse * 1.05) {
-						logger.warning(30_000L, "actualTR / desiredTR = " + ratio + ". Set nextPulse to max.");
 						nextPulse = maxMilliSolPerPulse * 1.05;
+						logger.warning(30_000L, "actualTR / desiredTR = " + ratio + ". Set nextPulse to max.");
 					}
 					goOn = false;
 				}


### PR DESCRIPTION
1.1.2024

- fix: avoid zero pulse time in Mind, BotMind and Heating's moderateTime()

Relates to #655