### PR TITLE
Create a Group Activity concept for meetings

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/BacklogCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/BacklogCommand.java
@@ -38,7 +38,7 @@ class BacklogCommand extends AbstractSettlementCommand {
         List<SettlementTask> tasks = stm.getAvailableTasks();
         if (tasks != null) {
             response.appendTableHeading(true, "Tasks", 35, "Subject", CommandHelper.BUILIDNG_WIDTH,
-                            "#", 3, "Score", -30);
+                            "#", 3, "Scope", 8, "Score", -30);
             for(SettlementTask t : tasks) {
                 String subjectName = null;
                 Entity subject = t.getFocus();
@@ -46,7 +46,7 @@ class BacklogCommand extends AbstractSettlementCommand {
                     subjectName = subject.getName();
                 }
                 response.appendTableRow(t.getShortName(), subjectName,
-                                t.getDemand(),
+                                t.getDemand(), t.getScope().toString(),
                                 t.getScore().getOutput());
             }
         }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/SimulationRuntime.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/SimulationRuntime.java
@@ -9,10 +9,13 @@ package com.mars_sim.core;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.apache.commons.io.FileUtils;
 
 import com.mars_sim.mapdata.common.FileLocator;
 import com.mars_sim.tools.Msg;
@@ -128,30 +131,16 @@ public class SimulationRuntime {
 			File child = files[i];
 
 			try {
-				if ((child.isDirectory() && !deleteDirectory(child)) 
-						|| !files[i].delete())
-					System.err.println("Failed to delete old file " + child);
+				if (child.isDirectory()) {
+					FileUtils.deleteDirectory(child);
+				}
+				else {
+					Files.delete(child.toPath());
+				}
 			}
 			catch(Exception e) {
-				// Pretty fatal
-				System.err.println("Failed to remove old file " + child);
+				logger.log(Level.WARNING, "Failed to remove old file " + child, e);
 			}
 		}
     }
