### PR TITLE
Correct maintenance accident factor method name

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/DriveGroundVehicle.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/DriveGroundVehicle.java
@@ -433,7 +433,7 @@ public class DriveGroundVehicle extends OperateVehicle {
 		// if (malfunctionManager == null)
 		MalfunctionManager malfunctionManager = vehicle.getMalfunctionManager();
 		// Modify based on the vehicle's wear condition.
-		chance *= malfunctionManager.getWearConditionAccidentModifier();
+		chance *= malfunctionManager.getAccidentModifier();
 
 		if (RandomUtil.lessThanRandPercent(chance * time)) {
 			malfunctionManager.createASeriesOfMalfunctions(vehicle.getName(), (Unit)worker);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/Task.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/Task.java
@@ -991,7 +991,7 @@ public abstract class Task implements Serializable, Comparable<Task> {
 		}
 
 		// Modify based on the entity building's wear condition.
-		chance *= entity.getMalfunctionManager().getWearConditionAccidentModifier();
+		chance *= entity.getMalfunctionManager().getAccidentModifier();
 
 		if (RandomUtil.lessThanRandPercent(chance * time)) {
 			entity.getMalfunctionManager().createASeriesOfMalfunctions(location, (Unit)worker);


### PR DESCRIPTION
1.11.2024

- fix: rename method to getAccidentModifier() in Task and DriverGroundVehicle