### PR TITLE
Vehicle Crew tab panel manages members better

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/Unit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Unit.java
@@ -562,8 +562,7 @@ public abstract class Unit implements UnitIdentifer, Comparable<Unit> {
 					i.unitUpdate(ue);
 				}
 				catch(RuntimeException rte) {
-					logger.warning(this, "Problem executing listener " + i + " for event " + ue
-									+ " due to " + rte.getMessage());
+					logger.severe(this, "Problem executing listener " + i + " for event " + ue, rte);
 				}
 			}
 		}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/parameter/ParameterManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/parameter/ParameterManager.java
@@ -76,6 +76,16 @@ public class ParameterManager implements Serializable {
         values.put(new ParameterKey(category, id), value);
     }
 
+    
+    /**
+     * Remove a value from the parameter manager
+     * @param category Categogory fo the new value
+     * @param id Identifier of the value being defined
+     */
+    public void removeValue(ParameterCategory category, String id) {
+        values.remove(new ParameterKey(category, id));
+    }
+
     /**
      * Get the known values held in the manager.
      * @return Keys and associated values.
@@ -140,4 +150,5 @@ public class ParameterManager implements Serializable {
         values.clear();
         values.putAll(preferences.values);
     }
+
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/TabPanelTable.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/TabPanelTable.java
@@ -56,6 +56,7 @@ public abstract class TabPanelTable extends TabPanel {
 
 	private String[] headerTooltips;
 	private String tableTitle;
+	private JTable table;
 	
 	/**
 	 * Constructor.
@@ -129,7 +130,7 @@ public abstract class TabPanelTable extends TabPanel {
 		var tableModel = createModel();
 		
 		// Prepare table.
-		var table = new JTable(tableModel);
+		table = new JTable(tableModel);
 		if (tableModel instanceof EntityModel) {
 			// Call up the window when clicking on a row on the table
 			EntityLauncher.attach(table, getDesktop());
@@ -154,6 +155,13 @@ public abstract class TabPanelTable extends TabPanel {
 		table.setAutoCreateRowSorter(true);
 
 		scrollPane.setViewportView(table);
+	}
+
+	/**
+	 * Get the central table of the panel
+	 */
+	protected JTable getMainTable() {
+		return table;
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/UnitWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/UnitWindow.java
@@ -20,8 +20,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
+import javax.swing.SwingConstants;
 
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitManager;
@@ -71,7 +70,7 @@ public abstract class UnitWindow extends ModalInternalFrame
 	 * @param unit           the unit for this window.
 	 * @param hasDescription true if unit description is to be displayed.
 	 */
-	public UnitWindow(MainDesktopPane desktop, Unit unit, String title, boolean hasDescription) {
+	protected UnitWindow(MainDesktopPane desktop, Unit unit, String title, boolean hasDescription) {
 		// Use JInternalFrame constructor
 		super(title, false, true, false, true);
 
@@ -109,19 +108,15 @@ public abstract class UnitWindow extends ModalInternalFrame
 		JPanel mainPane = new JPanel(new BorderLayout());
 		setContentPane(mainPane);
 
-		tabPane = new JTabbedPane(JTabbedPane.LEFT, JTabbedPane.SCROLL_TAB_LAYOUT);
+		tabPane = new JTabbedPane(SwingConstants.LEFT, JTabbedPane.SCROLL_TAB_LAYOUT);
 		tabPane.setPreferredSize(new Dimension(WIDTH - 25, HEIGHT - 120));
 
 		// Add a listener for the tab changes
-		tabPane.addChangeListener(new ChangeListener() {
-			public void stateChanged(ChangeEvent e) {
-				TabPanel newTab = getSelected();
-				if (!newTab.isUIDone()) {
-					if (oldTab == null || newTab != oldTab) {
-						oldTab = newTab;
-						newTab.initializeUI();
-					}
-				}
+		tabPane.addChangeListener(e -> {
+			TabPanel newTab = getSelected();
+			if (!newTab.isUIDone() && (oldTab == null || newTab != oldTab)) {
+				oldTab = newTab;
+				newTab.initializeUI();
 			}
 		});
 
@@ -176,11 +171,11 @@ public abstract class UnitWindow extends ModalInternalFrame
 	 * Adds tab panels with icons.
 	 */
 	protected void addTabIconPanels() {
-		tabPanels.forEach(panel -> {
+		tabPanels.forEach(panel ->
 			// Note: if adding panel.getTabTitle() as the first param, it would take up 
 			// too much space on the left for displaying the name of each tab
-			tabPane.addTab(null, panel.getTabIcon(), panel, panel.getTabToolTip());
-		});
+			tabPane.addTab(null, panel.getTabIcon(), panel, panel.getTabToolTip())
+		);
 	}
 	
 	/**
@@ -287,14 +282,6 @@ public abstract class UnitWindow extends ModalInternalFrame
 		}
 		else
 			agencyStr = unit.getAssociatedSettlement().getReportingAuthority().getName();
-
-//		Image img = ((Image) ImageLoader.getIconByName(AGENCY_FOLDER + agencyStr));
-////				.getScaledInstance(UnitWindow.STATUS_HEIGHT - 5, 
-////						UnitWindow.STATUS_HEIGHT - 5, Image.SCALE_SMOOTH);	
-//		JLabel agencyLabel = new JLabel(new ImageIcon(img));
-//
-////		Icon icon = ImageLoader.getIconByName(AGENCY_FOLDER + agencyStr);
-////		JLabel agencyLabel = new JLabel(icon);
 		
 		Icon icon = ImageLoader.getIconByName(AGENCY_FOLDER + agencyStr);
 		JLabel agencyLabel = null;
@@ -316,15 +303,10 @@ public abstract class UnitWindow extends ModalInternalFrame
     
     
 	/**
-	 * Prepares unit window for deletion.
+	 * Prepares unit window for deletion. Close all tabs
 	 */
-	public void destroy() {		
-		if (tabPanels != null)
-			tabPanels.clear();
-		tabPanels = null;
-		tabPane = null;
-		desktop = null;
-		unit = null;
+	public void destroy() {
+		tabPanels.forEach(t -> t.destroy());	
+		tabPanels.clear();
 	}
-
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelPreferences.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelPreferences.java
@@ -16,6 +16,7 @@ import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JList;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.plaf.basic.BasicComboBoxRenderer;
 import javax.swing.table.AbstractTableModel;
@@ -114,6 +115,10 @@ public class TabPanelPreferences extends TabPanelTable {
 		add.addActionListener(i -> addEntry());
 		newPanel.add(add);
 
+		JButton remove = new JButton(ImageLoader.getIconByName("action/delete"));
+		remove.addActionListener(i -> deleteEntry());
+		newPanel.add(remove);
+
 		// Add an explanation
 		JLabel message = new JLabel("Note: Click on modifier column to change");
 		message.setFont(StyleManager.getSmallFont());
@@ -155,6 +160,24 @@ public class TabPanelPreferences extends TabPanelTable {
 		tableModel.addEntry(key, newValue);
 	}
 
+	private void deleteEntry() {
+		var t = getMainTable();
+		int idx = t.getSelectedRow();
+		if (idx >= 0) {
+			idx = t.getRowSorter().convertRowIndexToModel(idx);
+ 			RenderableKey selection = tableModel.getValue(idx);
+			int input = JOptionPane.showConfirmDialog(this, 
+                "Delete Preference " + selection.category.getName() + ":" + selection.spec.displayName(), "Delete Preference", 
+                JOptionPane.OK_CANCEL_OPTION);
+			if (input == 0) {
+				tableModel.removeEntry(selection);
+
+				// Reload combo
+				populateNameCombo();
+			}
+		}
+	}
+
 	/**
 	 * Populates the name combo based on the type of preference.
 	 */
@@ -191,6 +214,10 @@ public class TabPanelPreferences extends TabPanelTable {
 						.toList());
 		}
 
+		public RenderableKey getValue(int idx) {
+			return items.get(idx);
+		}
+
 		/**
 		 * Adds an entry to the table and the underlying manager
 		 */
@@ -200,6 +227,18 @@ public class TabPanelPreferences extends TabPanelTable {
 				target.putValue(newKey.category(), newKey.spec().id(), value);
 				int newRow = items.size()-1;
 				fireTableRowsInserted(newRow, newRow);
+			}
+		}
+
+		/**
+		 * Remove an entry to the table and the underlying manager
+		 */
+		public void removeEntry(RenderableKey newKey) {
+			int idx = items.indexOf(newKey);
+			if (idx >= 0) {
+				items.remove(newKey);
+				target.removeValue(newKey.category(), newKey.spec().id());
+				fireTableRowsDeleted(idx, idx);
 			}
 		}
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/vehicle/TabPanelCrew.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/vehicle/TabPanelCrew.java
@@ -13,7 +13,6 @@ import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import javax.swing.BoxLayout;
@@ -66,13 +65,10 @@ public class TabPanelCrew extends TabPanel implements ActionListener {
 
 	private JLabel crewNumTF;
 
-	private int crewNumCache;
-	private int crewCapacityCache;
+	private int crewNumCache = -1;
 
 	/** The mission instance. */
-	private Mission mission;
-	/** The Crewable instance. */
-	private Crewable crewable;
+	private VehicleMission mission;
 
 	/**
 	 * Constructor.
@@ -89,8 +85,9 @@ public class TabPanelCrew extends TabPanel implements ActionListener {
 			vehicle, desktop
 		);
 
-		crewable = (Crewable) vehicle;
-		mission = vehicle.getMission();
+		if (vehicle.getMission() instanceof VehicleMission vm) {
+			mission = vm;
+		}
 	}
 
 	@Override
@@ -103,13 +100,12 @@ public class TabPanelCrew extends TabPanel implements ActionListener {
 		northPanel.add(crewCountPanel, BorderLayout.CENTER);
 
 		// Create crew num header label
-		crewNumCache = crewable.getCrewNum();
 		crewNumTF = crewCountPanel.addTextField(Msg.getString("TabPanelCrew.crewNum"),
-								Integer.toString(crewNumCache),
+								"",
 								 Msg.getString("TabPanelCrew.crew.tooltip"));
 
 		// Create crew cap header label
-		crewCapacityCache = crewable.getCrewCapacity();
+		int crewCapacityCache = ((Crewable) getUnit()).getCrewCapacity();
 		crewCountPanel.addTextField(Msg.getString("TabPanelCrew.crewCapacity"),
 								Integer.toString(crewCapacityCache),
 					 			Msg.getString("TabPanelCrew.crewCapacity.tooltip"));
@@ -163,15 +159,21 @@ public class TabPanelCrew extends TabPanel implements ActionListener {
 		Vehicle vehicle = (Vehicle) getUnit();
 		Crewable crewable = (Crewable) vehicle;
 		Mission newMission = vehicle.getMission();
-		if (mission != newMission) {
-			mission = newMission;
-			memberTableModel.setMission(newMission);
+		if ((mission == null) || !mission.equals(newMission)) {
+			if (newMission instanceof VehicleMission vm) {
+				mission = vm;
+			}
+			else {
+				mission = null;
+			}
+
+			memberTableModel.setMission(mission);
 		}
 
 		// Update crew num
 		if (crewNumCache != crewable.getCrewNum() ) {
 			crewNumCache = crewable.getCrewNum() ;
-			crewNumTF.setText(crewNumCache + "");
+			crewNumTF.setText(Integer.toString(crewNumCache));
 		}
 
 		// Update crew table
@@ -210,7 +212,7 @@ public class TabPanelCrew extends TabPanel implements ActionListener {
 	private class MemberTableModel extends AbstractTableModel implements UnitListener, EntityModel {
 
 		// Private members.
-		private Mission mission;
+		private VehicleMission mission;
 		private List<Worker> members;
 
 		/**
@@ -245,6 +247,7 @@ public class TabPanelCrew extends TabPanel implements ActionListener {
 		 * @param columnIndex the column's index.
 		 * @return the column name.
 		 */
+		@Override
 		public String getColumnName(int columnIndex) {
 			if (columnIndex == 0)
 				return Msg.getString("MainDetailPanel.column.name"); //$NON-NLS-1$
@@ -261,6 +264,7 @@ public class TabPanelCrew extends TabPanel implements ActionListener {
 		 * @param column the table column.
 		 * @return the value.
 		 */
+		@Override
 		public Object getValueAt(int row, int column) {
 			if (row < members.size()) {
 				Worker member = members.get(row);
@@ -285,12 +289,9 @@ public class TabPanelCrew extends TabPanel implements ActionListener {
 		 * @return
 		 */
 		boolean boarded(Worker member) {
-			if (mission instanceof VehicleMission) {			
-				if (member.getUnitType() == UnitType.PERSON) {
-					Rover r = (Rover)(((VehicleMission)mission).getVehicle());
-					if (r != null && r.isCrewmember((Person)member))
-						return true;
-				}
+			if (member.getUnitType() == UnitType.PERSON) {
+				Rover r = (Rover)mission.getVehicle();
+				return (r != null && r.isCrewmember((Person)member));
 			}
 			return false;
 		}
@@ -300,7 +301,7 @@ public class TabPanelCrew extends TabPanel implements ActionListener {
 		 *
 		 * @param newMission the new mission.
 		 */
-		void setMission(Mission newMission) {
+		void setMission(VehicleMission newMission) {
 			this.mission = newMission;
 			updateMembers();
 		}
@@ -310,6 +311,7 @@ public class TabPanelCrew extends TabPanel implements ActionListener {
 		 *
 		 * @param event the unit event.
 		 */
+		@Override
 		public void unitUpdate(UnitEvent event) {
 			UnitEventType type = event.getType();
 			Worker member = (Worker) event.getSource();
@@ -334,29 +336,21 @@ public class TabPanelCrew extends TabPanel implements ActionListener {
 				List<Worker> newList = new ArrayList<>(mission.getMembers());
 
 				if (!members.equals(newList)) {
-					List<Integer> rows = new ArrayList<>();
+					// Existing members, not in the new list then remove listener
+					members.stream()
+							.filter(m -> !newList.contains(m))
+							.forEach(mm -> mm.removeUnitListener(this));
 
-					for (Worker mm: members) {
-						if (!newList.contains(mm)) {
-							mm.removeUnitListener(this);
-						}
-					}
-
-					for (Worker mm: newList) {
-						if (!members.contains(mm)) {
-							mm.addUnitListener(this);
-							int index = newList.indexOf(mm);
-							rows.add(index);
-						}
-					}
+					// New members, not in the existing list then add listener
+					newList.stream()
+							.filter(m -> !members.contains(m))
+							.forEach(mm -> mm.addUnitListener(this));
 
 					// Replace the old member list with new one.
 					members = newList;
 
-					for (int i : rows) {
-						// Update this row
-						fireTableRowsUpdated(i, i);
-					}
+					// Update this row
+					fireTableDataChanged();
 				}
 			} else {
 				if (!members.isEmpty()) {
@@ -370,14 +364,8 @@ public class TabPanelCrew extends TabPanel implements ActionListener {
 		 * Clear all members from the table.
 		 */
 		private void clearMembers() {
-			if (members != null) {
-				Iterator<Worker> i = members.iterator();
-				while (i.hasNext()) {
-					Worker member = i.next();
-					member.removeUnitListener(this);
-				}
-				members.clear();
-			}
+			members.forEach(m -> m.removeUnitListener(this));
+			members.clear();
 		}
 
 		@Override

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/vehicle/VehicleUnitWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/vehicle/VehicleUnitWindow.java
@@ -41,8 +41,7 @@ public class VehicleUnitWindow extends UnitWindow {
 		super(desktop, vehicle, vehicle.getAssociatedSettlement().getName() + " - " + vehicle.getName(), true);
 		this.vehicle = vehicle;
 		
-		if (vehicle instanceof Crewable) {
-			Crewable crewableVehicle = (Crewable) vehicle;
+		if (vehicle instanceof Crewable crewableVehicle) {
 			if (crewableVehicle.getCrewCapacity() > 0)
 				addTabPanel(new TabPanelCrew(vehicle, desktop));
 			else if (crewableVehicle.getRobotCrewCapacity() > 0)
@@ -53,8 +52,7 @@ public class VehicleUnitWindow extends UnitWindow {
 
 		addTabPanel(new LocationTabPanel(vehicle, desktop));
 
-		if (vehicle instanceof Rover) {
-			Rover rover = (Rover) vehicle;
+		if (vehicle instanceof Rover rover) {
 			addTabPanel(new TabPanelEVA(rover, desktop));		
 			if (rover.hasLab())
 				addTabPanel(new LaboratoryTabPanel(rover, desktop));		
@@ -76,9 +74,6 @@ public class VehicleUnitWindow extends UnitWindow {
 		addTabPanel(new TabPanelTow(vehicle, desktop));
 		
 		sortTabPanels();
-
-		// Add general tab panel as the first tab
-//		addFirstPanel
 		
 		// Add to tab panels. 
 		addTabIconPanels();
@@ -91,7 +86,6 @@ public class VehicleUnitWindow extends UnitWindow {
 	public void update() {
 		super.update();
 		// Check if equipment has been salvaged.
-		// Vehicle vehicle = (Vehicle) getUnit();
 		if (!salvaged && vehicle.isSalvaged()) {
 			addTabPanel(new SalvageTabPanel(vehicle, desktop));
 			salvaged = true;


### PR DESCRIPTION
The Vehicle Crew tab handles the Unit management in a better logic. Also the UnitWindow destroys the tabs when the window is closed. This ensures that the tabs are deregistering any listeners when the window is closed.

In addition, this PR contains a change to add a Remove button to the Preferences tab