### PR TITLE
Correct missing building sets and shift building locations

### DIFF
--- a/mars-sim-core/src/main/resources/xml/building_packages.xml
+++ b/mars-sim-core/src/main/resources/xml/building_packages.xml
@@ -52,7 +52,7 @@
 	    <standalone type="ERV-C" xloc="12.0" yloc="39.0" facing="0.0" />
 	</building-package>
 
-	<building-package name="Air Set 1 = 1x1" >
+	<building-package name="Air Set 1 - 1x1" >
 	    <standalone type="Atmospheric Processor" xloc="10.0" yloc="-10.0" facing="90.0" />  
 	</building-package>
 	
@@ -131,10 +131,27 @@
 	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-5" facing="0.0" />	
 	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-10" facing="0.0" />	  
 	</building-package>
-	   
+
+	<building-package name="Kilo Set 1 - 1x4" >
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="0" facing="0.0" />
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-5" facing="0.0" />	
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-10" facing="0.0" />	  
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-15" facing="0.0" />
+	</building-package>
+	
+    <building-package name="TOPAZ-2A Set 1 - 1x1">
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="0.0" />    	
+	</building-package>
+		   
     <building-package name="TOPAZ-2A Set 1 - 1x2">
 	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="0.0" />
 	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="0.0" />     	
+	</building-package>
+	
+	<building-package name="TOPAZ-2A Set 1 - 1x3">
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="0.0" />
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="0.0" />  
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="40" facing="0.0" />   	
 	</building-package>
 	
     <building-package name="TOPAZ-2A Set 1 - 1x4">

--- a/mars-sim-core/src/main/resources/xml/building_packages.xml
+++ b/mars-sim-core/src/main/resources/xml/building_packages.xml
@@ -66,6 +66,12 @@
 	    <standalone type="Atmospheric Processor" xloc="10.0" yloc="-20.0" facing="90.0" />   
 	    <standalone type="Atmospheric Processor" xloc="10.0" yloc="-30.0" facing="90.0" /> 
 	</building-package>
+
+	<building-package name="Air Set 2 - 1x2" >
+	    <standalone type="Atmospheric Processor" xloc="-30.0" yloc="-10.0" facing="90.0" />
+	    <standalone type="Atmospheric Processor" xloc="-30.0" yloc="-20.0" facing="90.0" />    
+	</building-package>
+
 		
 	<building-package name="Sabatier Set 1 - 1x1" >
 	    <standalone type="Large Sabatier Processor" xloc="20.0" yloc="-10.0" facing="90.0" />    
@@ -82,7 +88,7 @@
     	<standalone type="Large Sabatier Processor" xloc="20.0" yloc="-30.0" facing="90.0" />	  
 	</building-package>
 	
-		<building-package name="Syngas Set 1 - 1x1" >
+	<building-package name="Syngas Set 1 - 1x1" >
 	    <standalone type="Syngas Plant" xloc="30.0" yloc="-10.0" facing="90.0" />    
 	</building-package>
 
@@ -97,86 +103,18 @@
     	<standalone type="Syngas Plant" xloc="30.0" yloc="-30.0" facing="90.0" />	  
 	</building-package>
 	
-	<building-package name="Nuclear Set 1 - combo" >
-	    <standalone type="MD1 Nuclear Reactor" xloc="200.0" yloc="0" facing="0.0" />
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="0" facing="0.0" />
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-5" facing="0.0" />
+	<building-package name="Methane Set 1 - 1x1" >
+	    <standalone type="Methane Power Generator" xloc="40.0"
+	        yloc="-10.0" facing="0.0" /> 
 	</building-package>
 
-	<building-package name="MD1 Set 1 - 1x1" >
-	    <standalone type="MD1 Nuclear Reactor" xloc="200.0" yloc="0" facing="0.0" />
+	<building-package name="Methane Set 1 - 1x2" >
+	    <standalone type="Methane Power Generator" xloc="40.0"
+	        yloc="-10.0" facing="0.0" />
+	    <standalone type="Methane Power Generator" xloc="40.0"
+	        yloc="-20.0" facing="0.0" />   
 	</building-package>
 	
