### PR TITLE
Rework to recognize non-contiguous building id

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/resupply/Resupply.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/resupply/Resupply.java
@@ -205,7 +205,7 @@ public class Resupply extends Transportable implements SettlementSupplies {
 				BuildingSpec spec = buildingConfig.getBuildingSpec(btemplate.getBuildingType());
 				BoundedObject correctedBounds = getCorrectedBounds(spec, btemplate.getBounds());
 
-				int buildingID = buildingManager.getNextTemplateID();
+				String buildingID = "" + buildingManager.getNextTemplateID();
 				
 				int zone = btemplate.getZone();
 				
@@ -568,7 +568,7 @@ public class Resupply extends Transportable implements SettlementSupplies {
 				// If no buildings at settlement, position new building at (0, 0) with random
 				// facing.
 				// Note: check to make sure it does not overlap another building.
-				int buildingID = buildingManager.getNextTemplateID();
+				String buildingID = "" + buildingManager.getNextTemplateID();
 				
 				int zone = 0;
 				
@@ -901,7 +901,7 @@ public class Resupply extends Transportable implements SettlementSupplies {
 			BoundedObject position =  new BoundedObject(rectCenterX, rectCenterY, width, length, rectRotation);
 			if (buildingManager.isBuildingLocationOpen(position)) {
 				// Set the new building here.
-				int buildingID = buildingManager.getNextTemplateID();
+				String buildingID = "" + buildingManager.getNextTemplateID();
 			
 				int zone = 0;
 				
@@ -996,7 +996,7 @@ public class Resupply extends Transportable implements SettlementSupplies {
 			double newLength = p1.distance(p2);
 			double facingDegrees = LocalAreaUtil.getDirection(p1, p2);
 		
-			int buildingID = buildingManager.getNextTemplateID();
+			String buildingID = "" + buildingManager.getNextTemplateID();
 		
 			int zone = 0;
 			

--- a/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/resupply/ResupplyConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/resupply/ResupplyConfig.java
@@ -91,9 +91,10 @@ public class ResupplyConfig implements Serializable {
 	            List<Element> buildingNodes = resupplyElement.getChildren(BUILDING);
 	            for (Element buildingElement : buildingNodes) {
 	                String buildingType = buildingElement.getAttributeValue(TYPE);
+//	                String buildingID = "" + buildingManager.getNextTemplateID();
 	                BoundedObject bounds = ConfigHelper.parseBoundedObject(buildingElement);
 	
-	                buildings.add(new BuildingTemplate(0, zone, buildingType,
+	                buildings.add(new BuildingTemplate("", zone, buildingType,
 	                        buildingType, bounds));
 	
 	            }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementConfig.java
@@ -303,13 +303,13 @@ public class SettlementConfig extends UserConfigurableConfig<SettlementTemplate>
 	 * @param templateElement
 	 * @param settlementTemplate
 	 * @param settlementTemplateName
-	 * @param existingIDs
+	 * @param existingStreetIDs
 	 * @param typeNumMap
 	 */
 	private void parseBuildingORConnectorList(Element templateElement, SettlementTemplate settlementTemplate, 
 			String elementName,
 			String settlementTemplateName, 
-			Set<Integer> existingIDs, 
+			Set<String> existingStreetIDs, 
 			Map<String, Integer> buildingTypeNumMap) {
 		
 		List<Element> buildingNodes = templateElement.getChildren(elementName);
@@ -318,18 +318,18 @@ public class SettlementConfig extends UserConfigurableConfig<SettlementTemplate>
 			BoundedObject bounds = ConfigHelper.parseBoundedObject(buildingElement);
 
 			// Track the id
-			int id = -1;
+			String id = "";
 
 			if (buildingElement.getAttribute(ID) != null) {
-				id = Integer.parseInt(buildingElement.getAttributeValue(ID));
+				id = buildingElement.getAttributeValue(ID);
 			}
 
-			if (existingIDs.contains(id)) {
+			if (existingStreetIDs.contains(id)) {
 				throw new IllegalStateException(
 						"Error in SettlementConfig: the id " + id + " in settlement template "
 								+ settlementTemplateName + " is not unique.");
-			} else if (id != -1) {
-				existingIDs.add(id);
+			} else if (!id.equalsIgnoreCase("")) {
+				existingStreetIDs.add(id);
 			}
 			
 			// Assume the zone as 0
@@ -367,14 +367,14 @@ public class SettlementConfig extends UserConfigurableConfig<SettlementTemplate>
 			if (connectionListElement != null) {
 				List<Element> connectionNodes = connectionListElement.getChildren(CONNECTION);
 				for (Element connectionElement : connectionNodes) {
-					int connectionID = Integer.parseInt(connectionElement.getAttributeValue(ID));
+					String connectionID = connectionElement.getAttributeValue(ID);
 
 					if (buildingType.equalsIgnoreCase(EVA_AIRLOCK)) {
 						buildingTemplate.addEVAAttachedBuildingID(connectionID);
 					}
 					
 					// Check that connection ID is not the same as the building ID.
-					if (connectionID == id) {
+					if (connectionID.equalsIgnoreCase(id)) {
 						throw new IllegalStateException(
 								"Connection ID cannot be the same as id for this building/connector " 
 								+ buildingType
@@ -465,7 +465,7 @@ public class SettlementConfig extends UserConfigurableConfig<SettlementTemplate>
 				defaultNumOfRobots);
 
 
-		Set<Integer> existingBuildingIDs = new HashSet<>();		
+		Set<String> existingBuildingIDs = new HashSet<>();		
 		Map<String, Integer> buildingTypeNumMap = new HashMap<>();
 		
 		// Process a list of buildings
@@ -476,7 +476,7 @@ public class SettlementConfig extends UserConfigurableConfig<SettlementTemplate>
 				buildingTypeNumMap);
 		
 		// Process a list of connectors
-		Set<Integer> existingConnectorIDs = new HashSet<>();
+		Set<String> existingConnectorIDs = new HashSet<>();
 		parseBuildingORConnectorList(templateElement, settlementTemplate, 
 				CONNECTOR,
 				settlementTemplateName, 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/ThermalSystem.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/ThermalSystem.java
@@ -14,7 +14,6 @@ import com.mars_sim.core.structure.building.Building;
 import com.mars_sim.core.structure.building.BuildingException;
 import com.mars_sim.core.structure.building.BuildingManager;
 import com.mars_sim.core.structure.building.function.FunctionType;
-import com.mars_sim.core.structure.building.function.HeatSourceType;
 import com.mars_sim.core.structure.building.function.ThermalGeneration;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.Temporal;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/Building.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/Building.java
@@ -119,7 +119,7 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 	/** The designated zone where this building is located at. */
 	protected int zone;
 	/** Unique template id assigned for the settlement template of this building belong. */
-	protected int templateID;
+	protected String templateID;
 	/** The base level for this building. -1 for in-ground, 0 for above-ground. */
 	protected int baseLevel;
 
@@ -232,7 +232,7 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 	 * @param manager      the building's building manager.
 	 * @throws BuildingException if building can not be created.
 	 */
-	public Building(int id, int zone, String buildingType, String name, BoundedObject bounds, BuildingManager manager) {
+	public Building(String id, int zone, String buildingType, String name, BoundedObject bounds, BuildingManager manager) {
 		super(name, manager.getSettlement().getCoordinates());
 
 		this.templateID = id;
@@ -1356,7 +1356,7 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 	 *
 	 * @return id.
 	 */
-	public int getTemplateID() {
+	public String getTemplateID() {
 		return templateID;
 	}
 
@@ -1375,7 +1375,7 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 	 *
 	 * @param id.
 	 */
-	public void setTemplateID(int id) {
+	public void setTemplateID(String id) {
 		templateID = id;
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingManager.java
@@ -559,7 +559,7 @@ public class BuildingManager implements Serializable {
 	 * @param id the template ID .
 	 * @return building or null if none found.
 	 */
-	public Building getBuildingByTemplateID(int id) {
+	public Building getBuildingByTemplateID(String id) {
 		// Use Java 8 stream
 		// Note: stream won't pass junit test.
 //		return buildings
@@ -573,7 +573,7 @@ public class BuildingManager implements Serializable {
 		Iterator<Building> i = buildings.iterator();
 		while (i.hasNext()) {
 			Building b = i.next();
-			if (b.getTemplateID() == id) {
+			if (b.getTemplateID().equalsIgnoreCase(id)) {
 				result = b;
 			}
 		}
@@ -2137,16 +2137,16 @@ public class BuildingManager implements Serializable {
 	 * @return template ID (starting from 0).
 	 */
 	public int getNextTemplateID() {
-
-		int largestID = 0;
-		for (Building building : buildings) {
-			int id = building.getTemplateID();
-			if (id > largestID) {
-				largestID = id;
-			}
-		}
-
-		return largestID + 1;
+		return buildings.size();
+//		int largestID = 0;
+//		for (Building building : buildings) {
+//			int id = building.getTemplateID();
+//			if (id > largestID) {
+//				largestID = id;
+//			}
+//		}
+//
+//		return largestID + 1;
 	}
 
 	/**
@@ -2775,7 +2775,7 @@ public class BuildingManager implements Serializable {
 				.getSettlementConfiguration().getItem(getSettlement().getTemplate());
 		List<BuildingTemplate> templates = settlementTemplate.getBuildings();
 
-		int idEVAAttachedBuilding = -1;
+		String idEVAAttachedBuilding = "";
 		String nickName = null;
 		Building eVAAttachedBuilding = null;
 		
@@ -2786,7 +2786,7 @@ public class BuildingManager implements Serializable {
 		}
 		
 		for (BuildingTemplate bt: templates) {
-			if (bt.getID() == idEVAAttachedBuilding) {
+			if (bt.getID().equalsIgnoreCase(idEVAAttachedBuilding)) {
 				nickName = bt.getBuildingName();
 			}
 		}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingPackageConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingPackageConfig.java
@@ -78,7 +78,7 @@ public class BuildingPackageConfig implements Serializable {
                 String buildingType = buildingElement.getAttributeValue(TYPE);
                 BoundedObject bounds = ConfigHelper.parseBoundedObject(buildingElement);
  
-                buildingPackage.addTemplate(new BuildingTemplate(-1, 1, buildingType,
+                buildingPackage.addTemplate(new BuildingTemplate("", 1, buildingType,
                         buildingType, bounds));
 			}
 			// Add buildingPackage to newList.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingTemplate.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingTemplate.java
@@ -23,23 +23,24 @@ public class BuildingTemplate implements Serializable, Comparable<BuildingTempla
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
 
-	private int bid;
 	private int zone;
-	private int eVAAttachedBuildingID;
-	private BoundedObject bounds;
-
+	
+	private String eVAAttachedStreetNum;
+	private String streetNum;
 	private String buildingType;
 	private String buildingName;
+
+	private BoundedObject bounds;
 
 	private List<BuildingConnectionTemplate> connectionList;
 
 	/*
 	 * * BuildingTemplate Constructor.
 	 */
-	public BuildingTemplate(int bid, int zone, String buildingType, String buildingName,
+	public BuildingTemplate(String id, int zone, String buildingType, String buildingName,
 			BoundedObject bounds) {
 
-		this.bid = bid;
+		this.streetNum = id;
 		this.zone = zone;
 		this.buildingType = buildingType;
 		this.buildingName = buildingName;
@@ -48,12 +49,12 @@ public class BuildingTemplate implements Serializable, Comparable<BuildingTempla
 	}
 
 	/**
-	 * Gets the building ID.
+	 * Gets the building street num.
 	 * 
 	 * @return id.
 	 */
-	public int getID() {
-		return bid;
+	public String getID() {
+		return streetNum;
 	}
 
 
@@ -108,7 +109,7 @@ public class BuildingTemplate implements Serializable, Comparable<BuildingTempla
 	 * @param id        the unique id of the building being connected to.
 	 * @param location the location (local to the building) (meters).
 	 */
-	public void addBuildingConnection(int id, LocalPosition location) {
+	public void addBuildingConnection(String id, LocalPosition location) {
 		BuildingConnectionTemplate template = new BuildingConnectionTemplate(id, location);
 		if (!connectionList.contains(template)) {
 			connectionList.add(template);
@@ -123,7 +124,7 @@ public class BuildingTemplate implements Serializable, Comparable<BuildingTempla
 	 * @param id        the unique id of the building being connected to.
 	 * @param hatchFace the facing of the hatch.
 	 */
-	public void addBuildingConnection(int id, String hatchFace) {
+	public void addBuildingConnection(String id, String hatchFace) {
 		BuildingConnectionTemplate template = new BuildingConnectionTemplate(id, hatchFace);
 		if (!connectionList.contains(template)) {
 			connectionList.add(template);
@@ -132,12 +133,12 @@ public class BuildingTemplate implements Serializable, Comparable<BuildingTempla
 		}
 	}
 	
-	public void addEVAAttachedBuildingID(int id) {
-		eVAAttachedBuildingID = id;
+	public void addEVAAttachedBuildingID(String id) {
+		eVAAttachedStreetNum = id;
 	}
 	
-	public int getEVAAttachedBuildingID() {
-		return eVAAttachedBuildingID;
+	public String getEVAAttachedBuildingID() {
+		return eVAAttachedStreetNum;
 	}
 	
 	/**
@@ -153,8 +154,11 @@ public class BuildingTemplate implements Serializable, Comparable<BuildingTempla
 	 * Compares to another building template.
 	 */
 	public int compareTo(BuildingTemplate o) {
-		int compareId = ((BuildingTemplate) o).bid;
-		return this.bid - compareId;
+		String compareId = ((BuildingTemplate) o).streetNum;
+		if (this.streetNum.equalsIgnoreCase(compareId)) 
+			return 0;
+		else
+			return -1;
 	}
 	
 	/**
@@ -166,7 +170,7 @@ public class BuildingTemplate implements Serializable, Comparable<BuildingTempla
 		private static final long serialVersionUID = 1L;
 
 		// Data members
-		private int id;
+		private String id;
 		private String hatchFace;
 		private LocalPosition location;
 
@@ -177,7 +181,7 @@ public class BuildingTemplate implements Serializable, Comparable<BuildingTempla
 		 * @param xLocation the x axis location (local to the building) (meters).
 		 * @param yLocation the y axis location (local to the building) (meters).
 		 */
-		private BuildingConnectionTemplate(int id, LocalPosition loc) {
+		private BuildingConnectionTemplate(String id, LocalPosition loc) {
 			this.id = id;
 			this.location = loc;
 		}
@@ -188,13 +192,13 @@ public class BuildingTemplate implements Serializable, Comparable<BuildingTempla
 		 * @param id        the unique id of the building being connected to.
 		 * @param hatchFace the face of the hatch .
 		 */
-		private BuildingConnectionTemplate(int id, String hatchFace) {
+		private BuildingConnectionTemplate(String id, String hatchFace) {
 			this.id = id;
 			this.hatchFace = hatchFace;
 		}
 
 
-		public int getID() {
+		public String getID() {
 			return id;
 		}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/connection/BuildingConnectorManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/connection/BuildingConnectorManager.java
@@ -96,7 +96,7 @@ public class BuildingConnectorManager implements Serializable {
 		Iterator<BuildingTemplate> i = buildingTemplates.iterator();
 		while (i.hasNext()) {
 			BuildingTemplate buildingTemplate = i.next();
-			int buildingID = buildingTemplate.getID();
+			String buildingID = buildingTemplate.getID();
 			Building building = buildingManager.getBuildingByTemplateID(buildingID);
 			if (building == null) {
 				throw new IllegalStateException(
@@ -108,7 +108,7 @@ public class BuildingConnectorManager implements Serializable {
 			Iterator<BuildingConnectionTemplate> j = buildingTemplate.getBuildingConnectionTemplates().iterator();
 			while (j.hasNext()) {
 				BuildingConnectionTemplate connectionTemplate = j.next();
-				int connectionID = connectionTemplate.getID();
+				String connectionID = connectionTemplate.getID();
 				Building connectionBuilding = buildingManager.getBuildingByTemplateID(connectionID);
 				if (connectionBuilding == null) {
 					throw new IllegalStateException(
@@ -349,7 +349,8 @@ public class BuildingConnectorManager implements Serializable {
 						+ "  validPartialConnectors: " + validPartialConnectors.size()
 //						+ "  " + partialConnector.building.getBuildingType() 
 						+ "  regarding " + partialConnector.building.getName()
-						+ " in " + settlement.getName() + ".");
+						+ " (templateID: " + ((Building)partialConnector.building).getTemplateID() 
+						+ ") in " + settlement.getName() + ".");
 			}
 		}
 	}
@@ -963,9 +964,11 @@ public class BuildingConnectorManager implements Serializable {
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
 		// Data members.
-		private Building building;
-		private LocalPosition pos;
 		private double facing;
+
+		private LocalPosition pos;
+
+		private Building building;
 		private Building connectToBuilding;
 
 		/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/construction/ConstructionSite.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/construction/ConstructionSite.java
@@ -393,7 +393,7 @@ implements  LocalBoundedObject {
         
         int zone = 0;
         
-        Building newBuilding = new Building(id, zone, buildingType, uniqueName,
+        Building newBuilding = new Building("" + id, zone, buildingType, uniqueName,
         		new BoundedObject(position, width, length, facing),
                 settlement.getBuildingManager());
         

--- a/mars-sim-core/src/main/resources/xml/building_packages.xml
+++ b/mars-sim-core/src/main/resources/xml/building_packages.xml
@@ -311,8 +311,8 @@
 	
 	<building-package name="Nuclear Set 1 - combo" >
 	    <standalone type="MD1 Nuclear Reactor" xloc="200.0" yloc="0" facing="90.0" />
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="0" facing="0.0" />
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-5" facing="0.0" />
+	    <standalone type="Kilopower Reactor" xloc="180.0" yloc="0" facing="0.0" />
+	    <standalone type="Kilopower Reactor" xloc="180.0" yloc="-5" facing="0.0" />
 	</building-package>
 
 	<building-package name="MD1 Set 1 - 1x1" >
@@ -330,62 +330,62 @@
 	
 	<building-package name="MD4 Set 1 - 1x2" >
 	    <standalone type="MD4 Nuclear Reactor" xloc="220.0" yloc="0" facing="90.0" />
-	    <standalone type="MD4 Nuclear Reactor" xloc="220.0" yloc="20" facing="90.0" />
+	    <standalone type="MD4 Nuclear Reactor" xloc="220.0" yloc="30" facing="90.0" />
 	</building-package>
 	
 	<building-package name="Kilo Set 1 - 1x2" >
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="0" facing="0.0" />
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-5" facing="0.0" />	    
+	    <standalone type="Kilopower Reactor" xloc="180.0" yloc="0" facing="0.0" />
+	    <standalone type="Kilopower Reactor" xloc="180.0" yloc="-5" facing="0.0" />	    
 	</building-package>
 	
 	<building-package name="Kilo Set 1 - 1x3" >
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="0" facing="0.0" />
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-5" facing="0.0" />	
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-10" facing="0.0" />	  
+	    <standalone type="Kilopower Reactor" xloc="180.0" yloc="0" facing="0.0" />
+	    <standalone type="Kilopower Reactor" xloc="180.0" yloc="-5" facing="0.0" />	
+	    <standalone type="Kilopower Reactor" xloc="180.0" yloc="-10" facing="0.0" />	  
 	</building-package>
 
 	<building-package name="Kilo Set 1 - 1x4" >
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="0" facing="0.0" />
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-5" facing="0.0" />	
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-10" facing="0.0" />	  
-	    <standalone type="Kilopower Reactor" xloc="190.0" yloc="-15" facing="0.0" />
+	    <standalone type="Kilopower Reactor" xloc="180.0" yloc="0" facing="0.0" />
+	    <standalone type="Kilopower Reactor" xloc="180.0" yloc="-5" facing="0.0" />	
+	    <standalone type="Kilopower Reactor" xloc="180.0" yloc="-10" facing="0.0" />	  
+	    <standalone type="Kilopower Reactor" xloc="180.0" yloc="-15" facing="0.0" />
 	</building-package>
 	
     <building-package name="TOPAZ-2A Set 1 - 1x1">
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="90.0" />    	
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="90.0" />    	
 	</building-package>
 		   
     <building-package name="TOPAZ-2A Set 1 - 1x2">
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="90.0" />
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="90.0" />     	
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="90.0" />
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="40" facing="90.0" />     	
 	</building-package>
 	
 	<building-package name="TOPAZ-2A Set 1 - 1x3">
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="90.0" />
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="90.0" />  
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="40" facing="90.0" />   	
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="90.0" />
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="40" facing="90.0" />  
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="60" facing="90.0" />   	
 	</building-package>
 	
     <building-package name="TOPAZ-2A Set 1 - 1x4">
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="0" facing="90.0" />
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="90.0" />  
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="40" facing="90.0" />
-	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="60" facing="90.0" />    	
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="20" facing="90.0" />
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="40" facing="90.0" />  
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="60" facing="90.0" />
+	    <standalone type="TOPAZ-2A Reactor" xloc="200.0" yloc="80" facing="90.0" />    	
 	</building-package>
 	
 	<building-package name="TOPAZ-3 Set 1 - 1x1">
-	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="0" facing="90.0" />    	
+	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="30" facing="90.0" />    	
 	</building-package>
 
 	<building-package name="TOPAZ-3 Set 1 - 1x2">
-	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="0" facing="90.0" />   
-	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="30" facing="90.0" />	
+	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="30" facing="90.0" />   
+	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="60" facing="90.0" />	
 	</building-package>
 
 	<building-package name="TOPAZ-3 Set 1 - 1x3">
-	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="0" facing="90.0" />   
-	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="30" facing="90.0" />
-	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="60" facing="90.0" />	
+	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="30" facing="90.0" />   
+	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="60" facing="90.0" />
+	    <standalone type="TOPAZ-3 Reactor" xloc="220.0" yloc="90" facing="90.0" />	
 	</building-package>
 	
 

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement.xsd
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement.xsd
@@ -9,7 +9,7 @@
                         <xs:attribute name="xloc" type="xs:decimal"/>
                         <xs:attribute name="yloc" type="xs:decimal"/>
                         <xs:attribute name="hatch-facing" type="xs:string"/>
-                        <xs:attribute name="id" type="xs:integer"/>                   
+                        <xs:attribute name="id" type="xs:string"/>                   
                     </xs:complexType>
                 </xs:element>
             </xs:sequence>
@@ -27,7 +27,7 @@
             <xs:attribute name="xloc" type="xs:decimal"/>
             <xs:attribute name="yloc" type="xs:decimal"/>
             <xs:attribute name="facing" type="xs:decimal"/>
-            <xs:attribute name="id" type="xs:integer"/>
+            <xs:attribute name="id" type="xs:string"/>
             <xs:attribute name="zone" type="xs:integer"/>            
         </xs:complexType>
     </xs:element>
@@ -43,7 +43,7 @@
             <xs:attribute name="xloc" type="xs:decimal"/>
             <xs:attribute name="yloc" type="xs:decimal"/>
             <xs:attribute name="facing" type="xs:decimal"/>
-            <xs:attribute name="id" type="xs:integer"/>
+            <xs:attribute name="id" type="xs:string"/>
             <xs:attribute name="zone" type="xs:integer"/>            
         </xs:complexType>
     </xs:element>

--- a/mars-sim-core/src/main/resources/xml/settlement/settlement_hub_base.xml
+++ b/mars-sim-core/src/main/resources/xml/settlement/settlement_hub_base.xml
@@ -1,157 +1,170 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
 <template xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="settlement.xsd"
         name="Hub Base" shift-pattern="Standard 4 Shift" 
-        default-population="36" number-of-robots="18" sponsor="MS"
+        default-population="48" number-of-robots="20" sponsor="MS"
         description="Base With Central Hub">
 
-        
+    <!-- HUBS : 0 to 100, 200, 300, 400 -->   
+    
     <building id="0" type="Central Hub A" xloc="-100.0" yloc="0.0" facing="0.0">
         <connection-list>
-            <connection id="1" hatch-facing="south" />
-            <connection id="9" hatch-facing="east" />
-            <connection id="19" hatch-facing="west" />           
+            <connection id="201" hatch-facing="south" />
+            <connection id="301" hatch-facing="east" />
+            <connection id="101" hatch-facing="west" />           
         </connection-list>
     </building>
             
-    <!-- SOUTH WING -->            
+    <!-- SOUTH WING : 201 to 299 -->            
             
-    <building id="1" type="Hallway" length="4.0" xloc="-100.0" yloc="-12" facing="0.0">
+    <building id="201" type="Hallway" length="4.0" xloc="-100.0" yloc="-12" facing="0.0">
         <connection-list>
             <connection id="0" hatch-facing="north" />
-            <connection id="2" hatch-facing="south" />
+            <connection id="202" hatch-facing="south" />
         </connection-list>
     </building>
       
-    <building id="2" type="Research Hab" xloc="-100.0" yloc="-18.5" facing="0.0">
+    <building id="202" type="Research Hab" xloc="-100.0" yloc="-18.5" facing="0.0">
         <connection-list>
-            <connection id="1" hatch-facing="north" />
-            <connection id="3" hatch-facing="south" />         
+            <connection id="201" hatch-facing="north" />
+            <connection id="203" hatch-facing="south" />         
         </connection-list>
     </building>
     
-    <building id="3" type="Hallway" length="4.0" xloc="-100.0" yloc="-25.0" facing="0.0">
+    <building id="203" type="Hallway" length="4.0" xloc="-100.0" yloc="-25.0" facing="0.0">
         <connection-list>
-            <connection id="2" hatch-facing="north" />
-            <connection id="4" hatch-facing="south" />
+            <connection id="202" hatch-facing="north" />
+            <connection id="204" hatch-facing="south" />
         </connection-list>
     </building>
 
-    <building id="4" type="Storage Hab" xloc="-100.0" yloc="-31.5" facing="0.0">
+    <building id="204" type="Storage Hab" xloc="-100.0" yloc="-31.5" facing="0.0">
         <connection-list>
-            <connection id="3" hatch-facing="north" />     
-            <connection id="5" hatch-facing="south" />  
-            <connection id="7" hatch-facing="west" />                                   
-        </connection-list>
-    </building>
-    
-    <!-- This EVA Airlock is attached to the Storage hab -->
-    <building id="7" type="EVA Airlock" xloc="-92.5" yloc="-31.5" facing="0.0">
-        <connection-list>
-            <connection id="4" hatch-facing="east" />
-        </connection-list>
-    </building>
-    
-    <!-- An EVA Airlock with building id 8 has been relocated to West Wing -->
-
-    <building id="5" type="Hallway" length="4.0" xloc="-100.0" yloc="-38.0" facing="0.0">
-        <connection-list>
-            <connection id="4" hatch-facing="north" />
-            <connection id="6" hatch-facing="south" />
-        </connection-list>
-    </building>
-    
-    <building id="6" type="Medical Hab" xloc="-100.0" yloc="-45.5" facing="0.0">
-        <connection-list>
-            <connection id="5" hatch-facing="north" />          
+            <connection id="203" hatch-facing="north" />     
+            <connection id="205" hatch-facing="south" />  
+            <connection id="207" hatch-facing="west" />                                   
         </connection-list>
     </building>
 
+    <building id="205" type="Hallway" length="4.0" xloc="-100.0" yloc="-38.0" facing="0.0">
+        <connection-list>
+            <connection id="204" hatch-facing="north" />
+            <connection id="206" hatch-facing="south" />
+        </connection-list>
+    </building>
+    
+    <building id="206" type="Medical Hab" xloc="-100.0" yloc="-45.5" facing="0.0">
+        <connection-list>
+            <connection id="205" hatch-facing="north" />          
+        </connection-list>
+    </building>
+
+   <!-- This EVA Airlock is attached to the Storage hab -->
+    <building id="207" type="EVA Airlock" xloc="-92.5" yloc="-31.5" facing="0.0">
+        <connection-list>
+            <connection id="204" hatch-facing="east" />
+        </connection-list>
+    </building>
+    
     <!-- End of SOUTH WING -->
     
 
-	<!-- EAST WING -->
+	<!-- EAST WING : 301 to 399 -->
 
-    <building id="9" type="Hallway" length="4.0" xloc="-112" yloc="0" facing="90.0">
+    <building id="301" type="Hallway" length="4.0" xloc="-112" yloc="0" facing="90.0">
         <connection-list>
             <connection id="0" hatch-facing="west" />
-            <connection id="10" hatch-facing="east" />
+            <connection id="302" hatch-facing="east" />
         </connection-list>
     </building>
 
-	<building id="10" type="Fish Farm" xloc="-118.5"  yloc="0" facing="270.0">
+	<building id="302" type="Fish Farm" xloc="-118.5"  yloc="0" facing="270.0">
         <connection-list>
-            <connection id="9" hatch-facing="west" />
-            <connection id="11" hatch-facing="east" />
+            <connection id="301" hatch-facing="west" />
+            <connection id="303" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="11" type="Hallway" length="4.0" xloc="-125.0" yloc="0" facing="90.0">
+    <building id="303" type="Hallway" length="4.0" xloc="-125.0" yloc="0" facing="90.0">
         <connection-list>
-            <connection id="10" hatch-facing="west" />
-            <connection id="12" hatch-facing="east" />
+            <connection id="302" hatch-facing="west" />
+            <connection id="304" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="12" type="Algae Pond" xloc="-131.5" yloc="0" facing="270.0">
+    <building id="304" type="Algae Pond" xloc="-131.5" yloc="0" facing="270.0">
         <connection-list>
-            <connection id="11" hatch-facing="west" />
-            <connection id="13" hatch-facing="east" />
-            <connection id="34" hatch-facing="north" />          
+            <connection id="303" hatch-facing="west" />
+            <connection id="305" hatch-facing="east" />
+            <connection id="304A" hatch-facing="north" />          
         </connection-list>
     </building>
     
-    <building id="13" type="Hallway" length="4.0" xloc="-138.0" yloc="0" facing="270.0">
+    <building id="305" type="Hallway" length="4.0" xloc="-138.0" yloc="0" facing="270.0">
         <connection-list>
-            <connection id="12" hatch-facing="west" />
-            <connection id="14" hatch-facing="east" />
+            <connection id="304" hatch-facing="west" />
+            <connection id="306" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="14" type="Residential Quarters" xloc="-144.5" yloc="0" facing="270.0">
+    <building id="306" type="Residential Quarters" xloc="-144.5" yloc="0" facing="270.0">
         <connection-list>
-            <connection id="13" hatch-facing="west" />
-            <connection id="15" hatch-facing="east" />                
+            <connection id="305" hatch-facing="west" />
+            <connection id="307" hatch-facing="east" />                
         </connection-list>
     </building>
     
-    <building id="15" type="Hallway" length="4.0" xloc="-151.0" yloc="0" facing="270.0">
+    <building id="307" type="Hallway" length="4.0" xloc="-151.0" yloc="0" facing="270.0">
         <connection-list>
-            <connection id="14" hatch-facing="west" />
-            <connection id="16" hatch-facing="east" />
+            <connection id="306" hatch-facing="west" />
+            <connection id="308" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="16" type="Residential Quarters" xloc="-157.5" yloc="0"  facing="270.0">
+    <building id="308" type="Residential Quarters" xloc="-157.5" yloc="0"  facing="270.0">
         <connection-list>
-            <connection id="15" hatch-facing="west" />
-            <connection id="17" hatch-facing="east" />  
+            <connection id="307" hatch-facing="west" />
+            <connection id="309" hatch-facing="east" />  
         </connection-list>
     </building>
     
-    <building id="17" type="Hallway" length="4.0" xloc="-164.0" yloc="0" facing="270.0">
+    <building id="309" type="Hallway" length="4.0" xloc="-164.0" yloc="0" facing="270.0">
         <connection-list>
-           <connection id="16" hatch-facing="west" />
-           <connection id="18" hatch-facing="east" />
+           <connection id="308" hatch-facing="west" />
+           <connection id="310" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="18" type="Residential Quarters" xloc="-170.5" yloc="0" facing="270.0">
+    <building id="310" type="Residential Quarters" xloc="-170.5" yloc="0" facing="270.0">
         <connection-list>
-            <connection id="17" hatch-facing="west" />
+            <connection id="309" hatch-facing="west" />
+            <connection id="311" hatch-facing="east" />            
         </connection-list>
     </building>
     
+    <building id="311" type="Hallway" length="4.0" xloc="-177.0" yloc="0" facing="270.0">
+        <connection-list>
+           <connection id="310" hatch-facing="west" />
+           <connection id="312" hatch-facing="east" />
+        </connection-list>
+    </building>
+    
+    <building id="312" type="Residential Quarters" xloc="-183.5" yloc="0" facing="270.0">
+        <connection-list>
+            <connection id="311" hatch-facing="west" />
+        </connection-list>
+    </building>
+ 
     <!-- EAST WING EXTENSION -->
     <!-- Connect this hallway to north of Algae Pond 12 -->
-    <building id="34" type="Hallway" length="4.0" xloc="-131.5" yloc="5.5" facing="0.0">
+    <building id="304A" type="Hallway" length="4.0" xloc="-131.5" yloc="5.5" facing="0.0">
         <connection-list>
-            <connection id="12" hatch-facing="south" />
-            <connection id="35" hatch-facing="north" />
+            <connection id="304" hatch-facing="south" />
+            <connection id="304B" hatch-facing="north" />
         </connection-list>
     </building>
-    <building id="35" type="Large Greenhouse" xloc="-131.5" yloc="16.5" facing="0.0">
+    <building id="304B" type="Large Greenhouse" xloc="-131.5" yloc="16.5" facing="0.0">
         <connection-list>
-            <connection id="34" hatch-facing="south" />
+            <connection id="304A" hatch-facing="south" />
         </connection-list>
     </building>
      <!-- End of EAST WING EXTENSION -->
@@ -159,96 +172,96 @@
     <!-- End of EAST WING -->
     
     
-    <!-- WEST WING -->
+    <!-- WEST WING : 101 to 199 -->
 
-    <building id="19" type="Hallway" length="4.0" xloc="-88" yloc="0" facing="90.0">
+    <building id="101" type="Hallway" length="4.0" xloc="-88" yloc="0" facing="90.0">
         <connection-list>
-            <connection id="20" hatch-facing="west" />
+            <connection id="102" hatch-facing="west" />
             <connection id="0" hatch-facing="east" />
         </connection-list>
     </building>
 
-	<building id="20" type="Lounge" xloc="-81.5" yloc="0" facing="270.0">
+	<building id="102" type="Lounge" xloc="-81.5" yloc="0" facing="270.0">
         <connection-list>
-            <connection id="21" hatch-facing="west" />
-            <connection id="19" hatch-facing="east" />
+            <connection id="103" hatch-facing="west" />
+            <connection id="101" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="21" type="Hallway" length="4.0" xloc="-75.0" yloc="0" facing="90.0">
+    <building id="103" type="Hallway" length="4.0" xloc="-75.0" yloc="0" facing="90.0">
         <connection-list>
-            <connection id="22" hatch-facing="west" />
-            <connection id="20" hatch-facing="east" />
+            <connection id="104" hatch-facing="west" />
+            <connection id="102" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="22" type="Laboratory" xloc="-68.5" yloc="0" facing="270.0">
+    <building id="104" type="Laboratory" xloc="-68.5" yloc="0" facing="270.0">
         <connection-list>
-            <connection id="23" hatch-facing="west" />
-            <connection id="21" hatch-facing="east" />
-            <connection id="32" hatch-facing="north" />           
+            <connection id="105" hatch-facing="west" />
+            <connection id="103" hatch-facing="east" />
+            <connection id="104A" hatch-facing="north" />           
         </connection-list>
     </building>
     
-    <building id="23" type="Hallway" length="4.0" xloc="-62.0" yloc="0" facing="270.0">
+    <building id="105" type="Hallway" length="4.0" xloc="-62.0" yloc="0" facing="270.0">
         <connection-list>
-            <connection id="24" hatch-facing="west" />
-            <connection id="22" hatch-facing="east" />
+            <connection id="106" hatch-facing="west" />
+            <connection id="104" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="24" type="Workshop" xloc="-55.5" yloc="0" facing="270.0">
+    <building id="106" type="Workshop" xloc="-55.5" yloc="0" facing="270.0">
         <connection-list>
-            <connection id="25" hatch-facing="west" />
-            <connection id="23" hatch-facing="east" />          
+            <connection id="106" hatch-facing="west" />
+            <connection id="105" hatch-facing="east" />          
         </connection-list>
     </building>
     
-    <building id="25" type="Hallway" length="4.0" xloc="-49.0" yloc="0" facing="270.0">
+    <building id="106" type="Hallway" length="4.0" xloc="-49.0" yloc="0" facing="270.0">
         <connection-list>
-            <connection id="26" hatch-facing="west" />
-            <connection id="24" hatch-facing="east" />
+            <connection id="108" hatch-facing="west" />
+            <connection id="106" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="26" type="Server Farm" xloc="-42.5" yloc="0"  facing="0">
+    <building id="108" type="Server Farm" xloc="-42.5" yloc="0"  facing="0">
         <connection-list>
-            <connection id="27" hatch-facing="west" />
-            <connection id="25" hatch-facing="east" />  
+            <connection id="109" hatch-facing="west" />
+            <connection id="106" hatch-facing="east" />  
         </connection-list>
     </building>
     
-    <building id="27" type="Hallway" length="4.0" xloc="-36.0" yloc="0" facing="270.0">
+    <building id="109" type="Hallway" length="4.0" xloc="-36.0" yloc="0" facing="270.0">
         <connection-list>
-           <connection id="28" hatch-facing="west" />
-           <connection id="26" hatch-facing="east" />
+           <connection id="110" hatch-facing="west" />
+           <connection id="108" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="28" type="Command and Control" xloc="-29.5" yloc="0" facing="270.0">
+    <building id="110" type="Command and Control" xloc="-29.5" yloc="0" facing="270.0">
         <connection-list>
-			<connection id="8" hatch-facing="west" />
-            <connection id="27" hatch-facing="east" />
+			<connection id="111" hatch-facing="west" />
+            <connection id="109" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <building id="8" type="EVA Airlock" xloc="-22" yloc="0" facing="0.0">
+    <building id="111" type="EVA Airlock" xloc="-22" yloc="0" facing="0.0">
         <connection-list>
-            <connection id="28" hatch-facing="east" />
+            <connection id="110" hatch-facing="east" />
         </connection-list>
     </building>
     
-    <!-- WEST WING EXTENSION -->
-    <!-- Connect this hallway to north of Inflatable Greenhouse 22 -->
-	<building id="32" type="Hallway" length="4.0" xloc="-68.5" yloc="5.5" facing="0.0">
+    <!-- WEST WING NORTH EXTENSION -->
+    <!-- This hallway connects the laboratory to the garage -->
+	<building id="104A" type="Hallway" length="4.0" xloc="-68.5" yloc="5.5" facing="0.0">
         <connection-list>
-            <connection id="22" hatch-facing="south" />
-            <connection id="33" hatch-facing="north" />
+            <connection id="104" hatch-facing="south" />
+            <connection id="104B" hatch-facing="north" />
         </connection-list>
     </building>
-    <building id="33" type="Loading Dock Garage" xloc="-68.5" yloc="16.5" facing="0.0">
+    <building id="104B" type="Garage" xloc="-68.5" yloc="15.5" facing="0.0">
         <connection-list>
-            <connection id="32" hatch-facing="south" />
+            <connection id="104A" hatch-facing="south" />
         </connection-list>
     </building>
     <!-- End of WEST WING EXTENSION -->
@@ -256,26 +269,26 @@
     <!-- End of WEST WING -->
     
     
-	<!-- ZONE 1 -->
+	<!-- ZONE 1 : 1001 and up -->
 
-    <building id="29" zone="1" type="Astronomy Observatory" xloc="-150.0" yloc="80.0" facing="0.0">
+    <building id="1001" zone="1" type="Astronomy Observatory" xloc="-150.0" yloc="80.0" facing="0.0">
         <connection-list>
-            <connection id="30" hatch-facing="south" />
+            <connection id="1002" hatch-facing="south" />
         </connection-list>
     </building>
 
     <!-- This hallway is between the EVA Airlock and the Astronomy Observatory -->
-    <building id="30" zone="1" type="Hallway" length="4.0" xloc="-150.0" yloc="75.5" facing="0.0">
+    <building id="1002" zone="1" type="Hallway" length="4.0" xloc="-150.0" yloc="75.5" facing="0.0">
         <connection-list>
-            <connection id="29" hatch-facing="north" />
-            <connection id="31" hatch-facing="south" />
+            <connection id="1001" hatch-facing="north" />
+            <connection id="1003" hatch-facing="south" />
         </connection-list>
     </building>
     
         <!-- EVA Airlock is attached to the Astronomy Observatory. With hallway in between --> 
-    <building id="31" zone="1" type="EVA Airlock" xloc="-150.0" yloc="69.5" facing="270.0">
+    <building id="1003" zone="1" type="EVA Airlock" xloc="-150.0" yloc="69.5" facing="270.0">
         <connection-list>
-            <connection id="30" hatch-facing="north" />
+            <connection id="1002" hatch-facing="north" />
         </connection-list>
     </building>
     
@@ -285,7 +298,7 @@
 	<!-- TEST ONLY SECTION -->
 
     <!-- EVA Airlock is attached to the Astronomy Observatory
-    <building id="8" zone="1" type="EVA Airlock" xloc="-55.0" yloc="-13.5" facing="90.0">
+    <building id="111" zone="1" type="EVA Airlock" xloc="-55.0" yloc="-13.5" facing="90.0">
         <connection-list>
             <connection id="7" hatch-facing="south" />
         </connection-list>
@@ -293,7 +306,7 @@
 	-->
 
     <!-- EVA Airlock is attached to the Astronomy Observatory
-    <building id="8" zone="1" type="EVA Airlock" xloc="-48.5" yloc="-20.0" facing="0.0">
+    <building id="111" zone="1" type="EVA Airlock" xloc="-48.5" yloc="-20.0" facing="0.0">
         <connection-list>
             <connection id="7" hatch-facing="east" />
         </connection-list>
@@ -301,7 +314,7 @@
      --> 
      
     <!-- EVA Airlock is attached to the Astronomy Observatory. With hallway in between, increase xloc="-61.5" to xloc="-65.5" 
-    <building id="8" zone="1" type="EVA Airlock" xloc="-65.5" yloc="-20.0" facing="180.0">
+    <building id="111" zone="1" type="EVA Airlock" xloc="-65.5" yloc="-20.0" facing="180.0">
         <connection-list>
             <connection id="9" hatch-facing="west" />
         </connection-list>
@@ -311,7 +324,7 @@
     <building id="9" zone="1" type="Hallway" length="4.0" xloc="-60.5" yloc="-20.0" facing="90.0">
         <connection-list>
             <connection id="7" hatch-facing="west" />
-            <connection id="8" hatch-facing="east" />
+            <connection id="111" hatch-facing="east" />
         </connection-list>
     </building>
 	--> 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/AbstractMarsSimUnitTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/AbstractMarsSimUnitTest.java
@@ -107,7 +107,7 @@ public abstract class AbstractMarsSimUnitTest extends TestCase {
 		String name = "B" + id;
 		
 	    MockBuilding building0 = new MockBuilding(buildingManager, name);
-	    building0.setTemplateID(id);
+	    building0.setTemplateID("" + id);
 	    building0.setName(name);
 	    building0.setWidth(BUILDING_WIDTH);
 	    building0.setLength(BUILDING_LENGTH);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/MockBuilding.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/MockBuilding.java
@@ -55,7 +55,7 @@ public class MockBuilding extends Building {
 		functions.add(new LifeSupport(this, getLifeSupportSpec()));
 	}
 
-	public void setTemplateID(int id) {
+	public void setTemplateID(String id) {
 		this.templateID = id;
 	}
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/connection/BuildingConnectorManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/connection/BuildingConnectorManagerTest.java
@@ -57,37 +57,37 @@ public class BuildingConnectorManagerTest extends TestCase {
         BuildingManager buildingManager = settlement.getBuildingManager();
 
         MockBuilding building0 = new MockBuilding(buildingManager, "B0");
-        building0.setTemplateID(0);
+        building0.setTemplateID("0");
         building0.setName("building 0");
         building0.setWidth(9D);
         building0.setLength(9D);
         building0.setLocation(0D,0D);
         building0.setFacing(0D);
-        BuildingTemplate buildingTemplate0 = new BuildingTemplate(0, 0, "building 0", "building 0", new BoundedObject(0D, 0D, 9D, 9D, 0D));
-        buildingTemplate0.addBuildingConnection(2, new LocalPosition(-4.5D, 0D));
+        BuildingTemplate buildingTemplate0 = new BuildingTemplate("0", 0, "building 0", "building 0", new BoundedObject(0D, 0D, 9D, 9D, 0D));
+        buildingTemplate0.addBuildingConnection("2", new LocalPosition(-4.5D, 0D));
         buildingManager.addBuilding(building0, false);
 
         MockBuilding building1 = new MockBuilding(buildingManager, "B1");
-        building1.setTemplateID(1);
+        building1.setTemplateID("1");
         building1.setName("building 1");
         building1.setWidth(6D);
         building1.setLength(9D);
         building1.setLocation(-12D, 0D);
         building1.setFacing(270D);
-        BuildingTemplate buildingTemplate1 = new BuildingTemplate(1, 0, "building 1","building 1", new BoundedObject(-12D, 0D, 6D, 9D, 270D));
-        buildingTemplate1.addBuildingConnection(2, new LocalPosition(0D, 4.5D));
+        BuildingTemplate buildingTemplate1 = new BuildingTemplate("1", 0, "building 1","building 1", new BoundedObject(-12D, 0D, 6D, 9D, 270D));
+        buildingTemplate1.addBuildingConnection("2", new LocalPosition(0D, 4.5D));
         buildingManager.addBuilding(building1, false);
 
         MockBuilding building2 = new MockBuilding(buildingManager, "B2");
-        building2.setTemplateID(2);
+        building2.setTemplateID("2");
         building2.setName("building 2");
         building2.setWidth(2D);
         building2.setLength(3D);
         building2.setLocation(-6D, 0D);
         building2.setFacing(270D);
-        BuildingTemplate buildingTemplate2 = new BuildingTemplate(2, 0, "building 2","building 2", new BoundedObject(-6D, 0D, 6D, 9D, 270D));
-        buildingTemplate2.addBuildingConnection(0, new LocalPosition(0D, 1.5D));
-        buildingTemplate2.addBuildingConnection(1, new LocalPosition(0D, -1.5D));
+        BuildingTemplate buildingTemplate2 = new BuildingTemplate("2", 0, "building 2","building 2", new BoundedObject(-6D, 0D, 6D, 9D, 270D));
+        buildingTemplate2.addBuildingConnection("0", new LocalPosition(0D, 1.5D));
+        buildingTemplate2.addBuildingConnection("1", new LocalPosition(0D, -1.5D));
         buildingManager.addBuilding(building2, false);
 
         List<BuildingTemplate> buildingTemplates = new ArrayList<BuildingTemplate>();
@@ -155,37 +155,37 @@ public class BuildingConnectorManagerTest extends TestCase {
         BuildingManager buildingManager = settlement.getBuildingManager();
 
         MockBuilding building0 = new MockBuilding(buildingManager, "B0");
-        building0.setTemplateID(0);
+        building0.setTemplateID("0");
         building0.setName("building 0");
         building0.setWidth(9D);
         building0.setLength(9D);
         building0.setLocation(0D, 0D);
         building0.setFacing(0D);
-        BuildingTemplate buildingTemplate0 = new BuildingTemplate(0, 0, "building 0", "building 0", new BoundedObject(0D, 0D, 9D, 9D, 0D));
-        buildingTemplate0.addBuildingConnection(2, new LocalPosition(-4.5D, 0D));
+        BuildingTemplate buildingTemplate0 = new BuildingTemplate("0", 0, "building 0", "building 0", new BoundedObject(0D, 0D, 9D, 9D, 0D));
+        buildingTemplate0.addBuildingConnection("2", new LocalPosition(-4.5D, 0D));
         buildingManager.addBuilding(building0, false);
 
         MockBuilding building1 = new MockBuilding(buildingManager, "B1");
-        building1.setTemplateID(1);
+        building1.setTemplateID("1");
         building1.setName("building 1");
         building1.setWidth(6D);
         building1.setLength(9D);
         building1.setLocation(-12D, 0D);
         building1.setFacing(270D);
-        BuildingTemplate buildingTemplate1 = new BuildingTemplate(1, 0, "building 1", "building 1", new BoundedObject(-12D, 0D, 6D, 9D, 270D));
-        buildingTemplate1.addBuildingConnection(2, new LocalPosition(0D, 4.5D));
+        BuildingTemplate buildingTemplate1 = new BuildingTemplate("1", 0, "building 1", "building 1", new BoundedObject(-12D, 0D, 6D, 9D, 270D));
+        buildingTemplate1.addBuildingConnection("2", new LocalPosition(0D, 4.5D));
         buildingManager.addBuilding(building1, false);
 
         MockBuilding building2 = new MockBuilding(buildingManager, "B2");
-        building2.setTemplateID(2);
+        building2.setTemplateID("2");
         building2.setName("building 2");
         building2.setWidth(2D);
         building2.setLength(3D);
         building2.setLocation(-6D, 0D);
         building2.setFacing(270D);
-        BuildingTemplate buildingTemplate2 = new BuildingTemplate(2, 0, "building 2", "building 2", new BoundedObject(-6D, 0D, 6D, 9D, 270D));
-        buildingTemplate2.addBuildingConnection(0, new LocalPosition(0D, 1.5D));
-        buildingTemplate2.addBuildingConnection(1, new LocalPosition(0D, -1.5D));
+        BuildingTemplate buildingTemplate2 = new BuildingTemplate("2", 0, "building 2", "building 2", new BoundedObject(-6D, 0D, 6D, 9D, 270D));
+        buildingTemplate2.addBuildingConnection("0", new LocalPosition(0D, 1.5D));
+        buildingTemplate2.addBuildingConnection("1", new LocalPosition(0D, -1.5D));
         buildingManager.addBuilding(building2, false);
 
         List<BuildingTemplate> buildingTemplates = new ArrayList<BuildingTemplate>();

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/resupply/ResupplyMissionEditingPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/resupply/ResupplyMissionEditingPanel.java
@@ -713,7 +713,7 @@ public class ResupplyMissionEditingPanel extends TransportItemEditingPanel {
 						String type = item.type.trim();
 						// NOTE: The parameters does NOT mater right now. When a building arrive,
 						// the parameters for each building's template will be re-assembled
-						newBuildings.add(new BuildingTemplate(0, 0, type, type, new BoundedObject(0D, 0D, -1D, -1D, 0D)));
+						newBuildings.add(new BuildingTemplate("", 0, type, type, new BoundedObject(0D, 0D, -1D, -1D, 0D)));
 					}
 				}
 			}
@@ -829,7 +829,7 @@ public class ResupplyMissionEditingPanel extends TransportItemEditingPanel {
 						// NOTE: The parameters does NOT mater right now. When a building arrive,
 						// the parameters for each building's template will be re-assembled
 
-						newBuildings.add(new BuildingTemplate(0, 0, type, type,
+						newBuildings.add(new BuildingTemplate("", 0, type, type,
 											new BoundedObject(0D, 38D, 7D, 9D, 270D)));
 					}
 					


### PR DESCRIPTION
1.19.2024

Note: by relaxing the rule of setting building id, it makes creating new settlement templates faster and simpler

- change: rework SettlementConfig and others to recognize non-contiguous building id in all settlement templates
- change: rework building id in settlement_hub_base.xml - use 0 to 100, 200, 300, 400, 1000 for hub buildings - use 201 to 299 for south wing - use 301 to 399 for east wing - use 101 to 199 for west wing - use 1001 up for zone 1