### PR TITLE
Allow sleeping in another zone

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
@@ -1192,6 +1192,11 @@ public class Person extends Unit implements Worker, Temporal, Researcher {
 	public void setBed(AllocatedSpot bed2) {
 		this.bed = bed2;	}
 
+	/**
+	 * Does this person have an assigned bed ?
+	 * 
+	 * @return
+	 */
 	public boolean hasBed() {
 		return bed != null;
 	}
@@ -1203,7 +1208,6 @@ public class Person extends Unit implements Worker, Temporal, Researcher {
 	public String getCountry() {
 		return country;
 	}
-
 
 	public boolean isDeclaredDead() {
 		return declaredDead;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/job/Astronomer.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/job/Astronomer.java
@@ -65,7 +65,7 @@ public class Astronomer extends Job  {
 			result += observatory.getObservatoryCapacity() * observatory.getTechnologyLevel() / 2.0;
 		}
 
-		result = (result + population / 24D) / 2.0;
+		result = (result + population / 24D) / 4.0;
 				
 		return result;
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/job/Doctor.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/job/Doctor.java
@@ -73,7 +73,7 @@ public class Doctor extends Job {
 			result += (double) j.next().getMedical().getTechLevel() / 3D;
 		}
 
-		result = (result + population / 10D) / 5.0;
+		result = (result + population / 10D) / 8.0;
 				
 		return result;
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/Sleep.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/Sleep.java
@@ -299,22 +299,23 @@ public class Sleep extends Task {
 	 * Finds an empty activity spot in a building that supports life.
 	 * 
 	 * @param s
-	 * @param w
+	 * @param p
 	 * @return
 	 */
-	private AllocatedSpot findSleepRoughLocation(Settlement s, Worker w) {
+	private AllocatedSpot findSleepRoughLocation(Settlement s, Person p) {
 		var buildMgr = s.getBuildingManager();
-		for (Building b: buildMgr.getBuildingSet(FunctionType.LIFE_SUPPORT)) {
+		// Find a building in the same zone as the person
+		// Avoid sleeping inside EVA Airlock
+		for (Building b: buildMgr.getSameZoneBuildingsF1NoF2(p, 
+				FunctionType.LIFE_SUPPORT, FunctionType.EVA)) {
 			for (Function f : b.getFunctions()) {
 				for (ActivitySpot as : f.getActivitySpots()) {
 					if (as.isEmpty()) {
 						// Claim this activity spot
-						boolean canClaim = f.claimActivitySpot(as.getPos(), worker);
-						
-						if (!canClaim)
-							return null;
-						else
+						boolean canClaim = f.claimActivitySpot(as.getPos(), worker);					
+						if (canClaim) {
 							return worker.getActivitySpot();
+						}
 					}
 				}
 			}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/ObserveAstronomicalObjectsMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/ObserveAstronomicalObjectsMeta.java
@@ -82,7 +82,7 @@ public class ObserveAstronomicalObjectsMeta extends MetaTask implements Settleme
         if (ObserveAstronomicalObjects.areConditionsSuitable(target)
                 && !target.getBuildingManager().getBuildingSet(FunctionType.ASTRONOMICAL_OBSERVATION).isEmpty()) {    
             // Any Astro based study active at this Settlement
-            for(ScientificStudy s : getAstroStudies(target)) {
+            for (ScientificStudy s : getAstroStudies(target)) {
             	// Suitable study so create tasks for each Observatory
                 RatingScore score = new RatingScore(100);
                 score.addModifier(GOODS_MODIFIER, (target.getGoodsManager().getTourismFactor()

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/SleepMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/SleepMeta.java
@@ -53,17 +53,17 @@ public class SleepMeta extends FactoryMetaTask {
     	if (person.isOutside())
     		return 0;
     	
-    	if (person.isInSettlement()) {
-	        Building b = person.getBuildingLocation();
-	        if ((b != null) && (b.getCategory() == BuildingCategory.EVA_AIRLOCK)) {
-		        boolean inZone0 = b.getEVA().getAirlock().isInZone(person, AirlockZone.ZONE_0);
-		        if (!inZone0)
-		        	// if a person is in zone 0 at the inner door trying to ingress,
-		        	// and at the same time very fatigue, 
-		        	// then it's okay to allow this person to fall asleep.
-		        	return 0;
-	        }
-    	}
+//    	if (person.isInSettlement()) {
+//	        Building b = person.getBuildingLocation();
+//	        if ((b != null) && (b.getCategory() == BuildingCategory.EVA_AIRLOCK)) {
+//		        boolean inZone0 = b.getEVA().getAirlock().isInZone(person, AirlockZone.ZONE_0);
+//		        if (!inZone0)
+//		        	// if a person is in zone 0 at the inner door trying to ingress,
+//		        	// and at the same time very fatigue, 
+//		        	// then it's okay to allow this person to fall asleep.
+//		        	return 0;
+//	        }
+//    	}
     	
    		CircadianClock circadian = person.getCircadianClock();
    		PhysicalCondition pc = person.getPhysicalCondition();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/SleepMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/SleepMeta.java
@@ -53,18 +53,6 @@ public class SleepMeta extends FactoryMetaTask {
     	if (person.isOutside())
     		return 0;
     	
-//    	if (person.isInSettlement()) {
-//	        Building b = person.getBuildingLocation();
-//	        if ((b != null) && (b.getCategory() == BuildingCategory.EVA_AIRLOCK)) {
-//		        boolean inZone0 = b.getEVA().getAirlock().isInZone(person, AirlockZone.ZONE_0);
-//		        if (!inZone0)
-//		        	// if a person is in zone 0 at the inner door trying to ingress,
-//		        	// and at the same time very fatigue, 
-//		        	// then it's okay to allow this person to fall asleep.
-//		        	return 0;
-//	        }
-//    	}
-    	
    		CircadianClock circadian = person.getCircadianClock();
    		PhysicalCondition pc = person.getPhysicalCondition();
  

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/TaskFactory.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/TaskFactory.java
@@ -10,7 +10,7 @@ import com.mars_sim.core.person.Person;
 import com.mars_sim.core.robot.Robot;
 
 /**
- * Represents a Task Factory that can create Tasks for Workers
+ * Represents a Task Factory that can create Tasks for Workers.
  */
 public interface TaskFactory {
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingManager.java
@@ -804,7 +804,8 @@ public class BuildingManager implements Serializable {
 	/**
 	 * Gets the buildings in a settlement have function f1 and have no f2.
 	 *
-	 * @param functions the array of required functions {@link BuildingFunctions}.
+	 * @param f1 the required function 
+	 * @param f2 the excluded function
 	 * @return list of buildings.
 	 */
 	public Set<Building> getBuildingsF1NoF2(FunctionType f1, FunctionType f2) {
@@ -814,9 +815,26 @@ public class BuildingManager implements Serializable {
 	}
 	
 	/**
+	 * Gets the buildings in the same zone as the person in a settlement that 
+	 * has function f1 and have no f2.
+	 *
+	 * @param p
+	 * @param f1 the required function 
+	 * @param f2 the excluded function
+	 * @return list of buildings
+	 */
+	public Set<Building> getSameZoneBuildingsF1NoF2(Person p, FunctionType f1, FunctionType f2) {
+		return buildings.stream()
+				.filter(b -> b.hasFunction(f1) && !b.hasFunction(f2)
+						&& p.getBuildingLocation().getZone() == b.getZone())
+				.collect(Collectors.toSet());
+	}
+	
+	/**
 	 * Gets the buildings in a settlement have both function f1 and f2.
 	 *
-	 * @param functions the array of required functions {@link BuildingFunctions}.
+	 * @param f1 the first required function 
+	 * @param f2 the second required function
 	 * @return list of buildings.
 	 */
 	public Set<Building> getBuildings(FunctionType f1, FunctionType f2) {


### PR DESCRIPTION
1.5.2024

- new: add findTempBed() in Sleep
- fix: rework Sleep's walkToDestination() to consider a person in a different zone
- change: revise getProbability() in SleepMeta to allow sleeping in a different zone

Relates to #1208