-	<building-package name="MD1 Set 1 - 1x2" >
-	    <standalone type="MD1 Nuclear Reactor" xloc="200.0" yloc="0" facing="0.0" />
-	    <standalone type="MD1 Nuclear Reactor" xloc="200.0" yloc="20" facing="0.0" />
-	</building-package>
-	
-	<building-package name="MD4 Set 1 - 1x1" >
-	    <standalone type="MD4 Nuclear Reactor" xloc="220.0" yloc="0" facing="0.0" />
-	</building-package>
-	
-	<building-package name="MD4 Set 1 - 1x2" >
-	    <standalone type="MD4 Nuclear Reactor" xloc="220.0" yloc="0" facing="0.0" />
-	    <standalone type="MD4 Nuclear Reactor" xloc="220.0" yloc="20" facing="0.0" />
-	</building-package>
-	
-	<building-package name="Kilo Set 1 - 1x2" >
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="0" facing="0.0" />
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-5" facing="0.0" />	    
-	</building-package>
-	
-	<building-package name="Kilo Set 1 - 1x3" >
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="0" facing="0.0" />
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-5" facing="0.0" />	
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-10" facing="0.0" />	  
-	</building-package>
-
-	<building-package name="Kilo Set 1 - 1x4" >
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="0" facing="0.0" />
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-5" facing="0.0" />	
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-10" facing="0.0" />	  
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-15" facing="0.0" />
-	</building-package>
-	
-    <building-package name="TOPAZ-2A Set 1 - 1x1">
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="0.0" />    	
-	</building-package>
-		   
-    <building-package name="TOPAZ-2A Set 1 - 1x2">
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="0.0" />
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="0.0" />     	
-	</building-package>
-	
-	<building-package name="TOPAZ-2A Set 1 - 1x3">
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="0.0" />
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="0.0" />  
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="40" facing="0.0" />   	
-	</building-package>
-	
-    <building-package name="TOPAZ-2A Set 1 - 1x4">
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="0.0" />
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="0.0" />  
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="40" facing="0.0" />
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="60" facing="0.0" />    	
-	</building-package>
-	
-	<building-package name="TOPAZ-3 Set 1 - 1x1">
-	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="0" facing="0.0" />    	
-	</building-package>
-
-	<building-package name="TOPAZ-3 Set 1 - 1x2">
-	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="0" facing="0.0" />   
-	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="30" facing="0.0" />	
-	</building-package>
-
-	<building-package name="TOPAZ-3 Set 1 - 1x3">
-	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="0" facing="0.0" />   
-	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="30" facing="0.0" />
-	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="60" facing="0.0" />	
-	</building-package>
-	
-		
 	<building-package name="Solar Set 1 - 1x3" >   
 	    <standalone type="Medium Battery Array" xloc="40.0"
 	        yloc="-50.0" facing="0.0" />
@@ -227,149 +165,228 @@
 	    <standalone type="Solar Photovoltaic Array" xloc="40.0"
 	        yloc="-120.0" facing="0.0" />
 	
-	    <standalone type="Medium Battery Array" xloc="55.0"
-	        yloc="-50.0" facing="0.0" />
-	    <standalone type="Solar Photovoltaic Array" xloc="55.0"
-	        yloc="-60.0" facing="0.0" />
-	    <standalone type="Solar Photovoltaic Array" xloc="55.0"
-	        yloc="-70.0" facing="0.0" />
-	    <standalone type="Solar Photovoltaic Array" xloc="55.0"
-	        yloc="-80.0" facing="0.0" />           	    
+	    <standalone type="Medium Battery Array" xloc="40.0"
+	        yloc="-130.0" facing="0.0" />
+	    <standalone type="Solar Photovoltaic Array" xloc="40.0"
+	        yloc="-140.0" facing="0.0" />
+	    <standalone type="Solar Photovoltaic Array" xloc="40.0"
+	        yloc="-150.0" facing="0.0" />
+	    <standalone type="Solar Photovoltaic Array" xloc="40.0"
+	        yloc="-160.0" facing="0.0" />           	    
+	</building-package>
+	
+   	<building-package name="Small Areothermal Well Set 1 - 1x2">
+	    <standalone type="Small Areothermal Well" xloc="50.0"
+	        yloc="-10.0" facing="0.0" />
+	    <standalone type="Small Areothermal Well" xloc="50.0"
+	        yloc="-20.0" facing="0.0" />
 	</building-package>
 
-	<building-package name="Solar Set 1 - 2x3" >
-	    <standalone type="Medium Battery Array" xloc="40.0"
+	<building-package name="Solar Set 2 - 1x3" >
+	    <standalone type="Medium Battery Array" xloc="50.0"
 	        yloc="-50.0" facing="0.0" />
-	    <standalone type="Solar Photovoltaic Array" xloc="40.0"
+	    <standalone type="Solar Photovoltaic Array" xloc="50.0"
 	        yloc="-60.0" facing="0.0" />
-	    <standalone type="Solar Photovoltaic Array" xloc="40.0"
+	    <standalone type="Solar Photovoltaic Array" xloc="50.0"
 	        yloc="-70.0" facing="0.0" />
-	    <standalone type="Solar Photovoltaic Array" xloc="40.0"
+	    <standalone type="Solar Photovoltaic Array" xloc="50.0"
+	        yloc="-80.0" facing="0.0" />
+	</building-package>            	    
+	            	    
+	<building-package name="Solar Set 2 - 1x6" >
+	    <standalone type="Medium Battery Array" xloc="50.0"
+	        yloc="-50.0" facing="0.0" />
+	    <standalone type="Solar Photovoltaic Array" xloc="50.0"
+	        yloc="-60.0" facing="0.0" />
+	    <standalone type="Solar Photovoltaic Array" xloc="50.0"
+	        yloc="-70.0" facing="0.0" />
+	    <standalone type="Solar Photovoltaic Array" xloc="50.0"
 	        yloc="-80.0" facing="0.0" />
 	            	    
-	    <standalone type="Medium Battery Array" xloc="55.0"
+	    <standalone type="Medium Battery Array" xloc="50.0"
 	        yloc="-50.0" facing="0.0" />
-	    <standalone type="Solar Photovoltaic Array" xloc="55.0"
+	    <standalone type="Solar Photovoltaic Array" xloc="50.0"
 	        yloc="-60.0" facing="0.0" />
