### PR TITLE
Convert LocalDig meta to SettlementTask approach

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
@@ -406,7 +406,7 @@ public class Simulation implements ClockListener, Serializable {
 		ResourceProcess.initializeInstances(masterClock);
 
 		eventManager = new HistoricalEventManager(masterClock);
-		BuildingManager.initializeInstances(simulationConfig, masterClock, eventManager, unitManager);
+		BuildingManager.initializeInstances(simulationConfig, masterClock, unitManager);
 
 		AbstractMission.initializeInstances(this, eventManager, unitManager,
 			surfaceFeatures, missionManager, simulationConfig.getPersonConfig());
@@ -565,7 +565,7 @@ public class Simulation implements ClockListener, Serializable {
 		// Initialize Unit related class
 		SalvageValues.initializeInstances(unitManager, masterClock);
 		
-		BuildingManager.initializeInstances(simulationConfig, masterClock, eventManager, unitManager);
+		BuildingManager.initializeInstances(simulationConfig, masterClock, unitManager);
 
 		
 		doneInitializing = true;
@@ -708,7 +708,7 @@ public class Simulation implements ClockListener, Serializable {
 		HealthProblem.initializeInstances(medicalManager, eventManager);
 
 		// Re-initialize Structure related class
-		BuildingManager.initializeInstances(simulationConfig, masterClock, eventManager, unitManager);
+		BuildingManager.initializeInstances(simulationConfig, masterClock, unitManager);
 	
 		// Start a chain of calls to set instances
 		// Warning: must call this at the end of this method

--- a/mars-sim-core/src/main/java/com/mars_sim/core/data/RatingScore.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/data/RatingScore.java
@@ -13,8 +13,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.mars_sim.tools.Msg;
-
 /**
  * A class to represent a score Rating. Consists of a base value and a set
  * of modifiers that are applied to create a final score.
@@ -22,11 +20,6 @@ import com.mars_sim.tools.Msg;
 public class RatingScore implements Serializable {
 
 	private static final long serialVersionUID = 1L;
-
-	/**
-     * Prefix to the key in the message bundle
-     */
-    private static final String RATING_KEY = "RatingScore.";
 
     private static final DecimalFormat SCORE_FORMAT = new DecimalFormat("0.###");
 
@@ -195,33 +188,6 @@ public class RatingScore implements Serializable {
                                 .map(entry -> entry.getKey() + ": " + SCORE_FORMAT.format(entry.getValue()))
                                 .collect(Collectors.joining(", ")));
         output.append(")");
-        return output.toString();
-    }
-
-    /**
-     * Produces a structure output of this rating. This s not ideal being in this class.
-     * 
-     * @return HTML formatted string localised.
-     */
-    public String getHTMLOutput() {
-        
-        StringBuilder output = new StringBuilder();
-        output.append("<html>");
-        output.append("<b>Score: ").append(SCORE_FORMAT.format(score)).append("</b><br>");
-
-        output.append(bases.entrySet().stream()
-                                .map(entry -> "  " + Msg.getString(RATING_KEY + entry.getKey())
-                                                    + ": " + SCORE_FORMAT.format(entry.getValue()))
-                                .collect(Collectors.joining("<br>")));
-
-        if (!modifiers.isEmpty()) {
-            output.append("<br>");
-        }
-        output.append(modifiers.entrySet().stream()
-                                .map(entry -> "  " + Msg.getString(RATING_KEY + entry.getKey())
-                                                    + ": x" + SCORE_FORMAT.format(entry.getValue()))
-                                .collect(Collectors.joining("<br>")));
-        output.append("</html>");
         return output.toString();
     }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/EVAOperation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/EVAOperation.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 import com.mars_sim.core.LocalAreaUtil;
 import com.mars_sim.core.Unit;
@@ -232,7 +233,6 @@ public abstract class EVAOperation extends Task {
 	protected double performMappedPhase(double time) {
 		if (person.isOutside()) {
 			if (person.isSuperUnFit()) {
-//				setPhase(WALK_BACK_INSIDE);
 				walkBackInsidePhase(time);
 			}
 			else
@@ -265,7 +265,6 @@ public abstract class EVAOperation extends Task {
                 addSubTask(walkingTask);
             }
             else {
-//				logger.severe(person, 30_000, "Cannot walk to outside site.");
                 endTask();
             }
         }
@@ -463,20 +462,6 @@ public abstract class EVAOperation extends Task {
 
 		// This is equivalent of a 1% sun ratio as below
 		return (sunlight >= minEVASunlight && !inDarkPolarRegion);
-
-		// This is the old logic used originally in EVAOperation
-		// if (surfaceFeatures.inDarkPolarRegion(person.getCoordinates())) {
-		// 	return false;
-		// }
-
-		// // if it's at night
-		// // Note: sunlight ratio cannot be smaller than zero.
-		// if (surfaceFeatures.getSunlightRatio(person.getCoordinates()) < .01) {
-		// 	return false;
-		// }
-
-		// // if the sunlight is getting less
-        // return surfaceFeatures.getTrend(person.getCoordinates()) < 0;
 	}
 
 	/**
@@ -893,5 +878,16 @@ public abstract class EVAOperation extends Task {
 		outsideSkill = null;
 		
 		super.destroy();
+	}
+
+	/**
+	 * Get the number of Persons doing EVAOperations in a Settlement
+	 * @param settlement
+	 * @return
+	 */
+    public static int getActivePersons(Settlement settlement) {
+		return settlement.getAllAssociatedPeople().stream()
+							.filter(p -> p.getTaskManager().getTask() instanceof EVAOperation)
+							.collect(Collectors.counting()).intValue();
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/DigLocalIceMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/DigLocalIceMeta.java
@@ -24,9 +24,7 @@ import com.mars_sim.tools.Msg;
  * Meta task for the DigLocalIce task.
  */
 public class DigLocalIceMeta extends DigLocalMeta {
-	
-	private static final int THRESHOLD_AMOUNT = 50;
-	
+		
     /** Task name */
     private static final String NAME = Msg.getString(
             "Task.description.digLocalIce"); //$NON-NLS-1$
@@ -49,8 +47,7 @@ public class DigLocalIceMeta extends DigLocalMeta {
     public List<SettlementTask> getSettlementTasks(Settlement settlement) {
     	
         // Check if settlement has DIG_LOCAL_REGOLITH override flag set.
-        if (settlement.getProcessOverride(OverrideType.DIG_LOCAL_ICE)
-            || (settlement.getAmountResourceRemainingCapacity(ResourceUtil.iceID) < THRESHOLD_AMOUNT)) {
+        if (settlement.getProcessOverride(OverrideType.DIG_LOCAL_ICE)) {
         	return Collections.emptyList();
         }
     	

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/DigLocalIceMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/DigLocalIceMeta.java
@@ -6,13 +6,14 @@
  */
 package com.mars_sim.core.person.ai.task.meta;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.task.DigLocalIce;
+import com.mars_sim.core.person.ai.task.util.SettlementTask;
 import com.mars_sim.core.person.ai.task.util.Task;
-import com.mars_sim.core.person.ai.task.util.TaskJob;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.structure.OverrideType;
 import com.mars_sim.core.structure.Settlement;
@@ -36,30 +37,24 @@ public class DigLocalIceMeta extends DigLocalMeta {
 	}
 
     @Override
-    public Task constructInstance(Person person) {
+    protected Task createTask(Person person) {
         return new DigLocalIce(person);
     }
 
-    /**
-     * Assess a Person's suitability to dig ice locally. Depends on many factors.
-     * @param person Being assessed.
-     * @return List of potential TaskJobs
+        /**
+     * Assess what digging tasks can be done at a Settlement
+     * @param settlement The focus of the search
      */
     @Override
-    public List<TaskJob> getTaskJobs(Person person) {
-
-        Settlement settlement = person.getSettlement();
+    public List<SettlementTask> getSettlementTasks(Settlement settlement) {
     	
         // Check if settlement has DIG_LOCAL_REGOLITH override flag set.
-        if ((settlement == null) 
-            || !person.isInSettlement()
-            || settlement.getProcessOverride(OverrideType.DIG_LOCAL_ICE)
+        if (settlement.getProcessOverride(OverrideType.DIG_LOCAL_ICE)
             || (settlement.getAmountResourceRemainingCapacity(ResourceUtil.iceID) < THRESHOLD_AMOUNT)) {
-        	return EMPTY_TASKLIST;
+        	return Collections.emptyList();
         }
     	
-    	return getTaskJobs(ResourceUtil.iceID, settlement, 
-    			person, settlement.getIceCollectionRate() * settlement.getIceProbabilityValue());
-
+    	return getSettlementTaskJobs(ResourceUtil.iceID, settlement, 
+            settlement.getIceCollectionRate() * settlement.getIceProbabilityValue());
     }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/DigLocalRegolithMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/DigLocalRegolithMeta.java
@@ -23,11 +23,7 @@ import com.mars_sim.tools.Msg;
  * Meta task for the DigLocalRegolith task.
  */
 public class DigLocalRegolithMeta extends DigLocalMeta {
-    
-	// May add back private static SimLogger logger = SimLogger.getLogger(DigLocalRegolithMeta.class.getName())
-	
-	private static final int THRESHOLD_AMOUNT = 50;
-	
+    		
     /** Task name */
     private static final String NAME = Msg.getString(
             "Task.description.digLocalRegolith"); //$NON-NLS-1$
@@ -49,8 +45,7 @@ public class DigLocalRegolithMeta extends DigLocalMeta {
     public List<SettlementTask> getSettlementTasks(Settlement settlement) {
     	
         // Check if settlement has DIG_LOCAL_REGOLITH override flag set.
-        if (settlement.getProcessOverride(OverrideType.DIG_LOCAL_REGOLITH)
-            || (settlement.getAmountResourceRemainingCapacity(ResourceUtil.regolithID) < THRESHOLD_AMOUNT)) {
+        if (settlement.getProcessOverride(OverrideType.DIG_LOCAL_REGOLITH)) {
         	return Collections.emptyList();
         }
     	

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/DigLocalRegolithMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/DigLocalRegolithMeta.java
@@ -6,13 +6,14 @@
  */
 package com.mars_sim.core.person.ai.task.meta;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.task.DigLocalRegolith;
+import com.mars_sim.core.person.ai.task.util.SettlementTask;
 import com.mars_sim.core.person.ai.task.util.Task;
-import com.mars_sim.core.person.ai.task.util.TaskJob;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.structure.OverrideType;
 import com.mars_sim.core.structure.Settlement;
@@ -36,29 +37,24 @@ public class DigLocalRegolithMeta extends DigLocalMeta {
 	}
 
     @Override
-    public Task constructInstance(Person person) {
+    protected Task createTask(Person person) {
         return new DigLocalRegolith(person);
     }
 
     /**
-     * Assess a Persons suitability to dig Regolith locally. Depends on many conditions.
-     * @param person Being assessed
-     * @return TaskJobs that could be done
+     * Assess what digging tasks can be done at a Settlement
+     * @param settlement The focus of the search
      */
     @Override
-    public List<TaskJob> getTaskJobs(Person person) {
-    	
-    	Settlement settlement = person.getSettlement();
+    public List<SettlementTask> getSettlementTasks(Settlement settlement) {
     	
         // Check if settlement has DIG_LOCAL_REGOLITH override flag set.
-        if ((settlement == null) 
-            || !person.isInSettlement()
-            || settlement.getProcessOverride(OverrideType.DIG_LOCAL_REGOLITH)
+        if (settlement.getProcessOverride(OverrideType.DIG_LOCAL_REGOLITH)
             || (settlement.getAmountResourceRemainingCapacity(ResourceUtil.regolithID) < THRESHOLD_AMOUNT)) {
-        	return EMPTY_TASKLIST;
+        	return Collections.emptyList();
         }
     	
-    	return getTaskJobs(ResourceUtil.regolithID, settlement, 
-    			person, settlement.getRegolithCollectionRate() * settlement.getRegolithProbabilityValue());
+    	return getSettlementTaskJobs(ResourceUtil.regolithID, settlement, 
+    			settlement.getRegolithCollectionRate() * settlement.getRegolithProbabilityValue());
     }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/SettlementTask.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/SettlementTask.java
@@ -94,7 +94,7 @@ public abstract class SettlementTask extends AbstractTaskJob {
      * 
      * @return
      */
-    SettlementMetaTask getMeta() {
+    public SettlementMetaTask getMeta() {
         return metaTask;
     }
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -44,7 +44,6 @@ import com.mars_sim.core.equipment.EquipmentOwner;
 import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.equipment.ItemHolder;
 import com.mars_sim.core.equipment.ResourceHolder;
-import com.mars_sim.core.events.ScheduledEventHandler;
 import com.mars_sim.core.events.ScheduledEventManager;
 import com.mars_sim.core.goods.CreditManager;
 import com.mars_sim.core.goods.GoodsManager;
@@ -67,10 +66,7 @@ import com.mars_sim.core.person.ai.mission.MissionType;
 import com.mars_sim.core.person.ai.role.RoleType;
 import com.mars_sim.core.person.ai.shift.ShiftManager;
 import com.mars_sim.core.person.ai.shift.ShiftPattern;
-import com.mars_sim.core.person.ai.task.DigLocalRegolith;
 import com.mars_sim.core.person.ai.task.Walk;
-import com.mars_sim.core.person.ai.task.util.FactoryMetaTask;
-import com.mars_sim.core.person.ai.task.util.MetaTaskUtil;
 import com.mars_sim.core.person.ai.task.util.SettlementTaskManager;
 import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.person.health.RadiationExposure;
@@ -123,8 +119,6 @@ public class Settlement extends Structure implements Temporal,
 	/**
 	 * Shared preference key for Mission limits
 	 */
-	private static final int WAIT_FOR_SUNLIGHT_DELAY = 40;
-	private static final int AIRLOCK_OPERATION_OFFSET = 40;
 	private static final int UPDATE_GOODS_PERIOD = (1000/20); // Update 20 times per day
 	public static final int CHECK_MISSION = 20; // once every 10 millisols
 	public static final int CHECK_RESOURCES = 30;
@@ -254,8 +248,6 @@ public class Settlement extends Structure implements Temporal,
 	/** The background map image id used by this settlement. */
 	private int mapImageID;
 	
-//	private long tLast;
-	
 	/** The average regolith collection rate nearby. */
 	private double regolithCollectionRate = RandomUtil.getRandomDouble(4, 8);
 	/** The average ice collection rate of the water ice nearby. */
@@ -330,9 +322,6 @@ public class Settlement extends Structure implements Temporal,
 	private SolMetricDataLogger<Integer> dailyResourceOutput;
 	/** The settlement's daily labor hours output. */
 	private SolMetricDataLogger<Integer> dailyLaborTime;
-
-	/** The object that keeps track of wheelbarrows. */
-//	private StorableItem wheelbarrows;
 	
 	/** The settlement's achievement in scientific fields. */
 	private EnumMap<ScienceType, Double> scientificAchievement;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -211,6 +211,8 @@ public class Settlement extends Structure implements Temporal,
 	private static final double MAX_MISSION_SCORE = 1000D;
 	/** Normal air pressure [in kPa]. */
 	private static final double NORMAL_AIR_PRESSURE = 34D;
+	/** Maximum percentage of citizens that are EVA'ing. */
+	private static final double EVA_PERCENTAGE = 0.25;
 
 	/** The settlement water consumption */
 	private static double waterConsumptionRate;
@@ -749,19 +751,6 @@ public class Settlement extends Structure implements Temporal,
 	}
 
 	/**
-	 * Gets the number of citizens doing EVA outside.
-	 * 
-	 * @return
-	 */
-	public Long getNumOutsideEVA() {
-		return citizens.stream()
-				.filter(p -> !p.isDeclaredDead()
-						&& (p.getLocationStateType() == LocationStateType.SETTLEMENT_VICINITY
-						|| p.getLocationStateType() == LocationStateType.MARS_SURFACE))
-				.collect(Collectors.counting());
-	}
-
-	/**
 	 * Gets the robot capacity of the settlement
 	 *
 	 * @return the robot capacity
@@ -978,9 +967,7 @@ public class Settlement extends Structure implements Temporal,
 			logger.info(this, "On Sol 1, " + firstSite.getFormattedString() 
 						+ " was the very first exploration site chosen to be analyzed and explored.");
 			
-			checkMineralMapImprovement();
-			
-			setAppointedTask(pulse.getMarsTime());
+			checkMineralMapImprovement();			
 		}
 		
 		int sol = pulse.getMarsTime().getMissionSol();
@@ -1020,8 +1007,6 @@ public class Settlement extends Structure implements Temporal,
 			// Perform the end of day tasks
 			performEndOfDayTasks(pulse.getMarsTime());	
 
-			setAppointedTask(pulse.getMarsTime());
-
 			int range = (int) getVehicleWithMinimalRange().getRange();
 			
 			int skill = 0;
@@ -1054,44 +1039,6 @@ public class Settlement extends Structure implements Temporal,
 		trackByMSol(pulse);
 
 		return true;
-	}
-
-	/**
-	 * Sets up the daily appointed task of doing EVA.
-	 * 
-	 * @param currentTime
-	 */
-	private void setAppointedTask(MarsTime currentTime) {
-		int numAirlocks = getAirlockNum();
-		// Note: leave 1 chamber open
-		int numPerAirlock = 3; 
-		int count = 0; 
-		double multiplier = 0.1 + numAirlocks / numPerAirlock;	
-		for (Person p: citizens) {
-			double deltaTime = AIRLOCK_OPERATION_OFFSET * Math.floor(count * multiplier);
-
-			int startTimeEVA = (int)deltaTime +  WAIT_FOR_SUNLIGHT_DELAY + (int)(surfaceFeatures.getOrbitInfo().getSunTimes(location))[0];
-			int futureTime = startTimeEVA - currentTime.getMillisolInt();
-			if (futureTime < 0) {
-				futureTime += 1000;
-			}
-			MarsTime mTime = currentTime.addTime(futureTime);
-
-			// On Duty if less than 75% of the shift completed
-			boolean isOnDuty = (p.getShiftSlot().getShift().getShiftCompleted(mTime.getMillisolInt()) < 0.30D);
-			
-			// Select only personnel on duty and without a mission
-			if (isOnDuty && p.getMission() == null) {
-				count++;
-
-				FactoryMetaTask mt = (FactoryMetaTask) MetaTaskUtil.getMetaTask(DigLocalRegolith.SIMPLE_NAME);
-				ScheduledEventHandler appointment = new PersonFutureTask(p, mt);
-
-				// Gets the number of digits in millisol time 
-				futureEvents.addEvent(mTime, appointment);
-
-			}
-		}
 	}
 	
 	/**
@@ -1933,9 +1880,7 @@ public class Settlement extends Structure implements Temporal,
 	 * @return true if added successfully
 	 */
 	public boolean containsPerson(Person p) {
-		if (indoorPeopleMap.contains(p))
-			return true;
-		return false;
+		return indoorPeopleMap.contains(p);
 	}
 
 	/**
@@ -2006,6 +1951,9 @@ public class Settlement extends Structure implements Temporal,
 			setMissionLimit(MissionType.TRAVEL_TO_SETTLEMENT.name(), 0, 20);
 			setMissionLimit(MissionType.DELIVERY.name(), 0, 6);
 
+			// EVA capacity
+			int evaCapacity = (int)Math.ceil(numCitizens * EVA_PERCENTAGE);
+			preferences.putValue(SettlementParameters.INSTANCE, SettlementParameters.MAX_EVA, evaCapacity);
 
 			fireUnitUpdate(UnitEventType.ADD_ASSOCIATED_PERSON_EVENT, this);
 			return true;
@@ -2101,10 +2049,7 @@ public class Settlement extends Structure implements Temporal,
 		if (robotsWithin.contains(r)) {
 			return true;
 		}
-		if (robotsWithin.add(r)) {
-			return true;
-		}
-		return false;
+		return robotsWithin.add(r);
 	}
 
 	/**
@@ -2116,10 +2061,7 @@ public class Settlement extends Structure implements Temporal,
 		if (!robotsWithin.contains(r)) {
 			return true;
 		}
-		if (robotsWithin.remove(r)) {
-			return true;
-		}
-		return false;
+		return robotsWithin.remove(r);
 	}
 
 	/**
@@ -2150,10 +2092,7 @@ public class Settlement extends Structure implements Temporal,
 	public boolean removeParkedVehicle(Vehicle vehicle) {
 		if (!parkedVehicles.contains(vehicle))
 			return true;
-		if (parkedVehicles.remove(vehicle)) {
-			return true;
-		}
-		return false;
+		return parkedVehicles.remove(vehicle);
 	}
 
 	/**
@@ -2163,10 +2102,7 @@ public class Settlement extends Structure implements Temporal,
 	 * @return
 	 */
 	public boolean containsParkedVehicle(Vehicle vehicle) {
-		if (parkedVehicles.contains(vehicle)) {
-			return true;
-		}
-		return false;
+		return parkedVehicles.contains(vehicle);
 	}
 
 	/**
@@ -2717,7 +2653,6 @@ public class Settlement extends Structure implements Temporal,
 		double requiredWater = waterConsumptionRate * getNumCitizens() * 90;
 
 		int newRatio = Math.max(1, (int)((requiredWater + reserveWater) / storedWater));
-//		logger.info(this, 20_000L, "Calculated Water Ratio: " + newRatio);		
 		if (newRatio < 1)
 			newRatio = 1;
 		else if (newRatio > 1)
@@ -2913,12 +2848,6 @@ public class Settlement extends Structure implements Temporal,
 			result = 0;
 		if (result > MAX_PROB)
 			result = MAX_PROB;
-		
-//		logger.info(this, 30_000L, "regolithDemand: " + regolithDemand
-//						+ "   cementDemand: " + cementDemand
-//						+ "   concreteDemand: " + concreteDemand
-//						+ "   sandDemand: " + sandDemand
-//						+ "   regolith Prob value: " + result);
 		return result;
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementParameters.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementParameters.java
@@ -6,17 +6,19 @@
  */
 package com.mars_sim.core.structure;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import com.mars_sim.core.parameter.ParameterCategory;
+import com.mars_sim.core.parameter.ParameterValueType;
 
 /**
  * Defines the parameters values that are applicable to the behaviour of a Settlement.
  */
 public class SettlementParameters extends ParameterCategory {
 
-    public static final ParameterCategory INSTANCE = new SettlementParameters();
+    public static final SettlementParameters INSTANCE = new SettlementParameters();
+    public static final String MAX_EVA = "max_eva";
     
     private SettlementParameters() {
         super("CONFIGURATION");
@@ -27,6 +29,8 @@ public class SettlementParameters extends ParameterCategory {
      */
     @Override
     protected Map<String, ParameterSpec> calculateSpecs() {
-        return Collections.emptyMap();
+        Map<String, ParameterSpec> results = new HashMap<>();
+        results.put(MAX_EVA, new ParameterSpec(MAX_EVA, "Max EVA", ParameterValueType.INTEGER));
+        return results;
     }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingManager.java
@@ -145,7 +145,6 @@ public class BuildingManager implements Serializable {
 	private Set<Building> farmsNeedingWorkCache = new UnitSet<>();
 	
 	private static SimulationConfig simulationConfig;
-	private static HistoricalEventManager eventManager;
 	private static MasterClock masterClock;
 	private static UnitManager unitManager;
 
@@ -3136,15 +3135,6 @@ public class BuildingManager implements Serializable {
 	}
 
 	/**
-	 * Gets an instance of the historical event manager.
-	 *
-	 * @return
-	 */
-	public HistoricalEventManager getEventManager() {
-		return eventManager;
-	}
-
-	/**
 	 * Gets a set of garages for the settlement.
 	 *
 	 * @return
@@ -3160,10 +3150,9 @@ public class BuildingManager implements Serializable {
 	 * @param {{@link MarsClock}
 	 */
 	public static void initializeInstances(SimulationConfig sc, MasterClock c0,
-			HistoricalEventManager e, UnitManager u) {
+			UnitManager u) {
 		simulationConfig = sc;
 		masterClock = c0;
-		eventManager = e;
 		unitManager = u;
 	}
 

--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -1041,6 +1041,7 @@ RatingScore.entropy.CUs = Entropy per CU
 RatingScore.entropy.node = Entropy per Node
 RatingScore.entropy.lab = Entropy per Lab
 
+RatingScore.capacity = Capacity
 RatingScore.eva = EVA Weight
 RatingScore.experience = Experience
 RatingScore.extrovert = Person Extrovert

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BacklogTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BacklogTableModel.java
@@ -21,6 +21,7 @@ import com.mars_sim.core.UnitListener;
 import com.mars_sim.core.person.ai.task.util.SettlementTask;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.tools.Msg;
+import com.mars_sim.ui.swing.utils.RatingScoreRenderer;
 
 /**
  * This class models how SettlementTasks are organized and displayed
@@ -195,7 +196,12 @@ public class BacklogTableModel extends AbstractMonitorModel
 		if ((columnIndex == SCORE_COL) && (rowIndex < tasks.size())) {
 			SettlementTask selectedTask = tasks.get(rowIndex).task;
 
-			result = selectedTask.getScore().getHTMLOutput();
+			StringBuilder builder = new StringBuilder();
+			builder.append("<html><b>Task:").append(selectedTask.getName()).append("</b><br>");
+			builder.append(RatingScoreRenderer.getHTMLFragment(selectedTask.getScore()));
+			builder.append("</html>");
+
+			result = builder.toString();
 		}
         return result;
     }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/PersonTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/PersonTableModel.java
@@ -34,6 +34,7 @@ import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.vehicle.Crewable;
 import com.mars_sim.tools.Msg;
+import com.mars_sim.ui.swing.utils.RatingScoreRenderer;
 
 /**
  * The PersonTableModel that maintains a list of Person objects. By defaults the
@@ -412,7 +413,8 @@ public class PersonTableModel extends UnitTableModel<Person> {
 			if (p != null) {
 				// If the Person is dead, there is no Task Manager
 				var score = p.getMind().getTaskManager().getScore();
-				result = (score != null ? score.getHTMLOutput() : null);
+				result = (score != null ? "<html>" + RatingScoreRenderer.getHTMLFragment(score) + "</html>"
+								: null);
 			}
 		}
         return result;

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TableTab.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TableTab.java
@@ -73,8 +73,14 @@ abstract class TableTab extends MonitorTab {
             @Override
             public String getToolTipText(MouseEvent e) {
                 java.awt.Point p = e.getPoint();
-                int rowIndex = rowAtPoint(p);
+
+				// Column accounts for reordering/hidden columns
                 int colIndex = columnAtPoint(p);
+				TableColumn col = table.getColumnModel().getColumn(colIndex);
+				colIndex = col.getModelIndex();
+
+				// Row accounts for sorting	
+				int rowIndex = rowAtPoint(p);
 				var sorter = getRowSorter();
 				if (sorter != null) {
 					rowIndex = sorter.convertRowIndexToModel(rowIndex);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelActivity.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelActivity.java
@@ -45,6 +45,7 @@ import com.mars_sim.ui.swing.tool.monitor.MonitorWindow;
 import com.mars_sim.ui.swing.tool.monitor.PersonTableModel;
 import com.mars_sim.ui.swing.unit_window.TabPanel;
 import com.mars_sim.ui.swing.utils.AttributePanel;
+import com.mars_sim.ui.swing.utils.RatingScoreRenderer;
 
 /**
  * The TabPanelActivity is a tab panel for a person's current tasks and
@@ -195,10 +196,11 @@ public class TabPanelActivity extends TabPanel implements ActionListener {
 
 		Mission mission = worker.getMission();
 
-		String prefix = "";
+		boolean addLine = false;
+		StringBuilder prefix = new StringBuilder();
 		StringBuilder newTaskText = new StringBuilder();
 		for (Task t : taskManager.getTaskStack()) {
-			if (prefix.length() > 0) {
+			if (addLine) {
 				newTaskText.append("\n");
 			}
 			newTaskText.append(prefix);
@@ -207,7 +209,8 @@ public class TabPanelActivity extends TabPanel implements ActionListener {
 				newTaskText.append(phase.getName()).append(" - ");
 			}
 			newTaskText.append(t.getDescription());
-			prefix = prefix + "-";
+			prefix.append('-');
+			addLine = true;
 		}
 		String newContent = newTaskText.toString();
 		if (!newContent.equals(taskStack.getText())) {
@@ -232,7 +235,8 @@ public class TabPanelActivity extends TabPanel implements ActionListener {
 		RatingScore score = taskManager.getScore();
 		if (score != null) {
 			scoreLabel = StyleManager.DECIMAL_PLACES2.format(score.getScore());
-			scoreTooltip = score.getHTMLOutput();
+			scoreTooltip = "<html>" + RatingScoreRenderer.getHTMLFragment(score) + "</html>";
+
 		}
 
 		updateLabel(scoreTextArea, scoreLabel);
@@ -308,7 +312,8 @@ public class TabPanelActivity extends TabPanel implements ActionListener {
 		public String getScoreText(int rowIndex, int colIndex) {
 			if ((colIndex == 0) && (rowIndex < tasks.size())) {
 				var t = tasks.get(rowIndex);
-				return t.getScore().getHTMLOutput();
+				return "<html>" + RatingScoreRenderer.getHTMLFragment(t.getScore()) + "</html>";
+
 			}
 			return null;
 		}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/RatingScoreRenderer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/RatingScoreRenderer.java
@@ -1,0 +1,53 @@
+/*
+ * Mars Simulation Project
+ * RatingScoreRenderer.java
+ * @date 2024-01-21
+ * @author Barry Evans
+ */
+package com.mars_sim.ui.swing.utils;
+
+import java.text.DecimalFormat;
+import java.util.stream.Collectors;
+
+import com.mars_sim.core.data.RatingScore;
+import com.mars_sim.tools.Msg;
+
+/**
+ * This static class provides methods to render a RatingScore.
+ */
+public class RatingScoreRenderer {
+
+    /**
+     * Prefix to the key in the message bundle
+     */
+    private static final String RATING_KEY = "RatingScore.";
+    private static final DecimalFormat SCORE_FORMAT = new DecimalFormat("0.###");
+
+    private RatingScoreRenderer() {}
+
+    /**
+     * Render a RatingScore into a HTML fragment that shows the Base and Modifiers
+     * @param score
+     * @return
+     */
+    public static String getHTMLFragment(RatingScore score) {
+        StringBuilder output = new StringBuilder();
+        output.append("<b>Score: ").append(SCORE_FORMAT.format(score.getScore())).append("</b><br>");
+
+        var bases = score.getBases();
+        output.append(bases.entrySet().stream()
+                                .map(entry -> "  " + Msg.getString(RATING_KEY + entry.getKey())
+                                                    + ": " + SCORE_FORMAT.format(entry.getValue()))
+                                .collect(Collectors.joining("<br>")));
+
+        var modifiers = score.getModifiers();
+        if (!modifiers.isEmpty()) {
+            output.append("<br>");
+        }
+        output.append(modifiers.entrySet().stream()
+                                .map(entry -> "  " + Msg.getString(RATING_KEY + entry.getKey())
+                                                    + ": x" + SCORE_FORMAT.format(entry.getValue()))
+                                .collect(Collectors.joining("<br>")));
+        return output.toString();
+    }
+}


### PR DESCRIPTION
This converts DigLocalMeta to the SettlementTask approach. This means the score for digging a resource is only calculated once and added to the backlog. The score takes into account how much capacity is remaining and reduces the score as capacity is reduced. The demand property is now the number of unused EVAOperaton slots.

The maximum EVAOperations is now a configurable parameter of the Settlement using the existing ParameterManager approach. The default is 25% of the settlement population. The demand of these items in the Backlog are controlled immediately by adjusting the parameter in the UI. So increasing will allow more EVS and decreasing to stop them being created.

In addition fix the missing Tooltips in TableTab due to a mis-alignment between visual column index to model column index.
Moved HTML rendering of RatingScore to new dedicated RatignScoreRenderer in UI module.

Close #1189