### PR TITLE
Create a Group Activity tab to the Settlement window

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityMetaTask.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/activities/GroupActivityMetaTask.java
@@ -60,11 +60,7 @@ public class GroupActivityMetaTask extends MetaTask implements SettlementMetaTas
      */
     @Override
     public List<SettlementTask> getSettlementTasks(Settlement settlement) {
-       var active = settlement.getFutureManager().getEvents().stream()
-                .filter(e -> e.getHandler() instanceof GroupActivity)
-                .map(e -> (GroupActivity)e.getHandler())
-                .filter(GroupActivity::isActive)
-                .toList();
+        var active = settlement.getGroupActivities(true);
         
          List<SettlementTask> results = new ArrayList<>();
          for(var a : active) {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -3800,4 +3800,16 @@ public class Settlement extends Structure implements Temporal,
 		
 		scientificAchievement = null;
 	}
+
+	/**
+	 * Get the GroupActivity instanes associated with a Settlement
+	 * @param justActive Filter to only return active meetings
+	 */
+    public List<GroupActivity> getGroupActivities(boolean justActive) {
+       return getFutureManager().getEvents().stream()
+                .filter(e -> e.getHandler() instanceof GroupActivity)
+                .map(e -> (GroupActivity)e.getHandler())
+                .filter(e -> (!justActive || e.isActive()))
+                .toList();
+    }
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/TabPanelTable.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/TabPanelTable.java
@@ -59,8 +59,8 @@ public abstract class TabPanelTable extends TabPanel {
 		}
 	}
 
-	private JScrollPane scrollPane;
 	private String[] headerTooltips;