-	    <standalone type="Solar Photovoltaic Array" xloc="55.0"
+	    <standalone type="Solar Photovoltaic Array" xloc="50.0"
 	        yloc="-70.0" facing="0.0" />
-	    <standalone type="Solar Photovoltaic Array" xloc="55.0"
+	    <standalone type="Solar Photovoltaic Array" xloc="50.0"
 	        yloc="-80.0" facing="0.0" />      	    
 	</building-package>
 	
-		<building-package name="Solar Thermal Set 1 - 1x3" >   
-	    <standalone type="Medium Battery Array" xloc="40.0"
+	<building-package name="Solar Thermal Set 1 - 1x3" >   
+	    <standalone type="Medium Battery Array" xloc="60.0"
 	        yloc="-50.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-60.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-70.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-80.0" facing="0.0" />       	    
 	</building-package>
 	
 	<building-package name="Solar Thermal Set 1 - 1x6" > 
-	    <standalone type="Medium Battery Array" xloc="40.0"
+	    <standalone type="Medium Battery Array" xloc="60.0"
 	        yloc="-50.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-60.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-70.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-80.0" facing="0.0" />
 	        
-	    <standalone type="Medium Battery Array" xloc="40.0"
+	    <standalone type="Medium Battery Array" xloc="60.0"
 	        yloc="-90.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-100.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-110.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-120.0" facing="0.0" />
 	</building-package>
 		
 	<building-package name="Solar Thermal Set 1 - 1x9" >
-	    <standalone type="Medium Battery Array" xloc="40.0"
+	    <standalone type="Medium Battery Array" xloc="60.0"
 	        yloc="-50.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-60.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-70.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-80.0" facing="0.0" />
 	        
-	    <standalone type="Medium Battery Array" xloc="40.0"
+	    <standalone type="Medium Battery Array" xloc="60.0"
 	        yloc="-90.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-100.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-110.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="40.0"
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
 	        yloc="-120.0" facing="0.0" />
 	
-	    <standalone type="Medium Battery Array" xloc="55.0"
-	        yloc="-50.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="55.0"
-	        yloc="-60.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="55.0"
-	        yloc="-70.0" facing="0.0" />
-	    <standalone type="Solar Thermal Collector" xloc="55.0"
-	        yloc="-80.0" facing="0.0" />           	    
-	</building-package>
-	
-	<building-package name="Methane Set 1 - 1x1" >
-	    <standalone type="Methane Power Generator" xloc="40.0"
-	        yloc="-40.0" facing="0.0" /> 
+	    <standalone type="Medium Battery Array" xloc="60.0"
+	        yloc="-130.0" facing="0.0" />
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
+	        yloc="-140.0" facing="0.0" />
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
+	        yloc="-150.0" facing="0.0" />
+	    <standalone type="Solar Thermal Collector" xloc="60.0"
+	        yloc="-160.0" facing="0.0" />           	    
 	</building-package>
 
-	<building-package name="Methane Set 1 - 1x2" >
-	    <standalone type="Methane Power Generator" xloc="40.0"
-	        yloc="-40.0" facing="0.0" />
-	    <standalone type="Methane Power Generator" xloc="55.0"
-	        yloc="-40.0" facing="0.0" />   
-	</building-package>
-	
    	<building-package name="Wind Set 1 - 1x3">
-		<standalone type="Medium Battery Array" xloc="65.0" yloc="-50.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-60.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-70.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-80.0" facing="0.0" />
+		<standalone type="Medium Battery Array" xloc="70.0" yloc="-50.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-60.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-70.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-80.0" facing="0.0" />
 	</building-package>
 	
    	<building-package name="Wind Set 1 - 1x6">
-		<standalone type="Medium Battery Array" xloc="65.0" yloc="-50.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-60.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-70.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-80.0" facing="0.0" />
+		<standalone type="Medium Battery Array" xloc="70.0" yloc="-50.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-60.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-70.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-80.0" facing="0.0" />
 
-		<standalone type="Medium Battery Array" xloc="65.0" yloc="-90.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-100.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-110.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-120.0" facing="0.0" />
+		<standalone type="Medium Battery Array" xloc="70.0" yloc="-90.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-100.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-110.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-120.0" facing="0.0" />
 	</building-package>
 
    	<building-package name="Wind Set 1 - 1x9">
-		<standalone type="Medium Battery Array" xloc="65.0" yloc="-50.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-60.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-70.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-80.0" facing="0.0" />
+		<standalone type="Medium Battery Array" xloc="70.0" yloc="-50.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-60.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-70.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-80.0" facing="0.0" />
 
-		<standalone type="Medium Battery Array" xloc="65.0" yloc="-90.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-100.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-110.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-120.0" facing="0.0" />
+		<standalone type="Medium Battery Array" xloc="70.0" yloc="-90.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-100.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-110.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-120.0" facing="0.0" />
 
-		<standalone type="Medium Battery Array" xloc="65.0" yloc="-130.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-140.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-150.0" facing="0.0" />
-	    <standalone type="Wind Turbine" xloc="65.0" yloc="-160.0" facing="0.0" />
+		<standalone type="Medium Battery Array" xloc="70.0" yloc="-130.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-140.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-150.0" facing="0.0" />
+	    <standalone type="Wind Turbine" xloc="70.0" yloc="-160.0" facing="0.0" />
 	</building-package>
 	