-
-	/*
-	* Deletes a non empty directory.
-	*/
-	private static boolean deleteDirectory(File dir) {
-		File[] children = dir.listFiles();
-		for (File child : children) {
-			if (child.isDirectory() && !deleteDirectory(child)) {
-				return false;
-			}
-			if (!child.delete()) {
-				return false;
-			}
-		}
-		return true;
-	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivity.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivity.java
@@ -1,0 +1,182 @@
+/*
+ * Mars Simulation Project
+ * GroupActivity.java
+ * @date 2023-03-17
+ * @author Barry Evans
+ */
+package com.mars_sim.core.activities;
+
+import com.mars_sim.core.environment.MarsSurface;
+import com.mars_sim.core.events.ScheduledEventHandler;
+import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.core.structure.building.Building;
+import com.mars_sim.core.structure.building.BuildingCategory;
+import com.mars_sim.core.time.MarsTime;
+
+/**
+ * This represents a scheduled GroupActivity based on a definition. This will cycle through a state flow
+ * as time advances and uses the ScheduledEvent logic to advance it.
+ * The activity can be reused or be a one off; defined bu the associated definition.
+ */
+public class GroupActivity implements ScheduledEventHandler {
+
+    // TODO Temporary static activity definition
+    public static final GroupActivityInfo TEAM_MEETING = new GroupActivityInfo("Team Meeting", 400, 5,
+                                             50, 2, 0.5D, 500, BuildingCategory.COMMAND);
+
+
+    public enum ActivityState {
+        SCHEDULED, PENDING, ACTIVE, DONE, UNSCHEDULED;
+    }
+
+    private GroupActivityInfo definition;
+    private ActivityState state = ActivityState.UNSCHEDULED;
+    private Building meetingPlace;
+    private Settlement owner;
+
+    /**
+     * Create an activity for a specific Settlement. This will schedule the initial ScheduledEvent to
+     * handle the first occurance of this Activity adjusted to the local time zone, e.g. if the Info
+     * define midday, it will be midday local time.
+     * 
+     * @param definition Activity being created
+     * @param owner Owning Settlement
+     * @param now Current time for scheduling
+     */
+    public GroupActivity(GroupActivityInfo definition, Settlement owner, MarsTime now) {
+        this.definition = definition;
+        this.owner = owner;
+
+        attachToSettlement(now);
+    }
+
+    private void attachToSettlement(MarsTime now) {    
+        // Calculate the duration to the next scheduled start of this activity
+        // But adjust to the local time zone
+        int offset = MarsSurface.getTimeOffset(owner.getCoordinates());
+        int standardStartTime = (definition.scheduledStart() + offset) % 1000;
+
+        // mSols to the schedued start
+        int toEvent = standardStartTime - now.getMillisolInt();
+        if (toEvent < 0) {
+            // Passed today
+            toEvent = 1000 + toEvent;
+        } 
+
+        state = ActivityState.SCHEDULED;
+        owner.getFutureManager().addEvent(now.addTime(toEvent), this);
+    }
+
+    /**
+     * Description of the future scheduled event for this activity.
+     */
+    @Override
+    public String getEventDescription() {
+        return getName() + " - " + switch(state) {
+            case ACTIVE -> "end";
+            case DONE -> "done";
+            case PENDING -> "starting";
+            case SCHEDULED -> "scheduled start";
+            case UNSCHEDULED -> "unscheduled";
+        };
+    }
+
+    /**
+     * A timed changed has arrived for this activity. It will involve moving the state onwards.
+     */
+    @Override
+    public int execute(MarsTime currentTime) {
+        switch(state) {
+            case SCHEDULED:
+                if (selectMeetingPlace()) {
+                    state = ActivityState.PENDING;
+                    return definition.waitDuration();
+                }
+                else {
+                    // Reschedule
+                    return 1000;
+                }
+            case ACTIVE:
+                // Activity has completed, so rescheduled in the future
+                meetingPlace = null;
+                int freq = definition.solFrequency();
+                if (freq > 0) {
+                    state = ActivityState.SCHEDULED;
+                    return 1000 * freq;
+                }
+                else {
+                    state = ActivityState.DONE;
+                    return -1; // A one off
+                }
+            
+            case PENDING:
+                // Waitng time is over, start
+                state = ActivityState.ACTIVE;
+                return definition.activityDuration();
+            default:
+                throw new IllegalStateException("Don;t know about state " + state);
+        }
+    }
+
+    /**
+     * Find a meeting place of the correct type
+     */
+    private boolean selectMeetingPlace() {
+        // Select the largest
+        var selected = owner.getBuildingManager().getBuildingsOfSameCategory(definition.place()).stream()
+                            .filter(b -> b.getLifeSupport() != null)
+                            // Sorted in reverse order so largest first
+                            .sorted((a,b) -> Integer.compare(b.getLifeSupport().getOccupantCapacity(),
+                                                            a.getLifeSupport().getOccupantCapacity()))
+                            .findFirst();
+        if (selected.isPresent()) {
+            meetingPlace = selected.get();
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * The definition of this activity defining the behaviour.
+     * @return
+     */
+    public GroupActivityInfo getDefinition() {
+        return definition;
+    }   
+    
+    /**
+     * Is this activity active, i.e can Persons join it.
+     * @return
+     */
+    public boolean isActive() {
+        return (state == ActivityState.PENDING) || (state == ActivityState.ACTIVE);
+    }
+
+    /**
+     * Curent state of the activity.
+     * @return
+     */
+    public ActivityState getState() {
+        return state;
+    }
+
+    /**
+     * Allocated meeting place for this activity based on the type of category
+     * @return
+     */
+    public Building getMeetingPlace() {
+        return meetingPlace;
+    }
+
+    public String getName() {
+        return definition.name();
+    }
+
+    /**
+     * Get the total time this activity could take. Is the wait & actvity duration.
+     * @return
+     */
+    public double getTotalDuration() {
+        return definition.waitDuration() + definition.activityDuration();
+    }
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivity.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivity.java
@@ -25,7 +25,7 @@ public class GroupActivity implements ScheduledEventHandler {
      * The State that a Group Activity transitions
      */
     public enum ActivityState {
-        SCHEDULED, PENDING, ACTIVE, DONE, UNSCHEDULED;
+        SCHEDULED, PENDING, ACTIVE, DONE, UNSCHEDULED, CANCELLED;
     }
 
     private GroupActivityInfo definition;
@@ -101,6 +101,7 @@ public class GroupActivity implements ScheduledEventHandler {
     public String getEventDescription() {
         return getName() + " - " + switch(state) {
             case ACTIVE -> "end";
+            case CANCELLED -> "cancelled";
             case DONE -> "done";
             case PENDING -> "starting";
             case SCHEDULED -> "scheduled start";
@@ -120,8 +121,9 @@ public class GroupActivity implements ScheduledEventHandler {
                     return definition.waitDuration();
                 }
                 else {
-                    // Reschedule
-                    return 1000;
+                    // Cancel it
+                    state = ActivityState.CANCELLED;
+                    return -1;
                 }
             case ACTIVE:
                 // Activity has completed, so rescheduled in the future
@@ -173,6 +175,10 @@ public class GroupActivity implements ScheduledEventHandler {
         return definition;
     }   
     
+    /**
+     * Person who insitgates the meeting, could be null
+     * @return Meeting Instigator
+     */
     public Person getInstigator() {
         return instigator;
     }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivity.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivity.java
@@ -8,6 +8,7 @@ package com.mars_sim.core.activities;
 
 import com.mars_sim.core.environment.MarsSurface;
 import com.mars_sim.core.events.ScheduledEventHandler;
+import com.mars_sim.core.person.ai.task.util.MetaTask.TaskScope;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.building.Building;
 import com.mars_sim.core.structure.building.BuildingCategory;
@@ -20,9 +21,9 @@ import com.mars_sim.core.time.MarsTime;
  */
 public class GroupActivity implements ScheduledEventHandler {
 
-    // TODO Temporary static activity definition
+    // Temporary static activity definition
     public static final GroupActivityInfo TEAM_MEETING = new GroupActivityInfo("Team Meeting", 400, 5,
-                                             50, 2, 0.5D, 500, BuildingCategory.COMMAND);
+                                             50, 2, 0.5D, 500, TaskScope.ANY_HOUR, BuildingCategory.COMMAND);
 
 
     public enum ActivityState {
@@ -54,7 +55,7 @@ public class GroupActivity implements ScheduledEventHandler {
         // Calculate the duration to the next scheduled start of this activity
         // But adjust to the local time zone
         int offset = MarsSurface.getTimeOffset(owner.getCoordinates());
-        int standardStartTime = (definition.scheduledStart() + offset) % 1000;
+        int standardStartTime = (definition.startTime() + offset) % 1000;
 
         // mSols to the schedued start
         int toEvent = standardStartTime - now.getMillisolInt();
@@ -176,7 +177,7 @@ public class GroupActivity implements ScheduledEventHandler {
      * Get the total time this activity could take. Is the wait & actvity duration.
      * @return
      */
-    public double getTotalDuration() {
+    public int getTotalDuration() {
         return definition.waitDuration() + definition.activityDuration();
     }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityInfo.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityInfo.java
@@ -20,6 +20,7 @@ import com.mars_sim.core.structure.building.BuildingCategory;
  * @param activtyDuratino Duratino of the actual activity
  * @param solFrequency Often does this activity report; negative mean never
  * @param percentagePop What percentage of the settlement population can join
+ * @param score The score of the activity
  * @param scope The scope of on/off duty worker
  * @param place The category of a meeting place to host the Activity
  * 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityInfo.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityInfo.java
@@ -8,12 +8,23 @@ package com.mars_sim.core.activities;
 
 import java.io.Serializable;
 
+import com.mars_sim.core.person.ai.task.util.MetaTask.TaskScope;
 import com.mars_sim.core.structure.building.BuildingCategory;
 
 /**
- * Respresents the definition of a group activity that involves many Persons in a single Settlement.
+ * Represents the definition of a group activity that involves many Persons in a single Settlement.
+ * @param name The name of the group activity
+ * @param startTime Start time in a sol for the activity
+ * @param waitDuration Time spent that Person can wait before the activity starts
+ * @param activtyDuratino Duratino of the actual activity
+ * @param solFrequency Often does this activity report; negative mean never
+ * @param percentagePop What percentage of the settlement population can join
+ * @param scope The scope of on/off duty worker
+ * @param place The category of a meeting place to host the Activity
+ * 
  */
-public record GroupActivityInfo(String name, int scheduledStart, int waitDuration,
+public record GroupActivityInfo(String name, int startTime, int waitDuration,
                                 int activityDuration, int solFrequency,
-                                double percentagePop, int score, BuildingCategory place)
+                                double percentagePop, int score, TaskScope scope,
+                                BuildingCategory place)
             implements Serializable {}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityInfo.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityInfo.java
@@ -1,0 +1,19 @@
+/*
+ * Mars Simulation Project
+ * GroupActivityInfo.java
+ * @date 2023-03-17
+ * @author Barry Evans
+ */
+package com.mars_sim.core.activities;
+
+import java.io.Serializable;
+
+import com.mars_sim.core.structure.building.BuildingCategory;
+
+/**
+ * Respresents the definition of a group activity that involves many Persons in a single Settlement.
+ */
+public record GroupActivityInfo(String name, int scheduledStart, int waitDuration,
+                                int activityDuration, int solFrequency,
+                                double percentagePop, int score, BuildingCategory place)
+            implements Serializable {}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityInfo.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityInfo.java
@@ -15,6 +15,7 @@ import com.mars_sim.core.structure.building.BuildingCategory;
  * Represents the definition of a group activity that involves many Persons in a single Settlement.
  * @param name The name of the group activity
  * @param startTime Start time in a sol for the activity
+ * @param firstSol Sol to the first initial meeting. 
  * @param waitDuration Time spent that Person can wait before the activity starts
  * @param activtyDuratino Duratino of the actual activity
  * @param solFrequency Often does this activity report; negative mean never
@@ -23,8 +24,8 @@ import com.mars_sim.core.structure.building.BuildingCategory;
  * @param place The category of a meeting place to host the Activity
  * 
  */
-public record GroupActivityInfo(String name, int startTime, int waitDuration,
-                                int activityDuration, int solFrequency,
+public record GroupActivityInfo(String name, int startTime, int firstSol,
+                                int waitDuration, int activityDuration, int solFrequency,
                                 double percentagePop, int score, TaskScope scope,
                                 BuildingCategory place)
             implements Serializable {}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityMetaTask.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityMetaTask.java
@@ -1,0 +1,73 @@
+/*
+ * Mars Simulation Project
+ * GroupActivityMetaTask.java
+ * @date 2023-03-17
+ * @author Barry Evans
+ */
+package com.mars_sim.core.activities;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.mars_sim.core.data.RatingScore;
+import com.mars_sim.core.person.Person;
+import com.mars_sim.core.person.ai.task.util.MetaTask;
+import com.mars_sim.core.person.ai.task.util.SettlementMetaTask;
+import com.mars_sim.core.person.ai.task.util.SettlementTask;
+import com.mars_sim.core.person.ai.task.util.Task;
+import com.mars_sim.core.structure.Settlement;
+
+/**
+ * This converts any active GroupActivities into a Schedueld Task that allow sPersons to join the
+ * activity.
+ */
+public class GroupActivityMetaTask extends MetaTask implements SettlementMetaTask {
+
+    private class GroupActivitySettlementTask extends SettlementTask {
+
+        private GroupActivity activity;
+
+        protected GroupActivitySettlementTask(SettlementMetaTask parent, GroupActivity activity,
+                                    RatingScore score, int attendees) {
+            super(parent, activity.getDefinition().name(), activity.getMeetingPlace(), score);
+            this.activity = activity;
+            setDemand(attendees);
+        }
+
+        @Override
+        public Task createTask(Person person) {
+            return new GroupActivityTask(activity, person);
+        }
+
+    }
+
+    private static final String NAME = "GroupActivity";
+
+    public GroupActivityMetaTask() {
+		super(NAME, WorkerType.PERSON, TaskScope.ANY_HOUR);
+    }
+
+    /**
+     * Create a Scheduled Task for any active Activity. The assigned Building will have been selected
+     * as part of the Activity.
+     * @return List of tasks associated with the active Group Activities
+     */
+    @Override
+    public List<SettlementTask> getSettlementTasks(Settlement settlement) {
+       var active = settlement.getFutureManager().getEvents().stream()
+                .filter(e -> e.getHandler() instanceof GroupActivity)
+                .map(e -> (GroupActivity)e.getHandler())
+                .filter(GroupActivity::isActive)
+                .toList();
+        
+         List<SettlementTask> results = new ArrayList<>();
+         for(var a : active) {
+            var score = new RatingScore(a.getDefinition().score());
+            int expected = (int) (settlement.getNumCitizens() * a.getDefinition().percentagePop());
+            results.add(new GroupActivitySettlementTask(this, a, score, expected));
+         }
+
+         return results;
+    }
+
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityMetaTask.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityMetaTask.java
@@ -32,6 +32,7 @@ public class GroupActivityMetaTask extends MetaTask implements SettlementMetaTas
             super(parent, activity.getDefinition().name(), activity.getMeetingPlace(), score);
             this.activity = activity;
             setDemand(attendees);
+            setScope(activity.getDefinition().scope());
         }
 
         @Override

--- a/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityTask.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityTask.java
@@ -1,0 +1,74 @@
+/*
+ * Mars Simulation Project
+ * GroupActivityInfo.java
+ * @date 2023-03-23
+ * @author Barry Evans
+ */
+package com.mars_sim.core.activities;
+
+import com.mars_sim.core.activities.GroupActivity.ActivityState;
+import com.mars_sim.core.person.Person;
+import com.mars_sim.core.person.ai.task.util.Task;
+import com.mars_sim.core.person.ai.task.util.TaskPhase;
+
+/**
+ * This acts as a Task to participate in a Group Activity. It goes through 2 phases
+ * to reflect the starting and active states of a meeting. The Task will be ended once the
+ * activity completes.
+ */
+public class GroupActivityTask extends Task {
+
+    private static final TaskPhase WAITING = new TaskPhase("Waiting"); 
+    private static final TaskPhase ACTIVE = new TaskPhase("Active"); 
+
+    private GroupActivity activity;
+    private ActivityState currentState;
+
+    public GroupActivityTask(GroupActivity activity, Person person) {
+        super(activity.getName(), person, false, false, 0D, activity.getTotalDuration());
+        this.activity = activity;
+
+        // TODO
+        // Check is in Settlement
+        // Add 2 phases
+        // Set the pahase according to the activity state
+        this.currentState = activity.getState();
+
+        // Walk to meeting place
+        if (!person.getBuildingLocation().equals(activity.getMeetingPlace())) {
+            walkToRandomLocInBuilding(activity.getMeetingPlace(), true);
+        }
+
+        
+		// Initialize phase
+		addPhase(WAITING);
+        addPhase(ACTIVE);
+
+		setPhase(toPhase(activity));
+    }
+
+    private static TaskPhase toPhase(GroupActivity a) {
+        return switch(a.getState()) {
+            case PENDING -> WAITING;
+            case ACTIVE -> ACTIVE;
+            default -> null;
+        };
+    }
+
+    @Override
+    protected double performMappedPhase(double time) {
+        if (!activity.isActive()) {
+            endTask();
+            return time;
+        }
+
+        // Change phase
+        if ((activity.getState() == ActivityState.ACTIVE)
+                && (currentState == ActivityState.PENDING)) {
+            currentState = ActivityState.ACTIVE;
+            setPhase(toPhase(activity));
+        }
+        return 0D;
+    }
+
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityTask.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityTask.java
@@ -24,22 +24,22 @@ public class GroupActivityTask extends Task {
     private GroupActivity activity;
     private ActivityState currentState;
 
+    /**
+     * Create a Task to participate in a Group Activity.
+     * @param activity Activity to participate in.
+     * @param person Worker taking part
+     */
     public GroupActivityTask(GroupActivity activity, Person person) {
         super(activity.getName(), person, false, false, 0D, activity.getTotalDuration());
         this.activity = activity;
 
-        // TODO
-        // Check is in Settlement
-        // Add 2 phases
-        // Set the pahase according to the activity state
         this.currentState = activity.getState();
 
         // Walk to meeting place
         if (!person.getBuildingLocation().equals(activity.getMeetingPlace())) {
             walkToRandomLocInBuilding(activity.getMeetingPlace(), true);
         }
-
-        
+ 
 		// Initialize phase
 		addPhase(WAITING);
         addPhase(ACTIVE);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/configuration/ConfigHelper.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/configuration/ConfigHelper.java
@@ -54,6 +54,19 @@ public class ConfigHelper {
 	}
 
 	/**
+	 * Get an enum from a text value. The value is first converted into a valid format.
+	 * This involves changing to upper case and replacing ' ' & '-' with a '_'.
+	 * 
+	 * @param enumClass The Class of the associated Enum range
+	 * @param text
+	 * @return
+	 */
+	public static <E extends Enum<E>> E getEnum(Class<E> enumClass, String text) {
+		var name = convertToEnumName(text);
+		return E.valueOf(enumClass, name);
+	}
+
+	/**
 	 * Parses an element that conforms to the Bounded Object pattern of x,y,w,h,f.
 	 * 
 	 * @param element

--- a/mars-sim-core/src/main/java/com/mars_sim/core/environment/RandomMineralMap.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/environment/RandomMineralMap.java
@@ -145,26 +145,18 @@ public class RandomMineralMap implements MineralMap {
 					
 			// Get the new remainingConc by multiplying it with concentrationNumber; 
 			double remainingConc = 1.0 * conc * concentrationNumber;
-			
-//				logger.info("regionArray size: " + length
-//						+ "  concentrationNumber: " + concentrationNumber
-//						+ "  remainingConc: " + remainingConc);
 		
 			for (int x = 0; x < concentrationNumber; x++) {
 
 				remainingConc = createMinerals(remainingConc, 
 						regionArray[RandomUtil.getRandomInt(length - 1)], x, concentrationNumber, conc, mineralType.name);
-				
-//				logger.info("  x: " + x + "  remainingConc: " + remainingConc);
-				
+								
 				if (remainingConc <= 0.0) 
 					break;
 			}
 				
 			
 		} // end of iterating MineralType
-
-		logger.info("# of Global Mineral Locations: " + allMineralsByLoc.size());
 	}
 
 	/**
@@ -245,9 +237,7 @@ public class RandomMineralMap implements MineralMap {
 			for (int x = 0; x < concentrationNumber; x++) {
 				
 				remainingConc = createMinerals(remainingConc, location, x, 
-						concentrationNumber, conc, mineralType.name);
-				
-//				logger.info(location +  " # of Local Mineral Locations: " + allMineralsByLocation.get(location).size());
+						concentrationNumber, conc, mineralType.name);				
 			}
 		}
 		
@@ -303,7 +293,6 @@ public class RandomMineralMap implements MineralMap {
 	 */
 	private Set<Coordinates> getTopoRegionSet(String imageMapName) {
 		Set<Coordinates> result = new HashSet<>(3000);
-//		[landrus, 26.11.09]: don't use the system classloader in a webstart env.
 		URL imageMapURL = getClass().getResource(IMAGES_FOLDER + imageMapName);
 		ImageIcon mapIcon = new ImageIcon(imageMapURL);
 		Image mapImage = mapIcon.getImage();
@@ -411,17 +400,6 @@ public class RandomMineralMap implements MineralMap {
 						effect = (1D - (distance / fuzzyRange)) * conc;				
 					
 					if (effect > 0D) {
-						
-//						if (angleCache != angle) {
-//							angleCache = angle;
-//							logger.info("mag: " + Math.round(mag* 1000.0)/1000.0 
-//									+ "  angle: "+ Math.round(angle * 1000.0)/1000.0
-//									+ "  distance: " + Math.round(distance * 1000.0)/1000.0
-//									+ "  conc: " + Math.round(conc * 1000.0)/1000.0
-//									+ "  ratio: " + Math.round(distance / fuzzyRange * 1000.0)/1000.0
-//									+ "  fuzzyRange: " + Math.round(fuzzyRange * 1000.0)/1000.0
-//									+ "  effect: " + Math.round(effect * 1000.0)/1000.0) ;
-//						}
 						
 						if (emptyMap) {
 							newMap = new HashMap<>();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/events/ScheduledEventManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/events/ScheduledEventManager.java
@@ -44,6 +44,14 @@ public class ScheduledEventManager implements Serializable, Temporal {
         }
         
         /**
+         * Get the handler waiting for this scheduled event to occur.
+         * @return
+         */
+        public ScheduledEventHandler getHandler() {
+            return handler;
+        }
+
+        /**
          * Gets the description of the target handler.
          */
         public String getDescription() {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/resupply/Resupply.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/resupply/Resupply.java
@@ -22,12 +22,14 @@ import com.mars_sim.core.Simulation;
 import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.UnitEventType;
 import com.mars_sim.core.UnitManager;
+import com.mars_sim.core.activities.GroupActivity;
 import com.mars_sim.core.events.ScheduledEventManager;
 import com.mars_sim.core.interplanetary.transport.Transportable;
 import com.mars_sim.core.interplanetary.transport.resupply.ResupplyConfig.SupplyManifest;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.resource.AmountResource;
 import com.mars_sim.core.resource.Part;
+import com.mars_sim.core.structure.GroupActivityType;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.SettlementBuilder;
 import com.mars_sim.core.structure.SettlementSupplies;
@@ -169,6 +171,13 @@ public class Resupply extends Transportable implements SettlementSupplies {
 		
 		// Deliver the rest of the supplies and add people.
 		deliverOthers(sim, sc);
+
+		// If there are new immigrients then have a welcome meeting
+		if (newImmigrantNum > 0) {
+			GroupActivity.createPersonActivity("Welcome new arrivals of " + getName(),
+									GroupActivityType.ANNOUNCEMENT, settlement, null, 1, 
+									sim.getMasterClock().getMarsTime());
+		}
 
 		// If a schedule then create the next one
 		if (template.getFrequency() > 0) {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
@@ -256,13 +256,6 @@ public class Person extends Unit implements Worker, Temporal, Researcher, Apprai
 		var currentEarthTime = masterClock.getEarthTime();
 		calculateBirthDate(currentEarthTime, age);
 
-		var nextBirthday = LocalDate.of(currentEarthTime.getYear() + 1,
-								birthDate.getMonth(), birthDate.getDayOfMonth());
-		var earthDays = ChronoUnit.DAYS.between(currentEarthTime.toLocalDate(), nextBirthday) % 365;
-		GroupActivity.createPersonActivity("Birthday Party", GroupActivityType.BIRTHDAY, settlement,
-						this, 
-						(int)((earthDays * MarsTime.MILLISOLS_PER_EARTHDAY)/1000D),
-						masterClock.getMarsTime());
 
 		// Create favorites
 		favorite = new Favorite(this);
@@ -518,6 +511,22 @@ public class Person extends Unit implements Worker, Temporal, Researcher, Apprai
 		// Calculate the year
 		// Set the age
 		age = updateAge(earthLocalTime);
+
+		// Calculate next birthday
+		int day = birthDate.getDayOfMonth();
+		int month = birthDate.getMonthValue();
+		if (birthDate.isLeapYear() && (day == 29) &&(month == 2)) {
+			// Leap year and 29th of February
+			day = 28;
+		}
+		var nextBirthday = LocalDate.of(earthLocalTime.getYear() + 1, month, day);
+
+		// Create a future activity so many earth days in the future
+		var earthDays = ChronoUnit.DAYS.between(earthLocalTime.toLocalDate(), nextBirthday) % 365;
+		GroupActivity.createPersonActivity("Birthday Party", GroupActivityType.BIRTHDAY,
+									getAssociatedSettlement(), this, 
+									(int)((earthDays * MarsTime.MILLISOLS_PER_EARTHDAY)/1000D),
+									masterClock.getMarsTime());
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/ConstructionMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/ConstructionMission.java
@@ -18,7 +18,6 @@ import java.util.Map;
 
 import com.mars_sim.core.LocalAreaUtil;
 import com.mars_sim.core.SimulationConfig;
-import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitEventType;
 import com.mars_sim.core.UnitType;
 import com.mars_sim.core.equipment.EVASuit;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/ConstructionMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/ConstructionMission.java
@@ -825,7 +825,7 @@ public class ConstructionMission extends AbstractMission
 
 			if (site.isAllConstructionComplete()) {
 				// Construct building if all 3 stages of the site construction have been complete.
-				Building building = site.createBuilding(((Unit)settlement).getIdentifier());
+				Building building = site.createBuilding(settlement);
 				manager.removeConstructionSite(site);
 				settlement.fireUnitUpdate(UnitEventType.FINISH_CONSTRUCTION_BUILDING_EVENT, building);
 				logger.info(settlement, "New building '" + site.getBuildingName() + "' constructed.");

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/role/Role.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/role/Role.java
@@ -7,6 +7,7 @@
 package com.mars_sim.core.person.ai.role;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 
 import com.mars_sim.core.Simulation;
@@ -72,7 +73,7 @@ public class Role implements Serializable {
 			var home = person.getAssociatedSettlement();
 
 			// Note : if this is a leadership role, only one person should occupy this position 
-			List<Person> predecessors = null;
+			List<Person> predecessors = Collections.emptyList();
 			if (newType.isChief() || newType.isCouncil()) {
 				// Find a list of predecessors who are occupying this role
 				predecessors = home.getChainOfCommand().findPeopleWithRole(newType);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/role/Role.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/role/Role.java
@@ -9,10 +9,13 @@ package com.mars_sim.core.person.ai.role;
 import java.io.Serializable;
 import java.util.List;
 
+import com.mars_sim.core.Simulation;
 import com.mars_sim.core.UnitEventType;
+import com.mars_sim.core.activities.GroupActivity;
 import com.mars_sim.core.data.History;
 import com.mars_sim.core.data.History.HistoryItem;
 import com.mars_sim.core.person.Person;
+import com.mars_sim.core.structure.GroupActivityType;
 
 public class Role implements Serializable {
 
@@ -66,11 +69,13 @@ public class Role implements Serializable {
 		}
 
 		if (newType != oldType) {
+			var home = person.getAssociatedSettlement();
+
 			// Note : if this is a leadership role, only one person should occupy this position 
 			List<Person> predecessors = null;
 			if (newType.isChief() || newType.isCouncil()) {
 				// Find a list of predecessors who are occupying this role
-				predecessors = person.getAssociatedSettlement().getChainOfCommand().findPeopleWithRole(newType);
+				predecessors = home.getChainOfCommand().findPeopleWithRole(newType);
 				if (!predecessors.isEmpty()) {
 					// Predecessors to seek for a new role to fill
 					predecessors.get(0).getRole().obtainNewRole();
@@ -85,10 +90,17 @@ public class Role implements Serializable {
 			roleHistory.add(roleType);
 			
 			// Save the role in the settlement Registry
-			person.getAssociatedSettlement().getChainOfCommand().registerRole(roleType);
+			home.getChainOfCommand().registerRole(roleType);
 
 			// Records the role change and fire unit update
 			person.fireUnitUpdate(UnitEventType.ROLE_EVENT, roleType);
+
+			// For Council members being changed have a meeting
+			if (roleType.isCouncil() && !predecessors.isEmpty()) {
+				GroupActivity.createPersonActivity("Council Announcement for " + roleType.getName(),
+									GroupActivityType.ANNOUNCEMENT, home, person, 0, 
+									Simulation.instance().getMasterClock().getMarsTime());
+			}
 		}
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/shift/ShiftPattern.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/shift/ShiftPattern.java
@@ -18,12 +18,14 @@ public class ShiftPattern {
     private String name;
     private int rotationSols;
     private int leavePerc;
+    private int minPopulation;
 
-    public ShiftPattern(String name, List<ShiftSpec> shifts, int rotationSols, int leavePerc) {
+    public ShiftPattern(String name, List<ShiftSpec> shifts, int rotationSols, int leavePerc, int minPop) {
         this.name = name;
         this.shifts = shifts;
         this.rotationSols = rotationSols;
         this.leavePerc = leavePerc;
+        this.minPopulation = minPop;
     }
 
     public List<ShiftSpec> getShifts() {
@@ -40,6 +42,14 @@ public class ShiftPattern {
 
     public int getRotationSols() {
         return rotationSols;
+    }
+
+    /**
+     * Get teh adivsed minum population for this shift pattern
+     * @return
+     */
+    public int getMinPopulation() {
+        return minPopulation;
     }
 
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/social/Relation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/social/Relation.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import com.mars_sim.core.UnitManager;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.core.tool.MathUtils;
 import com.mars_sim.tools.util.RandomUtil;
 
 /**
@@ -45,6 +46,8 @@ public class Relation implements Serializable {
 	// d2 : socio-cultural
 
 	public static final Opinion EMPTY_OPINION = new Opinion(50, 50, 50);
+
+	public static final double MAX_OPINION = 100D;
 	
 	/** A unit's opinion of another unit. */
 	private Map<Integer, Opinion> opinionMap = new HashMap<>();
@@ -118,27 +121,13 @@ public class Relation implements Serializable {
 				d0 = d0 + d/4;
 			}
 			
-			d2 = limit(d2);
-			d0 = limit(d0);
-			d1 = limit(d1);
+			d0 = MathUtils.between(d0, 0, MAX_OPINION);
+			d1 = MathUtils.between(d1, 0, MAX_OPINION);
+			d2 = MathUtils.between(d2, 0, MAX_OPINION);
 		}
 
 		found = new Opinion(d0, d1, d2);
 		opinionMap.put(id, found);
-	}
-	
-	/**
-	 * Places a limit over a value.
-	 * 
-	 * @param value
-	 * @return
-	 */
-	private double limit(double value) {
-		if (value < 0)
-			value = 0;
-		else if (value > 100)
-			value = 100;
-		return value;
 	}
 	
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/MetaTask.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/MetaTask.java
@@ -44,7 +44,7 @@ public abstract class MetaTask {
 	/**
 	 *  Defines the scope of this Task.
 	 */
-	protected enum TaskScope {
+	public enum TaskScope {
 		ANY_HOUR, WORK_HOUR, NONWORK_HOUR
 	}
 	

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/MetaTaskUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/MetaTaskUtil.java
@@ -15,6 +15,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.mars_sim.core.Simulation;
+import com.mars_sim.core.activities.GroupActivityMetaTask;
 import com.mars_sim.core.person.ai.task.meta.AnalyzeMapDataMeta;
 import com.mars_sim.core.person.ai.task.meta.AssistScientificStudyResearcherMeta;
 import com.mars_sim.core.person.ai.task.meta.BudgetResourcesMeta;
@@ -140,6 +141,8 @@ public class MetaTaskUtil {
 		allMetaTasks.add(new ExamineBodyMeta());
 		converseMeta = new ConverseMeta();
 		allMetaTasks.add(converseMeta);
+		allMetaTasks.add(new GroupActivityMetaTask());
+
 		allMetaTasks.add(new InviteStudyCollaboratorMeta());
 		
 		allMetaTasks.add(new ListenToMusicMeta());

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/SettlementTask.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/SettlementTask.java
@@ -8,6 +8,7 @@ package com.mars_sim.core.person.ai.task.util;
 
 import com.mars_sim.core.Entity;
 import com.mars_sim.core.data.RatingScore;
+import com.mars_sim.core.person.ai.task.util.MetaTask.TaskScope;
 
 /**
  * This represents a TaskJob created by a SettlementMetaTask. 
@@ -23,6 +24,7 @@ public abstract class SettlementTask extends AbstractTaskJob {
     private Entity focus;
     private String shortName;
     private boolean needsEVA = false;
+    private TaskScope scope = TaskScope.WORK_HOUR;
 
     /**
      * Creates an abstract Settlement task for the backlog that relates to an Entity within a Settlement
@@ -61,6 +63,22 @@ public abstract class SettlementTask extends AbstractTaskJob {
         needsEVA = eva;
     }
     
+        
+    /**
+     * Overrie the default scope
+     * @param newScope
+     */
+    protected void setScope(TaskScope newScope) {
+        scope = newScope;
+    }
+
+    /**
+     * What is the scope of working hours for this Task.
+     */
+    public TaskScope getScope() {
+        return scope;
+    }
+
     /**
      * Sets a specific level of demand for this job.
      * 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/SettlementTaskManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/SettlementTaskManager.java
@@ -9,10 +9,12 @@ package com.mars_sim.core.person.ai.task.util;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import com.mars_sim.core.UnitEventType;
 import com.mars_sim.core.data.RatingScore;
 import com.mars_sim.core.person.Person;
+import com.mars_sim.core.person.ai.task.util.MetaTask.TaskScope;
 import com.mars_sim.core.robot.Robot;
 import com.mars_sim.core.structure.Settlement;
 
@@ -23,6 +25,8 @@ import com.mars_sim.core.structure.Settlement;
 public class SettlementTaskManager implements Serializable {
 
 	private static final long serialVersionUID = 1L;
+    private static final Set<TaskScope> ON_DUTY_SCOPES = Set.of(TaskScope.ANY_HOUR, TaskScope.WORK_HOUR);;
+    private static final Set<TaskScope> OFF_DUTY_SCOPES = Set.of(TaskScope.ANY_HOUR, TaskScope.NONWORK_HOUR);
 	
     /**
      * Acts as a proxy to a SettlementTask. The proxy ensures that the root Task which is shared
@@ -32,7 +36,6 @@ public class SettlementTaskManager implements Serializable {
     class SettlementTaskProxy extends AbstractTaskJob  {
 
 		private static final long serialVersionUID = 1L;
-		
         private SettlementTask source;
         private SettlementTaskManager manager;
 
@@ -90,12 +93,21 @@ public class SettlementTaskManager implements Serializable {
     }
 
     /**
+     * Get the MetaTasks that can be used for these Settlement manager.
+     * By default this is the global list from MetaTaskUtil
+     * @return
+     */
+    protected List<SettlementMetaTask> getMetaTasks() {
+        return MetaTaskUtil.getSettlementMetaTasks();
+    }
+
+    /**
      * Gets the current cached Settlement Tasks. If there is no cache or marked as refresh then a list is created.
      */
     private List<SettlementTask> getTasks() {
         if (refreshTasks || (tasks == null)) {
             tasks = new ArrayList<>();
-            for(SettlementMetaTask mt : MetaTaskUtil.getSettlementMetaTasks()) {
+            for(SettlementMetaTask mt : getMetaTasks()) {
                 tasks.addAll(mt.getSettlementTasks(owner));
             }
             refreshTasks = false;
@@ -149,12 +161,21 @@ public class SettlementTaskManager implements Serializable {
      * @see SettlementMetaTask#assessPersonSuitability(SettlementTask, Person)
      */
     public List<TaskJob> getTasks(Person p) {
+        Set<TaskScope> acceptable = switch(p.getShiftSlot().getStatus()) {
+            case OFF_DUTY, ON_LEAVE -> OFF_DUTY_SCOPES;
+            case ON_CALL, ON_DUTY -> ON_DUTY_SCOPES;
+        };
+
         List<TaskJob> result = new ArrayList<>();
         for(SettlementTask st : getTasks()) {
-            SettlementMetaTask mt = st.getMeta();
-            RatingScore score = mt.assessPersonSuitability(st, p);
-            if (score.getScore() > 0) {
-                result.add(new SettlementTaskProxy(this, st, score));
+            // Check scope first to avoid scoring
+            var scope = st.getScope();
+            if (acceptable.contains(scope)) {
+                SettlementMetaTask mt = st.getMeta();
+                RatingScore score = mt.assessPersonSuitability(st, p);
+                if (score.getScore() > 0) {
+                    result.add(new SettlementTaskProxy(this, st, score));
+                }
             }
         }
         return result;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/SettlementTaskManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/SettlementTaskManager.java
@@ -25,7 +25,7 @@ import com.mars_sim.core.structure.Settlement;
 public class SettlementTaskManager implements Serializable {
 
 	private static final long serialVersionUID = 1L;
-    private static final Set<TaskScope> ON_DUTY_SCOPES = Set.of(TaskScope.ANY_HOUR, TaskScope.WORK_HOUR);;
+    private static final Set<TaskScope> ON_DUTY_SCOPES = Set.of(TaskScope.ANY_HOUR, TaskScope.WORK_HOUR);
     private static final Set<TaskScope> OFF_DUTY_SCOPES = Set.of(TaskScope.ANY_HOUR, TaskScope.NONWORK_HOUR);
 	
     /**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/GroupActivitySchedule.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/GroupActivitySchedule.java
@@ -1,0 +1,22 @@
+/*
+ * Mars Simulation Project
+ * GroupActivitySchedule.java
+ * @date 2024-03-24
+ * @author Barry Evans
+ */
+package com.mars_sim.core.structure;
+
+import java.util.List;
+import java.util.Map;
+
+import com.mars_sim.core.activities.GroupActivityInfo;
+
+/**
+ * Defines a scheduled for group activities
+ * @param name Name of the schedule
+ * @param minPop Optional minimum population
+ * @param specials The type based special GroupActivities
+ * @param meetings Regular repeating meetings
+ */
+public record GroupActivitySchedule(String name, int minPop, Map<GroupActivityType,GroupActivityInfo> specials, 
+                List<GroupActivityInfo> meetings) {}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/GroupActivityType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/GroupActivityType.java
@@ -1,0 +1,14 @@
+/*
+ * Mars Simulation Project
+ * GroupActivityType.java
+ * @date 2024-03-24
+ * @author Barry Evans
+ */
+package com.mars_sim.core.structure;
+
+/**
+ * Defines the types of special one off Group Activities that ca be created
+ */
+public enum GroupActivityType {
+    BIRTHDAY, FUNERAL, WELCOME, ANNOUNCEMENT;
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -544,8 +544,13 @@ public class Settlement extends Structure implements Temporal,
 		// Create the daily labor hours map
 		dailyLaborTime = new SolMetricDataLogger<>(MAX_NUM_SOLS);
 
-		// add a hardcode GroupActivity
-		new GroupActivity(GroupActivity.TEAM_MEETING, this, masterClock.getMarsTime());
+		// Create meetings
+		var meetings = sTemplate.getActivitySchedule();
+		if (meetings != null) {
+			for(var ga : meetings.meetings()) {
+				new GroupActivity(ga, this, masterClock.getMarsTime());
+			}
+		}
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -25,6 +25,7 @@ import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitEventType;
 import com.mars_sim.core.UnitType;
+import com.mars_sim.core.activities.GroupActivity;
 import com.mars_sim.core.air.AirComposition;
 import com.mars_sim.core.authority.Authority;
 import com.mars_sim.core.data.History;
@@ -226,7 +227,7 @@ public class Settlement extends Structure implements Temporal,
 	/** Numbers of vehicles owned by this settlement. */
 	private int numOwnedVehicles;
 	/** The composite value of the minerals nearby. */
-	public int mineralValue = -1;
+	private int mineralValue = -1;
 	/** The background map image id used by this settlement. */
 	private int mapImageID;
 	
@@ -235,7 +236,7 @@ public class Settlement extends Structure implements Temporal,
 	/** The average ice collection rate of the water ice nearby. */
 	private double iceCollectionRate = RandomUtil.getRandomDouble(0.2, 1);
 	/** The rate [kg per millisol] of filtering grey water for irrigating the crop. */
-	public double greyWaterFilteringRate = 1;
+	private double greyWaterFilteringRate = 1;
 	/** The currently minimum passing score for mission approval. */
 	private double minimumPassingScore = INITIAL_MISSION_PASSING_SCORE;
 	/** The settlement's current indoor temperature. */
@@ -243,9 +244,9 @@ public class Settlement extends Structure implements Temporal,
 	/** The settlement's current indoor pressure [in kPa], not Pascal. */
 	private double currentPressure = NORMAL_AIR_PRESSURE;
 	/** The settlement's current meal replenishment rate. */
-	public double mealsReplenishmentRate = 0.3;
+	private double mealsReplenishmentRate = 0.3;
 	/** The settlement's current dessert replenishment rate. */
-	public double dessertsReplenishmentRate = 0.4;
+	private double dessertsReplenishmentRate = 0.4;
 	/** The settlement's current probability value for ice. */
 	private double iceProbabilityValue = 400D;
 	/** The settlement's current probability value for regolith. */
@@ -256,7 +257,7 @@ public class Settlement extends Structure implements Temporal,
 	private double cropArea = -1;
 
 	/** The settlement terrain profile. */
-	public double[] terrainProfile = new double[2];
+	private double[] terrainProfile = new double[2];
 	/** The settlement template name. */
 	private String stormMsg;
 	/** The settlement template name. */
@@ -543,6 +544,8 @@ public class Settlement extends Structure implements Temporal,
 		// Create the daily labor hours map
 		dailyLaborTime = new SolMetricDataLogger<>(MAX_NUM_SOLS);
 
+		// TODO add a hardcode GroupActivity
+		new GroupActivity(GroupActivity.TEAM_MEETING, this, masterClock.getMarsTime());
 	}
 
 	/**
@@ -2997,32 +3000,6 @@ public class Settlement extends Structure implements Temporal,
 		range = Math.min(range, limit);
 		
 		Coordinates chosen = null;
-		
-		// Remove coordinates that have been explored or staked by other settlements
-		
-//		Set<Coordinates> surfaceFeaturesSet = surfaceFeatures.getDeclaredCoordinates(false);
-		
-		// Create a set
-//		Set<Coordinates> intersection = new HashSet<>(nearbyMineralLocations);
-		
-//		logger.info(this, "1. surfaceFeatures sets:" + surfaceFeaturesSet.size()
-//					+ "  nearbyMineralLocations sets:" + nearbyMineralLocations.size()
-//					+ "  intersection sets:" + intersection.size());
-
-		// Execute to create the union of the two sets
-//		intersection.retainAll(surfaceFeaturesSet);
-		
-//		logger.info(this, "2. surfaceFeatures sets:" + surfaceFeaturesSet.size()
-//					+ "  nearbyMineralLocations sets:" + nearbyMineralLocations.size()
-//					+ "  intersection sets:" + intersection.size());
-		
-		// Remove the union
-//		nearbyMineralLocations.removeAll(intersection);
-		
-//		logger.info(this, "3. surfaceFeatures sets:" + surfaceFeaturesSet.size()
-//					+ "  nearbyMineralLocations sets:" + nearbyMineralLocations.size()
-//					+ "  intersection sets:" + intersection.size());
-		
 		if (nearbyMineralLocations.isEmpty()) {
 			logger.info(this, "nearbyMineralLocations is empty.");
 			return null;
@@ -3084,10 +3061,6 @@ public class Settlement extends Structure implements Temporal,
 			el = surfaceFeatures.declareRegionOfInterest(siteLocation,
 					skill, this);
 		}
-
-//		if (el != null)
-//			// remove this coordinate from nearbyMineralLocations
-//			nearbyMineralLocations.remove(siteLocation);
 		
 		return el;
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -383,7 +383,7 @@ public class Settlement extends Structure implements Temporal,
 		creditManager = new CreditManager(this, unitManager);
 
 		// Mock use the default shifts
-		ShiftPattern shifts = settlementConfig.getShiftPattern(SettlementConfig.STANDARD_3_SHIFT);
+		ShiftPattern shifts = settlementConfig.getShiftByPopulation(10);
 		shiftManager = new ShiftManager(this, shifts,
 										masterClock.getMarsTime().getMillisolInt());
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -544,7 +544,7 @@ public class Settlement extends Structure implements Temporal,
 		// Create the daily labor hours map
 		dailyLaborTime = new SolMetricDataLogger<>(MAX_NUM_SOLS);
 
-		// TODO add a hardcode GroupActivity
+		// add a hardcode GroupActivity
 		new GroupActivity(GroupActivity.TEAM_MEETING, this, masterClock.getMarsTime());
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -3800,5 +3800,4 @@ public class Settlement extends Structure implements Temporal,
 		
 		scientificAchievement = null;
 	}
-
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementConfig.java
@@ -126,6 +126,7 @@ public class SettlementConfig extends UserConfigurableConfig<SettlementTemplate>
 	private static final String MEETING = "meeting";
 	private static final String ACTIVITY = "activity";
 	private static final String START_TIME = "startTime";
+	private static final String SCORE = "score";
 	private static final String DURATION = "duration";
 	private static final String WAIT_DURATION = "waitDuration";
 	private static final String SCOPE = "scope";
@@ -241,6 +242,7 @@ public class SettlementConfig extends UserConfigurableConfig<SettlementTemplate>
 		int startTime = ConfigHelper.getAttributeInt(ra, START_TIME);
 		int firstSol = ConfigHelper.getOptionalAttributeInt(ra, FIRST_SOL, 0);
 		int freq = ConfigHelper.getOptionalAttributeInt(ra, ACTIVITY_FREQ, -1);
+		int score = ConfigHelper.getOptionalAttributeInt(ra, SCORE, -1);
 		int wait = ConfigHelper.getAttributeInt(ra, WAIT_DURATION);
 		int duration = ConfigHelper.getAttributeInt(ra, DURATION);
 		double pop = ConfigHelper.getAttributeDouble(ra, POPULATION);
@@ -251,7 +253,7 @@ public class SettlementConfig extends UserConfigurableConfig<SettlementTemplate>
 			meetingPlace = ConfigHelper.getEnum(BuildingCategory.class, locationText);
 		}
 
-		return new GroupActivityInfo(name, startTime, firstSol, wait, duration, freq, pop, duration, scope, meetingPlace);
+		return new GroupActivityInfo(name, startTime, firstSol, wait, duration, freq, pop, score, scope, meetingPlace);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementTemplate.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementTemplate.java
@@ -56,16 +56,21 @@ public class SettlementTemplate implements Serializable, UserConfigurable, Settl
 
 	private ObjectiveType objective = ObjectiveType.CROP_FARM;
 
+	private GroupActivitySchedule activitySchedule;
+
 	/**
 	 * Constructor. Called by SettlementConfig.java
 	 * 
 	 * @param name
+	 * @param activitySchedule 
 	 * @param pattern
 	 * @param defaultPopulation
 	 * @param defaultNumOfRobots
 	 */
 	public SettlementTemplate(String name, String desription, boolean bundled,
-								String sponsor, ShiftPattern shiftDefn, int defaultPopulation, int defaultNumOfRobots) {
+								String sponsor, ShiftPattern shiftDefn,
+								GroupActivitySchedule activitySchedule,
+								int defaultPopulation, int defaultNumOfRobots) {
 		this.name = name;
 		this.description = desription;
 		this.bundled = bundled;
@@ -73,6 +78,7 @@ public class SettlementTemplate implements Serializable, UserConfigurable, Settl
 		this.defaultPopulation = defaultPopulation;
 		this.defaultNumOfRobots = defaultNumOfRobots;
 		this.shiftDefn = shiftDefn;
+		this.activitySchedule = activitySchedule;
 
 		buildings = new ArrayList<>();
 		vehicles = new HashMap<>();
@@ -130,6 +136,15 @@ public class SettlementTemplate implements Serializable, UserConfigurable, Settl
 		return shiftDefn;
 	}
 	
+	/**
+	 * Gets the Activity scheduled for this settlement.
+	 * 
+	 * @return ShiftPattern
+	 */
+	public GroupActivitySchedule getActivitySchedule() {
+		return activitySchedule;
+	}
+
 	/**
 	 * Gets the default robot capacity of the template.
 	 * 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/Building.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/Building.java
@@ -405,7 +405,6 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 		return earthReturn;
 	}
 
-
 	public FoodProduction getFoodProduction() {
 		if (foodFactory == null)
 			foodFactory = (FoodProduction) getFunction(FunctionType.FOOD_PRODUCTION);
@@ -598,7 +597,7 @@ public class Building extends Structure implements Malfunctionable, Indoor,
 
 		return null;
 	}
-	
+		
 	/**
 	 * Determines the building functions.
 	 *

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingCategory.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingCategory.java
@@ -15,6 +15,7 @@ public enum BuildingCategory {
     MEDICAL,
     ERV,
     FARMING, 
+    ASTRONOMY,
     LABORATORY, 
     LIVING,
     PROCESSING,

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingConfig.java
@@ -185,7 +185,7 @@ public class BuildingConfig {
 				}
 			}
 			
-			FunctionSpec fspec = new FunctionSpec(props, spots);
+			FunctionSpec fspec = new FunctionSpec(function, props, spots);
 
 			supportedFunctions.put(function, fspec);
 		}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingManager.java
@@ -452,7 +452,7 @@ public class BuildingManager implements Serializable {
 	 *                                  connections.
 	 */
 	public void addBuilding(BuildingTemplate template, boolean createBuildingConnections) {
-		addBuilding(new Building(template, this), template, createBuildingConnections);
+		addBuilding(Building.createBuilding(template, settlement), template, createBuildingConnections);
 	}
 
 	/**
@@ -3129,6 +3129,10 @@ public class BuildingManager implements Serializable {
 		unitManager = u;
 	}
 
+	static BuildingConfig getBuildingConfig() {
+		return simulationConfig.getBuildingConfiguration();
+	}
+	
 	/**
 	 * Reconstructs the building lists after loading from a saved sim.
 	 */

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingSpec.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/BuildingSpec.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import com.mars_sim.core.science.ScienceType;
 import com.mars_sim.core.structure.building.function.FunctionType;
+import com.mars_sim.mapdata.location.BoundedObject;
 import com.mars_sim.mapdata.location.LocalPosition;
 
 /**
@@ -289,4 +290,21 @@ public class BuildingSpec {
 	void setFlyerParking(Set<LocalPosition> droneParking) {
 		this.flyerParking = Collections.unmodifiableSet(droneParking);
 	}
+
+	/**
+	 * Combines a custom bounds definitino with what is validate for this building
+	 * @param bounds Request bounds
+	 * @return Combined valid bounds
+	 */
+    public BoundedObject getValidBounds(BoundedObject bounds) {
+		var newWidth = width;
+		if (newWidth < 0) {
+			newWidth = bounds.getWidth();
+		}
+		var newLength = length;
+		if (newLength < 0) {
+			newLength = bounds.getLength();
+		}
+        return new BoundedObject(bounds.getPosition(), newWidth, newLength, bounds.getFacing());
+    }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/FunctionSpec.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/FunctionSpec.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import com.mars_sim.core.structure.building.function.FunctionType;
 import com.mars_sim.mapdata.location.LocalPosition;
 
 /**
@@ -25,7 +26,7 @@ public class FunctionSpec {
 	// Name of the standard tech level property
 	private static final String TECH_LEVEL = "tech-level";
 
-	private BuildingSpec buildingSpec;
+	private FunctionType type;
 	private Map<String, Object> props;
 	private Set<NamedPosition> spots;
 
@@ -35,8 +36,9 @@ public class FunctionSpec {
 	 * @param props
 	 * @param spots
 	 */
-	public FunctionSpec(Map<String, Object> props, Set<NamedPosition> spots) {
+	public FunctionSpec(FunctionType type, Map<String, Object> props, Set<NamedPosition> spots) {
 		this.props = props;
+		this.type = type;
 		if (spots == null) {
 			this.spots = Collections.emptySet();
 		} else {
@@ -44,6 +46,10 @@ public class FunctionSpec {
 		}
 	}
 
+	public FunctionType getType() {
+		return type;
+	}
+	
 	public Set<NamedPosition> getActivitySpots() {
 		return spots;
 	}
@@ -140,23 +146,4 @@ public class FunctionSpec {
 		}
 		return Boolean.parseBoolean((String) value);
     }
-
-	/**
-	 * Sets the building specs instance.
-	 * 
-	 * @param spec
-	 */
-	public void setBuildingSpec(BuildingSpec spec) {
-		buildingSpec = spec;
-	}
-
-	/**
-	 * Gets the building specs instance.
-	 * 
-	 * @param spec
-	 */
-	public BuildingSpec getBuildingSpec() {
-		return buildingSpec;
-	}
-
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/FunctionType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/FunctionType.java
@@ -14,7 +14,7 @@ public enum FunctionType {
 
     ADMINISTRATION              (BuildingCategory.COMMAND, Msg.getString("FunctionType.administration")), //$NON-NLS=1$
 	ALGAE_FARMING				(BuildingCategory.FARMING, Msg.getString("FunctionType.algaeFarming")), //$NON-NLS-1$
-    ASTRONOMICAL_OBSERVATION	(BuildingCategory.LABORATORY, Msg.getString("FunctionType.astronomicalObservations")), //$NON-NLS-1$
+    ASTRONOMICAL_OBSERVATION	(BuildingCategory.ASTRONOMY, Msg.getString("FunctionType.astronomicalObservations")), //$NON-NLS-1$
 	BUILDING_CONNECTION			(BuildingCategory.HALLWAY, Msg.getString("FunctionType.buildingConnection")), //$NON-NLS-1$
 	COMMUNICATION				(BuildingCategory.COMMAND,Msg.getString("FunctionType.communication")), //$NON-NLS-1$
 	COMPUTATION					(BuildingCategory.LABORATORY, Msg.getString("FunctionType.computation")), //$NON-NLS-1$

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/MedicalCare.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/MedicalCare.java
@@ -49,10 +49,10 @@ public class MedicalCare extends Function implements MedicalAid {
 
 		int techLevel = spec.getTechLevel();
 		
-		Set<LocalPosition> bedSet = spec.getBuildingSpec().getBeds();
+		// THis is not good. all details should be in the FunctionSpec
+		Set<LocalPosition> bedSet = buildingConfig.getBuildingSpec(building.getBuildingType()).getBeds();
 
 		// NOTE: distinguish between activity spots and bed locations
-		
 		medicalStation = new MedicalStation(building.getName(), techLevel, bedSet.size());
 		
 		medicalStation.setSickBeds(bedSet);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/construction/ConstructionSite.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/construction/ConstructionSite.java
@@ -22,7 +22,6 @@ import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.Structure;
 import com.mars_sim.core.structure.building.Building;
-import com.mars_sim.core.structure.building.BuildingCategory;
 import com.mars_sim.core.structure.building.BuildingConfig;
 import com.mars_sim.core.structure.building.BuildingManager;
 import com.mars_sim.core.vehicle.GroundVehicle;
@@ -91,7 +90,7 @@ implements  LocalBoundedObject {
 
     private MissionPhase phase;
 
-    private BuildingConfig buildingConfig = SimulationConfig.instance().getBuildingConfiguration();
+    private static BuildingConfig buildingConfig = SimulationConfig.instance().getBuildingConfiguration();
     
     /**
      * Constructor.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/construction/ConstructionSite.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/construction/ConstructionSite.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.UnitType;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.person.ai.mission.ConstructionMission;
@@ -21,6 +22,8 @@ import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.Structure;
 import com.mars_sim.core.structure.building.Building;
+import com.mars_sim.core.structure.building.BuildingCategory;
+import com.mars_sim.core.structure.building.BuildingConfig;
 import com.mars_sim.core.structure.building.BuildingManager;
 import com.mars_sim.core.vehicle.GroundVehicle;
 import com.mars_sim.mapdata.location.BoundedObject;
@@ -87,6 +90,8 @@ implements  LocalBoundedObject {
     private ConstructionStageInfo stageInfo;
 
     private MissionPhase phase;
+
+    private BuildingConfig buildingConfig = SimulationConfig.instance().getBuildingConfiguration();
     
     /**
      * Constructor.
@@ -382,20 +387,19 @@ implements  LocalBoundedObject {
      * @return newly constructed building.
      * @throws Exception if error constructing building.
      */
-    public Building createBuilding(int settlementID) {
+    public Building createBuilding(Settlement settlement2) {
         if (buildingStage == null) throw new IllegalStateException("Building stage doesn't exist");
 
-        Settlement settlement = unitManager.getSettlementByID(settlementID);
         BuildingManager manager = settlement.getBuildingManager();
         int id = manager.getNextTemplateID();
         String buildingType = buildingStage.getInfo().getName();
         String uniqueName = manager.getUniqueName(buildingType);
         
         int zone = 0;
-        
-        Building newBuilding = new Building("" + id, zone, buildingType, uniqueName,
-        		new BoundedObject(position, width, length, facing),
-                settlement.getBuildingManager());
+        var spec = buildingConfig.getBuildingSpec(buildingType);
+
+        Building newBuilding = new Building(settlement, Integer.toString(id), zone, uniqueName,
+        		new BoundedObject(position, width, length, facing), spec);
         
         manager.addBuilding(newBuilding, true);
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/time/MarsTime.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/time/MarsTime.java
@@ -65,14 +65,14 @@ public class MarsTime implements Serializable {
 	/** Number of hours per millisol. */
 	public static final double HOURS_PER_MILLISOL = SECONDS_PER_MILLISOL / 3600;
 	
-	/** Number of millisols per minute. */
-	public static final double MILLISOLS_PER_SEC  = 1 / SECONDS_PER_MILLISOL;
-	/** Number of millisols per minute. */
+	/** Number of millisols per earth minute. */
 	public static final double MILLISOLS_PER_MINUTE  = 1 / MINUTES_PER_MILLISOL;
-	/** Number of millisols per hour. */
+	/** Number of millisols per earth hour. */
 	public static final double MILLISOLS_PER_HOUR  = 60 * MILLISOLS_PER_MINUTE;
-	/** Number of millisols per day. */	
-	public static final double MILLISOLS_PER_DAY = 24 * MILLISOLS_PER_HOUR;
+	/** Number of millisols per earth day. */	
+	public static final double MILLISOLS_PER_EARTHDAY = 24 * MILLISOLS_PER_HOUR;
+	/** Number of sols per earth day */
+	public static final double SOLS_PER_EARTHDAY = MILLISOLS_PER_EARTHDAY/1000D;
 
 	// Mars is near perihelion when it is summer in the southern hemisphere and
 	// winter in the north, and near aphelion when it is winter in the southern

--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -67,6 +67,8 @@ BiologyStudyFieldMissionCustomInfoPanel.leadResearcher            = Lead Researc
 BiologyStudyFieldMissionCustomInfoPanel.researchCompletion        = Study Research Completion:
 BiologyStudyFieldMissionCustomInfoPanel.tooltip.openInScienceTool = Open study in science tool.
 
+
+BuildingCategory.ASTRONOMY  = Astronomy
 BuildingCategory.COMMAND    = Command
 BuildingCategory.MEDICAL    = Medical
 BuildingCategory.ERV        = Earth Return

--- a/mars-sim-core/src/main/resources/xml/settlements.xml
+++ b/mars-sim-core/src/main/resources/xml/settlements.xml
@@ -61,6 +61,7 @@
 	<!ATTLIST activity startTime CDATA #REQUIRED>
 	<!ATTLIST activity frequency CDATA #IMPLIED>
 	<!ATTLIST activity firstSol CDATA #IMPLIED>
+	<!ATTLIST activity score CDATA #IMPLIED>
 	<!ATTLIST activity population CDATA #REQUIRED>
 	<!ATTLIST activity waitDuration CDATA #REQUIRED>
 	<!ATTLIST activity duration CDATA #REQUIRED>
@@ -171,17 +172,17 @@
 	<group-activities>
 		<activities>
 			<!-- 355 sols is the equivalent of 365 days-->
-			<activity name="Birthday Celebration" startTime="700" frequency="355"
+			<activity name="Birthday Celebration" startTime="700" frequency="355" score="200"
 						population="0.3" waitDuration="20" duration="100" scope="NONWORK_HOUR"/>
 			<!-- One off Announcement to base-->
-			<activity name="Announcement" startTime="400" 
+			<activity name="Announcement" startTime="400" score="600"
 						population="0.9" waitDuration="20" duration="100" scope="ANY_HOUR"/>
-
-			<activity name="Team Meeting" startTime="500" frequency="6"
+						
+			<activity name="Team Meeting" startTime="500" frequency="6" score="500"
 						population="0.7" waitDuration="20" duration="100" scope="ANY_HOUR"/>
-			<activity name="Movie Night" startTime="700" firstSol="4" frequency="20"
+			<activity name="Movie Night" startTime="700" firstSol="4" frequency="20" score="200"
 						population="0.3" waitDuration="20" duration="150" scope="NONWORK_HOUR"/>
-			<activity name="Safety Training" startTime="400" firstSol="7" frequency="20"
+			<activity name="Safety Training" startTime="400" firstSol="7" frequency="20" score="400"
 						population="0.3" waitDuration="20" duration="10" scope="WORK_HOUR"/>
 		</activities>
 

--- a/mars-sim-core/src/main/resources/xml/settlements.xml
+++ b/mars-sim-core/src/main/resources/xml/settlements.xml
@@ -1,7 +1,7 @@
 <?xml version = "1.0" encoding = "UTF-8" standalone = "yes" ?>
 <!DOCTYPE settlement-configuration [
 	<!ELEMENT settlement-configuration (mission-control, life-support-requirements,
-						essential-resources, shifts, settlement-template-list)>
+						essential-resources, shifts, activities, settlement-template-list)>
 
 	<!ELEMENT mission-control (rover-life-support-range-error-margin, rover-fuel-range-error-margin)>
 	<!ELEMENT rover-life-support-range-error-margin EMPTY>
@@ -51,6 +51,31 @@
 	<!ATTLIST shift start CDATA #REQUIRED>
 	<!ATTLIST shift end CDATA #REQUIRED>
 	<!ATTLIST shift pop-percentage CDATA #REQUIRED>
+
+	<!ELEMENT activities (activity-ruleset*)>
+	<!ELEMENT activity-ruleset (special-activity*, repeating-activity*)>
+	<!ATTLIST activity-ruleset name CDATA #REQUIRED>
+	<!ATTLIST activity-rulesetn minPopulation CDATA #IMPLIED>
+
+	<!ELEMENT special-activity EMPTY>
+	<!ATTLIST special-activity name CDATA #REQUIRED>
+	<!ATTLIST special-activity type CDATA #REQUIRED>
+	<!ATTLIST special-activity startTime CDATA #REQUIRED>
+	<!ATTLIST special-activity population CDATA #REQUIRED>
+	<!ATTLIST special-activity waitDuration CDATA #REQUIRED>
+	<!ATTLIST special-activity duration CDATA #REQUIRED>
+	<!ATTLIST special-activity scope CDATA #REQUIRED>
+	<!ATTLIST special-activity location CDATA #IMPLIED>
+
+	<!ELEMENT repeating-activity EMPTY>
+	<!ATTLIST repeating-activity name CDATA #REQUIRED>
+	<!ATTLIST repeating-activity startTime CDATA #REQUIRED>
+	<!ATTLIST repeating-activity frequency CDATA #REQUIRED>
+	<!ATTLIST repeating-activity population CDATA #REQUIRED>
+	<!ATTLIST repeating-activity waitDuration CDATA #REQUIRED>
+	<!ATTLIST repeating-activity duration CDATA #REQUIRED>
+	<!ATTLIST repeating-activity scope CDATA #REQUIRED>
+	<!ATTLIST repeating-activity location CDATA #IMPLIED>
 
 	<!ELEMENT settlement-template-list (template*)>
 	<!ELEMENT template EMPTY>
@@ -143,6 +168,28 @@
 			<shift name="Night" start="900" end="200" pop-percentage ="20"/>
 		</shift-pattern>
 	</shifts>
+
+	<!-- Activities are alway scheduled for LIVING by default-->
+	<activities>
+		<!-- Activities for a small settlement is just essential meetings -->
+		<activity-ruleset name="Small Settlement" minPopulation="6">
+			<repeating-activity name="Team Meeting" startTime="500" frequency="6"
+						population="0.7" waitDuration="20" duration="100"
+						scope="ANY_HOUR"/>
+		</activity-ruleset>
+
+		<!-- Activities for a large settlement include a social life and regular meetings-->
+		<activity-ruleset name="Large Settlement" minPopulation="15">
+			<special-activity type="BIRTHDAY" name="Birthday Celebration" startTime="700"
+						population="0.3" waitDuration="20" duration="100" scope="NONWORK_HOUR"/>
+			<repeating-activity name="Team Meeting" startTime="500" frequency="6"
+						population="0.7" waitDuration="20" duration="100" scope="ANY_HOUR"/>
+			<repeating-activity name="Movie Night" startTime="700" firstSol="4" frequency="20"
+						population="0.3" waitDuration="20" duration="150" scope="NONWORK_HOUR"/>
+			<repeating-activity name="Safety Training" startTime="400" firstSol="7" frequency="20"
+						population="0.3" waitDuration="20" duration="10" scope="WORK_HOUR"/>
+		</activity-ruleset>
+	</activities>
 
 	<settlement-template-list>
 		<!-- Settlement template for the Zubrin Mars Direct mission plan. -->

--- a/mars-sim-core/src/main/resources/xml/settlements.xml
+++ b/mars-sim-core/src/main/resources/xml/settlements.xml
@@ -52,10 +52,10 @@
 	<!ATTLIST shift end CDATA #REQUIRED>
 	<!ATTLIST shift pop-percentage CDATA #REQUIRED>
 
-	<!ELEMENT activities (activity-ruleset*)>
-	<!ELEMENT activity-ruleset (special-activity*, repeating-activity*)>
-	<!ATTLIST activity-ruleset name CDATA #REQUIRED>
-	<!ATTLIST activity-rulesetn minPopulation CDATA #IMPLIED>
+	<!ELEMENT activities (activity-schedule*)>
+	<!ELEMENT activity-schedule (special-activity*, repeating-activity*)>
+	<!ATTLIST activity-schedule name CDATA #REQUIRED>
+	<!ATTLIST activity-schedule minPopulation CDATA #IMPLIED>
 
 	<!ELEMENT special-activity EMPTY>
 	<!ATTLIST special-activity name CDATA #REQUIRED>
@@ -143,18 +143,18 @@
 	<!-- The Standard patterns are the default and but always be present. 
 		The others can be added/deleted -->
 	<shifts>
-		<shift-pattern name="Standard 4 Shift" rotation-sols="2">
+		<shift-pattern name="Standard 4 Shift" rotation-sols="2" minPopulation="36">
 			<shift name="A" start="0" end="250" pop-percentage ="30"/>
 			<shift name="B" start="250" end="500" pop-percentage ="30"/>
 			<shift name="C" start="500" end="750" pop-percentage ="30"/>
 			<shift name="Night" start="750" end="0" pop-percentage ="10"/>
 		</shift-pattern>
-		<shift-pattern name="Standard 3 Shift" rotation-sols="2">
+		<shift-pattern name="Standard 3 Shift" rotation-sols="2" minPopulation="24">
 			<shift name="A" start="200" end="550" pop-percentage ="40"/>
 			<shift name="B" start="550" end="900" pop-percentage ="40"/>
 			<shift name="Night" start="900" end="200" pop-percentage ="20"/>
 		</shift-pattern>
-		<shift-pattern name="Standard 2 Shift" leave-perc="3" rotation-sols="4">
+		<shift-pattern name="Standard 2 Shift" leave-perc="3" rotation-sols="4" minPopulation="1">
 			<shift name="Day" start="200" end="700" pop-percentage ="50"/>
 			<shift name="Night" start="700" end="200" pop-percentage ="50"/>
 		</shift-pattern>
@@ -162,7 +162,7 @@
 			<shift name="Day" start="500" end="930" pop-percentage ="90"/>
 			<shift name="Night" start="900" end="530" pop-percentage ="10"/>
 		</shift-pattern>
-		<shift-pattern name="Long 3 Shift" rotation-sols="4">
+		<shift-pattern name="Long 3 Shift" rotation-sols="4" minPopulation="12">
 			<shift name="A" start="200" end="600" pop-percentage ="40"/>
 			<shift name="B" start="500" end="900" pop-percentage ="40"/>
 			<shift name="Night" start="900" end="200" pop-percentage ="20"/>
@@ -172,14 +172,14 @@
 	<!-- Activities are alway scheduled for LIVING by default-->
 	<activities>
 		<!-- Activities for a small settlement is just essential meetings -->
-		<activity-ruleset name="Small Settlement" minPopulation="6">
+		<activity-schedule name="Small Settlement" minPopulation="6">
 			<repeating-activity name="Team Meeting" startTime="500" frequency="6"
 						population="0.7" waitDuration="20" duration="100"
 						scope="ANY_HOUR"/>
-		</activity-ruleset>
+		</activity-schedule>
 
 		<!-- Activities for a large settlement include a social life and regular meetings-->
-		<activity-ruleset name="Large Settlement" minPopulation="15">
+		<activity-schedule name="Large Settlement" minPopulation="15">
 			<special-activity type="BIRTHDAY" name="Birthday Celebration" startTime="700"
 						population="0.3" waitDuration="20" duration="100" scope="NONWORK_HOUR"/>
 			<repeating-activity name="Team Meeting" startTime="500" frequency="6"
@@ -188,7 +188,7 @@
 						population="0.3" waitDuration="20" duration="150" scope="NONWORK_HOUR"/>
 			<repeating-activity name="Safety Training" startTime="400" firstSol="7" frequency="20"
 						population="0.3" waitDuration="20" duration="10" scope="WORK_HOUR"/>
-		</activity-ruleset>
+		</activity-schedule>
 	</activities>
 
 	<settlement-template-list>

--- a/mars-sim-core/src/main/resources/xml/settlements.xml
+++ b/mars-sim-core/src/main/resources/xml/settlements.xml
@@ -174,10 +174,16 @@
 			<!-- 355 sols is the equivalent of 365 days-->
 			<activity name="Birthday Celebration" startTime="700" frequency="355" score="200"
 						population="0.3" waitDuration="20" duration="100" scope="NONWORK_HOUR"/>
+
 			<!-- One off Announcement to base-->
 			<activity name="Announcement" startTime="400" score="600"
 						population="0.9" waitDuration="20" duration="100" scope="ANY_HOUR"/>
-						
+
+			<!-- Sky watching party starts 2nd sol into Settlement and evey 10 sols-->
+			<activity name="Night Sky Party" startTime="850" firstSol="2" score="400" frequency="10"
+						population="0.2" waitDuration="80" duration="150" scope="NONWORK_HOUR"
+						location="ASTRONOMY"/>
+
 			<activity name="Team Meeting" startTime="500" frequency="6" score="500"
 						population="0.7" waitDuration="20" duration="100" scope="ANY_HOUR"/>
 			<activity name="Movie Night" startTime="700" firstSol="4" frequency="20" score="200"
@@ -199,6 +205,9 @@
 			<meeting name="Team Meeting"/>
 			<meeting name="Movie Night"/>
 			<meeting name="Safety Training"/>
+
+			<!-- This needs an obseratory but will be cancelled when one not available-->
+			<meeting name="Night Sky Party"/>
 		</schedule>
 	</group-activities>
 

--- a/mars-sim-core/src/main/resources/xml/settlements.xml
+++ b/mars-sim-core/src/main/resources/xml/settlements.xml
@@ -1,7 +1,7 @@
 <?xml version = "1.0" encoding = "UTF-8" standalone = "yes" ?>
 <!DOCTYPE settlement-configuration [
 	<!ELEMENT settlement-configuration (mission-control, life-support-requirements,
-						essential-resources, shifts, activities, settlement-template-list)>
+						essential-resources, shifts, group-activities, settlement-template-list)>
 
 	<!ELEMENT mission-control (rover-life-support-range-error-margin, rover-fuel-range-error-margin)>
 	<!ELEMENT rover-life-support-range-error-margin EMPTY>
@@ -52,30 +52,28 @@
 	<!ATTLIST shift end CDATA #REQUIRED>
 	<!ATTLIST shift pop-percentage CDATA #REQUIRED>
 
-	<!ELEMENT activities (activity-schedule*)>
-	<!ELEMENT activity-schedule (special-activity*, repeating-activity*)>
-	<!ATTLIST activity-schedule name CDATA #REQUIRED>
-	<!ATTLIST activity-schedule minPopulation CDATA #IMPLIED>
+	<!ELEMENT grouo-activities (activities, schedule*)>
 
-	<!ELEMENT special-activity EMPTY>
-	<!ATTLIST special-activity name CDATA #REQUIRED>
-	<!ATTLIST special-activity type CDATA #REQUIRED>
-	<!ATTLIST special-activity startTime CDATA #REQUIRED>
-	<!ATTLIST special-activity population CDATA #REQUIRED>
-	<!ATTLIST special-activity waitDuration CDATA #REQUIRED>
-	<!ATTLIST special-activity duration CDATA #REQUIRED>
-	<!ATTLIST special-activity scope CDATA #REQUIRED>
-	<!ATTLIST special-activity location CDATA #IMPLIED>
+	<!ELEMENT activities (activity*)>
+	<!ELEMENT activity EMPTY>
+	<!ATTLIST activity name CDATA #REQUIRED>
+	<!ATTLIST activity type CDATA #IMPLIED>
+	<!ATTLIST activity startTime CDATA #REQUIRED>
+	<!ATTLIST activity frequency CDATA #IMPLIED>
+	<!ATTLIST activity firstSol CDATA #IMPLIED>
+	<!ATTLIST activity population CDATA #REQUIRED>
+	<!ATTLIST activity waitDuration CDATA #REQUIRED>
+	<!ATTLIST activity duration CDATA #REQUIRED>
+	<!ATTLIST activity scope CDATA #REQUIRED>
+	<!ATTLIST activity location CDATA #IMPLIED>
+	
+	<!ELEMENT schedule (meeting*)>
+	<!ATTLIST schedule name CDATA #REQUIRED>
+	<!ATTLIST schedule minPopulation CDATA #IMPLIED>
 
-	<!ELEMENT repeating-activity EMPTY>
-	<!ATTLIST repeating-activity name CDATA #REQUIRED>
-	<!ATTLIST repeating-activity startTime CDATA #REQUIRED>
-	<!ATTLIST repeating-activity frequency CDATA #REQUIRED>
-	<!ATTLIST repeating-activity population CDATA #REQUIRED>
-	<!ATTLIST repeating-activity waitDuration CDATA #REQUIRED>
-	<!ATTLIST repeating-activity duration CDATA #REQUIRED>
-	<!ATTLIST repeating-activity scope CDATA #REQUIRED>
-	<!ATTLIST repeating-activity location CDATA #IMPLIED>
+	<!ELEMENT meeting EMPTY>
+	<!ATTLIST meeting name CDATA #REQUIRED>
+	<!ATTLIST meeting type CDATA #IMPLIED>
 
 	<!ELEMENT settlement-template-list (template*)>
 	<!ELEMENT template EMPTY>
@@ -170,26 +168,38 @@
 	</shifts>
 
 	<!-- Activities are alway scheduled for LIVING by default-->
-	<activities>
+	<group-activities>
+		<activities>
+			<!-- 355 sols is the equivalent of 365 days-->
+			<activity name="Birthday Celebration" startTime="700" frequency="355"
+						population="0.3" waitDuration="20" duration="100" scope="NONWORK_HOUR"/>
+			<!-- One off Announcement to base-->
+			<activity name="Announcement" startTime="400" 
+						population="0.9" waitDuration="20" duration="100" scope="ANY_HOUR"/>
+
+			<activity name="Team Meeting" startTime="500" frequency="6"
+						population="0.7" waitDuration="20" duration="100" scope="ANY_HOUR"/>
+			<activity name="Movie Night" startTime="700" firstSol="4" frequency="20"
+						population="0.3" waitDuration="20" duration="150" scope="NONWORK_HOUR"/>
+			<activity name="Safety Training" startTime="400" firstSol="7" frequency="20"
+						population="0.3" waitDuration="20" duration="10" scope="WORK_HOUR"/>
+		</activities>
+
 		<!-- Activities for a small settlement is just essential meetings -->
-		<activity-schedule name="Small Settlement" minPopulation="6">
-			<repeating-activity name="Team Meeting" startTime="500" frequency="6"
-						population="0.7" waitDuration="20" duration="100"
-						scope="ANY_HOUR"/>
-		</activity-schedule>
+		<schedule name="Small Settlement" minPopulation="6">
+			<rmeeting name="Team Meeting"/>
+		</schedule>
 
 		<!-- Activities for a large settlement include a social life and regular meetings-->
-		<activity-schedule name="Large Settlement" minPopulation="15">
-			<special-activity type="BIRTHDAY" name="Birthday Celebration" startTime="700"
-						population="0.3" waitDuration="20" duration="100" scope="NONWORK_HOUR"/>
-			<repeating-activity name="Team Meeting" startTime="500" frequency="6"
-						population="0.7" waitDuration="20" duration="100" scope="ANY_HOUR"/>
-			<repeating-activity name="Movie Night" startTime="700" firstSol="4" frequency="20"
-						population="0.3" waitDuration="20" duration="150" scope="NONWORK_HOUR"/>
-			<repeating-activity name="Safety Training" startTime="400" firstSol="7" frequency="20"
-						population="0.3" waitDuration="20" duration="10" scope="WORK_HOUR"/>
-		</activity-schedule>
-	</activities>
+		<schedule name="Large Settlement" minPopulation="15">
+			<meeting type="BIRTHDAY" name="Birthday Celebration"/>
+			<meeting type="Announcement" name="Announcement"/>
+
+			<meeting name="Team Meeting"/>
+			<meeting name="Movie Night"/>
+			<meeting name="Safety Training"/>
+		</schedule>
+	</group-activities>
 
 	<settlement-template-list>
 		<!-- Settlement template for the Zubrin Mars Direct mission plan. -->

--- a/mars-sim-core/src/test/java/com/mars_sim/core/AbstractMarsSimUnitTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/AbstractMarsSimUnitTest.java
@@ -225,4 +225,23 @@ public abstract class AbstractMarsSimUnitTest extends TestCase {
 		sim.getMasterClock().setMarsTime(marsTime);
         return new ClockPulse(pulseID++, 1D, marsTime, null, newSol, newHalfSol, true);
     }
+
+	/**
+	 * Better Assert method 
+	 */
+	public static void assertGreaterThan(String message, int minValue, int actual) {
+		if (actual < minValue) {
+			fail(message + " ==> " +
+					"Expected: a value greater than <" + minValue + ">\n" +
+					"Actual was <" + actual + ">");
+		}
+	}
+
+	public static void assertLessThan(String message, int maxValue, int actual) {
+		if (actual > maxValue) {
+			fail(message + " ==> " +
+					"Expected: a value less than <" + maxValue + ">\n" +
+					"Actual was <" + actual + ">");
+		}
+	}
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/AbstractMarsSimUnitTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/AbstractMarsSimUnitTest.java
@@ -229,7 +229,7 @@ public abstract class AbstractMarsSimUnitTest extends TestCase {
 	/**
 	 * Better Assert method 
 	 */
-	public static void assertGreaterThan(String message, int minValue, int actual) {
+	public static void assertGreaterThan(String message, double minValue, double actual) {
 		if (actual < minValue) {
 			fail(message + " ==> " +
 					"Expected: a value greater than <" + minValue + ">\n" +

--- a/mars-sim-core/src/test/java/com/mars_sim/core/TestLocalAreaUtil.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/TestLocalAreaUtil.java
@@ -6,8 +6,10 @@ import org.junit.Before;
 
 import com.mars_sim.core.structure.MockSettlement;
 import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.core.structure.building.BuildingCategory;
 import com.mars_sim.core.structure.building.MockBuilding;
 import com.mars_sim.core.structure.building.function.Function;
+import com.mars_sim.mapdata.location.BoundedObject;
 import com.mars_sim.mapdata.location.LocalPosition;
 
 import junit.framework.TestCase;
@@ -235,11 +237,8 @@ public class TestLocalAreaUtil extends TestCase {
         
         Settlement settlement = new MockSettlement();
  
-        MockBuilding mb0 = new MockBuilding(settlement.getBuildingManager(), "Mock B0");
-        mb0.setWidth(10D);
-        mb0.setLength(10D);
-        mb0.setLocation(0D, 0D);
-        mb0.setFacing(0D);
+        var bounds = new BoundedObject(0D, 0D, 10, 10, 0);
+        MockBuilding mb0 = new MockBuilding(settlement, "Mock B0", 1, bounds, "Mock", BuildingCategory.COMMAND);
         
         assertTrue(LocalAreaUtil.isPositionWithinLocalBoundedObject(new LocalPosition(0D, 0D), mb0));
         assertTrue(LocalAreaUtil.isPositionWithinLocalBoundedObject(new LocalPosition(4.99D, 4.99D), mb0));
@@ -261,8 +260,9 @@ public class TestLocalAreaUtil extends TestCase {
         assertFalse(LocalAreaUtil.isPositionWithinLocalBoundedObject(new LocalPosition(0D, -5.01D), mb0));
         
         // Rotate building 45 degrees.
-        mb0.setFacing(45D);
-        
+        bounds = new BoundedObject(0D, 0D, 10, 10, 45D);
+        mb0 = new MockBuilding(settlement, "Mock B0", 1, bounds, "Mock", BuildingCategory.COMMAND);
+                
         assertTrue(LocalAreaUtil.isPositionWithinLocalBoundedObject(new LocalPosition(0D, 0D), mb0));
         assertFalse(LocalAreaUtil.isPositionWithinLocalBoundedObject(new LocalPosition(4.99D, 4.99D), mb0));
         assertFalse(LocalAreaUtil.isPositionWithinLocalBoundedObject(new LocalPosition(-4.99D, 4.99D), mb0));

--- a/mars-sim-core/src/test/java/com/mars_sim/core/VersionTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/VersionTest.java
@@ -9,14 +9,14 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
-public class VersionTest {
+class VersionTest {
     @Test
     void testSaveAndReload() throws IOException {
         Version orig = new Version("A", "B", true);
         byte[] content;
         try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
             orig.store(output);
-            output.close();;
+            output.close();
             content = output.toByteArray();
         }
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityMetaTaskTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityMetaTaskTest.java
@@ -68,13 +68,14 @@ public class GroupActivityMetaTaskTest extends AbstractMarsSimUnitTest{
         var s = buildSettlement();
         buildAccommodation(s.getBuildingManager(), LocalPosition.DEFAULT_POSITION, BUILDING_LENGTH, 0);
 
-        // Create a friendship group
+        // Create a friendship group where friend has a better opniino of the instigator thn the enemy
         var i = buildPerson("instigator", s);
-        var f = buildPerson("friend", s);
-        RelationshipUtil.changeOpinion(f, i, RelationshipType.FACE_TO_FACE_COMMUNICATION, 2D);
-
         var e = buildPerson("enermy", s);
-        RelationshipUtil.changeOpinion(e, i, RelationshipType.FACE_TO_FACE_COMMUNICATION, -2D);
+        RelationshipUtil.changeOpinion(e, i, RelationshipType.FACE_TO_FACE_COMMUNICATION, 1D);
+        var eOpinion = e.getRelation().getOpinion(i).getAverage();
+        var f = buildPerson("friend", s);
+        RelationshipUtil.changeOpinion(f, i, RelationshipType.FACE_TO_FACE_COMMUNICATION, eOpinion + 10D);
+
         assertGreaterThan("Friend is more popular than enermy",
                                     e.getRelation().getOpinion(i).getAverage(),
                                     f.getRelation().getOpinion(i).getAverage());

--- a/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityMetaTaskTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityMetaTaskTest.java
@@ -2,6 +2,7 @@ package com.mars_sim.core.activities;
 
 
 import com.mars_sim.core.AbstractMarsSimUnitTest;
+import com.mars_sim.core.person.ai.social.Relation;
 import com.mars_sim.core.person.ai.social.RelationshipType;
 import com.mars_sim.core.person.ai.social.RelationshipUtil;
 import com.mars_sim.core.person.ai.task.util.MetaTask.TaskScope;
@@ -74,7 +75,8 @@ public class GroupActivityMetaTaskTest extends AbstractMarsSimUnitTest{
         RelationshipUtil.changeOpinion(e, i, RelationshipType.FACE_TO_FACE_COMMUNICATION, 1D);
         var eOpinion = e.getRelation().getOpinion(i).getAverage();
         var f = buildPerson("friend", s);
-        RelationshipUtil.changeOpinion(f, i, RelationshipType.FACE_TO_FACE_COMMUNICATION, eOpinion + 10D);
+        RelationshipUtil.changeOpinion(f, i, RelationshipType.FACE_TO_FACE_COMMUNICATION, eOpinion
+                                                                + Relation.MAX_OPINION);
 
         assertGreaterThan("Friend is more popular than enermy",
                                     e.getRelation().getOpinion(i).getAverage(),

--- a/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityMetaTaskTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityMetaTaskTest.java
@@ -1,0 +1,57 @@
+package com.mars_sim.core.activities;
+
+
+import com.mars_sim.core.AbstractMarsSimUnitTest;
+import com.mars_sim.core.structure.building.BuildingCategory;
+import com.mars_sim.core.time.MarsTime;
+import com.mars_sim.mapdata.location.LocalPosition;
+
+public class GroupActivityMetaTaskTest extends AbstractMarsSimUnitTest{
+
+    private final static GroupActivityInfo ONE = new GroupActivityInfo("One", 800, 10, 50, 0, 1D, 100, BuildingCategory.LIVING);
+
+    public void testGetSettlementTasks() {
+        var s = buildSettlement();
+        buildPerson("P1", s);
+        buildPerson("P2", s);
+
+        buildAccommodation(s.getBuildingManager(), LocalPosition.DEFAULT_POSITION, BUILDING_LENGTH, 0);
+
+        var t = new MarsTime(1, 1, 1, 0, 1);
+        var ga = new GroupActivity(ONE, s, t);
+
+        // Find a meeting as the test case
+        var events = s.getFutureManager().getEvents().stream()
+                        .filter(e -> e.getHandler() instanceof GroupActivity)
+                        .toList();
+        assertFalse("Group Activity found", events.isEmpty());
+
+        var selected = events.get(0);
+        assertEquals("Future event is correct activity", ga, selected.getHandler());
+
+        var mt = new GroupActivityMetaTask();
+
+        var tasks = mt.getSettlementTasks(s);
+        assertTrue("No initial tasks is empty", tasks.isEmpty());
+
+        // Advance activity to pending
+        var time = selected.getWhen();
+        ga.execute(time);
+        tasks = mt.getSettlementTasks(s);
+        assertEquals("One task for Pending state", 1, tasks.size());
+        assertEquals("Demand Pending state", (int)(s.getNumCitizens() * ONE.percentagePop()), tasks.get(0).getDemand());
+        
+        // Advance activity to active
+        time = time.addTime(ga.getDefinition().waitDuration());
+        ga.execute(time);
+        tasks = mt.getSettlementTasks(s);
+        assertEquals("One task for Active state", 1, tasks.size());
+        assertEquals("Demand Active state", (int)(s.getNumCitizens() * ONE.percentagePop()), tasks.get(0).getDemand());
+
+        // Advance activity to end
+        time = time.addTime(ga.getDefinition().activityDuration());
+        ga.execute(time);
+        tasks = mt.getSettlementTasks(s);
+        assertTrue("No tasks after activity complete", tasks.isEmpty());
+    }
+}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityMetaTaskTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityMetaTaskTest.java
@@ -2,13 +2,15 @@ package com.mars_sim.core.activities;
 
 
 import com.mars_sim.core.AbstractMarsSimUnitTest;
+import com.mars_sim.core.person.ai.task.util.MetaTask.TaskScope;
 import com.mars_sim.core.structure.building.BuildingCategory;
 import com.mars_sim.core.time.MarsTime;
 import com.mars_sim.mapdata.location.LocalPosition;
 
 public class GroupActivityMetaTaskTest extends AbstractMarsSimUnitTest{
 
-    private final static GroupActivityInfo ONE = new GroupActivityInfo("One", 800, 10, 50, 0, 1D, 100, BuildingCategory.LIVING);
+    private final static GroupActivityInfo ONE = new GroupActivityInfo("One", 800, 10, 50, 0, 1D, 100,
+                        TaskScope.NONWORK_HOUR, BuildingCategory.LIVING);
 
     public void testGetSettlementTasks() {
         var s = buildSettlement();
@@ -41,6 +43,10 @@ public class GroupActivityMetaTaskTest extends AbstractMarsSimUnitTest{
         assertEquals("One task for Pending state", 1, tasks.size());
         assertEquals("Demand Pending state", (int)(s.getNumCitizens() * ONE.percentagePop()), tasks.get(0).getDemand());
         
+        // Check tasks are for Any hour
+        var anyHour = tasks.stream().filter(h -> h.getScope() == ONE.scope()).toList();
+        assertEquals("All Task are Any Hour", tasks.size(), anyHour.size());
+
         // Advance activity to active
         time = time.addTime(ga.getDefinition().waitDuration());
         ga.execute(time);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityMetaTaskTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityMetaTaskTest.java
@@ -9,7 +9,7 @@ import com.mars_sim.mapdata.location.LocalPosition;
 
 public class GroupActivityMetaTaskTest extends AbstractMarsSimUnitTest{
 
-    private final static GroupActivityInfo ONE = new GroupActivityInfo("One", 800, 10, 50, 0, 1D, 100,
+    private final static GroupActivityInfo ONE = new GroupActivityInfo("One", 800, 0, 10, 50, 0, 1D, 100,
                         TaskScope.NONWORK_HOUR, BuildingCategory.LIVING);
 
     public void testGetSettlementTasks() {

--- a/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityTest.java
@@ -7,6 +7,7 @@ import com.mars_sim.core.AbstractMarsSimUnitTest;
 import com.mars_sim.core.activities.GroupActivity.ActivityState;
 import com.mars_sim.core.environment.MarsSurface;
 import com.mars_sim.core.events.ScheduledEventManager.ScheduledEvent;
+import com.mars_sim.core.person.ai.task.util.MetaTask.TaskScope;
 import com.mars_sim.core.structure.building.Building;
 import com.mars_sim.core.structure.building.BuildingCategory;
 import com.mars_sim.core.time.MarsTime;
@@ -15,8 +16,10 @@ import com.mars_sim.mapdata.location.LocalPosition;
 
 public class GroupActivityTest extends AbstractMarsSimUnitTest {
 
-    private final static GroupActivityInfo REPEATING = new GroupActivityInfo("Repeat", 250, 10, 50, 2, 0.5D, 100, BuildingCategory.LIVING);
-    private final static GroupActivityInfo ONE = new GroupActivityInfo("One", 800, 10, 50, 0, 0.5D, 100, BuildingCategory.LIVING);
+    private final static GroupActivityInfo REPEATING = new GroupActivityInfo("Repeat", 250, 10, 50, 2, 0.5D, 100,
+                                                            TaskScope.ANY_HOUR, BuildingCategory.LIVING);
+    private final static GroupActivityInfo ONE = new GroupActivityInfo("One", 800, 10, 50, 0, 0.5D, 100,
+                                                            TaskScope.NONWORK_HOUR, BuildingCategory.LIVING);
 
     public void testOneOffCycle() {
         var s = buildSettlement();
@@ -28,7 +31,7 @@ public class GroupActivityTest extends AbstractMarsSimUnitTest {
         assertEquals("Scheduled actvity", ActivityState.SCHEDULED, ga.getState());
 
         // Advance to pending
-        t = t.addTime(ONE.scheduledStart());
+        t = t.addTime(ONE.startTime());
         int advance = ga.execute(t);
         assertEquals("Pending actvity", ActivityState.PENDING, ga.getState());
         assertEquals("Wait duration", ONE.waitDuration(), advance);
@@ -60,7 +63,7 @@ public class GroupActivityTest extends AbstractMarsSimUnitTest {
         var ga = new GroupActivity(REPEATING, s, t);
 
         // Advance to pending
-        t = t.addTime(REPEATING.scheduledStart());
+        t = t.addTime(REPEATING.startTime());
         int advance = ga.execute(t);
         assertEquals("Pending actvity", ActivityState.PENDING, ga.getState());
         assertEquals("Wait duration", REPEATING.waitDuration(), advance);
@@ -103,7 +106,7 @@ public class GroupActivityTest extends AbstractMarsSimUnitTest {
                                     .toList();
         assertEquals("Expected events - " + message, 1, matched.size());
         var event = matched.get(0);
-        assertEquals("Scheduled start of event - "+ message, (info.scheduledStart() + offset) % 1000,
+        assertEquals("Scheduled start of event - "+ message, (info.startTime() + offset) % 1000,
                                 event.getWhen().getMillisolInt());
         double toEvent = event.getWhen().getTimeDiff(t);
         assertTrue("Scheduled start in future - " + message, toEvent >= 0D);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityTest.java
@@ -1,0 +1,112 @@
+package com.mars_sim.core.activities;
+
+
+import java.util.List;
+
+import com.mars_sim.core.AbstractMarsSimUnitTest;
+import com.mars_sim.core.activities.GroupActivity.ActivityState;
+import com.mars_sim.core.environment.MarsSurface;
+import com.mars_sim.core.events.ScheduledEventManager.ScheduledEvent;
+import com.mars_sim.core.structure.building.Building;
+import com.mars_sim.core.structure.building.BuildingCategory;
+import com.mars_sim.core.time.MarsTime;
+import com.mars_sim.mapdata.location.Coordinates;
+import com.mars_sim.mapdata.location.LocalPosition;
+
+public class GroupActivityTest extends AbstractMarsSimUnitTest {
+
+    private final static GroupActivityInfo REPEATING = new GroupActivityInfo("Repeat", 250, 10, 50, 2, 0.5D, 100, BuildingCategory.LIVING);
+    private final static GroupActivityInfo ONE = new GroupActivityInfo("One", 800, 10, 50, 0, 0.5D, 100, BuildingCategory.LIVING);
+
+    public void testOneOffCycle() {
+        var s = buildSettlement();
+        buildAccommodation(s.getBuildingManager(), LocalPosition.DEFAULT_POSITION, BUILDING_LENGTH, 0);
+
+        var t = new MarsTime(1, 1, 1, 0, 1);
+
+        var ga = new GroupActivity(ONE, s, t);
+        assertEquals("Scheduled actvity", ActivityState.SCHEDULED, ga.getState());
+
+        // Advance to pending
+        t = t.addTime(ONE.scheduledStart());
+        int advance = ga.execute(t);
+        assertEquals("Pending actvity", ActivityState.PENDING, ga.getState());
+        assertEquals("Wait duration", ONE.waitDuration(), advance);
+        Building meeting = ga.getMeetingPlace();
+        assertNotNull("Allocated meeting place", meeting);
+        assertEquals("Selected meeting place", ONE.place(), meeting.getCategory());
+
+        // Advance to active
+        t = t.addTime(ONE.waitDuration());
+        advance = ga.execute(t);
+        assertEquals("Active actvity", ActivityState.ACTIVE, ga.getState());
+        assertEquals("Active duration", ONE.activityDuration(), advance);
+
+        // Advance to end
+        t = t.addTime(ONE.activityDuration());
+        advance = ga.execute(t);
+        assertEquals("Active actvity", ActivityState.DONE, ga.getState());
+        assertEquals("Activity no event", -1, advance);
+        meeting = ga.getMeetingPlace();
+        assertNull("Released meeting place", meeting);
+    }
+
+    public void testRepeatCycle() {
+        var s = buildSettlement();
+        buildAccommodation(s.getBuildingManager(), LocalPosition.DEFAULT_POSITION, BUILDING_LENGTH, 0);
+
+        var t = new MarsTime(1, 1, 1, 0, 1);
+
+        var ga = new GroupActivity(REPEATING, s, t);
+
+        // Advance to pending
+        t = t.addTime(REPEATING.scheduledStart());
+        int advance = ga.execute(t);
+        assertEquals("Pending actvity", ActivityState.PENDING, ga.getState());
+        assertEquals("Wait duration", REPEATING.waitDuration(), advance);
+
+        // Advance to active
+        t = t.addTime(REPEATING.waitDuration());
+        advance = ga.execute(t);
+        assertEquals("Active actvity", ActivityState.ACTIVE, ga.getState());
+        assertEquals("Active duration", REPEATING.activityDuration(), advance);
+
+        // Advance to end
+        t = t.addTime(REPEATING.activityDuration());
+        advance = ga.execute(t);
+        assertEquals("Active actvity", ActivityState.SCHEDULED, ga.getState());
+        assertEquals("Activity no event", REPEATING.solFrequency() * 1000, advance);
+        assertNull("Released meeting place", ga.getMeetingPlace());
+    }
+
+    public void testInitialEvent() {
+        // Simplest first with zero time and no offset
+        var t = new MarsTime(1, 1, 1, 0, 1);
+        testStartEvent("Standard @ 0", ONE, t, new Coordinates("0.0 N", "0.0 E"));
+
+        t = new MarsTime(1, 1, 1, 500, 1);
+        testStartEvent("Standard @ 500", ONE, t, new Coordinates("0.0 N", "0.0 E"));
+        testStartEvent("Quarter @ 500", ONE, t, new Coordinates("0.0 N", "90.0 E"));
+        testStartEvent("Thirds @ 500", ONE, t, new Coordinates("0.0 N", "270.0 E"));
+
+    }
+
+    private void testStartEvent(String message, GroupActivityInfo info, MarsTime t, Coordinates locn) {
+        var s = buildSettlement();
+        s.setCoordinates(locn); // THis will mov ethe local timezine by 250
+        var offset = MarsSurface.getTimeOffset(locn);
+
+        new GroupActivity(info, s, t);
+        var fm = s.getFutureManager();
+        List<ScheduledEvent> matched = fm.getEvents().stream()
+                                    .filter(ev -> ev.getHandler() instanceof GroupActivity)
+                                    .toList();
+        assertEquals("Expected events - " + message, 1, matched.size());
+        var event = matched.get(0);
+        assertEquals("Scheduled start of event - "+ message, (info.scheduledStart() + offset) % 1000,
+                                event.getWhen().getMillisolInt());
+        double toEvent = event.getWhen().getTimeDiff(t);
+        assertTrue("Scheduled start in future - " + message, toEvent >= 0D);
+        assertTrue("Scheduled start within 1 sol - " + message, toEvent < 1000D);
+    }
+}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityTest.java
@@ -16,9 +16,9 @@ import com.mars_sim.mapdata.location.LocalPosition;
 
 public class GroupActivityTest extends AbstractMarsSimUnitTest {
 
-    private final static GroupActivityInfo REPEATING = new GroupActivityInfo("Repeat", 250, 10, 50, 2, 0.5D, 100,
+    private final static GroupActivityInfo REPEATING = new GroupActivityInfo("Repeat", 250, 0, 10, 50, 2, 0.5D, 100,
                                                             TaskScope.ANY_HOUR, BuildingCategory.LIVING);
-    private final static GroupActivityInfo ONE = new GroupActivityInfo("One", 800, 10, 50, 0, 0.5D, 100,
+    private final static GroupActivityInfo ONE = new GroupActivityInfo("One", 800, 1, 10, 50, 0, 0.5D, 100,
                                                             TaskScope.NONWORK_HOUR, BuildingCategory.LIVING);
 
     public void testOneOffCycle() {
@@ -29,6 +29,7 @@ public class GroupActivityTest extends AbstractMarsSimUnitTest {
 
         var ga = new GroupActivity(ONE, s, t);
         assertEquals("Scheduled actvity", ActivityState.SCHEDULED, ga.getState());
+        assertEquals("First meeting", t.addTime(ONE.startTime() + (1000 * ONE.firstSol())), ga.getStartTime());
 
         // Advance to pending
         t = t.addTime(ONE.startTime());
@@ -110,6 +111,7 @@ public class GroupActivityTest extends AbstractMarsSimUnitTest {
                                 event.getWhen().getMillisolInt());
         double toEvent = event.getWhen().getTimeDiff(t);
         assertTrue("Scheduled start in future - " + message, toEvent >= 0D);
-        assertTrue("Scheduled start within 1 sol - " + message, toEvent < 1000D);
+        assertTrue("Scheduled start within target sols - " + message, toEvent <
+                                                ((info.firstSol() + 1) * 1000D));
     }
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/WalkInteriorTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/WalkInteriorTest.java
@@ -36,7 +36,7 @@ public class WalkInteriorTest extends AbstractMarsSimUnitTest {
         Settlement settlement = buildSettlement();
         BuildingManager buildingManager = settlement.getBuildingManager();
 
-        Building b1 = buildEVA(buildingManager, LocalPosition.DEFAULT_POSITION, 0D, 0);
+        Building b1 = buildAccommodation(buildingManager, LocalPosition.DEFAULT_POSITION, 0D, 0);
 
 		Person person = buildPerson("Walker", settlement);
 		person.setPosition(LocalPosition.DEFAULT_POSITION);
@@ -64,7 +64,7 @@ public class WalkInteriorTest extends AbstractMarsSimUnitTest {
         BuildingConnectorManager connectorManager = settlement.getBuildingConnectorManager();
 
 
-        Building b1 = buildEVA(buildingManager, LocalPosition.DEFAULT_POSITION, 0D, 0);
+        Building b1 = buildAccommodation(buildingManager, LocalPosition.DEFAULT_POSITION, 0D, 0);
         Building b2 = buildBuilding(buildingManager, new LocalPosition(-6D, 0D), 270D, 1);
         Building b3 = buildBuilding(buildingManager, new LocalPosition(-12D, 0D), 270D, 2);
         Building b4 = buildBuilding(buildingManager, new LocalPosition(-18D, 0D), 270D, 3);
@@ -98,7 +98,7 @@ public class WalkInteriorTest extends AbstractMarsSimUnitTest {
         BuildingConnectorManager connectorManager = settlement.getBuildingConnectorManager();
 
 
-        Building b3 = buildEVA(buildingManager, LocalPosition.DEFAULT_POSITION, 0D, 0);
+        Building b3 = buildAccommodation(buildingManager, LocalPosition.DEFAULT_POSITION, 0D, 0);
         Building b4 = buildBuilding(buildingManager, new LocalPosition(-6D, 0D), 270D, 2);
         Building b5 = buildBuilding(buildingManager, new LocalPosition(-12D, 0D), 270D, 1);
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/WalkingStepsTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/WalkingStepsTest.java
@@ -10,6 +10,7 @@ package com.mars_sim.core.person.ai.task;
 import java.util.Iterator;
 
 import com.mars_sim.core.AbstractMarsSimUnitTest;
+import com.mars_sim.core.LocalAreaUtil;
 import com.mars_sim.core.person.GenderType;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.task.WalkingSteps.WalkStep;
@@ -17,7 +18,6 @@ import com.mars_sim.core.structure.MockSettlement;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.building.Building;
 import com.mars_sim.core.structure.building.BuildingManager;
-import com.mars_sim.core.structure.building.MockBuilding;
 import com.mars_sim.core.structure.building.connection.BuildingConnector;
 import com.mars_sim.core.structure.building.connection.BuildingConnectorManager;
 import com.mars_sim.core.structure.building.function.VehicleGarage;
@@ -45,7 +45,7 @@ public class WalkingStepsTest extends AbstractMarsSimUnitTest {
         BuildingConnectorManager connectorManager = settlement.getBuildingConnectorManager();
         assertNotNull(connectorManager);
 
-        Building building0 = buildEVA(buildingManager, LocalPosition.DEFAULT_POSITION, 0D, 0);
+        Building building0 = buildAccommodation(buildingManager, LocalPosition.DEFAULT_POSITION, 0D, 0);
 
         Building building1 = buildBuilding(buildingManager, new LocalPosition(-12D, 0D), 270D, 1);
 
@@ -118,7 +118,7 @@ public class WalkingStepsTest extends AbstractMarsSimUnitTest {
         BuildingManager buildingManager = settlement.getBuildingManager();
 
         LocalPosition target = new LocalPosition(-12D, 0D);
-        Building building0 = buildBuilding(buildingManager, LOCAL_POSITION1, 0D, 0); 
+        Building building0 = buildAccommodation(buildingManager, LOCAL_POSITION1, 0D, 0); 
         Building building1 = buildEVA(buildingManager, target, 270D, 1); 
 
         buildingManager.setupBuildingFunctionsMap();
@@ -126,13 +126,14 @@ public class WalkingStepsTest extends AbstractMarsSimUnitTest {
 		Person person = Person.create("Walker", settlement, GenderType.MALE).build();
 
         BuildingManager.addToBuilding(person, building0);
+        assertNotNull("Perons s in start building", person.getBuildingLocation());
 
         WalkingSteps walkingSteps = new WalkingSteps(person, target, building1);
         assertNotNull(walkingSteps);
 
         boolean canWalk = walkingSteps.canWalkAllSteps();
         
-        assertFalse(canWalk);
+        assertFalse("No walking path found", canWalk);
 
         assertNotNull(walkingSteps.getWalkingStepsList());
 
@@ -187,27 +188,25 @@ public class WalkingStepsTest extends AbstractMarsSimUnitTest {
         BuildingManager buildingManager = settlement.getBuildingManager();
 
         LocalPosition target = new LocalPosition(-12D, 0D);
-        Building building0 = buildBuilding(buildingManager, LOCAL_POSITION1, 0D, 0);
-        Building building1 = buildBuilding(buildingManager, target, 270D, 1);
+        Building building0 = buildAccommodation(buildingManager, LOCAL_POSITION1, 0D, 0);
+        Building building1 = buildBuilding(buildingManager, new LocalPosition(BUILDING_LENGTH + 1, 0D), 0D, 1);
 
+        assertFalse("Target is not in the target building", LocalAreaUtil.isPositionWithinLocalBoundedObject(target, building1));
         buildingManager.setupBuildingFunctionsMap();
 
 		Person person = Person.create("Walker", settlement, GenderType.MALE).build();
 
-
         BuildingManager.addToBuilding(person, building0);
+        assertNotNull("Person is in building", person.getBuildingLocation());
 
         WalkingSteps walkingSteps = new WalkingSteps(person, target, building1);
-        assertNotNull(walkingSteps);
 
         assertFalse(walkingSteps.canWalkAllSteps());
 
         assertNotNull(walkingSteps.getWalkingStepsList());
 
         int steps = walkingSteps.getWalkingStepsNumber();
-//        System.out.println("steps: " + steps);
         assertEquals(0, steps); 
-//        assertEquals(2, walkingSteps.getWalkingStepsNumber()); 
 
         assertEquals(0, walkingSteps.getWalkingStepsList().size()); 
     }
@@ -231,17 +230,17 @@ public class WalkingStepsTest extends AbstractMarsSimUnitTest {
 		Person person = Person.create("Walker", settlement, GenderType.MALE).build();
 
         BuildingManager.addToBuilding(person, building0);
+        assertNotNull("Person in start building", person.getBuildingLocation());
 
         WalkingSteps walkingSteps = new WalkingSteps(person, target, building1);
-        assertNotNull(walkingSteps);
 
-        assertTrue(walkingSteps.canWalkAllSteps());
+        assertTrue("Found a walking path", walkingSteps.canWalkAllSteps());
 
-        assertNotNull(walkingSteps.getWalkingStepsList());
+        assertNotNull("Has a walking path", walkingSteps.getWalkingStepsList());
 
-        assertEquals(5, walkingSteps.getWalkingStepsNumber());
+        assertEquals("Walking path steps", 5, walkingSteps.getWalkingStepsNumber());
 
-        assertEquals(5, walkingSteps.getWalkingStepsList().size());
+        assertEquals("Path size", 5, walkingSteps.getWalkingStepsList().size());
 
         WalkStep walkStep1 = walkingSteps.getWalkingStepsList().get(0);
 
@@ -317,7 +316,7 @@ public class WalkingStepsTest extends AbstractMarsSimUnitTest {
 		
         BuildingManager buildingManager = settlement.getBuildingManager();
 
-        Building building0 = buildBuilding(buildingManager, LocalPosition.DEFAULT_POSITION, 0D, 0);
+        Building building0 = buildAccommodation(buildingManager, LocalPosition.DEFAULT_POSITION, 0D, 0);
 
         buildingManager.setupBuildingFunctionsMap();
 
@@ -457,7 +456,6 @@ public class WalkingStepsTest extends AbstractMarsSimUnitTest {
         Rover rover = buildRover(settlement, "Test Rover", parked);
         
         Building building0 = buildEVA(buildingManager, LocalPosition.DEFAULT_POSITION, 0D, 0);
-        		new MockBuilding(buildingManager, "B0");
         buildingManager.setupBuildingFunctionsMap();
 
 		Person person = Person.create("Walker", settlement, GenderType.MALE).build();
@@ -509,7 +507,7 @@ public class WalkingStepsTest extends AbstractMarsSimUnitTest {
         LocalPosition parked = new LocalPosition(15D, -10D);
         Rover rover = buildRover(settlement, "Test Rover", parked);
 
-        Building building0 = buildBuilding(buildingManager, LocalPosition.DEFAULT_POSITION, 0D, 0);
+        Building building0 = buildAccommodation(buildingManager, LocalPosition.DEFAULT_POSITION, 0D, 0);
         buildingManager.setupBuildingFunctionsMap();
         
 		Person person = Person.create("Walker", settlement, GenderType.MALE).build();

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/util/SettlementTaskManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/util/SettlementTaskManagerTest.java
@@ -1,0 +1,175 @@
+package com.mars_sim.core.person.ai.task.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.mars_sim.core.AbstractMarsSimUnitTest;
+import com.mars_sim.core.data.RatingScore;
+import com.mars_sim.core.person.Person;
+import com.mars_sim.core.person.ai.shift.ShiftSlot.WorkStatus;
+import com.mars_sim.core.person.ai.task.util.MetaTask.TaskScope;
+import com.mars_sim.core.structure.Settlement;
+
+public class SettlementTaskManagerTest extends AbstractMarsSimUnitTest {
+    // Test settlement task that just record tinme
+    private static class TestTask extends SettlementTask {
+        private static final RatingScore DEFAULT_SCORE = new RatingScore(10);
+
+        private static int counter = 0;
+
+        private long when;
+
+        protected TestTask(SettlementMetaTask parent, String name, TaskScope scope) {
+            super(parent, name, null, DEFAULT_SCORE);
+            setScope(scope);
+            when = counter++;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = super.hashCode();
+            result = prime * result + (int) (when ^ (when >>> 32));
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (getClass() != obj.getClass())
+                return false;
+            TestTask other = (TestTask) obj;
+            return (when == other.when);
+        }
+        
+    }
+
+    // Test Meta that create testTasks 
+    private static class TestMetaTask extends MetaTask implements SettlementMetaTask  {
+        private boolean reject;
+
+        protected TestMetaTask(TaskScope scope, boolean personReject) {
+            super(scope.name(), WorkerType.BOTH, scope);
+            this.reject = personReject;
+        }
+
+        @Override
+        public List<SettlementTask> getSettlementTasks(Settlement settlement) {
+            List<SettlementTask> tasks = new ArrayList<>();
+            for(int i = 0; i < TASKS_PER_META; i++) {
+                tasks.add(new TestTask(this, getName() + i, getScope()));
+            }
+            return tasks;
+        }
+
+        /**
+         * Simulate Person not being suitable
+         */
+        @Override
+        public RatingScore assessPersonSuitability(SettlementTask t, Person p) {
+            if (reject) {
+                return RatingScore.ZERO_RATING;
+            }
+            return t.getScore();
+        }
+    };
+
+    private static final List<SettlementMetaTask> SCOPE_METATTASKS = List.of(
+                            new TestMetaTask(TaskScope.ANY_HOUR, false),
+                            new TestMetaTask(TaskScope.WORK_HOUR, false),
+                            new TestMetaTask(TaskScope.NONWORK_HOUR, false));
+
+    private static final int TASKS_PER_META = 2;
+
+    /**
+     * Build a SettlementTaskManager that uses a number of testMetaTask
+     */
+    private SettlementTaskManager buildManager(Settlement s, List<SettlementMetaTask> tasks) {
+        return new SettlementTaskManager(s) {
+            @Override
+            protected List<SettlementMetaTask> getMetaTasks() {
+                return tasks;
+            }
+        };
+    }
+
+    public void testGetTasks() {
+        var s = buildSettlement();
+        var manager = buildManager(s, SCOPE_METATTASKS);
+        Person p = buildPerson("Worker", s);
+
+        // Triggers the creation of the internal task cache
+        manager.getTasks(p);
+        var available1 = manager.getAvailableTasks();
+        assertEquals("Number of Settlement Tasks", SCOPE_METATTASKS.size() * TASKS_PER_META, available1.size());
+
+        // No refresh so same list
+        manager.getTasks(p);
+        var available2 = manager.getAvailableTasks();
+        assertEquals("Settlement Tasks same on second call", available1, available2);
+
+        // Do a refresh by simulating time passing
+        manager.timePassing();
+        manager.getTasks(p);
+        var available3 = manager.getAvailableTasks();
+        assertFalse("Settlement Tasks change after timepassing", available1.equals(available3));
+
+    }
+
+    public void testGetNonWorkTasks() {
+        var s = buildSettlement();
+        var manager = buildManager(s, SCOPE_METATTASKS);
+        Person p = buildPerson("OffDuty", s);
+        assertEquals("Person on leave", WorkStatus.OFF_DUTY, p.getShiftSlot().getStatus());
+
+
+        // Should only be 2 set of tasks, ALL & NonWork
+        var available1 = manager.getTasks(p);
+        assertEquals("Number of OffDuty Tasks", 2 * TASKS_PER_META, available1.size());
+        List<String> scopes = available1.stream().map(TaskJob::getName).toList();
+        for(int i = 0; i < TASKS_PER_META; i++) {
+            String name = TaskScope.ANY_HOUR.name() + i;
+            assertTrue("Task present " + name, scopes.contains(name));
+            name = TaskScope.NONWORK_HOUR.name() + i;
+            assertTrue("Task present " + name, scopes.contains(name));
+        }
+    }
+
+    public void testGetWorkTasks() {
+        var s = buildSettlement();
+        var manager = buildManager(s, SCOPE_METATTASKS);
+        Person p = buildPerson("OnDuty", s);
+        p.getShiftSlot().setOnCall(true);
+        assertEquals("Person on duty", WorkStatus.ON_CALL, p.getShiftSlot().getStatus());
+
+        // Should only be 2 set of tasks, ALL & NonWork
+        var available1 = manager.getTasks(p);
+        assertEquals("Number of OffDuty Tasks", 2 * TASKS_PER_META, available1.size());
+        List<String> scopes = available1.stream().map(TaskJob::getName).toList();
+        for(int i = 0; i < TASKS_PER_META; i++) {
+            String name = TaskScope.ANY_HOUR.name() + i;
+            assertTrue("Task present " + name, scopes.contains(name));
+            name = TaskScope.WORK_HOUR.name() + i;
+            assertTrue("Task present " + name, scopes.contains(name));
+        }
+    }
+
+    /**
+     * Check that a Peron can reject tasks
+     */
+    public void testPersonScoring() {
+        var s = buildSettlement();
+
+        // One meta rejects and one accepts
+        var manager = buildManager(s, List.of(
+            new TestMetaTask(TaskScope.ANY_HOUR, true),
+            new TestMetaTask(TaskScope.ANY_HOUR, false)));
+        Person p = buildPerson("Worker", s);
+
+        // Triggers the creation of the internal task cache
+        var selected = manager.getTasks(p);
+        var available1 = manager.getAvailableTasks(); 
+
+        assertEquals("Number of Suitable Settlement Tasks", TASKS_PER_META, selected.size());
+        assertEquals("Number of Total Settlement Tasks", 2 * TASKS_PER_META, available1.size());
+    }
+}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/MockSettlement.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/MockSettlement.java
@@ -1,9 +1,7 @@
 package com.mars_sim.core.structure;
 
 import java.util.ArrayList;
-import java.util.logging.Logger;
 
-import com.mars_sim.core.Simulation;
 import com.mars_sim.core.structure.building.BuildingManager;
 import com.mars_sim.core.structure.building.connection.BuildingConnectorManager;
 import com.mars_sim.core.structure.construction.ConstructionManager;
@@ -16,12 +14,7 @@ public class MockSettlement extends Settlement {
 	 *
 	 */
 	public static final String DEFAULT_NAME = "Mock Settlement";
-
-	/* default logger. */
-	private static final Logger logger = Logger.getLogger(MockSettlement.class.getName());
-	
-	private Simulation sim = Simulation.instance();
-
+	public static final String SETTLEMENT_TEMPLATE = "Alpha Base";
 
 	public MockSettlement()  {
 		this(DEFAULT_NAME);
@@ -30,12 +23,7 @@ public class MockSettlement extends Settlement {
 	public MockSettlement(String name) {
 		// Use Settlement constructor.
 		super(name, new Coordinates(Math.PI / 2D, 0));
-		
-		if (sim == null)
-			logger.severe("sim is null");
-		
-		if (sim.getUnitManager() == null)
-			logger.severe("unitManager is null");
+	
 					
         // Set inventory total mass capacity.
 		getEquipmentInventory().addCargoCapacity(Double.MAX_VALUE);
@@ -53,4 +41,9 @@ public class MockSettlement extends Settlement {
         // Initialize power grid
         powerGrid = new PowerGrid(this);
 	}	
+
+	@Override
+	public String getTemplate() {
+		return SETTLEMENT_TEMPLATE;
+	}
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/SettlementConfigTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/SettlementConfigTest.java
@@ -6,6 +6,9 @@ import com.mars_sim.core.AbstractMarsSimUnitTest;
 public class SettlementConfigTest extends AbstractMarsSimUnitTest {
 
     private static final String ALPHA_BASE = "Alpha Base";
+    private static final String STANDARD_4_SHIFT = "Standard 4 Shift";
+	private static final String STANDARD_3_SHIFT = "Standard 3 Shift";
+	private static final String STANDARD_2_SHIFT = "Standard 2 Shift";
 
     public void testGetEssentialResources() {
         var config = simConfig.getSettlementConfiguration();
@@ -24,15 +27,29 @@ public class SettlementConfigTest extends AbstractMarsSimUnitTest {
         var config = simConfig.getSettlementConfiguration();
 
         // Check standard shifts
-        testShiftSize(config, SettlementConfig.STANDARD_2_SHIFT, 2);
-        testShiftSize(config, SettlementConfig.STANDARD_3_SHIFT, 3);
-        testShiftSize(config, SettlementConfig.STANDARD_4_SHIFT, 4);   
+        testShiftSize(config, STANDARD_2_SHIFT, 2);
+        testShiftSize(config, STANDARD_3_SHIFT, 3);
+        testShiftSize(config, STANDARD_4_SHIFT, 4);   
     }
 
     private void testShiftSize(SettlementConfig config, String name, int shifts) {
-        var shift = config.getShiftPattern(name);
+        var shift = config.getShiftByName(name);
         assertNotNull("Shift pattern " + name, shift);
         assertEquals("Shift size for " + name, shifts, shift.getShifts().size());
+    }
+
+    public void testShiftByPopulation() {
+        var config = simConfig.getSettlementConfiguration();
+    
+        var large = config.getShiftByPopulation(30);
+        assertTrue("Large shift has smaller min pop", 30 > large.getMinPopulation());
+        assertEquals("Shift pattern for large", "Standard 3 Shift", large.getName());
+
+
+        var small = config.getShiftByPopulation(8);
+        assertTrue("Small shift has smaller min pop", 8 > small.getMinPopulation());
+        assertEquals("Shift pattern for small", "Standard 2 Shift", small.getName());
+
     }
 
     public void testGetActivityByPopulation() {

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/SettlementConfigTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/SettlementConfigTest.java
@@ -1,5 +1,6 @@
 package com.mars_sim.core.structure;
 
+
 import com.mars_sim.core.AbstractMarsSimUnitTest;
 
 public class SettlementConfigTest extends AbstractMarsSimUnitTest {
@@ -19,7 +20,7 @@ public class SettlementConfigTest extends AbstractMarsSimUnitTest {
         assertNotNull("Settlement template " + ALPHA_BASE, config.getItem(ALPHA_BASE));
     }
 
-    public void testGetShiftPattern() {
+    public void testDefaultShiftPattern() {
         var config = simConfig.getSettlementConfiguration();
 
         // Check standard shifts
@@ -32,5 +33,21 @@ public class SettlementConfigTest extends AbstractMarsSimUnitTest {
         var shift = config.getShiftPattern(name);
         assertNotNull("Shift pattern " + name, shift);
         assertEquals("Shift size for " + name, shifts, shift.getShifts().size());
+    }
+
+    public void testGetActivityByPopulation() {
+        var config = simConfig.getSettlementConfiguration();
+    
+        var large = config.getActivityByPopulation(30);
+        assertTrue("Large ruleset has smaller min pop", 30 > large.minPop());
+        assertEquals("Activity Ruleset for large", "Large Settlement", large.name());
+
+
+        var small = config.getActivityByPopulation(8);
+        assertTrue("Large ruleset has medium min pop", 8 > small.minPop());
+        assertEquals("Activity Ruleset for small", "Small Settlement", small.name());
+
+        var verysmall = config.getActivityByPopulation(4);
+        assertNull("No activities for vry small population", verysmall);
     }
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/ShiftManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/ShiftManagerTest.java
@@ -39,7 +39,7 @@ public class ShiftManagerTest extends AbstractMarsSimUnitTest {
             startTime = endTime;
         }
 
-        ShiftPattern sp = new ShiftPattern("Test", specs, 20, 0);
+        ShiftPattern sp = new ShiftPattern("Test", specs, 20, 0, -1);
 
         return new ShiftManager(owner, sp, 0);
     }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/BuildingTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/BuildingTest.java
@@ -1,0 +1,32 @@
+package com.mars_sim.core.structure.building;
+
+import com.mars_sim.core.AbstractMarsSimUnitTest;
+import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.mapdata.location.BoundedObject;
+import com.mars_sim.mapdata.location.LocalPosition;
+
+public class BuildingTest extends AbstractMarsSimUnitTest{
+
+    private static final String LANDER_HAB = "Lander Hab";
+
+    public void testCreateLanderHab() {
+        var habSpec = simConfig.getBuildingConfiguration().getBuildingSpec(LANDER_HAB);
+
+        Settlement s = buildSettlement();
+        BoundedObject bounds = new BoundedObject(LocalPosition.DEFAULT_POSITION, -1, -1, 90D);
+        BuildingTemplate template = new BuildingTemplate("1", 0, LANDER_HAB, "B1", bounds);
+        var b = Building.createBuilding(template, s);
+
+        assertNotNull("Building created", b);
+        assertEquals("Building position", LocalPosition.DEFAULT_POSITION, b.getPosition());
+        assertEquals("Building facing", 90D, b.getFacing());
+        assertEquals("Building width", habSpec.getWidth(), b.getWidth());
+        assertEquals("Building length", habSpec.getLength(), b.getLength());
+        assertEquals("Building name", "B1", b.getName());
+
+
+
+        assertEquals("Building function count", habSpec.getFunctionSupported().size(), b.getFunctions().size());
+        assertNotNull("Building has life support", b.getLifeSupport());
+    }
+}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/MockBuilding.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/MockBuilding.java
@@ -1,93 +1,38 @@
 package com.mars_sim.core.structure.building;
 
-import java.util.ArrayList;
 import java.util.Map;
 
 import com.mars_sim.core.malfunction.MalfunctionManager;
-import com.mars_sim.core.structure.building.function.Function;
-import com.mars_sim.core.structure.building.function.LifeSupport;
-import com.mars_sim.mapdata.location.LocalPosition;
+import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.core.structure.building.function.FunctionType;
+import com.mars_sim.mapdata.location.BoundedObject;
 
 @SuppressWarnings("serial")
 public class MockBuilding extends Building {
 
 	/* default logger. */
-//	private static final Logger logger = Logger.getLogger(Building.class.getName());
 	private static FunctionSpec lifeSupportSpec = null;
 	
 	private static FunctionSpec getLifeSupportSpec() {
 		if (lifeSupportSpec == null) {
 			
-			lifeSupportSpec = new FunctionSpec(Map.of(BuildingConfig.POWER_REQUIRED, 1D,
+			lifeSupportSpec = new FunctionSpec(FunctionType.LIFE_SUPPORT, Map.of(BuildingConfig.POWER_REQUIRED, 1D,
 													  FunctionSpec.CAPACITY, 10),
 														null);
 		}
 		return lifeSupportSpec;
 	}
 
-    public MockBuilding() {
-    	super();
-    }
     
-    public MockBuilding(BuildingManager manager, String name)  {
-		super(manager, name);
-		buildingType = "Mock Type";
-
-		if (manager == null) {
-			throw new IllegalArgumentException("Bulding manager can not be null");
-		}
-		manager.addMockBuilding(this);
+    public MockBuilding(Settlement owner, String name, int id, BoundedObject bounds, String buildingType, BuildingCategory cat)  {
+		super(owner, Integer.toString(id), 1, "Mock Building " + id, bounds, buildingType, cat);
 
 		malfunctionManager = new MalfunctionManager(this, 0D, 0D);
-		functions = new ArrayList<>();
-		functions.add(new LifeSupport(this, getLifeSupportSpec()));
-	}
-    
-	public MockBuilding(BuildingTemplate template, BuildingManager manager)  {
-		super(template, manager);
-		buildingType = "Mock Type";
-		changeName("Mock Building");
-		
-		unitManager.addUnit(this);
-
-		malfunctionManager = new MalfunctionManager(this, 0D, 0D);
-		functions = new ArrayList<>();
-		functions.add(new LifeSupport(this, getLifeSupportSpec()));
+		addFunction(getLifeSupportSpec());
 	}
 
-	public void setTemplateID(String id) {
-		this.templateID = id;
-	}
-
-	public void setBuildingType(String type) {
-	    this.buildingType = type;
-	}
-
-	public void setLocation(LocalPosition loc) {
-		this.loc = loc;
-	}
-	
-	public void setZLocation(double zLoc) {
-	    this.zLoc = zLoc;
-	}
-	
-	public void setWidth(double width) {
-	    this.width = width;
-	}
-
-	public void setLength(double length) {
-	    this.length = length;
-	}
-
-	public void setFacing(double facing) {
-	    this.facing = facing;
-	}
-
-	public void addFunction(Function function) {
-	    functions.add(function);
-	}
-	
-	public void setLocation(double x, double y) {
-		loc = new LocalPosition(x, y);	
+	public MockBuilding(Settlement owner, int id, BoundedObject bounds) {
+		super(owner, Integer.toString(id), 1, "Mock Building " + id, bounds, "Mock", BuildingCategory.LIVING);
 	}
 }
+

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/connection/BuildingConnectorManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/connection/BuildingConnectorManagerTest.java
@@ -56,35 +56,17 @@ public class BuildingConnectorManagerTest extends TestCase {
         Settlement settlement = new MockSettlement();
         BuildingManager buildingManager = settlement.getBuildingManager();
 
-        MockBuilding building0 = new MockBuilding(buildingManager, "B0");
-        building0.setTemplateID("0");
-        building0.setName("building 0");
-        building0.setWidth(9D);
-        building0.setLength(9D);
-        building0.setLocation(0D,0D);
-        building0.setFacing(0D);
+        MockBuilding building0 = new MockBuilding(settlement, 0, new BoundedObject(0D, 0D, 9D, 9D, 0D));
         BuildingTemplate buildingTemplate0 = new BuildingTemplate("0", 0, "building 0", "building 0", new BoundedObject(0D, 0D, 9D, 9D, 0D));
         buildingTemplate0.addBuildingConnection("2", new LocalPosition(-4.5D, 0D));
         buildingManager.addBuilding(building0, false);
 
-        MockBuilding building1 = new MockBuilding(buildingManager, "B1");
-        building1.setTemplateID("1");
-        building1.setName("building 1");
-        building1.setWidth(6D);
-        building1.setLength(9D);
-        building1.setLocation(-12D, 0D);
-        building1.setFacing(270D);
+        MockBuilding building1 = new MockBuilding(settlement, 1, new BoundedObject(-12D, 0D, 6D, 9D, 270D));
         BuildingTemplate buildingTemplate1 = new BuildingTemplate("1", 0, "building 1","building 1", new BoundedObject(-12D, 0D, 6D, 9D, 270D));
         buildingTemplate1.addBuildingConnection("2", new LocalPosition(0D, 4.5D));
         buildingManager.addBuilding(building1, false);
 
-        MockBuilding building2 = new MockBuilding(buildingManager, "B2");
-        building2.setTemplateID("2");
-        building2.setName("building 2");
-        building2.setWidth(2D);
-        building2.setLength(3D);
-        building2.setLocation(-6D, 0D);
-        building2.setFacing(270D);
+        MockBuilding building2 = new MockBuilding(settlement, 2, new BoundedObject(-6D, 0D, 2D, 3D, 270D));
         BuildingTemplate buildingTemplate2 = new BuildingTemplate("2", 0, "building 2","building 2", new BoundedObject(-6D, 0D, 6D, 9D, 270D));
         buildingTemplate2.addBuildingConnection("0", new LocalPosition(0D, 1.5D));
         buildingTemplate2.addBuildingConnection("1", new LocalPosition(0D, -1.5D));
@@ -154,35 +136,17 @@ public class BuildingConnectorManagerTest extends TestCase {
         Settlement settlement = new MockSettlement();
         BuildingManager buildingManager = settlement.getBuildingManager();
 
-        MockBuilding building0 = new MockBuilding(buildingManager, "B0");
-        building0.setTemplateID("0");
-        building0.setName("building 0");
-        building0.setWidth(9D);
-        building0.setLength(9D);
-        building0.setLocation(0D, 0D);
-        building0.setFacing(0D);
+        MockBuilding building0 = new MockBuilding(settlement, 0, new BoundedObject(0D, 0D, 9D, 9D, 0D));
         BuildingTemplate buildingTemplate0 = new BuildingTemplate("0", 0, "building 0", "building 0", new BoundedObject(0D, 0D, 9D, 9D, 0D));
         buildingTemplate0.addBuildingConnection("2", new LocalPosition(-4.5D, 0D));
         buildingManager.addBuilding(building0, false);
 
-        MockBuilding building1 = new MockBuilding(buildingManager, "B1");
-        building1.setTemplateID("1");
-        building1.setName("building 1");
-        building1.setWidth(6D);
-        building1.setLength(9D);
-        building1.setLocation(-12D, 0D);
-        building1.setFacing(270D);
+        MockBuilding building1 = new MockBuilding(settlement, 1, new BoundedObject(-12D, 0D, 6D, 9D, 270D));
         BuildingTemplate buildingTemplate1 = new BuildingTemplate("1", 0, "building 1", "building 1", new BoundedObject(-12D, 0D, 6D, 9D, 270D));
         buildingTemplate1.addBuildingConnection("2", new LocalPosition(0D, 4.5D));
         buildingManager.addBuilding(building1, false);
 
-        MockBuilding building2 = new MockBuilding(buildingManager, "B2");
-        building2.setTemplateID("2");
-        building2.setName("building 2");
-        building2.setWidth(2D);
-        building2.setLength(3D);
-        building2.setLocation(-6D, 0D);
-        building2.setFacing(270D);
+        MockBuilding building2 = new MockBuilding(settlement, 2, new BoundedObject(-6D, 0D, 2D, 3D, 270D));
         BuildingTemplate buildingTemplate2 = new BuildingTemplate("2", 0, "building 2", "building 2", new BoundedObject(-6D, 0D, 6D, 9D, 270D));
         buildingTemplate2.addBuildingConnection("0", new LocalPosition(0D, 1.5D));
         buildingTemplate2.addBuildingConnection("1", new LocalPosition(0D, -1.5D));

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/connection/BuildingConnectorTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/connection/BuildingConnectorTest.java
@@ -1,6 +1,8 @@
 package com.mars_sim.core.structure.building.connection;
 
+import com.mars_sim.core.structure.MockSettlement;
 import com.mars_sim.core.structure.building.MockBuilding;
+import com.mars_sim.mapdata.location.BoundedObject;
 import com.mars_sim.mapdata.location.LocalPosition;
 
 import junit.framework.TestCase;
@@ -13,17 +15,10 @@ public class BuildingConnectorTest extends TestCase {
 
 	public void testNonSplitBuildingConnector() {
         
-        MockBuilding building1 = new MockBuilding();
-        building1.setWidth(10D);
-        building1.setLength(10D);
-        building1.setLocation(0D, 0D);
-        building1.setFacing(0D);
-        
-        MockBuilding building2 = new MockBuilding();
-        building2.setWidth(10D);
-        building2.setLength(10D);
-        building2.setLocation(0D, 0D);
-        building2.setFacing(0D);
+        MockSettlement settlement = new MockSettlement();
+        MockBuilding building1 = new MockBuilding(settlement, 1, new BoundedObject(0D, 0D, 10D, 10D, 0D));
+        MockBuilding building2 = new MockBuilding(settlement, 2, new BoundedObject(0D, 0D, 10D, 10D, 0D));
+
         
         BuildingConnector connector = new BuildingConnector(building1, 
                 BUILDING_POSITION, 0D, building2, BUILDING2_POSITION, 180D);
@@ -58,18 +53,10 @@ public class BuildingConnectorTest extends TestCase {
     
     public void testSplitBuildingConnector() {
         
-        MockBuilding building1 = new MockBuilding();
-        building1.setWidth(10D);
-        building1.setLength(10D);
-        building1.setLocation(0D, 0D);
-        building1.setFacing(0D);
-        
-        MockBuilding building2 = new MockBuilding();
-        building2.setWidth(10D);
-        building2.setLength(10D);
-        building2.setLocation(0D, 12D);
-        building2.setFacing(0D);
-        
+        MockSettlement settlement = new MockSettlement();
+        MockBuilding building1 = new MockBuilding(settlement, 1, new BoundedObject(0D, 0D, 10D, 10D, 0D));
+        MockBuilding building2 = new MockBuilding(settlement, 2, new BoundedObject(0D, 12D, 10D, 10D, 0D));
+
         BuildingConnector connector = new BuildingConnector(building1, 
                 BUILDING2_POSITION, 0D, building2, BUILDING3_POSITION, 180D);
         assertNotNull(connector);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/connection/HatchTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/connection/HatchTest.java
@@ -1,6 +1,8 @@
 package com.mars_sim.core.structure.building.connection;
 
+import com.mars_sim.core.structure.MockSettlement;
 import com.mars_sim.core.structure.building.MockBuilding;
+import com.mars_sim.mapdata.location.BoundedObject;
 import com.mars_sim.mapdata.location.LocalPosition;
 
 import junit.framework.TestCase;
@@ -10,12 +12,14 @@ public class HatchTest extends TestCase {
 	
     private static final LocalPosition BUILDING_POSITION = new LocalPosition(0D, 0D);
     private static final LocalPosition HATCH_POSITION = new LocalPosition(5D, 12D);
+    private static final BoundedObject BUILDING_POSN = new BoundedObject(0, 0, 10, 10, 0);
 
 
 	public void testConstructor() {
         
-        MockBuilding building1 = new MockBuilding();
-        MockBuilding building2 = new MockBuilding();
+        MockSettlement settlement = new MockSettlement();
+        MockBuilding building1 = new MockBuilding(settlement, 1, BUILDING_POSN);
+        MockBuilding building2 = new MockBuilding(settlement, 2, BUILDING_POSN);
         BuildingConnector connector = new BuildingConnector(building1, 
                 BUILDING_POSITION, 0D, building2, BUILDING_POSITION, 0D);
         
@@ -31,9 +35,9 @@ public class HatchTest extends TestCase {
     }
     
     public void testSetLocation() {
-        
-        MockBuilding building1 = new MockBuilding();
-        MockBuilding building2 = new MockBuilding();
+        MockSettlement settlement = new MockSettlement();
+        MockBuilding building1 = new MockBuilding(settlement, 1, BUILDING_POSN);
+        MockBuilding building2 = new MockBuilding(settlement, 2, BUILDING_POSN);
         BuildingConnector connector = new BuildingConnector(building1, 
         		BUILDING_POSITION, 0D, building2, BUILDING_POSITION, 0D);
         
@@ -45,8 +49,9 @@ public class HatchTest extends TestCase {
     
     public void testEquals() {
         
-        MockBuilding building1 = new MockBuilding();
-        MockBuilding building2 = new MockBuilding();
+        MockSettlement settlement = new MockSettlement();
+        MockBuilding building1 = new MockBuilding(settlement, 1, BUILDING_POSN);
+        MockBuilding building2 = new MockBuilding(settlement, 2, BUILDING_POSN);
         BuildingConnector connector = new BuildingConnector(building1, 
         		BUILDING_POSITION, 0D, building2, BUILDING_POSITION, 0D);
         

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/connection/InsideBuildingPathTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/connection/InsideBuildingPathTest.java
@@ -2,7 +2,9 @@ package com.mars_sim.core.structure.building.connection;
 
 import java.util.List;
 
+import com.mars_sim.core.structure.MockSettlement;
 import com.mars_sim.core.structure.building.MockBuilding;
+import com.mars_sim.mapdata.location.BoundedObject;
 import com.mars_sim.mapdata.location.LocalPosition;
 
 import junit.framework.TestCase;
@@ -12,6 +14,7 @@ public class InsideBuildingPathTest extends TestCase {
     private static final LocalPosition POSITION_5X5 = new LocalPosition(5D, 5D);
 	private static final LocalPosition POSITION_10X5 = new LocalPosition(10D, 5D);
 	private static final LocalPosition POSITION_10X10 = new LocalPosition(10D, 10D);
+    private static final BoundedObject BUILDING_POSN = new BoundedObject(0, 0, 20, 20, 0);
 
 	public void testConstructor() {
         
@@ -34,7 +37,8 @@ public class InsideBuildingPathTest extends TestCase {
         assertNotNull(remainingLocations1);
         assertEquals(0, remainingLocations1.size());
         
-        MockBuilding building = new MockBuilding();
+        MockSettlement settlement = new MockSettlement();
+        MockBuilding building = new MockBuilding(settlement, 1, BUILDING_POSN);
         InsidePathLocation location = new BuildingLocation(building, POSITION_5X5);
         
         assertFalse(path.containsPathLocation(location));
@@ -56,7 +60,8 @@ public class InsideBuildingPathTest extends TestCase {
         
         InsideBuildingPath path = new InsideBuildingPath();
         
-        MockBuilding building = new MockBuilding();
+        MockSettlement settlement = new MockSettlement();
+        MockBuilding building = new MockBuilding(settlement, 1, BUILDING_POSN);
         InsidePathLocation location1 = new BuildingLocation(building, POSITION_5X5);
         path.addPathLocation(location1);
         
@@ -74,7 +79,8 @@ public class InsideBuildingPathTest extends TestCase {
         
         InsideBuildingPath path = new InsideBuildingPath();
         
-        MockBuilding building = new MockBuilding();
+        MockSettlement settlement = new MockSettlement();
+        MockBuilding building = new MockBuilding(settlement, 1, BUILDING_POSN);
         
         InsidePathLocation location1 = new BuildingLocation(building, POSITION_5X5);
         path.addPathLocation(location1);
@@ -108,8 +114,9 @@ public class InsideBuildingPathTest extends TestCase {
     public void testIsEndOfPath() {
         
         InsideBuildingPath path = new InsideBuildingPath();
-        
-        MockBuilding building = new MockBuilding();
+
+        MockSettlement settlement = new MockSettlement();
+        MockBuilding building = new MockBuilding(settlement, 1, BUILDING_POSN);
         
         InsidePathLocation location1 = new BuildingLocation(building, POSITION_5X5);
         path.addPathLocation(location1);
@@ -139,7 +146,8 @@ public class InsideBuildingPathTest extends TestCase {
         
         InsideBuildingPath path = new InsideBuildingPath();
         
-        MockBuilding building = new MockBuilding();
+        MockSettlement settlement = new MockSettlement();
+        MockBuilding building = new MockBuilding(settlement, 1, BUILDING_POSN);
         
         InsidePathLocation location1 = new BuildingLocation(building, POSITION_5X5);
         path.addPathLocation(location1);
@@ -166,8 +174,8 @@ public class InsideBuildingPathTest extends TestCase {
         
         InsideBuildingPath path1 = new InsideBuildingPath();
         
-        MockBuilding building = new MockBuilding();
-        
+        MockSettlement settlement = new MockSettlement();
+        MockBuilding building = new MockBuilding(settlement, 1, BUILDING_POSN);        
         InsidePathLocation location1 = new BuildingLocation(building, POSITION_5X5);
         path1.addPathLocation(location1);
         

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/function/FunctionTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/building/function/FunctionTest.java
@@ -21,6 +21,7 @@ public class FunctionTest extends AbstractMarsSimUnitTest {
         var home = buildSettlement("Test");
         var building = buildRecreation(home.getBuildingManager(), LocalPosition.DEFAULT_POSITION, 0D, 0);
         var b = building.getRecreation();
+        assertNotNull("Builidng has Recreation", b);
 
         var spots = b.getActivitySpots();
         assertFalse("Has Activity spots", spots.isEmpty());

--- a/mars-sim-tools/src/main/resources/help/whatsnew.html
+++ b/mars-sim-tools/src/main/resources/help/whatsnew.html
@@ -19,6 +19,7 @@
   <LI>Settlement Template: Optionally the default Objective can be defined.</LI>
   <LI>Process Definitions: Standard approach to defining the processes for Salvage, Food Production and Manufacturing.</LI>
   <LI>Settement Tasks: Can be selected by On duty & Off duty Persons.</LI>
+  <LI>Group Activity: Group activities are automatically schedueld for a Settlement. This can include Birthday parties, Council Announcements, Team Meetings etc.</LI>
 </OL>
   
 <H4>B. UI IMPROVEMENT :</H4>

--- a/mars-sim-tools/src/main/resources/help/whatsnew.html
+++ b/mars-sim-tools/src/main/resources/help/whatsnew.html
@@ -18,6 +18,7 @@
   <LI>Preferences: Preference management is structured into categories.</LI>
   <LI>Settlement Template: Optionally the default Objective can be defined.</LI>
   <LI>Process Definitions: Standard approach to defining the processes for Salvage, Food Production and Manufacturing.</LI>
+  <LI>Settement Tasks: Can be selected by On duty & Off duty Persons.</LI>
 </OL>
   
 <H4>B. UI IMPROVEMENT :</H4>
@@ -25,6 +26,7 @@
   <LI>Monitor Tool: Filtering supports selection of a Reporting Authority as well as Settlement.</LI>
   <LI>Settlement: Number of active Missions controlled by the Preference panel.</LI>
   <LI>Settlement: New Process history tab that shows all completed Processes.</LI>
+  <LI>Monitor Tool: Backlog show the work scope of tasks.</LI>
 
 </OL>  
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/MainWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/MainWindow.java
@@ -27,7 +27,6 @@ import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
 import javax.swing.JButton;

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/MainWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/MainWindow.java
@@ -17,11 +17,8 @@ import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Image;
 import java.awt.Toolkit;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.awt.event.WindowStateListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
@@ -92,7 +89,7 @@ public class MainWindow
 	/** The main window frame. */
 	private static JFrame frame;
 
-	private UIConfig configs;
+	private transient UIConfig configs;
 
 	private static SplashWindow splashWindow;
 
@@ -118,7 +115,7 @@ public class MainWindow
 
 	private JMemoryMeter memoryBar;
 
-	private HelpLibrary helpLibrary;
+	private transient HelpLibrary helpLibrary;
 
 	private boolean useExternalBrowser;
 
@@ -165,7 +162,7 @@ public class MainWindow
 			logger.log(Level.CONFIG, "Detecting only one screen.");
 			logger.config("1 screen detected.");
 		} else if (gs.length == 0) {
-			throw new RuntimeException("No Screens Found.");
+			throw new IllegalStateException("No Screens Found.");
 			// NOTE: what about the future server version of mars-sim in which no screen is
 			// needed.
 		} else {
@@ -342,16 +339,13 @@ public class MainWindow
 			}
 		});
 
-		frame.addWindowStateListener(new WindowStateListener() {
-			public void windowStateChanged(WindowEvent e) {
-				int state = e.getNewState();
-				isIconified = (state == Frame.ICONIFIED);
-				if (state == Frame.MAXIMIZED_HORIZ
-						|| state == Frame.MAXIMIZED_VERT)
-					// frame.update(getGraphics());
-					logger.log(Level.CONFIG, "MainWindow set to maximum."); //$NON-NLS-1$
-				repaint();
-			}
+		frame.addWindowStateListener(e -> {
+			int state = e.getNewState();
+			isIconified = (state == Frame.ICONIFIED);
+			if (state == Frame.MAXIMIZED_HORIZ
+					|| state == Frame.MAXIMIZED_VERT)
+				logger.log(Level.CONFIG, "MainWindow set to maximum."); //$NON-NLS-1$
+			repaint();
 		});
 
 		frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
@@ -382,12 +376,7 @@ public class MainWindow
 		JPanel bottomPane = new JPanel(new BorderLayout());
 
 		// Prepare unit toolbar
-		unitToolbar = new UnitToolBar(this) {
-			@Override
-			protected JButton createActionComponent(Action a) {
-				return super.createActionComponent(a);
-			}
-		};
+		unitToolbar = new UnitToolBar(this);
 
 		unitToolbar.setBorder(new MarsPanelBorder());
 		// Remove the toolbar border, to blend into figure contents
@@ -428,31 +417,6 @@ public class MainWindow
 		masterClock.addClockListener(this, 1000L);
 	}
 
-//	private JCheckBox createOverlayCheckBox() {
-//		JCheckBox checkBox = new JCheckBox("Pause Overlay On/Off", true);
-//		checkBox.setToolTipText("Turn on/off pause overlay in desktop");
-//
-//		checkBox.addItemListener(e -> displayOverlay());
-//
-//		return checkBox;
-//	}
-
-//	private void displayOverlay() {
-		//boolean isPaused = pauseSwitch.isSelected();
-		//boolean isBlocking = blockingSwitch.isSelected();
-
-		// Need to display the blocking image on the content pane
-		// if (isPaused && isBlocking) {
-		// // Checkbox has been selected
-		// layeredContent.add(blockingImage, 2);
-		// } else {
-		// // Checkbox has been unselected
-		// if (blockingImage.isShowing()) {
-		// layeredContent.remove(blockingImage);
-		// }
-		// };
-//	}
-
 	private void createPauseSwitch() {
 		pauseSwitch = new JToggleButton(PAUSE_ICON);
 		pauseSwitch.setToolTipText("Pause or Resume the Simulation");
@@ -481,12 +445,10 @@ public class MainWindow
 		decreaseSpeed.setIcon(DECREASE_ICON);
 		decreaseSpeed.setToolTipText("Decrease the sim speed (aka time ratio)");
 		
-		decreaseSpeed.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				if (!masterClock.isPaused()) {
-					masterClock.decreaseSpeed();
-				}
-			};
+		decreaseSpeed.addActionListener(e -> {
+			if (!masterClock.isPaused()) {
+				masterClock.decreaseSpeed();
+			}
 		});
 		
 		// Create pause switch
@@ -496,12 +458,10 @@ public class MainWindow
 		increaseSpeed.setIcon(INCREASE_ICON);
 		increaseSpeed.setToolTipText("Increase the sim speed (aka time ratio)");
 
-		increaseSpeed.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				if (!masterClock.isPaused()) {
-					masterClock.increaseSpeed();
-				}
-			};
+		increaseSpeed.addActionListener(e -> {
+			if (!masterClock.isPaused()) {
+				masterClock.increaseSpeed();
+			}
 		});
 		
 		// Add the increase speed button

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BacklogTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/BacklogTableModel.java
@@ -40,7 +40,8 @@ public class BacklogTableModel extends AbstractMonitorModel
 	private static final int SETTLEMENT_COL = DESC_COL+1;
 	private static final int ENTITY_COL = SETTLEMENT_COL+1;
 	private static final int EVA_COL = ENTITY_COL+1;
-	private static final int DEMAND_COL = EVA_COL+1;
+	private static final int SCOPE_COL = EVA_COL+1;
+	private static final int DEMAND_COL = SCOPE_COL+1;
 	static final int SCORE_COL = DEMAND_COL+1;
 
 	static {
@@ -50,6 +51,7 @@ public class BacklogTableModel extends AbstractMonitorModel
 		COLUMNS[DESC_COL] = new ColumnSpec("Description", String.class);
 		COLUMNS[DEMAND_COL]  = new ColumnSpec("Demand", Integer.class);
 		COLUMNS[EVA_COL]  = new ColumnSpec("EVA", String.class);
+		COLUMNS[SCOPE_COL]  = new ColumnSpec("Worker", String.class);
 		COLUMNS[SCORE_COL] = new ColumnSpec("Score", Double.class);
 	}
 
@@ -235,6 +237,12 @@ public class BacklogTableModel extends AbstractMonitorModel
 				return selectedTask.getShortName();
 			case EVA_COL:
 				return (selectedTask.isEVA() ? "Yes" : "No");
+			case SCOPE_COL:
+				return switch(selectedTask.getScope()) {
+					case ANY_HOUR -> "Any";
+					case NONWORK_HOUR -> "Off duty only";
+					case WORK_HOUR -> "On duty only";
+				};
 			case DEMAND_COL:
 				return selectedTask.getDemand();
 			case SCORE_COL:

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/svg/SVGMapUtil.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/svg/SVGMapUtil.java
@@ -40,22 +40,11 @@ public final class SVGMapUtil {
         svgMapProperties = new Properties();
 
         URL resource = SVGLoader.class.getResource(fileName);
-        InputStream inputStream = null;
-        try {
-            inputStream = resource.openStream();
+        try (InputStream inputStream = resource.openStream();) {
             svgMapProperties.load(inputStream);
         }
         catch (IOException e) {
             logger.log(Level.SEVERE, "Problem reading SVG properties file", e);
-        }
-        finally {
-            try {
-            	if (inputStream != null)
-            		inputStream.close();
-            }
-            catch (IOException e) {
-                // Do not report exception in finally
-            }
         }
     }
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelGeneral.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelGeneral.java
@@ -7,6 +7,8 @@
 package com.mars_sim.ui.swing.unit_window.person;
 
 import java.awt.BorderLayout;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -34,9 +36,7 @@ public class TabPanelGeneral extends TabPanel {
 	
 	private JLabel birthDateTF;
 	private JLabel storedMassLabel;
-	
-	private String birthDate;
-	
+		
 	/**
 	 * Constructor.
 	 * 
@@ -68,10 +68,11 @@ public class TabPanelGeneral extends TabPanel {
 		infoPanel.addTextField(Msg.getString("TabPanelGeneral.gender"), gender,null);
 		
 		// Prepare birthdate and age textfield
-		birthDate = person.getBirthDate();
+		var birthDate = person.getBirthDate();
+
 		String birthTxt = Msg.getString(
 			TAB_BIRTH_DATE_AGE,
-			birthDate,
+			birthDate.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)),
 			Integer.toString(person.getAge())); //$NON-NLS-1$
 		birthDateTF = infoPanel.addTextField(Msg.getString("TabPanelGeneral.birthDate"), birthTxt, null);
 		
@@ -122,18 +123,6 @@ public class TabPanelGeneral extends TabPanel {
 	 */
 	@Override
 	public void update() {
-		
-		String newBD = person.getBirthDate();
-		
-		if (!newBD.equalsIgnoreCase(birthDate)) {
-			// Update the age
-			String birthdate = Msg.getString(
-				TAB_BIRTH_DATE_AGE,
-				newBD,
-				Integer.toString(person.getAge())); 
-					
-			birthDateTF.setText(birthdate); 
-		}
 		
 		// Prepare total mass label
 		storedMassLabel.setText(StyleManager.DECIMAL_KG.format(person.getStoredMass()));

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelGeneral.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelGeneral.java
@@ -34,7 +34,6 @@ public class TabPanelGeneral extends TabPanel {
 	/** The Person instance. */
 	private Person person;
 	
-	private JLabel birthDateTF;
 	private JLabel storedMassLabel;
 		
 	/**
@@ -74,7 +73,7 @@ public class TabPanelGeneral extends TabPanel {
 			TAB_BIRTH_DATE_AGE,
 			birthDate.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)),
 			Integer.toString(person.getAge())); //$NON-NLS-1$
-		birthDateTF = infoPanel.addTextField(Msg.getString("TabPanelGeneral.birthDate"), birthTxt, null);
+		infoPanel.addTextField(Msg.getString("TabPanelGeneral.birthDate"), birthTxt, null);
 		
 		// Prepare country of origin textfield
 		String country = person.getCountry();

--- a/mars-sim-ui/src/test/java/com/mars_sim/ui/swing/tool/settlement/TestSVGMapUtil.java
+++ b/mars-sim-ui/src/test/java/com/mars_sim/ui/swing/tool/settlement/TestSVGMapUtil.java
@@ -20,9 +20,12 @@ import junit.framework.TestCase;
  */
 public class TestSVGMapUtil extends TestCase {
 
+    private SimulationConfig config;
+
     @Override
     public void setUp() throws Exception {
-    	SimulationConfig.instance().loadConfig();
+    	config = SimulationConfig.instance();
+        config.loadConfig();
     }
 
     /**
@@ -31,7 +34,7 @@ public class TestSVGMapUtil extends TestCase {
     public void testGetBuildingSVG() {
         
         // Check that all configured building names are mapped to a SVG image.
-        for(var bs : SimulationConfig.instance().getBuildingConfiguration().getBuildingTypes()) {
+        for(var bs : config.getBuildingConfiguration().getBuildingTypes()) {
             GraphicsNode svg = SVGMapUtil.getBuildingSVG(bs.getName());
             assertNotNull(bs.getName() + " is not mapped to a SVG image.", svg);
         }
@@ -43,11 +46,11 @@ public class TestSVGMapUtil extends TestCase {
     public void testGetConstructionSiteSVG() {
         
         // Check that all construction stage names are mapped to a SVG image.
-        ConstructionConfig config = SimulationConfig.instance().getConstructionConfiguration();
+        ConstructionConfig cConfig = config.getConstructionConfiguration();
         List<ConstructionStageInfo> constructionStages = new ArrayList<ConstructionStageInfo>();
-        constructionStages.addAll(config.getConstructionStageInfoList(ConstructionStageInfo.FOUNDATION));
-        constructionStages.addAll(config.getConstructionStageInfoList(ConstructionStageInfo.FRAME));
-        constructionStages.addAll(config.getConstructionStageInfoList(ConstructionStageInfo.BUILDING));
+        constructionStages.addAll(cConfig.getConstructionStageInfoList(ConstructionStageInfo.FOUNDATION));
+        constructionStages.addAll(cConfig.getConstructionStageInfoList(ConstructionStageInfo.FRAME));
+        constructionStages.addAll(cConfig.getConstructionStageInfoList(ConstructionStageInfo.BUILDING));
         
         Iterator<ConstructionStageInfo> i = constructionStages.iterator();
         while (i.hasNext()) {
@@ -64,7 +67,7 @@ public class TestSVGMapUtil extends TestCase {
     public void testGetVehicleSVG() {
         
         // Check that all vehicle types are mapped to a SVG image.
-        for(VehicleSpec vs :  SimulationConfig.instance().getVehicleConfiguration().getVehicleSpecs()) {
+        for(VehicleSpec vs :  config.getVehicleConfiguration().getVehicleSpecs()) {
             String vehicleType = vs.getBaseImage();
             GraphicsNode svg = SVGMapUtil.getVehicleSVG(vehicleType);
             assertNotNull(vehicleType + " is not mapped to a SVG image.", svg);
@@ -77,7 +80,7 @@ public class TestSVGMapUtil extends TestCase {
     public void testGetMaintenanceOverlaySVG() {
         
         // Check that all vehicle types have a maintenance overlay mapped to a SVG image.
-        for(VehicleSpec vs :  SimulationConfig.instance().getVehicleConfiguration().getVehicleSpecs()) {
+        for(VehicleSpec vs :  config.getVehicleConfiguration().getVehicleSpecs()) {
             VehicleType type = vs.getType();
             GraphicsNode svg = SVGMapUtil.getMaintenanceOverlaySVG(type.name());
             assertNotNull(type + " does not have a maintenance overlay mapped to a SVG image.", svg);
@@ -90,7 +93,7 @@ public class TestSVGMapUtil extends TestCase {
     public void testGetLoadingOverlaySVG() {
         
         // Check that all vehicle types have a loading overlay mapped to a SVG image.
-        for(VehicleSpec vs :  SimulationConfig.instance().getVehicleConfiguration().getVehicleSpecs()) {
+        for(VehicleSpec vs :  config.getVehicleConfiguration().getVehicleSpecs()) {
             VehicleType type = vs.getType();
             if (type != VehicleType.LUV) {
                 GraphicsNode svg = SVGMapUtil.getLoadingOverlaySVG(type.name());
@@ -105,7 +108,7 @@ public class TestSVGMapUtil extends TestCase {
     public void testGetAttachmentPartSVG() {
         
         // Check that all vehicle attachment parts are mapped to a SVG image.
-        Iterator<Part> i = SimulationConfig.instance().getVehicleConfiguration().
+        Iterator<Part> i = config.getVehicleConfiguration().
                 getVehicleSpec("Light Utility Vehicle").getAttachableParts().iterator();
         while (i.hasNext()) {
             Part attachmentPart = i.next();


### PR DESCRIPTION
This PR adds the concept of a Group Activity that can represent meetings. There are a number of parts involved:

- GroupActivityInfo is a record that defines the properties of an activity, duration, repeating frequency, meeting place
- GroupActivity is a scheduled activity in a Settlement using a info definition. It uses the existing Scheduled Event logic to advance
- GroupActivityMetaTask converts any active Activities into a SettlementTask that can be assigned
- GtroupActivityTask is assigned to a Person when they participate in an activity

To underpin this the constructor logic of ```Building``` has been corrected and simplified.
There has been numerous UnitTests added/modified.

It also adds configuration for the following default activities; other can be added via settlement.xml:

- Evening Sky Watching party
- Annual Birthday parties
- Announcement meeting when a new Council member is elected
- Welcome party for new arrivals
- Regular team meetings

When a group activity has a Person instigator the Opinion of that person influences the scoring for participants.

A further phase is needed to get participation to improve a Persons stats, e.g. skills.

close #1209 
part #971 