+	private String tableTitle;
 	
 	/**
 	 * Constructor.
@@ -73,14 +73,6 @@ public abstract class TabPanelTable extends TabPanel {
 	protected TabPanelTable(String tabTitle, Icon tabIcon, String tabToolTip, MainDesktopPane desktop) {
 		// Use the TabPanel constructor
 		super(tabTitle, tabIcon, tabToolTip, desktop);
-	}
-	
-	/**
-	 * Add some tooltips to the tabe header
-	 * @param tooltips
-	 */
-	protected void setHeaderToolTips(String [] tooltips) {
-		headerTooltips = tooltips;
 	}
 
 	/**
@@ -96,6 +88,26 @@ public abstract class TabPanelTable extends TabPanel {
 		super(tabTitle, tabIcon, tabToolTip, unit, desktop);
 	}
 
+		/**
+	 * Add some tooltips to the tabe header
+	 * @param tooltips
+	 */
+	protected void setHeaderToolTips(String [] tooltips) {
+		headerTooltips = tooltips;
+	}
+
+	/**
+	 * Add a title to the table
+	 * @param title
+	 */
+	protected void setTableTitle(String title) {
+		tableTitle = title;
+	}
+
+	/**
+	 * Called by Unit window framework, invoked subclass for the info panel and creates a table
+	 * itself.
+	 */
 	@Override
 	protected void buildUI(JPanel content) {
 		
@@ -106,7 +118,11 @@ public abstract class TabPanelTable extends TabPanel {
 		}
 
 		// Create scroll panel for the outer table panel.
-		scrollPane = new JScrollPane();
+		var scrollPane = new JScrollPane();
+		if (tableTitle != null) {
+			addBorder(scrollPane, tableTitle);
+		}
+
 		// increase vertical mousewheel scrolling speed for this one
 		scrollPane.getVerticalScrollBar().setUnitIncrement(16);
 		scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/TabPanelTable.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/TabPanelTable.java
@@ -1,0 +1,172 @@
+/*
+ * Mars Simulation Project
+ * TabPanelTable.java
+ * @date 2024-03-31
+ * @author Barry Evans
+ */
+package com.mars_sim.ui.swing.unit_window;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.event.MouseEvent;
+
+import javax.swing.Icon;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.table.JTableHeader;
+import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableModel;
+
+import com.mars_sim.core.Unit;
+import com.mars_sim.ui.swing.MainDesktopPane;
+import com.mars_sim.ui.swing.utils.UnitModel;
+import com.mars_sim.ui.swing.utils.UnitTableLauncher;
+
+/**
+ * This is a tab panel for display a table and a information panel
+ */
+@SuppressWarnings("serial")
+public abstract class TabPanelTable extends TabPanel {
+	
+	// implementation code to set a tooltip text to each column of JTableHeader
+	private static class ToolTipHeader extends JTableHeader {
+		String[] toolTips;
+		
+		public ToolTipHeader(TableColumnModel model) {
+			super(model);
+		}
+		
+		public String getToolTipText(MouseEvent e) {
+			int col = columnAtPoint(e.getPoint());
+			int modelCol = getTable().convertColumnIndexToModel(col);
+			String retStr;
+			try {
+				retStr = toolTips[modelCol];
+			} catch (NullPointerException ex) {
+				retStr = "";
+			} catch (ArrayIndexOutOfBoundsException ex) {
+				retStr = "";
+			}
+			if (retStr.length() < 1) {
+				retStr = super.getToolTipText(e);
+			}
+			return retStr;
+		}
+		
+		public void setToolTipStrings(String[] toolTips) {
+			this.toolTips = toolTips;
+		}
+	}
+
+	private JScrollPane scrollPane;
+	private String[] headerTooltips;
+	
+	/**
+	 * Constructor.
+	 * 
+	 * @param tabTitle   the title to be displayed in the tab (may be null).
+	 * @param tabIcon    the icon to be displayed in the tab (may be null).
+	 * @param tabToolTip the tool tip to be displayed in the icon (may be null).
+	 * @param desktop    the main desktop.
+	 */
+	protected TabPanelTable(String tabTitle, Icon tabIcon, String tabToolTip, MainDesktopPane desktop) {
+		// Use the TabPanel constructor
+		super(tabTitle, tabIcon, tabToolTip, desktop);
+	}
+	
+	/**
+	 * Add some tooltips to the tabe header
+	 * @param tooltips
+	 */
+	protected void setHeaderToolTips(String [] tooltips) {
+		headerTooltips = tooltips;
+	}
+
+	/**
+	 * Constructor when there is an associated Unit.
+	 *
+	 * @param tabTitle   the title to be displayed in the tab (may be null).
+	 * @param tabIcon    the icon to be displayed in the tab (may be null).
+	 * @param tabToolTip the tool tip to be displayed in the icon (may be null).
+	 * @param unit       the unit to display.
+	 * @param desktop    the main desktop.
+	 */
+	protected TabPanelTable(String tabTitle, Icon tabIcon, String tabToolTip, Unit unit, MainDesktopPane desktop) {
+		super(tabTitle, tabIcon, tabToolTip, unit, desktop);
+	}
+
+	@Override
+	protected void buildUI(JPanel content) {
+		
+		// Prepare  info panel.
+		JPanel infoPanel = createInfoPanel();
+		if (infoPanel != null) {
+			content.add(infoPanel, BorderLayout.NORTH);
+		}
+
+		// Create scroll panel for the outer table panel.
+		scrollPane = new JScrollPane();
+		// increase vertical mousewheel scrolling speed for this one
+		scrollPane.getVerticalScrollBar().setUnitIncrement(16);
+		scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+		content.add(scrollPane,BorderLayout.CENTER);
+		
+		// Prepare table model.
+		var tableModel = createModel();
+		
+		// Prepare table.
+		var table = new JTable(tableModel);
+		if (tableModel instanceof UnitModel) {
+			// Call up the window when clicking on a row on the table
+			table.addMouseListener(new UnitTableLauncher(getDesktop()));
+		}
+		
+		table.setRowSelectionAllowed(true);
+		var tc = table.getColumnModel();
+		setColumnDetails(tc);
+		
+				
+		// Set up tooltips for the column headers
+		if (headerTooltips != null) {
+			ToolTipHeader tooltipHeader = new ToolTipHeader(tc);
+			tooltipHeader.setToolTipStrings(headerTooltips);
+			table.setTableHeader(tooltipHeader);
+		}
+
+		// Resizable automatically when its Panel resizes
+		table.setPreferredScrollableViewportSize(new Dimension(225, -1));
+		table.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+
+		// Add sorting
+		table.setAutoCreateRowSorter(true);
+
+		scrollPane.setViewportView(table);
+	}
+
+	/**
+	 * This method should configure the table for any special renderers or
+	 * column widths. It should be overriden by subclasses.
+	 * @param columnModel Columns to be configured
+	 */
+	protected void setColumnDetails(TableColumnModel columnModel) {
+		// Default implementation does nothing
+	}
+
+	/**
+	 * This is for the model to be dispalyed in the table.
+	 * If the return is a UnitModel then the launcher will be enabled.
+	 * @return
+	 */
+	protected abstract TableModel createModel();
+
+	/**
+	 * If the panel has an info panel then it is created by this method. It will be placed
+	 * above the table.
+	 * Subclasses can override this if info is to be displayed
+	 * @return Could return null
+	 */
+	protected JPanel createInfoPanel() {
+		return null;
+	}
+}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/TabPanelTable.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/TabPanelTable.java
@@ -14,6 +14,7 @@ import javax.swing.Icon;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
+import javax.swing.ScrollPaneConstants;
 import javax.swing.table.JTableHeader;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
@@ -31,30 +32,28 @@ public abstract class TabPanelTable extends TabPanel {
 	
 	// implementation code to set a tooltip text to each column of JTableHeader
 	private static class ToolTipHeader extends JTableHeader {
-		String[] toolTips;
+		private String[] toolTips;
 		
-		public ToolTipHeader(TableColumnModel model) {
+		public ToolTipHeader(TableColumnModel model, String[] toolTips) {
 			super(model);
+			this.toolTips = toolTips;
 		}
 		
+		@Override
 		public String getToolTipText(MouseEvent e) {
+			String retStr = null;
 			int col = columnAtPoint(e.getPoint());
 			int modelCol = getTable().convertColumnIndexToModel(col);
-			String retStr;
-			try {
+			if (modelCol < toolTips.length) {
 				retStr = toolTips[modelCol];
-			} catch (NullPointerException ex) {
-				retStr = "";
-			} catch (ArrayIndexOutOfBoundsException ex) {
-				retStr = "";
 			}
-			if (retStr.length() < 1) {
+			if ((retStr == null) || (retStr.length() < 1)) {
 				retStr = super.getToolTipText(e);
 			}
 			return retStr;
 		}
 		
-		public void setToolTipStrings(String[] toolTips) {
+		public void setToolTipStrings() {
 			this.toolTips = toolTips;
 		}
 	}
@@ -125,7 +124,7 @@ public abstract class TabPanelTable extends TabPanel {
 
 		// increase vertical mousewheel scrolling speed for this one
 		scrollPane.getVerticalScrollBar().setUnitIncrement(16);
-		scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
 		content.add(scrollPane,BorderLayout.CENTER);
 		
 		// Prepare table model.
@@ -145,8 +144,7 @@ public abstract class TabPanelTable extends TabPanel {
 				
 		// Set up tooltips for the column headers
 		if (headerTooltips != null) {
-			ToolTipHeader tooltipHeader = new ToolTipHeader(tc);
-			tooltipHeader.setToolTipStrings(headerTooltips);
+			ToolTipHeader tooltipHeader = new ToolTipHeader(tc, headerTooltips);
 			table.setTableHeader(tooltipHeader);
 		}
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelAttribute.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelAttribute.java
@@ -6,16 +6,14 @@
  */
 package com.mars_sim.ui.swing.unit_window.person;
 
-import java.awt.Dimension;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableModel;
 
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.NaturalAttributeManager;
@@ -25,21 +23,18 @@ import com.mars_sim.core.robot.Robot;
 import com.mars_sim.tools.Msg;
 import com.mars_sim.ui.swing.ImageLoader;
 import com.mars_sim.ui.swing.MainDesktopPane;
-import com.mars_sim.ui.swing.unit_window.TabPanel;
+import com.mars_sim.ui.swing.unit_window.TabPanelTable;
 
 /**
  * The TabPanelAttribute is a tab panel for the natural attributes of a person.
  */
 @SuppressWarnings("serial")
-public class TabPanelAttribute
-extends TabPanel {
+public class TabPanelAttribute extends TabPanelTable {
 	
 	private static final String ATTRIBUTE_ICON = "attribute"; //$NON-NLS-1$
 	
 	private AttributeTableModel attributeTableModel;
 	
-	private JTable attributeTable;
-
 	/**
 	 * Constructor 1.
 	 * @param person {@link Person} the person.
@@ -71,34 +66,23 @@ extends TabPanel {
 	}
 
 	@Override
-	protected void buildUI(JPanel content) {
-
-		// Create attribute scroll panel
-		JScrollPane attributeScrollPanel = new JScrollPane();
-		content.add(attributeScrollPanel);
-
+	protected TableModel createModel() {
 		// Create attribute table model
 		attributeTableModel = new AttributeTableModel((Worker) getUnit());
-		
-		// Create attribute table
-		attributeTable = new JTable(attributeTableModel); //new JTable(attributeTableModel);//
-		attributeTable.setPreferredScrollableViewportSize(new Dimension(225, 100));
-		attributeTable.getColumnModel().getColumn(0).setPreferredWidth(100);
-		attributeTable.getColumnModel().getColumn(1).setPreferredWidth(70);
-		attributeTable.setRowSelectionAllowed(true);
-		
-		attributeScrollPanel.setViewportView(attributeTable);
-
-		attributeTable.setAutoCreateRowSorter(true);
+		return attributeTableModel;
+	}
+	
+	@Override
+	protected void setColumnDetails(TableColumnModel columnModel) {
+		columnModel.getColumn(0).setPreferredWidth(100);
+		columnModel.getColumn(1).setPreferredWidth(70);
  
 		// Align the content to the center of the cell
         // Note: DefaultTableCellRenderer does NOT work well with nimrod
 		DefaultTableCellRenderer renderer = new DefaultTableCellRenderer();
 		renderer.setHorizontalAlignment(SwingConstants.LEFT);
-		attributeTable.getColumnModel().getColumn(0).setCellRenderer(renderer);
-		attributeTable.getColumnModel().getColumn(1).setCellRenderer(renderer);
-
-        update();
+		columnModel.getColumn(0).setCellRenderer(renderer);
+		columnModel.getColumn(1).setCellRenderer(renderer);
 	}
 
 	/**
@@ -112,7 +96,6 @@ extends TabPanel {
 	@Override
 	public void destroy() {
 		attributeTableModel = null;
-		attributeTable = null;
 	}
 }
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelFavorite.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelFavorite.java
@@ -6,19 +6,15 @@
  */
 package com.mars_sim.ui.swing.unit_window.person;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.swing.BoxLayout;
-import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
 import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableModel;
 
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.fav.Favorite;
@@ -27,21 +23,17 @@ import com.mars_sim.tools.Msg;
 import com.mars_sim.ui.swing.ImageLoader;
 import com.mars_sim.ui.swing.MainDesktopPane;
 import com.mars_sim.ui.swing.NumberCellRenderer;
-import com.mars_sim.ui.swing.StyleManager;
-import com.mars_sim.ui.swing.unit_window.TabPanel;
+import com.mars_sim.ui.swing.unit_window.TabPanelTable;
 import com.mars_sim.ui.swing.utils.AttributePanel;
 
 /**
  * The TabPanelFavorite is a tab panel for general information about a person.
  */
 @SuppressWarnings("serial")
-public class TabPanelFavorite
-extends TabPanel {
+public class TabPanelFavorite extends TabPanelTable {
 
 	private static final String FAV_ICON = "favourite"; //$NON-NLS-1$
 	
-	/** The Preference Table. */	
-	private JTable table;
 	/** The Preference Table Model. */	
 	private PreferenceTableModel tableModel;
 	/** The Person instance. */
@@ -65,14 +57,9 @@ extends TabPanel {
 	}
 
 	@Override
-	protected void buildUI(JPanel content) {
-		JPanel topPanel = new JPanel(new BorderLayout(5, 5));
-		topPanel.setLayout(new BoxLayout(topPanel, BoxLayout.Y_AXIS));
-		content.add(topPanel, BorderLayout.NORTH);
-		
+	protected JPanel createInfoPanel() {
 		// Prepare SpringLayout for info panel.
 		AttributePanel infoPanel = new AttributePanel(4);
-		topPanel.add(infoPanel, BorderLayout.NORTH);
 
 		Favorite fav = person.getFavorite();
 		infoPanel.addTextField(Msg.getString("TabPanelFavorite.mainDish"), fav.getFavoriteMainDish(), null);
@@ -80,43 +67,20 @@ extends TabPanel {
 		infoPanel.addTextField(Msg.getString("TabPanelFavorite.dessert"), Conversion.capitalize(fav.getFavoriteDessert()), null);
 		infoPanel.addTextField(Msg.getString("TabPanelFavorite.activity"), fav.getFavoriteActivity().getName(), null);
 
-		// Create label panel.
-		JPanel labelPanel = new JPanel(new BorderLayout(5, 5));
-		content.add(labelPanel, BorderLayout.CENTER);
-		
-		// Create preference title label
-		JLabel preferenceLabel = new JLabel(Msg.getString("TabPanelFavorite.preferenceTable.title"), JLabel.CENTER); //$NON-NLS-1$
-		StyleManager.applySubHeading(preferenceLabel);
-		labelPanel.add(preferenceLabel, BorderLayout.NORTH);
-		
-		// Create scroll panel
-		JScrollPane scrollPane = new JScrollPane();
-		scrollPane.getVerticalScrollBar().setUnitIncrement(10);
-		scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-		labelPanel.add(scrollPane, BorderLayout.CENTER);
-		
-		// Create skill table
+		return infoPanel;
+	}
+
+	@Override
+	protected TableModel createModel() {
 		tableModel = new PreferenceTableModel(person);
-		table = new JTable(tableModel);
-
-		// Align the preference score to the center of the cell
-		// DefaultTableCellRenderer renderer = new DefaultTableCellRenderer();
-		// renderer.setHorizontalAlignment(SwingConstants.LEFT);
-		// table.getColumnModel().getColumn(0).setCellRenderer(renderer);
-		// renderer = new DefaultTableCellRenderer();
-		// renderer.setHorizontalAlignment(SwingConstants.CENTER);
-		// table.getColumnModel().getColumn(1).setCellRenderer(renderer);
-
-		table.setPreferredScrollableViewportSize(new Dimension(225, 200));
-		table.getColumnModel().getColumn(0).setPreferredWidth(150);
-		table.getColumnModel().getColumn(1).setPreferredWidth(30);
-		table.setRowSelectionAllowed(true);
-		table.setDefaultRenderer(Integer.class, new NumberCellRenderer());
-
-		// Added sorting
-		table.setAutoCreateRowSorter(true);
-
-		scrollPane.setViewportView(table);
+		return tableModel;
+	}
+	
+	@Override
+	protected void setColumnDetails(TableColumnModel model) {
+		model.getColumn(0).setPreferredWidth(150);
+		model.getColumn(1).setPreferredWidth(30);
+		model.getColumn(1).setCellRenderer(new NumberCellRenderer());
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelSkill.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelSkill.java
@@ -6,13 +6,11 @@
  */
 package com.mars_sim.ui.swing.unit_window.person;
 
-import java.awt.Dimension;
 import java.util.List;
 
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
 import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableModel;
 
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.person.ai.Skill;
@@ -22,18 +20,16 @@ import com.mars_sim.tools.Msg;
 import com.mars_sim.ui.swing.ImageLoader;
 import com.mars_sim.ui.swing.MainDesktopPane;
 import com.mars_sim.ui.swing.NumberCellRenderer;
-import com.mars_sim.ui.swing.unit_window.TabPanel;
+import com.mars_sim.ui.swing.unit_window.TabPanelTable;
 
 /**
  * The SkillTabPanel is a tab panel for the skills of a person or robot.
  */
 @SuppressWarnings("serial")
-public class TabPanelSkill
-extends TabPanel {
+public class TabPanelSkill extends TabPanelTable {
 
 	private static final String SKILL_ICON = "skill"; //$NON-NLS-1$
 	
-	private JTable skillTable ;
 	private SkillTableModel skillTableModel;
 
 	/**
@@ -56,27 +52,22 @@ extends TabPanel {
 	}
 
 	@Override
-	protected void buildUI(JPanel content) {
+	protected TableModel createModel() {
+		return skillTableModel;
+	}
 
-		// Create skill scroll panel
-		JScrollPane skillScrollPanel = new JScrollPane();
-		content.add(skillScrollPanel);
+	@Override
+	protected void setColumnDetails(TableColumnModel columnModel) {
+		columnModel.getColumn(0).setPreferredWidth(110);
+		columnModel.getColumn(1).setPreferredWidth(50);
+		columnModel.getColumn(2).setPreferredWidth(60);
+		columnModel.getColumn(3).setPreferredWidth(100);
 
-		// Create skill table
-		skillTable = new JTable(skillTableModel);
-		skillTable.setPreferredScrollableViewportSize(new Dimension(250, 100));
-		skillTable.getColumnModel().getColumn(0).setPreferredWidth(110);
-		skillTable.getColumnModel().getColumn(1).setPreferredWidth(50);
-		skillTable.getColumnModel().getColumn(2).setPreferredWidth(60);
-		skillTable.getColumnModel().getColumn(3).setPreferredWidth(100);
-		skillTable.setRowSelectionAllowed(true);
-		skillTable.setDefaultRenderer(Integer.class, new NumberCellRenderer(0));
-		skillTable.setDefaultRenderer(Double.class, new NumberCellRenderer(2));
-		
-		skillScrollPanel.setViewportView(skillTable);
+		columnModel.getColumn(1).setCellRenderer(new NumberCellRenderer(0));
 
-		// Added sorting
-		skillTable.setAutoCreateRowSorter(true);
+		var r = new NumberCellRenderer(2);
+		columnModel.getColumn(2).setCellRenderer(r);
+		columnModel.getColumn(3).setCellRenderer(r);
 	}
 
 	/**
@@ -84,9 +75,7 @@ extends TabPanel {
 	 */
 	@Override
 	public void update() {		
-		if (skillTable != null) {
-			skillTableModel.update();
-		}
+		skillTableModel.update();
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/SettlementUnitWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/SettlementUnitWindow.java
@@ -45,9 +45,7 @@ public class SettlementUnitWindow extends UnitWindow {
 	private static final String SPONSOR = "sponsor";
 	private static final String TEMPLATE = "template";
 
-	private static final String ONE_SPACE = " ";
-	private static final String TWO_SPACES = "  ";
-	private static final String SIX_SPACES = "      ";
+	private static final String X_OF_Y = "%d / %d";
 	
 	private JLabel popLabel;
 	private JLabel vehLabel;
@@ -91,9 +89,8 @@ public class SettlementUnitWindow extends UnitWindow {
 
 		// Create name label
 		UnitDisplayInfo displayInfo = UnitDisplayInfoFactory.getUnitDisplayInfo(unit);
-		String name = SIX_SPACES + unit.getShortenedName() + SIX_SPACES;
 
-		JLabel nameLabel = new JLabel(name, displayInfo.getButtonIcon(unit), SwingConstants.CENTER);
+		JLabel nameLabel = new JLabel(unit.getShortenedName() , displayInfo.getButtonIcon(unit), SwingConstants.CENTER);
 		nameLabel.setMinimumSize(new Dimension(120, UnitWindow.STATUS_HEIGHT));
 		
 		JPanel namePane = new JPanel(new BorderLayout(0, 0));
@@ -128,10 +125,10 @@ public class SettlementUnitWindow extends UnitWindow {
 		vehIconLabel.setToolTipText("# of vehicles : (in settlement / total)");
 		setImage(VEHICLE, vehIconLabel);
 
-		JPanel countryPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
-		JPanel popPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
-		JPanel templatePanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
-		JPanel vehPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+		JPanel countryPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0));
+		JPanel popPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0));
+		JPanel templatePanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0));
+		JPanel vehPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0));
 
 		countryLabel = new JLabel();
 		countryLabel.setFont(font);
@@ -178,8 +175,8 @@ public class SettlementUnitWindow extends UnitWindow {
 		if (list.size() == 1)
 			countryName = settlement.getReportingAuthority().getCountries().get(0);
 		
-		countryLabel.setText(TWO_SPACES + countryName + SIX_SPACES);
-		templateLabel.setText(TWO_SPACES + settlement.getTemplate() + SIX_SPACES);
+		countryLabel.setText(countryName);
+		templateLabel.setText(settlement.getTemplate());
 		
 	}
 	
@@ -201,6 +198,7 @@ public class SettlementUnitWindow extends UnitWindow {
 		addTabPanel(new TabPanelCredit(settlement, desktop));
 
 		addTabPanel(new TabPanelFoodProduction(settlement, desktop));
+		addTabPanel(new TabPanelGroupActivity(settlement, desktop));
 
 		addTabPanel(new TabPanelGoods(settlement, desktop));
 
@@ -262,10 +260,10 @@ public class SettlementUnitWindow extends UnitWindow {
 	 * Updates the status of the settlement
 	 */
 	public void statusUpdate() {
-		popLabel.setText(TWO_SPACES + settlement.getIndoorPeopleCount() 
-				+ ONE_SPACE + "/" + ONE_SPACE + settlement.getNumCitizens());
-		vehLabel.setText(TWO_SPACES + settlement.getNumParkedVehicles() 
-				+ ONE_SPACE + "/" + ONE_SPACE + settlement.getOwnedVehicleNum());
+		popLabel.setText(String.format(X_OF_Y, settlement.getIndoorPeopleCount(),
+										settlement.getNumCitizens()));
+		vehLabel.setText(String.format(X_OF_Y, settlement.getNumParkedVehicles(),
+										settlement.getOwnedVehicleNum()));
 	}
 	
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelCredit.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelCredit.java
@@ -6,19 +6,16 @@
  */
 package com.mars_sim.ui.swing.unit_window.structure;
 
-import java.awt.Dimension;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableModel;
 
 import com.mars_sim.core.CollectionUtils;
 import com.mars_sim.core.Simulation;
@@ -35,20 +32,16 @@ import com.mars_sim.tools.Msg;
 import com.mars_sim.ui.swing.ImageLoader;
 import com.mars_sim.ui.swing.MainDesktopPane;
 import com.mars_sim.ui.swing.NumberCellRenderer;
-import com.mars_sim.ui.swing.unit_window.TabPanel;
+import com.mars_sim.ui.swing.unit_window.TabPanelTable;
 import com.mars_sim.ui.swing.utils.UnitModel;
-import com.mars_sim.ui.swing.utils.UnitTableLauncher;
 
 @SuppressWarnings("serial")
-public class TabPanelCredit
-extends TabPanel {
+public class TabPanelCredit extends TabPanelTable {
 	
 	private static final String CREDIT_ICON = "credit";
 
 	/** The Settlement instance. */
 	private Settlement settlement;
-
-	private JTable creditTable;
 
 	private CreditTableModel creditTableModel;
 
@@ -71,43 +64,27 @@ extends TabPanel {
 	}
 
 	@Override
-	protected void buildUI(JPanel content) {
-
-		// Create scroll panel for the outer table panel.
-		JScrollPane creditScrollPanel = new JScrollPane();
-		creditScrollPanel.setPreferredSize(new Dimension(280, 280));
-		content.add(creditScrollPanel);
-
+	protected TableModel createModel() {
 		// Prepare credit table model.
 		creditTableModel = new CreditTableModel(settlement);
+		return creditTableModel;
+	}
 
-		// Prepare credit table.
-		creditTable = new JTable(creditTableModel);
-		creditScrollPanel.setViewportView(creditTable);
-		creditTable.setRowSelectionAllowed(true);
-		creditTable.addMouseListener(new UnitTableLauncher(getDesktop()));
+	@Override
+	protected void setColumnDetails(TableColumnModel columnModel) {
 
-		creditTable.setDefaultRenderer(Double.class, new NumberCellRenderer(2, true));
-		TableColumnModel columnModel = creditTable.getColumnModel();
 		columnModel.getColumn(0).setPreferredWidth(100);
 		columnModel.getColumn(1).setPreferredWidth(120);
 		columnModel.getColumn(2).setPreferredWidth(50);
 
-		// Resizable automatically when its Panel resizes
-		creditTable.setPreferredScrollableViewportSize(new Dimension(225, -1));
-
-		// Add sorting
-		creditTable.setAutoCreateRowSorter(true);
 
 		// Align the preference score to the center of the cell
 		DefaultTableCellRenderer renderer = new DefaultTableCellRenderer();
 		renderer.setHorizontalAlignment(SwingConstants.RIGHT);
 		columnModel.getColumn(0).setCellRenderer(renderer);
 		columnModel.getColumn(2).setCellRenderer(renderer);
-
-		DefaultTableCellRenderer centerRenderer = new DefaultTableCellRenderer();
-		centerRenderer.setHorizontalAlignment(SwingConstants.CENTER);
-		columnModel.getColumn(1).setCellRenderer(centerRenderer);
+		columnModel.getColumn(1).setCellRenderer(
+						new NumberCellRenderer(2, true));
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelGoods.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelGoods.java
@@ -6,15 +6,13 @@
  */
 package com.mars_sim.ui.swing.unit_window.structure;
 
-import java.awt.Dimension;
 import java.util.List;
 
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableModel;
 
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.goods.Good;
@@ -25,15 +23,14 @@ import com.mars_sim.tools.Msg;
 import com.mars_sim.ui.swing.ImageLoader;
 import com.mars_sim.ui.swing.MainDesktopPane;
 import com.mars_sim.ui.swing.NumberCellRenderer;
-import com.mars_sim.ui.swing.unit_window.TabPanel;
+import com.mars_sim.ui.swing.unit_window.TabPanelTable;
 
 @SuppressWarnings("serial")
-public class TabPanelGoods extends TabPanel {
+public class TabPanelGoods extends TabPanelTable {
 
 	private static final String GOOD_ICON = "trade";
 	
 	// Data members
-	private JTable goodsTable;
 	private GoodsTableModel goodsTableModel;
 
 	/**
@@ -51,41 +48,30 @@ public class TabPanelGoods extends TabPanel {
 		);
 	}
 	
+	/**
+	 * Create a table model for the Goods
+	 */
 	@Override
-	protected void buildUI(JPanel content) {
-		
- 		// Create scroll panel for the outer table panel.
-		JScrollPane goodsScrollPane = new JScrollPane();
-		goodsScrollPane.setPreferredSize(new Dimension(250, 300));
-		// increase vertical mousewheel scrolling speed for this one
-		goodsScrollPane.getVerticalScrollBar().setUnitIncrement(16);
-		content.add(goodsScrollPane);
-
-		// Prepare goods table model.
+	protected TableModel createModel() {
 		goodsTableModel = new GoodsTableModel(((Settlement) getUnit()).getGoodsManager());
-
-		// Prepare goods table.
-		goodsTable = new JTable(goodsTableModel);
-		goodsScrollPane.setViewportView(goodsTable);
-		goodsTable.setRowSelectionAllowed(true);
+		return goodsTableModel;
+	}
+	
+	/**
+	 * Set the width and default rendering
+	 * @param columnModel Columns to be configured
+	 */
+	@Override
+	protected void setColumnDetails(TableColumnModel columnModel) {
+				
+		columnModel.getColumn(0).setPreferredWidth(140);
+		columnModel.getColumn(1).setPreferredWidth(80);
 		
-		// Override default cell renderer for formatting double values.
-		goodsTable.setDefaultRenderer(Double.class, new NumberCellRenderer(2, true));
-		
-		goodsTable.getColumnModel().getColumn(0).setPreferredWidth(140);
-		goodsTable.getColumnModel().getColumn(1).setPreferredWidth(80);
-		
-		// Added the two methods below to make all heatTable columns
-		// Resizable automatically when its Panel resizes
-		goodsTable.setPreferredScrollableViewportSize(new Dimension(225, -1));
-
 		// Align the preference score to the center of the cell
 		DefaultTableCellRenderer renderer = new DefaultTableCellRenderer();
 		renderer.setHorizontalAlignment(SwingConstants.RIGHT);
-		goodsTable.getColumnModel().getColumn(0).setCellRenderer(renderer);
-
-		// Added sorting
-		goodsTable.setAutoCreateRowSorter(true);
+		columnModel.getColumn(0).setCellRenderer(renderer);
+		columnModel.getColumn(1).setCellRenderer(new NumberCellRenderer(2, true));
 	}
 
 	/**
@@ -99,11 +85,9 @@ public class TabPanelGoods extends TabPanel {
 	/**
 	 * Internal class used as model for the power table.
 	 */
-	private static class GoodsTableModel
-	extends AbstractTableModel {
+	private static class GoodsTableModel extends AbstractTableModel {
 
 		/** default serial id. */
-//		private static final long serialVersionUID = 1L;
 		// Data members
 		GoodsManager manager;
 		List<?> goods;
@@ -169,7 +153,6 @@ public class TabPanelGoods extends TabPanel {
 	public void destroy() {
 		super.destroy();
 		
-		goodsTable = null;
 		goodsTableModel = null;
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelGroupActivity.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelGroupActivity.java
@@ -1,0 +1,152 @@
+/*
+ * Mars Simulation Project
+ * TabPanelGroupActivity.java
+ * @date 2024-03-31
+ * @author Barry Evans
+ */
+package com.mars_sim.ui.swing.unit_window.structure;
+
+import java.util.List;
+
+import javax.swing.table.AbstractTableModel;
+
+import com.mars_sim.core.Unit;
+import com.mars_sim.core.activities.GroupActivity;
+import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.core.time.MarsTime;
+import com.mars_sim.ui.swing.ImageLoader;
+import com.mars_sim.ui.swing.MainDesktopPane;
+import com.mars_sim.ui.swing.unit_window.TabPanelTable;
+import com.mars_sim.ui.swing.utils.UnitModel;
+
+/**
+ * This is a tab panel for settlement's computing capability.
+ */
+@SuppressWarnings("serial")
+public class TabPanelGroupActivity extends TabPanelTable {
+
+	// default logger.
+
+	private static final String ICON = "schedule";
+	
+	/** The Settlement instance. */
+	private Settlement settlement;
+	
+	private TableModel tableModel;
+	
+	/**
+	 * Constructor.
+	 * 
+	 * @param unit the unit to display.
+	 * @param desktop the main desktop.
+	 */
+	public TabPanelGroupActivity(Settlement unit, MainDesktopPane desktop) {
+		// Use the TabPanel constructor
+		super(
+			"Group Activity",
+			ImageLoader.getIconByName(ICON),
+			"Scheduled Group Activities",
+			desktop
+		);
+		settlement = unit;
+	}
+	
+	/**
+	 * Create a table model that shows the comuting details of the Buildings
+	 * in the settlement.
+	 * 
+	 * @return Table model.
+	 */
+	protected TableModel createModel() {
+		tableModel = new TableModel(settlement);
+
+		return tableModel;
+	}
+
+	/**
+	 * Updates the info on this panel.
+	 */
+	@Override
+	public void update() {
+
+		// Update  table.
+		tableModel.update();
+	}
+
+	/**
+	 * Internal class used as model for the table.
+	 */
+	private class TableModel extends AbstractTableModel implements UnitModel {
+
+		/** default serial id. */
+		private static final long serialVersionUID = 1L;
+
+		private List<GroupActivity> activities;
+		private MarsTime earliest = null;
+
+		private TableModel(Settlement settlement) {
+			activities = settlement.getGroupActivities(false);
+			if (!activities.isEmpty()) {
+				earliest = activities.get(0).getStartTime();
+			}
+		}
+
+		public int getRowCount() {
+			return activities.size();
+		}
+
+		public int getColumnCount() {
+			return 4;
+		}
+		
+		public Class<?> getColumnClass(int columnIndex) {
+			if (columnIndex == 2) {
+				return MarsTime.class;
+			}
+			return String.class;
+		}
+
+		public String getColumnName(int columnIndex) {
+			return switch(columnIndex) {
+				case 0 -> "Name";
+				case 1 -> "State";
+				case 2 -> "When";
+				case 3 -> "Where";
+				default -> "";
+			};
+		}
+
+		public Object getValueAt(int row, int column) {
+			var ga = activities.get(row);
+			return switch(column) {
+				case 0 -> ga.getName();
+				case 1 -> ga.getState().name();
+				case 2 -> ga.getStartTime();
+				case 3 -> (ga.getMeetingPlace() != null ? ga.getMeetingPlace().getName() : null);
+				default -> "";
+			};
+		}
+
+		public void update() {
+			var newActivities = settlement.getGroupActivities(false);
+			MarsTime newEarliest = null;
+			if (!newActivities.isEmpty()) {
+				newEarliest = newActivities.get(0).getStartTime();
+			}
+
+			// Update table if new activities or earliest time has changed
+			if (!activities.equals(newActivities) || 
+					((earliest!= null && newEarliest!= null) && !earliest.equals(newEarliest))) {
+				activities = newActivities;
+				activities = settlement.getGroupActivities(false);
+				earliest = newEarliest;
+				fireTableDataChanged();
+			}
+		}
+
+		@Override
+		public Unit getAssociatedUnit(int row) {
+			return activities.get(row).getMeetingPlace();
+		}
+	}
+}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelGroupActivity.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelGroupActivity.java
@@ -57,6 +57,7 @@ public class TabPanelGroupActivity extends TabPanelTable {
 	 * 
 	 * @return Table model.
 	 */
+	@Override
 	protected TableModel createModel() {
 		tableModel = new TableModel(settlement);
 
@@ -91,14 +92,17 @@ public class TabPanelGroupActivity extends TabPanelTable {
 			}
 		}
 
+		@Override
 		public int getRowCount() {
 			return activities.size();
 		}
 
+		@Override
 		public int getColumnCount() {
 			return 4;
 		}
 		
+		@Override
 		public Class<?> getColumnClass(int columnIndex) {
 			if (columnIndex == 2) {
 				return MarsTime.class;
@@ -106,6 +110,7 @@ public class TabPanelGroupActivity extends TabPanelTable {
 			return String.class;
 		}
 
+		@Override
 		public String getColumnName(int columnIndex) {
 			return switch(columnIndex) {
 				case 0 -> "Name";
@@ -116,6 +121,7 @@ public class TabPanelGroupActivity extends TabPanelTable {
 			};
 		}
 
+		@Override
 		public Object getValueAt(int row, int column) {
 			var ga = activities.get(row);
 			return switch(column) {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelMaintenance.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelMaintenance.java
@@ -6,18 +6,12 @@
  */
 package com.mars_sim.ui.swing.unit_window.structure;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
 import javax.swing.table.AbstractTableModel;
-import javax.swing.table.JTableHeader;
 import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableModel;
 
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.malfunction.MalfunctionManager;
@@ -26,26 +20,20 @@ import com.mars_sim.core.structure.building.Building;
 import com.mars_sim.ui.swing.ImageLoader;
 import com.mars_sim.ui.swing.MainDesktopPane;
 import com.mars_sim.ui.swing.NumberCellRenderer;
-import com.mars_sim.ui.swing.unit_window.TabPanel;
+import com.mars_sim.ui.swing.unit_window.TabPanelTable;
 import com.mars_sim.ui.swing.utils.PercentageCellRenderer;
 import com.mars_sim.ui.swing.utils.UnitModel;
-import com.mars_sim.ui.swing.utils.UnitTableLauncher;
 
 /**
  * The TabPanelMaintenance is a tab panel for settlement's building maintenance.
  */
 @SuppressWarnings("serial")
-public class TabPanelMaintenance extends TabPanel {
+public class TabPanelMaintenance extends TabPanelTable {
 
 	private static final String SPANNER_ICON = "maintenance";
 
 	private BuildingMaintModel tableModel;
 	
-	protected String[] columnToolTips = {
-		    "The Building name", 
-		    "The Building Wear and Tear Condition",
-		    "The # of Sols since last Inspection",
-		    "The Percentage of Completion of Current Inspection"};
 		
 	/**
 	 * Constructor.
@@ -61,33 +49,13 @@ public class TabPanelMaintenance extends TabPanel {
 	}
 
 	@Override
-	protected void buildUI(JPanel content) {
-		
-		JScrollPane maintPane = new JScrollPane();
-		maintPane.setPreferredSize(new Dimension(160, 80));
-		content.add(maintPane, BorderLayout.CENTER);
+	protected TableModel createModel() {
+		return tableModel;
+	}
+	
 
-		// Create the parts table
-		JTable table = new JTable(tableModel) {
-		    //Implement table header tool tips.
-		    protected JTableHeader createDefaultTableHeader() {
-		        return new JTableHeader(columnModel) {
-		            public String getToolTipText(MouseEvent e) {
-		                java.awt.Point p = e.getPoint();
-		                int index = columnModel.getColumnIndexAtX(p.x);
-		                int realIndex = 
-		                        columnModel.getColumn(index).getModelIndex();
-		                return columnToolTips[realIndex];
-		            }
-		        };
-		    }
-		};
-		
-		table.setRowSelectionAllowed(true);
-		table.addMouseListener(new UnitTableLauncher(getDesktop()));
-		table.setAutoCreateRowSorter(true);
-
-		TableColumnModel tc = table.getColumnModel();
+	@Override
+	protected void setColumnDetails(TableColumnModel tc) {
 		tc.getColumn(0).setPreferredWidth(120);
 		tc.getColumn(1).setPreferredWidth(60);
 		tc.getColumn(1).setCellRenderer(new PercentageCellRenderer(false));
@@ -95,7 +63,6 @@ public class TabPanelMaintenance extends TabPanel {
 		tc.getColumn(2).setPreferredWidth(60);
 		tc.getColumn(3).setCellRenderer(new PercentageCellRenderer(false));
 		tc.getColumn(3).setPreferredWidth(60);
-		maintPane.setViewportView(table);
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelPreferences.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelPreferences.java
@@ -8,7 +8,6 @@ package com.mars_sim.ui.swing.unit_window.structure;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
-import java.awt.Dimension;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,11 +17,10 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
 import javax.swing.plaf.basic.BasicComboBoxRenderer;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableModel;
 
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.parameter.ParameterCategory;
@@ -39,9 +37,9 @@ import com.mars_sim.core.structure.SettlementParameters;
 import com.mars_sim.ui.swing.ImageLoader;
 import com.mars_sim.ui.swing.MainDesktopPane;
 import com.mars_sim.ui.swing.StyleManager;
-import com.mars_sim.ui.swing.unit_window.TabPanel;
+import com.mars_sim.ui.swing.unit_window.TabPanelTable;
 
-public class TabPanelPreferences extends TabPanel {
+public class TabPanelPreferences extends TabPanelTable {
 
 	/**
 	 * Represents a renderable version for a Parameter Key with a displayable label.
@@ -79,7 +77,7 @@ public class TabPanelPreferences extends TabPanel {
 	 * @param unit {@link Unit} the unit to display.
 	 * @param desktop {@link MainDesktopPane} the main desktop.
 	 */
-	public TabPanelPreferences(Unit unit, MainDesktopPane desktop) {
+	public TabPanelPreferences(Settlement unit, MainDesktopPane desktop) {
 		// Use TabPanel constructor.
 		super(
 			null,
@@ -87,39 +85,16 @@ public class TabPanelPreferences extends TabPanel {
 			"Preferences", //$NON-NLS-1$
 			unit, desktop
 		);
+		mgr = unit.getPreferences();
+
 	}
 	
+	/**
+	 * Info panel contains the controls to add/modifiy preferences
+	 */
 	@Override
-	protected void buildUI(JPanel content) {
-
+	protected JPanel createInfoPanel() {
 		JPanel topPanel = new JPanel(new BorderLayout());
-		content.add(topPanel);
-
- 		// Create scroll panel for the outer table panel.
-		JScrollPane scrollPane = new JScrollPane();
-		scrollPane.setPreferredSize(new Dimension(250, 250));
-		scrollPane.getVerticalScrollBar().setUnitIncrement(16);
-		topPanel.add(scrollPane, BorderLayout.CENTER);
-
-		// Prepare goods table model.
-		mgr = ((Settlement) getUnit()).getPreferences();
-		tableModel = new PreferenceTableModel(mgr);
-
-		// Prepare goods table.
-		JTable table = new JTable(tableModel);
-		scrollPane.setViewportView(table);
-		
-		// Override default cell renderer for formatting double values.
-		TableColumnModel cModel = table.getColumnModel();
-		cModel.getColumn(0).setPreferredWidth(30);
-		cModel.getColumn(2).setPreferredWidth(20);
-
-		// Add the two methods below to make all columns
-		// Resizable automatically when its Panel resizes
-		table.setPreferredScrollableViewportSize(new Dimension(225, -1));
-
-		// Add sorting
-		table.setAutoCreateRowSorter(true);
 
 		// Create editor control
 		JPanel newPanel = new JPanel();
@@ -145,6 +120,25 @@ public class TabPanelPreferences extends TabPanel {
 
 		// Load up combo
 		populateNameCombo();
+
+		return topPanel;
+	}
+
+	@Override
+	protected TableModel createModel() {
+		// Prepare goods table model.
+		tableModel = new PreferenceTableModel(mgr);
+		return tableModel;
+	}
+	
+	/**
+	 * Set the width of the preference columns
+	 */
+	@Override
+	protected void setColumnDetails(TableColumnModel cModel) {
+		// Override default cell renderer for formatting double values.
+		cModel.getColumn(0).setPreferredWidth(30);
+		cModel.getColumn(2).setPreferredWidth(20);
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelThermalSystem.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelThermalSystem.java
@@ -7,7 +7,6 @@
 package com.mars_sim.ui.swing.unit_window.structure;
 
 import java.awt.BorderLayout;
-import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -19,12 +18,11 @@ import javax.swing.Icon;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableModel;
 
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.structure.Settlement;
@@ -40,17 +38,15 @@ import com.mars_sim.tools.Msg;
 import com.mars_sim.ui.swing.ImageLoader;
 import com.mars_sim.ui.swing.MainDesktopPane;
 import com.mars_sim.ui.swing.StyleManager;
-import com.mars_sim.ui.swing.unit_window.TabPanel;
+import com.mars_sim.ui.swing.unit_window.TabPanelTable;
 import com.mars_sim.ui.swing.utils.AttributePanel;
 import com.mars_sim.ui.swing.utils.UnitModel;
-import com.mars_sim.ui.swing.utils.UnitTableLauncher;
 
 /**
  * This is a tab panel for settlement's Thermal System .
  */
 @SuppressWarnings("serial")
-public class TabPanelThermalSystem
-extends TabPanel {
+public class TabPanelThermalSystem extends TabPanelTable {
 
 	// default logger.
 	
@@ -65,10 +61,6 @@ extends TabPanel {
 	private double powerGenCache;
 	private double eheatCache;
 	private double epowerCache;
-
-	private JTable heatTable ;
-
-	private JScrollPane heatScrollPane;
 	
 	private JCheckBox checkbox;
 
@@ -104,17 +96,16 @@ extends TabPanel {
 		);
 		settlement = unit;
 	}
+
 	
 	@Override
-	protected void buildUI(JPanel content) {
-		
+	protected JPanel createInfoPanel() {
 		manager = settlement.getBuildingManager();
 		thermalSystem = settlement.getThermalSystem();
 		buildings = manager.getBuildingsWithThermal();
 
 		JPanel topContentPanel = new JPanel();
 		topContentPanel.setLayout(new BoxLayout(topContentPanel, BoxLayout.Y_AXIS));
-		content.add(topContentPanel, BorderLayout.NORTH);
 		
 		// Prepare heat info panel.
 		AttributePanel heatInfoPanel = new AttributePanel(5);
@@ -164,23 +155,19 @@ extends TabPanel {
 		checkbox.setSelected(false);
 		checkboxPane.add(checkbox);
 		
-		// Create scroll panel for the outer table panel.
-		heatScrollPane = new JScrollPane();
-		// increase vertical mousewheel scrolling speed for this one
-		heatScrollPane.getVerticalScrollBar().setUnitIncrement(16);
-		heatScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-		content.add(heatScrollPane,BorderLayout.CENTER);
-		
+		return topContentPanel;
+	}
+
+	@Override
+	protected TableModel createModel() {
 		// Prepare thermal control table model.
 		heatTableModel = new HeatTableModel(settlement);
-		
-		// Prepare thermal control table.
-		heatTable = new JTable(heatTableModel);
-		// Call up the building window when clicking on a row on the table
-		heatTable.addMouseListener(new UnitTableLauncher(getDesktop()));
-		
-		heatTable.setRowSelectionAllowed(true);
-		TableColumnModel heatColumns = heatTable.getColumnModel();
+		return heatTableModel;
+	}
+
+	@Override
+	protected void setColumnDetails(TableColumnModel heatColumns) {
+
 		heatColumns.getColumn(0).setPreferredWidth(10);
 		heatColumns.getColumn(1).setPreferredWidth(130);
 		heatColumns.getColumn(2).setPreferredWidth(30);
@@ -194,15 +181,6 @@ extends TabPanel {
 		heatColumns.getColumn(3).setCellRenderer(renderer);
 		heatColumns.getColumn(4).setCellRenderer(renderer);
 		heatColumns.getColumn(5).setCellRenderer(renderer);
-		
-		// Resizable automatically when its Panel resizes
-		heatTable.setPreferredScrollableViewportSize(new Dimension(225, -1));
-		heatTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
-
-		// Add sorting
-		heatTable.setAutoCreateRowSorter(true);
-
-		heatScrollPane.setViewportView(heatTable);
 	}
 
 	/**
@@ -430,8 +408,6 @@ extends TabPanel {
 		}
 
 		public void update() {
-			heatScrollPane.validate();
-
 			fireTableDataChanged();
 		}
 
@@ -448,8 +424,6 @@ extends TabPanel {
 	public void destroy() {
 		super.destroy();
 		
-		heatTable = null;
-		heatScrollPane = null;	
 		checkbox = null;
 		heatGenTF = null;
 		powerGenTF = null;

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/building/BuildingPanelMedicalCare.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/building/BuildingPanelMedicalCare.java
@@ -6,21 +6,20 @@
  */
 package com.mars_sim.ui.swing.unit_window.structure.building;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
 import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableModel;
 
+import com.mars_sim.core.Unit;
 import com.mars_sim.core.person.health.HealthProblem;
 import com.mars_sim.core.structure.building.function.MedicalCare;
 import com.mars_sim.tools.Msg;
 import com.mars_sim.ui.swing.ImageLoader;
 import com.mars_sim.ui.swing.MainDesktopPane;
+import com.mars_sim.ui.swing.unit_window.TabPanelTable;
 import com.mars_sim.ui.swing.utils.AttributePanel;
+import com.mars_sim.ui.swing.utils.UnitModel;
 
 
 /**
@@ -28,8 +27,7 @@ import com.mars_sim.ui.swing.utils.AttributePanel;
  * the medical info of a settlement building.
  */
 @SuppressWarnings("serial")
-public class BuildingPanelMedicalCare
-extends BuildingFunctionPanel {
+public class BuildingPanelMedicalCare extends TabPanelTable {
 
 	private static final String MEDICAL_ICON = "medical";
 
@@ -56,7 +54,7 @@ extends BuildingFunctionPanel {
 		super(
 			Msg.getString("BuildingPanelMedicalCare.title"), 
 			ImageLoader.getIconByName(MEDICAL_ICON),
-			medical.getBuilding(), 
+			Msg.getString("BuildingPanelMedicalCare.title"), 
 			desktop
 		);
 
@@ -68,11 +66,10 @@ extends BuildingFunctionPanel {
 	 * Build the UI
 	 */
 	@Override
-	protected void buildUI(JPanel center) {
+	protected JPanel createInfoPanel() {
 
 		// Create label panel
 		AttributePanel labelPanel = new AttributePanel(2);
-		center.add(labelPanel, BorderLayout.NORTH);
 		
 		// Create sick bed label
 		labelPanel.addTextField(Msg.getString("BuildingPanelMedicalCare.numberOfsickBeds"),
@@ -82,21 +79,14 @@ extends BuildingFunctionPanel {
 		physicianCache = medical.getPhysicianNum();
 		physicianLabel = labelPanel.addTextField(Msg.getString("BuildingPanelMedicalCare.numberOfPhysicians"),
 									  Integer.toString(physicianCache), null);
+		return labelPanel;
+	}
 
-		// Create scroll panel for medical table
-		JScrollPane scrollPanel = new JScrollPane();
-		scrollPanel.setPreferredSize(new Dimension(160, 80));
-		center.add(scrollPanel, BorderLayout.CENTER);
-	    scrollPanel.getViewport().setOpaque(false);
-	    scrollPanel.setOpaque(false);
-
+	@Override
+	protected TableModel createModel() {
 		// Prepare medical table model
 		medicalTableModel = new MedicalTableModel(medical);
-
-		// Prepare medical table
-		JTable medicalTable = new JTable(medicalTableModel);
-		medicalTable.setCellSelectionEnabled(false);
-		scrollPanel.setViewportView(medicalTable);
+		return medicalTableModel;
 	}
 
 	/**
@@ -118,7 +108,8 @@ extends BuildingFunctionPanel {
 	/**
 	 * Internal class used as model for the medical table.
 	 */
-	private static class MedicalTableModel extends AbstractTableModel {
+	private static class MedicalTableModel extends AbstractTableModel
+				implements UnitModel {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
@@ -166,6 +157,12 @@ extends BuildingFunctionPanel {
 				healthProblems = medical.getProblemsBeingTreated();
 
 			fireTableDataChanged();
+		}
+
+		@Override
+		public Unit getAssociatedUnit(int row) {
+			HealthProblem problem = (HealthProblem) healthProblems.get(row);
+			return problem.getSufferer();
 		}
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/building/BuildingPanelStorage.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/building/BuildingPanelStorage.java
@@ -6,8 +6,6 @@
  */
 package com.mars_sim.ui.swing.unit_window.structure.building;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -15,10 +13,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
 import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableModel;
 
 import com.mars_sim.core.equipment.ResourceHolder;
 import com.mars_sim.core.resource.ResourceUtil;
@@ -26,7 +23,8 @@ import com.mars_sim.core.structure.building.function.Storage;
 import com.mars_sim.tools.Msg;
 import com.mars_sim.ui.swing.ImageLoader;
 import com.mars_sim.ui.swing.MainDesktopPane;
-import com.mars_sim.ui.swing.StyleManager;
+import com.mars_sim.ui.swing.NumberCellRenderer;
+import com.mars_sim.ui.swing.unit_window.TabPanelTable;
 
 
 /**
@@ -34,7 +32,7 @@ import com.mars_sim.ui.swing.StyleManager;
  * the storage capacity of a settlement building.
  */
 @SuppressWarnings("serial")
-public class BuildingPanelStorage extends BuildingFunctionPanel {
+public class BuildingPanelStorage extends TabPanelTable {
 
 	private static final String STORE_ICON = "stock";
 
@@ -75,9 +73,8 @@ public class BuildingPanelStorage extends BuildingFunctionPanel {
 		}
 
 		public Class<?> getColumnClass(int column) {
-//			return String.class;
 			if (column == 0) return String.class;
-			else return Integer.class;
+			else return Double.class;
 		}
 
 		public String getColumnName(int column) {
@@ -100,13 +97,13 @@ public class BuildingPanelStorage extends BuildingFunctionPanel {
 				return nameList.get(row);
 			}
 			else if (column == 1) {
-				return StyleManager.DECIMAL_PLACES1.format(available.get(nameList.get(row)));
+				return available.get(nameList.get(row));
 			}
 			else if (column == 2) {
-				return StyleManager.DECIMAL_PLACES0.format(buildingStorage.get(nameList.get(row)));
+				return buildingStorage.get(nameList.get(row));
 			}
 			else {
-				return StyleManager.DECIMAL_PLACES0.format(settlementStorage.get(nameList.get(row)));
+				return settlementStorage.get(nameList.get(row));
 			}
 		}
 
@@ -127,33 +124,29 @@ public class BuildingPanelStorage extends BuildingFunctionPanel {
 		super(
 			Msg.getString("BuildingPanelStorage.tabTitle"), 
 			ImageLoader.getIconByName(STORE_ICON),
-			storage.getBuilding(), 
+			Msg.getString("BuildingPanelStorage.tabTitle"), 
 			desktop
 		);
 		
 		this.storage = storage;
 	}
 	
+	@Override
+	protected void setColumnDetails(TableColumnModel columnModel) {
+		var r = new NumberCellRenderer(0);
+		columnModel.getColumn(1).setCellRenderer(r);
+		columnModel.getColumn(2).setCellRenderer(r);
+
+		columnModel.getColumn(3).setCellRenderer(new NumberCellRenderer(0));
+	}
+
 	/**
 	 * Builds the UI.
 	 */
 	@Override
-	protected void buildUI(JPanel center) {
-
-		// Create scroll panel for storage table
-		JScrollPane scrollPanel = new JScrollPane();
-		scrollPanel.setPreferredSize(new Dimension(160, 120));
-		center.add(scrollPanel, BorderLayout.CENTER);
-	    scrollPanel.getViewport().setOpaque(false);
-	    scrollPanel.setOpaque(false);
+	protected TableModel createModel() {
 
 		// Prepare medical table model
-		StorageTableModel model = new StorageTableModel(storage);
-
-		// Prepare medical table
-		JTable storageTable = new JTable(model);
-		storageTable.setCellSelectionEnabled(false);
-		storageTable.setAutoCreateRowSorter(true);
-		scrollPanel.setViewportView(storageTable);
+		return new StorageTableModel(storage);
 	}
 }


### PR DESCRIPTION
This PR adds a new tab panel to the Settlement Unit window to show any Group Activitites.

To deliver this there has been a standardisatino of the tab panels. Many tab panel have the same pattern of an info panel with a table below.
This UI design is now captured as a new class ```TabPanelTable``` that centralises teh layout and construction of the panel.
The specific TabPanel just needs to problem a table model as a minumum. If that model implement the ```UnitModel``` interface then a Unit launcher will be automaticalyl added.

This pattern can be further extended to remove the use of the flat list ```UnitListPanel``` and convert those panels to the same approach.
The addition of a standard Person model with selectable column would be beneficial; based on the existing PersonTableModel used in the MonitorTool.

Close #1282