-   	<building-package name="Small Areothermal Well Set 1 - 1x2">
-	    <standalone type="Small Areothermal Well" xloc="80.0"
-	        yloc="0.0" facing="0.0" />
-	    <standalone type="Small Areothermal Well" xloc="80.0"
-	        yloc="10.0" facing="0.0" />
+	<building-package name="Nuclear Set 1 - combo" >
+	    <standalone type="MD1 Nuclear Reactor" xloc="200.0" yloc="0" facing="90.0" />
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="0" facing="0.0" />
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-5" facing="0.0" />
 	</building-package>
+
+	<building-package name="MD1 Set 1 - 1x1" >
+	    <standalone type="MD1 Nuclear Reactor" xloc="200.0" yloc="0" facing="90.0" />
+	</building-package>
+	
+	<building-package name="MD1 Set 1 - 1x2" >
+	    <standalone type="MD1 Nuclear Reactor" xloc="200.0" yloc="0" facing="90.0" />
+	    <standalone type="MD1 Nuclear Reactor" xloc="200.0" yloc="20" facing="90.0" />
+	</building-package>
+	
+	<building-package name="MD4 Set 1 - 1x1" >
+	    <standalone type="MD4 Nuclear Reactor" xloc="220.0" yloc="0" facing="90.0" />
+	</building-package>
+	
+	<building-package name="MD4 Set 1 - 1x2" >
+	    <standalone type="MD4 Nuclear Reactor" xloc="220.0" yloc="0" facing="90.0" />
+	    <standalone type="MD4 Nuclear Reactor" xloc="220.0" yloc="20" facing="90.0" />
+	</building-package>
+	
+	<building-package name="Kilo Set 1 - 1x2" >
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="0" facing="0.0" />
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-5" facing="0.0" />	    
+	</building-package>
+	
+	<building-package name="Kilo Set 1 - 1x3" >
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="0" facing="0.0" />
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-5" facing="0.0" />	
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-10" facing="0.0" />	  
+	</building-package>
+
+	<building-package name="Kilo Set 1 - 1x4" >
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="0" facing="0.0" />
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-5" facing="0.0" />	
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-10" facing="0.0" />	  
+	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-15" facing="0.0" />
+	</building-package>
+	
+    <building-package name="TOPAZ-2A Set 1 - 1x1">
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="90.0" />    	
+	</building-package>
+		   
+    <building-package name="TOPAZ-2A Set 1 - 1x2">
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="90.0" />
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="90.0" />     	
+	</building-package>
+	
+	<building-package name="TOPAZ-2A Set 1 - 1x3">
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="90.0" />
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="90.0" />  
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="40" facing="90.0" />   	
+	</building-package>
+	
+    <building-package name="TOPAZ-2A Set 1 - 1x4">
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="90.0" />
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="90.0" />  
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="40" facing="90.0" />
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="60" facing="90.0" />    	
+	</building-package>
+	
+	<building-package name="TOPAZ-3 Set 1 - 1x1">
+	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="0" facing="90.0" />    	
+	</building-package>
+
+	<building-package name="TOPAZ-3 Set 1 - 1x2">
+	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="0" facing="90.0" />   
+	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="30" facing="90.0" />	
+	</building-package>
+
+	<building-package name="TOPAZ-3 Set 1 - 1x3">
+	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="0" facing="90.0" />   
+	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="30" facing="90.0" />
+	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="60" facing="90.0" />	
+	</building-package>
+	
 
 </building-package-list>

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_hub_base.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_hub_base.xml
@@ -323,8 +323,6 @@
     <!-- Building Packages -->
     <building-package name="Storage Set 1 - 3x3"/>
    	<building-package name="ERV Set 1"/>
-    <building-package name="Storage Set 1 - 3x3"/>
-   	<building-package name="ERV Set 1"/>
    	<building-package name="Air Set 1 - 1x3"/>
     <building-package name="Sabatier Set 1 - 1x3"/>
 	<building-package name="Syngas Set 1 - 1x1"/>

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_hub_base.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_hub_base.xml
@@ -5,7 +5,7 @@
         description="Base With Central Hub">
 
         
-    <building id="0" type="Central Hub A" xloc="-100.0" yloc="100.0" facing="0.0">
+    <building id="0" type="Central Hub A" xloc="-100.0" yloc="0.0" facing="0.0">
         <connection-list>
             <connection id="1" hatch-facing="south" />
             <connection id="9" hatch-facing="east" />
@@ -15,28 +15,28 @@
             
     <!-- SOUTH WING -->            
             
-    <building id="1" type="Hallway" length="4.0" xloc="-100.0" yloc="88" facing="0.0">
+    <building id="1" type="Hallway" length="4.0" xloc="-100.0" yloc="-12" facing="0.0">
         <connection-list>
             <connection id="0" hatch-facing="north" />
             <connection id="2" hatch-facing="south" />
         </connection-list>
     </building>
       
-    <building id="2" type="Research Hab" xloc="-100.0" yloc="81.5" facing="0.0">
+    <building id="2" type="Research Hab" xloc="-100.0" yloc="-18.5" facing="0.0">
         <connection-list>
             <connection id="1" hatch-facing="north" />
             <connection id="3" hatch-facing="south" />         
         </connection-list>
     </building>
     
