### PR TITLE
Add missing airlock to 2 outposts

### DIFF
--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_mining_outpost.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_mining_outpost.xml
@@ -80,6 +80,7 @@
             <connection id="9" xloc="0.0" yloc="2.5" />
             <connection id="11" xloc="0.0" yloc="-2.5" />
             <connection id="6" xloc="2.5" yloc="0.0" />
+            <connection id="17" hatch-facing="south" />
         </connection-list>
     </building>
     <building id="11" type="Tunnel" length="2.0" xloc="13.0"
@@ -124,6 +125,13 @@
         </connection-list>
     </building>
     
+    <!-- EVA Airlock is attached to the Storage Shed 1 -->
+    <building id="17" type="EVA Airlock" xloc="9.5" yloc="-8.0" facing="270.0">
+        <connection-list>
+            <connection id="10" hatch-facing="north" />
+        </connection-list>
+    </building>
+
 
     <!-- Building Packages -->
     <building-package name="Storage Set 1 - 3x3"/>

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_trading_outpost.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_trading_outpost.xml
@@ -81,6 +81,7 @@
             <connection id="9" xloc="0.0" yloc="2.5" />
             <connection id="11" xloc="0.0" yloc="-2.5" />
             <connection id="6" xloc="2.5" yloc="0.0" />
+            <connection id="15" hatch-facing="south" />
         </connection-list>
     </building>
     <building id="11" type="Tunnel" length="2.0" xloc="13.0"
@@ -108,6 +109,13 @@
         yloc="-18.0" facing="180.0">
         <connection-list>
             <connection id="13" xloc="0.0" yloc="-9.0" />
+        </connection-list>
+    </building>
+
+    <!-- EVA Airlock is attached to the Storage Shed 1 -->
+    <building id="15" type="EVA Airlock" xloc="9.5" yloc="-8.0" facing="270.0">
+        <connection-list>
+            <connection id="10" hatch-facing="north" />
         </connection-list>
     </building>
 


### PR DESCRIPTION
1.18.2024

- new: add the missing EVA Airlock to both mining and trading outpost template