-    <building id="3" type="Hallway" length="4.0" xloc="-100.0" yloc="75.0" facing="0.0">
+    <building id="3" type="Hallway" length="4.0" xloc="-100.0" yloc="-25.0" facing="0.0">
         <connection-list>
             <connection id="2" hatch-facing="north" />
             <connection id="4" hatch-facing="south" />
         </connection-list>
     </building>
 
-    <building id="4" type="Storage Hab" xloc="-100.0" yloc="68.5" facing="0.0">
+    <building id="4" type="Storage Hab" xloc="-100.0" yloc="-31.5" facing="0.0">
         <connection-list>
             <connection id="3" hatch-facing="north" />     
             <connection id="5" hatch-facing="south" />  
@@ -45,7 +45,7 @@
     </building>
     
     <!-- This EVA Airlock is attached to the Storage hab -->
-    <building id="7" type="EVA Airlock" xloc="-92.5" yloc="68.5" facing="0.0">
+    <building id="7" type="EVA Airlock" xloc="-92.5" yloc="-31.5" facing="0.0">
         <connection-list>
             <connection id="4" hatch-facing="east" />
         </connection-list>
@@ -53,14 +53,14 @@
     
     <!-- An EVA Airlock with building id 8 has been relocated to West Wing -->
 
-    <building id="5" type="Hallway" length="4.0" xloc="-100.0" yloc="62.0" facing="0.0">
+    <building id="5" type="Hallway" length="4.0" xloc="-100.0" yloc="-38.0" facing="0.0">
         <connection-list>
             <connection id="4" hatch-facing="north" />
             <connection id="6" hatch-facing="south" />
         </connection-list>
     </building>
     
-    <building id="6" type="Medical Hab" xloc="-100.0" yloc="55.5" facing="0.0">
+    <building id="6" type="Medical Hab" xloc="-100.0" yloc="-45.5" facing="0.0">
         <connection-list>
             <connection id="5" hatch-facing="north" />          
         </connection-list>
@@ -71,28 +71,28 @@
 
 	<!-- EAST WING -->
 
-    <building id="9" type="Hallway" length="4.0" xloc="-112" yloc="100" facing="90.0">
+    <building id="9" type="Hallway" length="4.0" xloc="-112" yloc="0" facing="90.0">
         <connection-list>
             <connection id="0" hatch-facing="west" />
             <connection id="10" hatch-facing="east" />
         </connection-list>
     </building>
 
-	<building id="10" type="Fish Farm" xloc="-118.5"  yloc="100" facing="270.0">
+	<building id="10" type="Fish Farm" xloc="-118.5"  yloc="0" facing="270.0">
         <connection-list>
             <connection id="9" hatch-facing="west" />
             <connection id="11" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="11" type="Hallway" length="4.0" xloc="-125.0" yloc="100" facing="90.0">
+    <building id="11" type="Hallway" length="4.0" xloc="-125.0" yloc="0" facing="90.0">
         <connection-list>
             <connection id="10" hatch-facing="west" />
             <connection id="12" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="12" type="Algae Pond" xloc="-131.5" yloc="100" facing="270.0">
+    <building id="12" type="Algae Pond" xloc="-131.5" yloc="0" facing="270.0">
         <connection-list>
             <connection id="11" hatch-facing="west" />
             <connection id="13" hatch-facing="east" />
@@ -100,42 +100,42 @@
         </connection-list>
     </building>
     
-    <building id="13" type="Hallway" length="4.0" xloc="-138.0" yloc="100" facing="270.0">
+    <building id="13" type="Hallway" length="4.0" xloc="-138.0" yloc="0" facing="270.0">
         <connection-list>
             <connection id="12" hatch-facing="west" />
             <connection id="14" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="14" type="Residential Quarters" xloc="-144.5" yloc="100" facing="270.0">
+    <building id="14" type="Residential Quarters" xloc="-144.5" yloc="0" facing="270.0">
         <connection-list>
             <connection id="13" hatch-facing="west" />
             <connection id="15" hatch-facing="east" />                
         </connection-list>
     </building>
     
-    <building id="15" type="Hallway" length="4.0" xloc="-151.0" yloc="100" facing="270.0">
+    <building id="15" type="Hallway" length="4.0" xloc="-151.0" yloc="0" facing="270.0">
         <connection-list>
             <connection id="14" hatch-facing="west" />
             <connection id="16" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="16" type="Residential Quarters" xloc="-157.5" yloc="100"  facing="270.0">
+    <building id="16" type="Residential Quarters" xloc="-157.5" yloc="0"  facing="270.0">
         <connection-list>
             <connection id="15" hatch-facing="west" />
             <connection id="17" hatch-facing="east" />  
         </connection-list>
     </building>
     
-    <building id="17" type="Hallway" length="4.0" xloc="-164.0" yloc="100" facing="270.0">
+    <building id="17" type="Hallway" length="4.0" xloc="-164.0" yloc="0" facing="270.0">
         <connection-list>
            <connection id="16" hatch-facing="west" />
            <connection id="18" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="18" type="Residential Quarters" xloc="-170.5" yloc="100" facing="270.0">
+    <building id="18" type="Residential Quarters" xloc="-170.5" yloc="0" facing="270.0">
         <connection-list>
             <connection id="17" hatch-facing="west" />
         </connection-list>
@@ -143,13 +143,13 @@
     
     <!-- EAST WING EXTENSION -->
     <!-- Connect this hallway to north of Algae Pond 12 -->
-    <building id="34" type="Hallway" length="4.0" xloc="-131.5" yloc="105.5" facing="0.0">
+    <building id="34" type="Hallway" length="4.0" xloc="-131.5" yloc="5.5" facing="0.0">
         <connection-list>
             <connection id="12" hatch-facing="south" />
             <connection id="35" hatch-facing="north" />
         </connection-list>
     </building>
-    <building id="35" type="Large Greenhouse" xloc="-131.5" yloc="116.5" facing="0.0">
+    <building id="35" type="Large Greenhouse" xloc="-131.5" yloc="16.5" facing="0.0">
         <connection-list>
             <connection id="34" hatch-facing="south" />
         </connection-list>
@@ -161,28 +161,28 @@
     
     <!-- WEST WING -->
 
-    <building id="19" type="Hallway" length="4.0" xloc="-88" yloc="100" facing="90.0">
+    <building id="19" type="Hallway" length="4.0" xloc="-88" yloc="0" facing="90.0">
         <connection-list>
             <connection id="20" hatch-facing="west" />
             <connection id="0" hatch-facing="east" />
         </connection-list>
     </building>
 
-	<building id="20" type="Lounge" xloc="-81.5" yloc="100" facing="270.0">
+	<building id="20" type="Lounge" xloc="-81.5" yloc="0" facing="270.0">
         <connection-list>
             <connection id="21" hatch-facing="west" />
             <connection id="19" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="21" type="Hallway" length="4.0" xloc="-75.0" yloc="100" facing="90.0">
+    <building id="21" type="Hallway" length="4.0" xloc="-75.0" yloc="0" facing="90.0">
         <connection-list>
             <connection id="22" hatch-facing="west" />
             <connection id="20" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="22" type="Laboratory" xloc="-68.5" yloc="100" facing="270.0">
+    <building id="22" type="Laboratory" xloc="-68.5" yloc="0" facing="270.0">
         <connection-list>
             <connection id="23" hatch-facing="west" />
             <connection id="21" hatch-facing="east" />
@@ -190,49 +190,49 @@
         </connection-list>
     </building>
     
-    <building id="23" type="Hallway" length="4.0" xloc="-62.0" yloc="100" facing="270.0">
+    <building id="23" type="Hallway" length="4.0" xloc="-62.0" yloc="0" facing="270.0">
         <connection-list>
             <connection id="24" hatch-facing="west" />
             <connection id="22" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="24" type="Workshop" xloc="-55.5" yloc="100" facing="270.0">
+    <building id="24" type="Workshop" xloc="-55.5" yloc="0" facing="270.0">
         <connection-list>
             <connection id="25" hatch-facing="west" />
             <connection id="23" hatch-facing="east" />          
         </connection-list>
     </building>
     
-    <building id="25" type="Hallway" length="4.0" xloc="-49.0" yloc="100" facing="270.0">
+    <building id="25" type="Hallway" length="4.0" xloc="-49.0" yloc="0" facing="270.0">
         <connection-list>
             <connection id="26" hatch-facing="west" />
             <connection id="24" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="26" type="Server Farm" xloc="-42.5" yloc="100"  facing="0">
+    <building id="26" type="Server Farm" xloc="-42.5" yloc="0"  facing="0">
         <connection-list>
             <connection id="27" hatch-facing="west" />
             <connection id="25" hatch-facing="east" />  
         </connection-list>
     </building>
     
-    <building id="27" type="Hallway" length="4.0" xloc="-36.0" yloc="100" facing="270.0">
+    <building id="27" type="Hallway" length="4.0" xloc="-36.0" yloc="0" facing="270.0">
         <connection-list>
            <connection id="28" hatch-facing="west" />
            <connection id="26" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="28" type="Command and Control" xloc="-29.5" yloc="100" facing="270.0">
+    <building id="28" type="Command and Control" xloc="-29.5" yloc="0" facing="270.0">
         <connection-list>
 			<connection id="8" hatch-facing="west" />
             <connection id="27" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="8" type="EVA Airlock" xloc="-22" yloc="100" facing="0.0">
+    <building id="8" type="EVA Airlock" xloc="-22" yloc="0" facing="0.0">
         <connection-list>
             <connection id="28" hatch-facing="east" />
         </connection-list>
@@ -240,13 +240,13 @@
     
     <!-- WEST WING EXTENSION -->
     <!-- Connect this hallway to north of Inflatable Greenhouse 22 -->
-	<building id="32" type="Hallway" length="4.0" xloc="-68.5" yloc="105.5" facing="0.0">
+	<building id="32" type="Hallway" length="4.0" xloc="-68.5" yloc="5.5" facing="0.0">
         <connection-list>
             <connection id="22" hatch-facing="south" />
             <connection id="33" hatch-facing="north" />
         </connection-list>
     </building>
-    <building id="33" type="Loading Dock Garage" xloc="-68.5" yloc="116.5" facing="0.0">
+    <building id="33" type="Loading Dock Garage" xloc="-68.5" yloc="16.5" facing="0.0">
         <connection-list>
             <connection id="32" hatch-facing="south" />
         </connection-list>
@@ -258,14 +258,14 @@
     
 	<!-- ZONE 1 -->
 
-    <building id="29" zone="1" type="Astronomy Observatory" xloc="-55.0" yloc="-20.0" facing="0.0">
+    <building id="29" zone="1" type="Astronomy Observatory" xloc="-150.0" yloc="80.0" facing="0.0">
         <connection-list>
             <connection id="30" hatch-facing="south" />
         </connection-list>
     </building>
 
     <!-- This hallway is between the EVA Airlock and the Astronomy Observatory -->
-    <building id="30" zone="1" type="Hallway" length="4.0" xloc="-55.0" yloc="-25.5" facing="0.0">
+    <building id="30" zone="1" type="Hallway" length="4.0" xloc="-150.0" yloc="75.5" facing="0.0">
         <connection-list>
             <connection id="29" hatch-facing="north" />
             <connection id="31" hatch-facing="south" />
@@ -273,7 +273,7 @@
     </building>
     
         <!-- EVA Airlock is attached to the Astronomy Observatory. With hallway in between --> 
-    <building id="31" zone="1" type="EVA Airlock" xloc="-55.0" yloc="-30.5" facing="270.0">
+    <building id="31" zone="1" type="EVA Airlock" xloc="-150.0" yloc="69.5" facing="270.0">
         <connection-list>
             <connection id="30" hatch-facing="north" />
         </connection-list>

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_mining_outpost.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_mining_outpost.xml
@@ -127,7 +127,7 @@
 
     <!-- Building Packages -->
     <building-package name="Storage Set 1 - 3x3"/>
- 	<building-package name="Air Set 1 - 1x2"/>
+ 	<building-package name="Air Set 2 - 1x2"/>
     <building-package name="Sabatier Set 1 - 1x2"/>
 	<building-package name="Syngas Set 1 - 1x1"/>
  	<building-package name="Wind Set 1 - 1x9"/>   
@@ -151,9 +151,12 @@
  	<equipment type="wheelbarrow" number="12" />
     
     <!-- Life Support Resources -->
-	<resource type="food" amount="720" />
-	<resource type="water" amount="3600" />
-	<resource type="oxygen" amount="1440" />
+	<resource type="food" amount="2880" />
+	<resource type="water" amount="7200" />
+	<resource type="oxygen" amount="7200" />
+	<resource type="hydrogen" amount="7200" />
+	<resource type="methane" amount="7200" />
+	<resource type="methanol" amount="7200" />
 	
     <part-package name="package 1" number="1" />
   

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_0-ms.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_0-ms.xml
@@ -43,7 +43,7 @@
 
 
     <!-- Building Packages -->
-    <building-package name="Storage Bin Set 1"/>
+    <building-package name="Storage Set 1 - 3x3"/>
    	<building-package name="ERV Set 1"/>
     <building-package name="Sabatier Set 1 - 1x1"/>
    	<building-package name="Nuclear Set 1 - combo"/>

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_1-cn.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_1-cn.xml
@@ -52,7 +52,7 @@
 
 
     <!-- Building Packages -->
-    <building-package name="Storage Bin Set 1"/>
+    <building-package name="Storage Set 1 - 3x3"/>
    	<building-package name="ERV Set 1"/>
     <building-package name="Sabatier Set 1 - 1x1"/>
 	<building-package name="Solar Set 1 - 1x3"/>

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_1-sa.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_1-sa.xml
@@ -54,7 +54,7 @@
     <!-- Building Packages -->
     <building-package name="Storage Set 1 - 3x3"/>
    	<building-package name="ERV Set 1"/>
-   	<building-package name="Air Set 1"/>
+   	<building-package name="Air Set 1 - 1x1"/>
    	<building-package name="Solar Set 1 - 1x3"/>
 	<building-package name="Kilo Set 1 - 1x2"/>
 		   		

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_1-us.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_1-us.xml
@@ -57,8 +57,8 @@
     <building-package name="Sabatier Set 1 - 1x1"/>
 	<building-package name="Solar Set 1 - 1x3"/>
    	<building-package name="Nuclear Set 1 - combo"/>
-	<building-package name="Methane Set 1 - 1x1"/>
-   	
+	
+	
     <vehicle type="Explorer Rover" number="2" />
     <vehicle type="Light Utility Vehicle" number="1" />
     <vehicle type="Delivery Drone" number="1" />

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_2-cn.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_2-cn.xml
@@ -121,9 +121,7 @@
 	<building-package name="Solar Set 1 - 1x6"/>
    	<building-package name="Wind Set 1 - 1x6"/>	
    	<building-package name="TOPAZ-2A Set 1 - 1x2"/>
-	<building-package name="TOPAZ-3 Set 1 - 1x1"/>		   	
-	<building-package name="Methane Set 1 - 1x2"/>   	
-
+	<building-package name="TOPAZ-3 Set 1 - 1x1"/>
 
     <vehicle type="Explorer Rover" number="2" />
     <vehicle type="Light Utility Vehicle" number="1" />

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_2-in.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_2-in.xml
@@ -149,7 +149,7 @@
 
 
     <!-- Building Packages -->
-    <building-package name="Storage Bin Set 1"/>
+    <building-package name="Storage Set 1 - 3x3"/>
    	<building-package name="ERV Set 1"/>
     <building-package name="Sabatier Set 1 - 1x2"/>
 	<building-package name="Syngas Set 1 - 1x1"/>

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_2-ru.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_2-ru.xml
@@ -139,7 +139,6 @@
    	<building-package name="Wind Set 1 - 1x3"/>
     <building-package name="TOPAZ-2A Set 1 - 1x2"/>
     <building-package name="TOPAZ-3 Set 1 - 1x1"/>
-	<building-package name="Methane Set 1 - 1x2"/>      	
 
 
     <vehicle type="Explorer Rover" number="2" />

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_2-us.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_2-us.xml
@@ -114,7 +114,7 @@
 
 
     <!-- Building Packages -->
-    <building-package name="Storage Bin Set 1"/>
+    <building-package name="Storage Set 1 - 3x3"/>
    	<building-package name="ERV Set 1"/>
     <building-package name="Sabatier Set 1 - 1x3"/>
 	<building-package name="Syngas Set 1 - 1x1"/>

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_3-cn.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_3-cn.xml
@@ -193,8 +193,7 @@
    	<building-package name="Wind Set 1 - 1x9"/>	
    	<building-package name="TOPAZ-2A Set 1 - 1x3"/>
 	<building-package name="TOPAZ-3 Set 1 - 1x2"/>		   	
-	<building-package name="Methane Set 1 - 1x2"/>   	
-
+	
 
     <vehicle type="Explorer Rover" number="2" />
     <vehicle type="Transport Rover" number="1" />

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_3-ru.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_3-ru.xml
@@ -185,7 +185,7 @@
     <!-- Building Packages -->
     <building-package name="Storage Set 1 - 3x3"/>
    	<building-package name="ERV Set 1"/>
-    <building-package name="Air Set 1 - 1x1"/>
+    <building-package name="Air Set 1 - 1x2"/>
     <building-package name="Sabatier Set 1 - 1x3"/>
 	<building-package name="Syngas Set 1 - 1x2"/>
 	<building-package name="Solar Set 1 - 1x6"/>

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_3-ru.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_phase_3-ru.xml
@@ -192,7 +192,6 @@
    	<building-package name="Wind Set 1 - 1x6"/>	
    	<building-package name="TOPAZ-2A Set 1 - 1x3"/>
 	<building-package name="TOPAZ-3 Set 1 - 1x3"/>		   	
-	<building-package name="Methane Set 1 - 1x2"/>   	
 
 
     <vehicle type="Explorer Rover" number="2" />

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_trading_outpost.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_trading_outpost.xml
@@ -114,7 +114,7 @@
 
     <!-- Building Packages -->
     <building-package name="Storage Set 1 - 3x3"/>
-    <building-package name="Air Set 1 - 1x2"/>
+    <building-package name="Air Set 2 - 1x2"/>
     <building-package name="Sabatier Set 1 - 1x2"/>
 	<building-package name="Syngas Set 1 - 1x1"/>
  	<building-package name="Wind Set 1 - 1x9"/>   
@@ -138,9 +138,12 @@
  	<equipment type="wheelbarrow" number="12" />
     
     <!-- Life Support Resources -->
-	<resource type="food" amount="720" />
-	<resource type="water" amount="3600" />
-	<resource type="oxygen" amount="1440" />
+	<resource type="food" amount="2880" />
+	<resource type="water" amount="7200" />
+	<resource type="oxygen" amount="7200" />
+	<resource type="hydrogen" amount="7200" />
+	<resource type="methane" amount="7200" />
+	<resource type="methanol" amount="7200" />
 	
     <part-package name="package 1" number="1" />
  

--- a/mars-sim-main/MarsProject -new 864x trading outpost.launch
+++ b/mars-sim-main/MarsProject -new 864x trading outpost.launch
@@ -11,7 +11,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.mars_sim.main.MarsProject"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="mars-sim-main"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-new -timeratio 256 -template &quot;Phase 3-EU&quot; -lat 20.0N -lon 50.0W -sponsor ESA"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-new -timeratio 864 -template &quot;Trading Outpost&quot; -lat 35.23N -lon 163.95E -sponsor MS"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="mars-sim-main"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx2048m"/>

--- a/mars-sim-main/MarsProject -new NASA 3-us.launch
+++ b/mars-sim-main/MarsProject -new NASA 3-us.launch
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/mars-sim-main/src/main/java/com/mars_sim/main/MarsProject.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.mars_sim.main.MarsProject"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="mars-sim-main"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-new -timeratio 256 -template &quot;Phase 3-US&quot; -lat 20.0N -lon 50.0W -sponsor NASA"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="mars-sim-main"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx2048m"/>
+</launchConfiguration>


### PR DESCRIPTION
1.16.2024

- new: add missing TOPAZ-2A Set and Kilo Set
- fix: correct typo in Air Set
- change: shift all buildings in Hub Base by -100 in y-direction
- new: deconflict overlapped buildings
- change: rotate MD1, MD4 and TOPAZ power buildings
- change: comment out Methane Generators in some templates