### PR TITLE
Clean up logic in Settlement Map Window

### DIFF
--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -1252,23 +1252,15 @@ SettlementTransparentPanel.tooltip.zoom             = Zoom in and out the view o
 
 SettlementWindow.JDialog.changeSettlementName.input = Please enter the new settlement name
 SettlementWindow.JDialog.changeSettlementName.title = Rename the settlement
-SettlementWindow.menu.buildings                     = Buildings
-SettlementWindow.menu.constructionSites             = Construction Sites
-SettlementWindow.menu.daylightTracking              = Daylight Tracking
+
+SettlementWindow.menu.building_labels               = Buildings
+SettlementWindow.menu.construction_labels           = Construction Sites
+SettlementWindow.menu.daylight_layer                = Daylight Tracking
 SettlementWindow.menu.labelOptions                  = Label Display Options:
-SettlementWindow.menu.people                        = Settlers
-SettlementWindow.menu.robots                        = Bots
-SettlementWindow.menu.vehicles                      = Vehicles
-#SettlementWindow.renameSettlement.renameButton      = Rename
+SettlementWindow.menu.person_labels                 = Settlers
+SettlementWindow.menu.robot_labels                  = Bots
+SettlementWindow.menu.vehicle_labels                = Vehicles
 SettlementWindow.title                              = Settlement Map
-#SettlementWindow.button.info                        = Info
-#SettlementWindow.button.labels                      = Labels ▼
-#SettlementWindow.button.recenter                    = +
-#SettlementWindow.tooltip.clockwise                  = Rotate map clockwise
-#SettlementWindow.tooltip.counterClockwise           = Rotate map counter-clockwise
-#SettlementWindow.tooltip.info                       = Opens the Settlement Info Window
-#SettlementWindow.tooltip.labels                     = Add/remove label overlays
-#SettlementWindow.tooltip.recenter                   = Recenter view to center, normal zoom
 SettlementWindow.tooltip.selectSettlement           = Select a settlement here to display
 
 Simulation.localTime									= (Local Time)

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/SpotlightLayerUI.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/SpotlightLayerUI.java
@@ -24,14 +24,14 @@ import javax.swing.SwingUtilities;
 import javax.swing.plaf.LayerUI;
 
 import com.mars_sim.ui.swing.tool.settlement.SettlementMapPanel;
+import com.mars_sim.ui.swing.tool.settlement.SettlementMapPanel.DisplayOption;
 
 @SuppressWarnings("serial")
 public class SpotlightLayerUI extends LayerUI<JPanel> {
 
-	//private static final long serialVersionUID = 1L;
-
 	private boolean mActive;
-	private int mX, mY;
+	private int mX;
+	private int mY;
 
 	private SettlementMapPanel settlementMapPanel;
 
@@ -66,31 +66,24 @@ public class SpotlightLayerUI extends LayerUI<JPanel> {
 	    // Paint the view.
 	    super.paint (g2, c);
 
-	    if (mActive) {
-		    if (settlementMapPanel.isDaylightTrackingOn()) {
-			      // Create a radial gradient, transparent in the middle.
-			      java.awt.geom.Point2D center = new java.awt.geom.Point2D.Float(mX, mY);
-			      float radius = 60;
-			      float[] dist = {0.0f, 1.0f};
-			      //Color[] colors = {new Color(0.0f, 0.0f, 0.0f, 0.0f), Color.gray};
+	    if (mActive && settlementMapPanel.isOptionDisplayed(DisplayOption.DAYLIGHT_LAYER)) {
+			// Create a radial gradient, transparent in the middle.
+			java.awt.geom.Point2D center = new java.awt.geom.Point2D.Float(mX, mY);
+			float radius = 60;
+			float[] dist = {0.0f, 1.0f};
 
-			      Color[] colors = {
-			    		  //new Color(0.0f, 0.0f, 0.0f, 0.0f),
-			    		  //new Color(0, 0, 0, 0)
-			    		  //new Color(g2.getColor().getRed() * 0.25f, g2.getColor().getGreen() * 0.25f, g2.getColor().getBlue() * 0.25f, 0f),//, g.getColor().getAlpha()),
-			    		 //new Color(g2.getColor().getRed(), g2.getColor().getGreen(), g2.getColor().getBlue(), 0.0f)
-			    	  		new Color(.9f, .9f, .9f, .9f),
-			    	    	new Color(g2.getColor().getRed()/255f, g2.getColor().getGreen()/255f, g2.getColor().getBlue()/255f, 0.0f)
+			Color[] colors = {
+					new Color(.9f, .9f, .9f, .9f),
+					new Color(g2.getColor().getRed()/255f, g2.getColor().getGreen()/255f, g2.getColor().getBlue()/255f, 0.0f)
 
-			      };
+			};
 
-			      RadialGradientPaint p =
-			          new RadialGradientPaint(center, radius, dist, colors);
-			      g2.setPaint(p);
-			      g2.setComposite(AlphaComposite.getInstance(
-			          AlphaComposite.SRC_OVER, 0.4f));
-			      g2.fillRect(0, 0, c.getWidth(), c.getHeight());
-		    }
+			RadialGradientPaint p =
+				new RadialGradientPaint(center, radius, dist, colors);
+			g2.setPaint(p);
+			g2.setComposite(AlphaComposite.getInstance(
+				AlphaComposite.SRC_OVER, 0.4f));
+			g2.fillRect(0, 0, c.getWidth(), c.getHeight());
 	    }
 
 	    g2.dispose();

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/BuildingMapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/BuildingMapLayer.java
@@ -27,6 +27,7 @@ import com.mars_sim.core.structure.building.connection.Hatch;
 import com.mars_sim.core.structure.building.function.ActivitySpot;
 import com.mars_sim.core.structure.building.function.Function;
 import com.mars_sim.core.structure.building.function.FunctionType;
+import com.mars_sim.ui.swing.tool.settlement.SettlementMapPanel.DisplayOption;
 import com.mars_sim.ui.swing.tool.svg.SVGMapUtil;
 
 /**
@@ -94,7 +95,7 @@ public class BuildingMapLayer extends AbstractMapLayer {
         AffineTransform saveTransform = viewpoint.prepareGraphics();
 
         if (settlement != null) {  
-            boolean bldgLabels = mapPanel.isShowBuildingLabels();
+            boolean bldgLabels = mapPanel.isOptionDisplayed(DisplayOption.BUILDING_LABELS);
             Set<FunctionType> spotLabels = mapPanel.getShowSpotLabels();
 
             // Display svg images of all buildings in the entire settlement

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/ConstructionMapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/ConstructionMapLayer.java
@@ -16,6 +16,7 @@ import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.construction.ConstructionSite;
 import com.mars_sim.core.structure.construction.ConstructionStage;
 import com.mars_sim.core.tool.Msg;
+import com.mars_sim.ui.swing.tool.settlement.SettlementMapPanel.DisplayOption;
 import com.mars_sim.ui.swing.tool.svg.SVGMapUtil;
 
 /**
@@ -50,7 +51,7 @@ public class ConstructionMapLayer extends AbstractMapLayer {
         AffineTransform saveTransform = viewpoint.prepareGraphics();
 
         // Draw all construction sites.
-        boolean constLabels = mapPanel.isShowConstructionLabels();
+        boolean constLabels = mapPanel.isOptionDisplayed(DisplayOption.CONSTRUCTION_LABELS);
         for(ConstructionSite c : settlement.getConstructionManager()
                                 .getConstructionSites()) {
             drawConstructionSite(c, constLabels, viewpoint);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/DayNightMapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/DayNightMapLayer.java
@@ -11,6 +11,7 @@ import java.awt.Color;
 
 import com.mars_sim.core.environment.SurfaceFeatures;
 import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.ui.swing.tool.settlement.SettlementMapPanel.DisplayOption;
 
 /**
  * The DayNightMapLayer is a graphics layer to display twilight and night time shading of the settlement
@@ -37,7 +38,7 @@ public class DayNightMapLayer implements SettlementMapLayer {
 	@Override
 	public void displayLayer(Settlement settlement, MapViewPoint viewpoint) {
 
-		if (mapPanel.isDaylightTrackingOn()) {
+		if (mapPanel.isOptionDisplayed(DisplayOption.DAYLIGHT_LAYER)) {
 
 			// NOTE: whenever the user uses the combobox to switch to another settlement in Settlement Map Tool,
 			// the corresponding location instance of the new settlement will be reloaded

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/PersonMapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/PersonMapLayer.java
@@ -13,6 +13,7 @@ import com.mars_sim.core.CollectionUtils;
 import com.mars_sim.core.person.GenderType;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.ui.swing.tool.settlement.SettlementMapPanel.DisplayOption;
 
 /**
  * A settlement map layer for displaying people.
@@ -42,7 +43,7 @@ public class PersonMapLayer extends WorkerMapLayer<Person> {
 		Collection<Person> people = CollectionUtils.getPeopleInSettlementVicinity(settlement);		
 		Person selectedPerson = mapPanel.getSelectedPerson();
 
-		drawWorkers(people, selectedPerson, mapPanel.isShowPersonLabels(), viewpoint);
+		drawWorkers(people, selectedPerson, mapPanel.isOptionDisplayed(DisplayOption.PERSON_LABELS), viewpoint);
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/PopUpUnitMenu.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/PopUpUnitMenu.java
@@ -65,6 +65,8 @@ public class PopUpUnitMenu extends JPopupMenu {
 	private static Map<Integer, JInternalFrame> panels = new ConcurrentHashMap<>();
 
     public PopUpUnitMenu(final SettlementWindow swindow, final Unit unit){
+		add(unit.getUnitType().getName() + " : " + unit.getName());
+		addSeparator();
     	MainDesktopPane desktop = swindow.getDesktop();
     	
     	switch (unit.getUnitType()) {
@@ -150,13 +152,6 @@ public class PopUpUnitMenu extends JPopupMenu {
             	d.setOpacity(0.75f);
 		        d.setBackground(new Color(0,0,0,128));
                 d.setVisible(true);
-
-                // Make panel drag-able
-//        	    ComponentMover mover = new ComponentMover(desktop);
-//        	    mover.registerComponent(getComponents());
-//			    ComponentMover mover = new ComponentMover(d, desktop);
-//			    mover.registerComponent(b);
-
              }
         );
 
@@ -173,7 +168,6 @@ public class PopUpUnitMenu extends JPopupMenu {
     private JMenuItem buildDetailsItem(final Unit unit, final MainDesktopPane desktop) {
 		JMenuItem detailsItem = new JMenuItem(Msg.getString("PopUpUnitMenu.details"));
 
-//        detailsItem.setForeground(new Color(139,69,19));
         detailsItem.addActionListener(e -> {
 	            if (unit.getUnitType() == UnitType.VEHICLE
 	            		|| unit.getUnitType() == UnitType.PERSON
@@ -182,7 +176,6 @@ public class PopUpUnitMenu extends JPopupMenu {
 	            	desktop.showDetails(unit);
 	            }
 	            
-	            // TODO Why is this not a dedicated class ?
 	            else if (unit.getUnitType() == UnitType.CONSTRUCTION) {
 	            	buildConstructionWindow(unit, desktop);
 	            }
@@ -214,10 +207,10 @@ public class PopUpUnitMenu extends JPopupMenu {
 
         JInternalFrame d = new JInternalFrame(
         		unit.getSettlement().getName() + " - " + site,
-        		true,  //resizable
-                false, //not closable
-                true, //not maximizable
-                false); //iconifiable);
+        		true, 
+                false, 
+                true,
+                false); 
 
         d.setIconifiable(false);
         d.setClosable(true);
@@ -327,7 +320,7 @@ public class PopUpUnitMenu extends JPopupMenu {
 			if (siteAngle >= 360)
 				siteAngle = 0;
 			site.setFacing(siteAngle);
-			logger.info(site, "Just set facing to " + (int)Math.round(siteAngle) + ".");
+			logger.info(site, "Just set facing to " + siteAngle + ".");
 			repaint();
         });
 
@@ -364,11 +357,4 @@ public class PopUpUnitMenu extends JPopupMenu {
 
 		return confirmItem;
 	}
-	
-	
-	public void destroy() {
-		panels.clear();
-		panels = null;
-	}
-
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/RobotMapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/RobotMapLayer.java
@@ -12,6 +12,7 @@ import java.util.List;
 import com.mars_sim.core.CollectionUtils;
 import com.mars_sim.core.robot.Robot;
 import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.ui.swing.tool.settlement.SettlementMapPanel.DisplayOption;
 
 /**
  * A settlement map layer for displaying Robots.
@@ -40,7 +41,7 @@ public class RobotMapLayer extends WorkerMapLayer<Robot> {
 
 		List<Robot> robots = CollectionUtils.getAssociatedRobotsInSettlementVicinity(settlement);
 		Robot selectedRobot = mapPanel.getSelectedRobot();
-		drawWorkers(robots, selectedRobot, mapPanel.isShowRobotLabels(), viewpoint);
+		drawWorkers(robots, selectedRobot, mapPanel.isOptionDisplayed(DisplayOption.ROBOT_LABELS), viewpoint);
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementMapPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementMapPanel.java
@@ -12,7 +12,6 @@ import java.awt.Cursor;
 import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
-import java.awt.Point;
 import java.awt.RenderingHints;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -33,6 +32,8 @@ import javax.swing.JPanel;
 import com.mars_sim.core.CollectionUtils;
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitManager;
+import com.mars_sim.core.map.location.LocalBoundedObject;
+import com.mars_sim.core.map.location.LocalPosition;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.robot.Robot;
 import com.mars_sim.core.structure.Settlement;
@@ -52,15 +53,21 @@ import com.mars_sim.ui.swing.UIConfig;
 @SuppressWarnings("serial")
 public class SettlementMapPanel extends JPanel {
 
+	/**
+	 * Display options that can be selected
+	 */
+	public enum DisplayOption {
+		BUILDING_LABELS,
+		CONSTRUCTION_LABELS,
+		PERSON_LABELS,
+		ROBOT_LABELS,
+		VEHICLE_LABELS,
+		DAYLIGHT_LAYER
+	}
+
 	// Property names for UI Config
-	private static final String BUILDING_LBL_PROP = "BUILDING_LABELS";
-	private static final String CONSTRUCTION_LBL_PROP = "CONSTRUCTION_LABELS";
-	private static final String PERSON_LBL_PROP = "PERSON_LABELS";
-	private static final String VEHICLE_LBL_PROP = "VEHICLE_LABELS";
-	private static final String ROBOT_LBL_PROP = "ROBOT_LABELS";
 	private static final String SPOT_LBL_PROP = "SPOT_LABELS_";
 	private static final String SETTLEMENT_PROP = "SETTLEMENT";
-	private static final String DAYLIGHT_PROP = "DAYLIGHT_LAYER";
 	private static final String X_PROP = "XPOS";
 	private static final String Y_PROP = "YPOS";
 	private static final String SCALE_PROP = "SCALE";
@@ -70,14 +77,10 @@ public class SettlementMapPanel extends JPanel {
 	private static final double WIDTH = 6D;
 	public static final double DEFAULT_SCALE = 10D;
 
+
 	// Data members
 	private boolean exit = true;
-	private boolean showBuildingLabels;
-	private boolean showConstructionLabels;
-	private boolean showPersonLabels;
-	private boolean showVehicleLabels;
-	private boolean showRobotLabels;
-	private boolean showDaylightLayer;
+
 	
 	private double xPos;
 	private double yPos;
@@ -105,7 +108,8 @@ public class SettlementMapPanel extends JPanel {
 	private Map<Settlement, Robot> selectedRobot;
 	private Map<Settlement, Building> selectedBuilding;
 
-	private Font sansSerif = new Font("SansSerif", Font.BOLD, 11);
+	private static Font sansSerif = new Font("SansSerif", Font.BOLD, 11);
+	private Set<DisplayOption> displayOptions = new HashSet<>();
 
 	/**
 	 * Constructor 1: A panel for displaying a settlement map.
@@ -148,12 +152,11 @@ public class SettlementMapPanel extends JPanel {
 		yPos = UIConfig.extractDouble(userSettings, Y_PROP, 0D);
 		rotation = UIConfig.extractDouble(userSettings, ROTATION_PROP, 0D);
 		scale = UIConfig.extractDouble(userSettings, SCALE_PROP, DEFAULT_SCALE);
-		showBuildingLabels = UIConfig.extractBoolean(userSettings, BUILDING_LBL_PROP, false);
-		showConstructionLabels = UIConfig.extractBoolean(userSettings, CONSTRUCTION_LBL_PROP, false);
-		showPersonLabels = UIConfig.extractBoolean(userSettings, PERSON_LBL_PROP, false);
-		showVehicleLabels = UIConfig.extractBoolean(userSettings, VEHICLE_LBL_PROP, false);
-		showRobotLabels = UIConfig.extractBoolean(userSettings, ROBOT_LBL_PROP, false);
-		showDaylightLayer = UIConfig.extractBoolean(userSettings, DAYLIGHT_PROP, false); 
+		for(DisplayOption op : DisplayOption.values()) {
+			if (UIConfig.extractBoolean(userSettings, op.name(), false)) {
+				displayOptions.add(op);
+			}
+		}
 
 		for(FunctionType ft : FunctionType.values()) {
 			if (UIConfig.extractBoolean(userSettings, SPOT_LBL_PROP + ft.name(), false)) {
@@ -195,7 +198,7 @@ public class SettlementMapPanel extends JPanel {
 		dayNightMapLayer = new DayNightMapLayer(this);
 
 		// Check the DayNightLayer at the start of the sim
-		setShowDayNightLayer(false);
+		displayOptions.remove(DisplayOption.DAYLIGHT_LAYER);
 
 		// Create map layers.
 		mapLayers = new ArrayList<>();
@@ -270,7 +273,7 @@ public class SettlementMapPanel extends JPanel {
 					// Remove the settlement map coordinate of the hovering mouse pointer
 					settlementWindow.setMapXYCoord(convertToSettlementLocation(x,y), true);
 					// Remove the building coordinate
-					settlementWindow.setBuildingXYCoord(0, 0, true);
+					settlementWindow.setBuildingXYCoord(LocalPosition.DEFAULT_POSITION, true);
 					exit = true;
 				}
 			}
@@ -307,31 +310,28 @@ public class SettlementMapPanel extends JPanel {
 		int x = evt.getX();
 		int y = evt.getY();
 
-		final ConstructionSite site = selectConstructionSiteAt(x, y);
-		final Building building = selectBuildingAt(x, y);
-		final Vehicle vehicle = selectVehicleAt(x, y);
-		final Person person = selectPersonAt(x, y);
-		final Robot robot = selectRobotAt(x, y);
+		LocalPosition settlementPosition = convertToSettlementLocation(x, y);
+
 
 		// Deconflict cases by the virtue of the if-else order below
 		// when one or more are detected
-		if (person != null) {
-			setPopUp(evt, x, y, person);
+		Unit selectedUnit = selectPersonAt(settlementPosition);
+		if (selectedUnit == null) {
+			selectedUnit = selectRobotAt(settlementPosition);
+			if (selectedUnit == null) {
+				selectedUnit = selectVehicleAt(settlementPosition);
+				if (selectedUnit == null) {
+					selectedUnit = selectBuildingAt(settlementPosition);
+					if (selectedUnit == null) {
+						selectedUnit = selectConstructionSiteAt(settlementPosition);
+					}
+				}
+			}
 		}
-		else if (robot != null) {
-			setPopUp(evt, x, y, robot);
+		if (selectedUnit != null) {
+			setPopUp(evt, x, y, selectedUnit);
 		}
-		else if (vehicle != null) {
-			setPopUp(evt, x, y, vehicle);
-		}
-		else if (building != null) {
-			setPopUp(evt, x, y, building);
-		}
-		else if (site != null) {
-			setPopUp(evt, x, y, site);
-		}
-		
-		repaint();
+		repaint(); 
 	}
 
 	private void setPopUp(final MouseEvent evt, int x, int y, Unit unit) {
@@ -350,85 +350,20 @@ public class SettlementMapPanel extends JPanel {
 		
 		boolean showBlank = true;
 
-		Point.Double mousePos = convertToSettlementLocation(xPixel, yPixel);
+		LocalPosition mousePos = convertToSettlementLocation(xPixel, yPixel);
 
-		Iterator<Building> j = settlement.getBuildingManager().getBuildingSet().iterator();
-		while (j.hasNext()) {
-			Building building = j.next();
-
-			if (!building.getInTransport()) {
-
-				double width = building.getWidth();
-				double length = building.getLength();
-				int facing = (int) building.getFacing();
-				double x = building.getPosition().getX();
-				double y = building.getPosition().getY();
-				double xx = 0;
-				double yy = 0;
-
-				if (facing == 0) {
-					// Server Farm
-					xx = width / 2D;
-					yy = length / 2D;
-				} 
-				else if (facing == 90) {
-					yy = width / 2D;
-					xx = length / 2D;
-				}
-				else if (facing == 180) {
-					// Loading Dock Garage
-					xx = width / 2D;
-					yy = length / 2D;
-					
-				} 
-				else if (facing == 270) {
-					// Most of the 7mx9m modules such as Inflatable Greenhouse, 
-					// Fish Farm, Algae Pond, Command and Control, etc.
-					yy = width / 2D;
-					xx = length / 2D;
-				}
-
-				// Note: Both ERV Base and Starting ERV Base have 45 / 135 deg facing
-				// Fortunately, they both have the same width and length
-				// Future: Need to fix the xx and yy for the following two facings
-				else if (facing == 45) {
-					yy = width / 2D;
-					xx = length / 2D;
-				} else if (facing == 135) {
-					yy = width / 2D;
-					xx = length / 2D;
-				}
-
-				double mX = mousePos.getX();
-				double mY = mousePos.getY();
-
-				double rangeX = Math.round((mX - x) * 100.0) / 100.0;
-				double rangeY = Math.round((mY - y) * 100.0) / 100.0;
-
-				if (Math.abs(rangeX) <= Math.abs(xx) && Math.abs(rangeY) <= Math.abs(yy)) {
-					if (facing == 0) {
-						// Display the coordinate within a building of the hovering mouse pointer
-						settlementWindow.setBuildingXYCoord(rangeX, rangeY, false);
-					} else if (facing == 180) {
-						// Display the coordinate within a building of the hovering mouse pointer
-						settlementWindow.setBuildingXYCoord(-rangeX, -rangeY, false);
-					} else if (facing == 90) {
-						// Display the coordinate within a building of the hovering mouse pointer
-						settlementWindow.setBuildingXYCoord(rangeY, rangeX, false);
-					} else if (facing == 270) {
-						// Display the coordinate within a building of the hovering mouse pointer
-						settlementWindow.setBuildingXYCoord(-rangeY, rangeX, false);
-					}
-					// Note: not considering facing = 45 and 135 yet
-					showBlank = false;
-					break;
-				}
+		for(Building building : settlement.getBuildingManager().getBuildingSet()) {
+			if (!building.getInTransport() && isWithin(mousePos, building)) {
+				settlementWindow.setBuildingXYCoord(building.getPosition(), false);
+				// Note: not considering facing = 45 and 135 yet
+				showBlank = false;
+				break;
 			}
 		}
 
 		if (showBlank)
 			// Remove the building coordinate
-			settlementWindow.setBuildingXYCoord(0, 0, true);
+			settlementWindow.setBuildingXYCoord(LocalPosition.DEFAULT_POSITION, true);
 	}
 
 	/**
@@ -541,215 +476,140 @@ public class SettlementMapPanel extends JPanel {
 	/**
 	 * Selects a person if any person is at the given x and y pixel position.
 	 *
-	 * @param xPixel the x pixel position on the displayed map.
-	 * @param yPixel the y pixel position on the displayed map.
+	 * @param settlementPosition Position to search for
 	 * @return selectedPerson;
 	 */
-	public Person selectPersonAt(int xPixel, int yPixel) {
+	private Person selectPersonAt(LocalPosition settlementPosition) {
 		double range = WIDTH / scale;
-		Point.Double settlementPosition = convertToSettlementLocation(xPixel, yPixel);
-		Person foundPerson = null;
 
 		// Note 1: Not using settlement.getIndoorPeople() for now since it doesn't  
 		// 		   include those who have stepped outside
 		// Note 2: getIndoorPeople() will shorten the execution time to find people 
 		// Note 3: need to include non-associated people from other settlements
-		
-		Iterator<Person> i = CollectionUtils.getPeopleInSettlementVicinity(settlement).iterator();
-		while (i.hasNext()) {
-			Person person = i.next();
-			double distanceX = person.getPosition().getX() - settlementPosition.getX();
-			double distanceY = person.getPosition().getY() - settlementPosition.getY();
-			double distance = Math.hypot(distanceX, distanceY);
-			if (distance <= range) {
-				foundPerson = person;
+		for(Person person : CollectionUtils.getPeopleInSettlementVicinity(settlement)) {
+			if (person.getPosition().getDistanceTo(settlementPosition) < range) {
+				selectPerson(person);
+				return person;
+
 			}
 		}
-
-		if (foundPerson != null) {
-			selectPerson(foundPerson);
-
-		}
-		return foundPerson;
+		return null;
 	}
 
 	/**
 	 * Selects the robot if any robot is at the given x and y pixel position.
 	 *
-	 * @param xPixel the x pixel position on the displayed map.
-	 * @param yPixel the y pixel position on the displayed map.
+	 * @param settlementPosition Position to search for
 	 * @return selectedRobot;
 	 */
-	public Robot selectRobotAt(int xPixel, int yPixel) {
+	private Robot selectRobotAt(LocalPosition settlementPosition) {
 		double range = WIDTH / scale;
-		Point.Double settlementPosition = convertToSettlementLocation(xPixel, yPixel);
-		Robot foundRobot = null;
 
-		Iterator<Robot> i = CollectionUtils.getAssociatedRobotsInSettlementVicinity(settlement).iterator();
-		while (i.hasNext()) {
-			Robot robot = i.next();
-			double distanceX = robot.getPosition().getX() - settlementPosition.getX();
-			double distanceY = robot.getPosition().getY() - settlementPosition.getY();
-			double distance = Math.hypot(distanceX, distanceY);
-			if (distance <= range) {
-				foundRobot = robot;
+		for(Robot robot : CollectionUtils.getAssociatedRobotsInSettlementVicinity(settlement)) {
+			if (robot.getPosition().getDirectionTo(settlementPosition) <= range) {
+				selectRobot(robot);
+				return robot;
 			}
 		}
+		return null;
+	}
 
-		if (foundRobot != null) {
-			selectRobot(foundRobot);
+	/**
+	 * Is a position within the bounds of an Object. 
+	 * This should be in a common class.
+	 * @param pos
+	 * @param lbo
+	 * @return
+	 */
+	private static boolean isWithin(LocalPosition pos, LocalBoundedObject lbo) {
+		double width = lbo.getWidth();
+		double length = lbo.getLength();
+		int facing = (int) lbo.getFacing();
+		double x = lbo.getPosition().getX();
+		double y = lbo.getPosition().getY();
+		double xx = 0;
+		double yy = 0;
 
+		if (facing == 0) {
+			xx = width / 2D;
+			yy = length / 2D;
 		}
-		return foundRobot;
+		else if (facing == 90) {
+			yy = width / 2D;
+			xx = length / 2D;
+		}
+		// Loading Dock Garage
+		if (facing == 180) {
+			xx = width / 2D;
+			yy = length / 2D;
+		}
+		else if (facing == 270) {
+			yy = width / 2D;
+			xx = length / 2D;
+		}
+
+		// Note: Both ERV Base and Starting ERV Base have 45 / 135 deg facing
+		// Fortunately, they both have the same width and length
+		else if (facing == 45) {
+			yy = width / 2D;
+			xx = length / 2D;
+		} else if (facing == 135) {
+			yy = width / 2D;
+			xx = length / 2D;
+		}
+
+		double cX = pos.getX();
+		double cY = pos.getY();
+
+		double rangeX = Math.round((cX - x) * 100.0) / 100.0; 
+		double rangeY = Math.round((cY - y) * 100.0) / 100.0;
+
+		return Math.abs(rangeX) <= Math.abs(xx) && Math.abs(rangeY) <= Math.abs(yy);
 	}
 
 	/**
 	 * Selects a building.
 	 *
-	 * @param xPixel the x pixel position on the displayed map.
-	 * @param yPixel the y pixel position on the displayed map.
+	 * @param settlementPosition Position to search
 	 * @return selectedBuilding
 	 */
-	public Building selectBuildingAt(int xPixel, int yPixel) {
-
-		Building foundBuilding = null;
-		
-		Point.Double mousePos = convertToSettlementLocation(xPixel, yPixel);
-		
-		Iterator<Building> j = settlement.getBuildingManager().getBuildingSet().iterator();
-		while (j.hasNext()) {
-			Building building = j.next();
-
-			if (!building.getInTransport()) {
-
-				double width = building.getWidth();
-				double length = building.getLength();
-				int facing = (int) building.getFacing();
-				double x = building.getPosition().getX();
-				double y = building.getPosition().getY();
-				double xx = 0;
-				double yy = 0;
-
-				if (facing == 0) {
-					xx = width / 2D;
-					yy = length / 2D;
-				} else if (facing == 90) {
-					yy = width / 2D;
-					xx = length / 2D;
-				}
-				// Loading Dock Garage
-				if (facing == 180) {
-					xx = width / 2D;
-					yy = length / 2D;
-				} else if (facing == 270) {
-					yy = width / 2D;
-					xx = length / 2D;
-				}
-
-				// Note: Both ERV Base and Starting ERV Base have 45 / 135 deg facing
-				// Fortunately, they both have the same width and length
-				else if (facing == 45) {
-					yy = width / 2D;
-					xx = length / 2D;
-				} else if (facing == 135) {
-					yy = width / 2D;
-					xx = length / 2D;
-				}
-
-				double cX = mousePos.getX();
-				double cY = mousePos.getY();
-
-				double rangeX = Math.round((cX - x) * 100.0) / 100.0; 
-				double rangeY = Math.round((cY - y) * 100.0) / 100.0;
-
-				if (Math.abs(rangeX) <= Math.abs(xx) && Math.abs(rangeY) <= Math.abs(yy)) {
-					foundBuilding = building;
-					selectBuilding(foundBuilding);
-					return foundBuilding;
-				}
+	private Building selectBuildingAt(LocalPosition settlementPosition) {
+				
+		for(Building building : settlement.getBuildingManager().getBuildingSet()) {
+			if (!building.getInTransport() && isWithin(settlementPosition, building)) {
+				selectBuilding(building);
+				return building;
 			}
 		}
-		return foundBuilding;
+		return null;
 	}
 
 	/**
 	 * Selects a construction site.
 	 *
-	 * @param xPixel the x pixel position on the displayed map.
-	 * @param yPixel the y pixel position on the displayed map.
+	 * @param settlementPosition Position to search
 	 * @return selected construction site
 	 */
-	public ConstructionSite selectConstructionSiteAt(int xPixel, int yPixel) {
-		Point.Double clickPosition = convertToSettlementLocation(xPixel, yPixel);
-		ConstructionSite site = null;
-
-		Iterator<ConstructionSite> j = settlement.getConstructionManager().getConstructionSites().iterator();
-		while (j.hasNext()) {
-			ConstructionSite s = j.next();
-
-			if (!ConstructionMapLayer.getConstructionLabel(s).equals(Msg.getString("LabelMapLayer.noConstruction"))) {
-				double width = s.getWidth();
-				double length = s.getLength();
-				int facing = (int) s.getFacing();
-				double x = s.getPosition().getX();
-				double y = s.getPosition().getY();
-				double xx = 0;
-				double yy = 0;
-
-				if (facing == 0) {
-					xx = width / 2D;
-					yy = length / 2D;
-				} else if (facing == 90) {
-					yy = width / 2D;
-					xx = length / 2D;
-				}
-				// Loading Dock Garage
-				if (facing == 180) {
-					xx = width / 2D;
-					yy = length / 2D;
-				} else if (facing == 270) {
-					yy = width / 2D;
-					xx = length / 2D;
-				}
-
-				// Note: Both ERV Base and Starting ERV Base have 45 / 135 deg facing
-				// Fortunately, they both have the same width and length
-				else if (facing == 45) {
-					yy = width / 2D;
-					xx = length / 2D;
-				} else if (facing == 135) {
-					yy = width / 2D;
-					xx = length / 2D;
-				}
-
-				double distanceX = Math.abs(x - clickPosition.getX());
-				double distanceY = Math.abs(y - clickPosition.getY());
-
-				if (distanceX <= xx && distanceY <= yy) {
-					site = s;
-					break;
-				}
+	private ConstructionSite selectConstructionSiteAt(LocalPosition settlementPosition) {
+		for(ConstructionSite s : settlement.getConstructionManager().getConstructionSites()) {
+			if (!ConstructionMapLayer.getConstructionLabel(s).equals(Msg.getString("LabelMapLayer.noConstruction"))
+				&& isWithin(settlementPosition, s)) {
+					return s;
 			}
 		}
 
-		return site;
+		return null;
 	}
 
 	/**
 	 * Selects a vehicle.
 	 *
-	 * @param xPixel the x pixel position on the displayed map.
-	 * @param yPixel the y pixel position on the displayed map.
+	 * @param settlementPosition Poition to search
 	 * @return selectedVehicle
 	 */
-	public Vehicle selectVehicleAt(int xPixel, int yPixel) {
-		Point.Double pos = convertToSettlementLocation(xPixel, yPixel);
+	private Vehicle selectVehicleAt(LocalPosition settlementPosition) {
 
-		Vehicle selectedVehicle = null;
-
-		Iterator<Vehicle> j = settlement.getParkedGaragedVehicles().iterator(); // CollectionUtils.getVehiclesInSettlementVicinity(settlement).iterator();
-		while (j.hasNext()) {
-			Vehicle vehicle = j.next();
+		for(Vehicle vehicle : settlement.getParkedGaragedVehicles()) {
 			double width = vehicle.getWidth(); // width is on y-axis ?
 			double length = vehicle.getLength(); // length is on x-axis ?
 			double newRange;
@@ -759,64 +619,13 @@ public class SettlementMapPanel extends JPanel {
 				newRange = width / 2.0;
 			else
 				newRange = length / 2.0;
-
-			double x = vehicle.getPosition().getX();
-			double y = vehicle.getPosition().getY();
-
-			double distanceX = x - pos.getX();
-			double distanceY = y - pos.getY();
 			
-			double distance = Math.hypot(distanceX, distanceY);
-			if (distance <= newRange) {
-				selectedVehicle = vehicle;
-				break;
+			if (vehicle.getPosition().getDistanceTo(settlementPosition) <= newRange) {
+				return vehicle;
 			}
 		}
-		return selectedVehicle;
+		return null;
 	}
-
-	/**
-	 * Selects a vehicle, as used by TransportWizard.
-	 *
-	 * @param xLoc the position of the template building on the displayed map.
-	 * @param yLoc the position of the template building on the displayed map.
-	 * @return selectedVehicle
-	 */
-	public Vehicle selectVehicleAsObstacle(double xLoc, double yLoc) {
-
-		Vehicle selectedVehicle = null;
-
-		Iterator<Vehicle> j = settlement.getParkedGaragedVehicles().iterator(); // CollectionUtils.getVehiclesInSettlementVicinity(settlement).iterator();
-		while (j.hasNext()) {
-			Vehicle vehicle = j.next();
-			double width = vehicle.getWidth(); // width is on y-axis ?
-			double length = vehicle.getLength(); // length is on x-axis ?
-			double buildingWidth = 10;
-			double buildingLength = 10;
-			double newRange;
-
-			// Select whichever longer
-			if (width > length)
-				newRange = (width + buildingWidth) / 2.0;
-			else
-				newRange = (length + buildingLength) / 2.0;
-
-			double x = vehicle.getPosition().getX();
-			double y = vehicle.getPosition().getY();
-
-			// distances between the center of the vehicle and the center of the building
-			double distanceX = x - xLoc;
-			double distanceY = y - yLoc;
-			double distance = Math.hypot(distanceX, distanceY);
-			if (distance <= newRange) {
-				selectedVehicle = vehicle;
-
-				repaint();
-			}
-		}
-		return selectedVehicle;
-	}
-
 
 	/**
 	 * Selects a person on the map.
@@ -933,9 +742,7 @@ public class SettlementMapPanel extends JPanel {
 	 * @param yPixel the pixel Y position.
 	 * @return the X,Y settlement position.
 	 */
-	public Point.Double convertToSettlementLocation(int xPixel, int yPixel) {
-
-		Point.Double result = new Point.Double(0D, 0D);
+	private LocalPosition convertToSettlementLocation(int xPixel, int yPixel) {
 
 		double xDiff1 = (getWidth() / 2.0) - xPixel;
 		double yDiff1 = (getHeight() / 2.0) - yPixel;
@@ -950,27 +757,28 @@ public class SettlementMapPanel extends JPanel {
 		double newXPos = xPos + xDiff3;
 		double newYPos = yPos + yDiff3;
 
-		result.setLocation(newXPos, newYPos);
-
-		return result;
+		return new LocalPosition(newXPos, newYPos);
 	}
 
 	/**
-	 * Checks if building labels should be displayed.
-	 *
-	 * @return true if building labels should be displayed.
+	 * Is a display option enabled?
+	 * @param op
+	 * @return
 	 */
-	public boolean isShowBuildingLabels() {
-		return showBuildingLabels;
+	public boolean isOptionDisplayed(DisplayOption op) {
+		return displayOptions.contains(op);
 	}
 
+
 	/**
-	 * Sets if building labels should be displayed.
+	 * Toggle a display option, i.e if not set enable and vice versa.
 	 *
-	 * @param showLabels true if building labels should be displayed.
+	 * @param op Display option to toggle
 	 */
-	void setShowBuildingLabels(boolean showLabels) {
-		this.showBuildingLabels = showLabels;
+	void toggleDisplayOption(DisplayOption op) {
+		if (!displayOptions.remove(op)) {
+			displayOptions.add(op);
+		}
 		repaint();
 	}
 
@@ -1021,101 +829,6 @@ public class SettlementMapPanel extends JPanel {
 		repaint();
 	}
 
-	/**
-	 * Checks if construction site labels should be displayed.
-	 *
-	 * @return true if construction site labels should be displayed.
-	 */
-	public boolean isShowConstructionLabels() {
-		return showConstructionLabels;
-	}
-
-	/**
-	 * Sets if construction site labels should be displayed.
-	 *
-	 * @param showLabels true if construction site labels should be displayed.
-	 */
-	public void setShowConstructionLabels(boolean showLabels) {
-		this.showConstructionLabels = showLabels;
-		repaint();
-	}
-
-	/**
-	 * Checks if person labels should be displayed.
-	 *
-	 * @return true if person labels should be displayed.
-	 */
-	public boolean isShowPersonLabels() {
-		return showPersonLabels;
-	}
-
-	/**
-	 * Sets if person labels should be displayed.
-	 *
-	 * @param showLabels true if person labels should be displayed.
-	 */
-	public void setShowPersonLabels(boolean showLabels) {
-		this.showPersonLabels = showLabels;
-		repaint();
-	}
-
-	/**
-	 * Checks if Robot labels should be displayed.
-	 *
-	 * @return true if Robot labels should be displayed.
-	 */
-	public boolean isShowRobotLabels() {
-		return showRobotLabels;
-	}
-
-	/**
-	 * Sets if Robot labels should be displayed.
-	 *
-	 * @param showLabels true if Robot labels should be displayed.
-	 */
-	public void setShowRobotLabels(boolean showLabels) {
-		this.showRobotLabels = showLabels;
-		repaint();
-	}
-
-	/**
-	 * Checks if vehicle labels should be displayed.
-	 *
-	 * @return true if vehicle labels should be displayed.
-	 */
-	public boolean isShowVehicleLabels() {
-		return showVehicleLabels;
-	}
-
-	/**
-	 * Sets if vehicle labels should be displayed.
-	 *
-	 * @param showLabels true if vehicle labels should be displayed.
-	 */
-	public void setShowVehicleLabels(boolean showLabels) {
-		this.showVehicleLabels = showLabels;
-		repaint();
-	}
-
-	/**
-	 * Checks if DaylightLayer should be displayed.
-	 *
-	 * @return true if DaylightLayer should be displayed.
-	 */
-	public boolean isDaylightTrackingOn() {
-		return showDaylightLayer;
-	}
-
-	/**
-	 * Sets if DayNightLayer should be displayed.
-	 *
-	 * @param showDayNightLayer true if DayNightLayer should be displayed.
-	 */
-	public void setShowDayNightLayer(boolean showDayNightLayer) {
-		this.showDaylightLayer = showDayNightLayer;
-		repaint();
-	}
-
 	public DayNightMapLayer getDayNightMapLayer() {
 		return dayNightMapLayer;
 	}
@@ -1160,12 +873,10 @@ public class SettlementMapPanel extends JPanel {
 		Properties props = new Properties();
 		props.setProperty(SETTLEMENT_PROP, settlement.getName());
 
-		props.setProperty(BUILDING_LBL_PROP, Boolean.toString(showBuildingLabels));
-		props.setProperty(CONSTRUCTION_LBL_PROP, Boolean.toString(showConstructionLabels));
-		props.setProperty(PERSON_LBL_PROP, Boolean.toString(showPersonLabels));
-		props.setProperty(VEHICLE_LBL_PROP, Boolean.toString(showVehicleLabels));
-		props.setProperty(ROBOT_LBL_PROP, Boolean.toString(showRobotLabels));
-		props.setProperty(DAYLIGHT_PROP, Boolean.toString(showDaylightLayer));
+		for(DisplayOption op : DisplayOption.values()) {
+			props.setProperty(op.name(), Boolean.toString(displayOptions.contains(op)));
+		}
+
 		props.setProperty(X_PROP, Double.toString(xPos));
 		props.setProperty(Y_PROP, Double.toString(yPos));
 		props.setProperty(ROTATION_PROP, Double.toString(rotation));

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementMapPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementMapPanel.java
@@ -74,8 +74,8 @@ public class SettlementMapPanel extends JPanel {
 	private static final String ROTATION_PROP = "ROTATION";
 
 	// Static members.
-	private static final double WIDTH = 6D;
 	public static final double DEFAULT_SCALE = 10D;
+	private static final double SELECTION_RANGE = 0.10D; // This is the Settlement coordinate frame, 10cm
 
 
 	// Data members
@@ -243,9 +243,9 @@ public class SettlementMapPanel extends JPanel {
 				showBuildingCoord(x, y);
 				// Display the pixel coordinate of the window panel
 				// Note: the top left-most corner of window panel is (0,0)
-				settlementWindow.setPixelXYCoord(x, y, false);
+				settlementWindow.setPixelXYCoord(x, y);
 				// Display the settlement map coordinate of the hovering mouse pointer
-				settlementWindow.setMapXYCoord(convertToSettlementLocation(x,y), false);
+				settlementWindow.setMapXYCoord(convertToSettlementLocation(x,y));
 
 				if (exit) {
 					exit = false;
@@ -269,9 +269,9 @@ public class SettlementMapPanel extends JPanel {
 					settlementWindow.setPop(getSettlement().getNumCitizens());
 					// Remove the pixel coordinate of the window panel
 					// Note: the top left most corner is (0,0)
-					settlementWindow.setPixelXYCoord(x, y, true);
+					settlementWindow.setPixelXYCoord(x,y);
 					// Remove the settlement map coordinate of the hovering mouse pointer
-					settlementWindow.setMapXYCoord(convertToSettlementLocation(x,y), true);
+					settlementWindow.setMapXYCoord(convertToSettlementLocation(x,y));
 					// Remove the building coordinate
 					settlementWindow.setBuildingXYCoord(LocalPosition.DEFAULT_POSITION, true);
 					exit = true;
@@ -480,14 +480,13 @@ public class SettlementMapPanel extends JPanel {
 	 * @return selectedPerson;
 	 */
 	private Person selectPersonAt(LocalPosition settlementPosition) {
-		double range = WIDTH / scale;
 
 		// Note 1: Not using settlement.getIndoorPeople() for now since it doesn't  
 		// 		   include those who have stepped outside
 		// Note 2: getIndoorPeople() will shorten the execution time to find people 
 		// Note 3: need to include non-associated people from other settlements
 		for(Person person : CollectionUtils.getPeopleInSettlementVicinity(settlement)) {
-			if (person.getPosition().getDistanceTo(settlementPosition) < range) {
+			if (person.getPosition().getDistanceTo(settlementPosition) < SELECTION_RANGE) {
 				selectPerson(person);
 				return person;
 
@@ -503,10 +502,9 @@ public class SettlementMapPanel extends JPanel {
 	 * @return selectedRobot;
 	 */
 	private Robot selectRobotAt(LocalPosition settlementPosition) {
-		double range = WIDTH / scale;
 
 		for(Robot robot : CollectionUtils.getAssociatedRobotsInSettlementVicinity(settlement)) {
-			if (robot.getPosition().getDirectionTo(settlementPosition) <= range) {
+			if (robot.getPosition().getDistanceTo(settlementPosition) <= SELECTION_RANGE) {
 				selectRobot(robot);
 				return robot;
 			}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementTransparentPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementTransparentPanel.java
@@ -73,6 +73,7 @@ import com.mars_sim.core.tool.Msg;
 import com.mars_sim.ui.swing.ImageLoader;
 import com.mars_sim.ui.swing.MainDesktopPane;
 import com.mars_sim.ui.swing.StyleManager;
+import com.mars_sim.ui.swing.tool.settlement.SettlementMapPanel.DisplayOption;
 
 import eu.hansolo.steelseries.gauges.DisplaySingle;
 import eu.hansolo.steelseries.tools.LcdColor;
@@ -206,11 +207,11 @@ public class SettlementTransparentPanel extends JComponent {
 	    	@Override
 	    	public Dimension getMinimumSize() {
 	    		return new Dimension(50, 100);
-	    	};
+	    	}
 	    	@Override
 	    	public Dimension getPreferredSize() {
 	    		return new Dimension(50, 100);
-	    	};
+	    	}
 	    };
 
         buildInfoP();
@@ -248,10 +249,6 @@ public class SettlementTransparentPanel extends JComponent {
 	    sunlightPanel.setBackground(new Color(0,0,0,128));
 	    sunlightPanel.setOpaque(false);
 	    sunlightPanel.add(sunPane, BorderLayout.NORTH);
-
-        // Make panel drag-able
-//	    ComponentMover mover = new ComponentMover(desktop.getMainWindow());
-//	    mover.registerComponent(sunPane.getComponents());
 	    
 	    JPanel centerPanel = new JPanel(new BorderLayout(2, 2));
 	    centerPanel.setBackground(new Color(0,0,0,128));
@@ -869,9 +866,7 @@ public class SettlementTransparentPanel extends JComponent {
 		recenterButton.setBackground(new Color(0,0,0,128));
 
 		recenterButton.setToolTipText(Msg.getString("SettlementTransparentPanel.tooltip.recenter")); //$NON-NLS-1$
-		recenterButton.addActionListener(e -> {
-				mapPanel.reCenter();
-		});
+		recenterButton.addActionListener(e -> mapPanel.reCenter());
 
 		// Create rotate counter-clockwise button.
         final Icon ccwIcon = ImageLoader.getIconByName("settlement_map/left");
@@ -939,6 +934,14 @@ public class SettlementTransparentPanel extends JComponent {
 		labelsMenu = null;
 	}
 
+	private JCheckBoxMenuItem createDisplayToggle(String label, SettlementMapPanel.DisplayOption op) {
+		JCheckBoxMenuItem result = new JCheckBoxMenuItem(label, mapPanel.isOptionDisplayed(op));
+		result.setContentAreaFilled(false);
+		result.addActionListener(e -> mapPanel.toggleDisplayOption(op));
+		result.setSelected(mapPanel.isOptionDisplayed(op));
+		return result;
+	}
+
 	/**
 	 * Creates the labels popup menu.
 	 * 
@@ -947,15 +950,6 @@ public class SettlementTransparentPanel extends JComponent {
 	private JPopupMenu createLabelsMenu() {
 		JPopupMenu popMenu = new JPopupMenu(Msg.getString("SettlementWindow.menu.labelOptions")); //$NON-NLS-1$
 		popMenu.setBorderPainted(false);
-
-		// Create Day Night Layer menu item.
-		JCheckBoxMenuItem dayNightLabelMenuItem = new JCheckBoxMenuItem(
-				Msg.getString("SettlementWindow.menu.daylightTracking"), mapPanel.isDaylightTrackingOn()); //$NON-NLS-1$
-		dayNightLabelMenuItem.setContentAreaFilled(false);
-		dayNightLabelMenuItem.addActionListener(e ->
-				mapPanel.setShowDayNightLayer(!mapPanel.isDaylightTrackingOn()));
-		dayNightLabelMenuItem.setSelected(mapPanel.isDaylightTrackingOn());
-		popMenu.add(dayNightLabelMenuItem);
 
 		// Activity spot menu
 		var spotLabelMenuItem = new JMenu("Activity Spots");
@@ -984,45 +978,11 @@ public class SettlementTransparentPanel extends JComponent {
 			spotLabelMenuItem.add(ftItem);
 		}
 
-		// Create building label menu item.
-		var buildingLabelMenuItem = new JCheckBoxMenuItem(
-				Msg.getString("SettlementWindow.menu.buildings"), mapPanel.isShowBuildingLabels()); //$NON-NLS-1$
-		buildingLabelMenuItem.setContentAreaFilled(false);
-		buildingLabelMenuItem.addActionListener(e ->
-				mapPanel.setShowBuildingLabels(!mapPanel.isShowBuildingLabels()));
-		popMenu.add(buildingLabelMenuItem);
-
-		// Create construction/salvage label menu item.
-		var constructionLabelMenuItem = new JCheckBoxMenuItem(
-				Msg.getString("SettlementWindow.menu.constructionSites"), mapPanel.isShowConstructionLabels()); //$NON-NLS-1$
-		constructionLabelMenuItem.setContentAreaFilled(false);
-		constructionLabelMenuItem.addActionListener(e -> 
-				mapPanel.setShowConstructionLabels(!mapPanel.isShowConstructionLabels()));
-		popMenu.add(constructionLabelMenuItem);
-
-		// Create vehicle label menu item.
-		var vehicleLabelMenuItem = new JCheckBoxMenuItem(
-				Msg.getString("SettlementWindow.menu.vehicles"), mapPanel.isShowVehicleLabels()); //$NON-NLS-1$
-		vehicleLabelMenuItem.setContentAreaFilled(false);
-		vehicleLabelMenuItem.addActionListener(e -> 
-				mapPanel.setShowVehicleLabels(!mapPanel.isShowVehicleLabels()));
-		popMenu.add(vehicleLabelMenuItem);
-
-		// Create person label menu item.
-		var personLabelMenuItem = new JCheckBoxMenuItem(
-				Msg.getString("SettlementWindow.menu.people"), mapPanel.isShowPersonLabels()); //$NON-NLS-1$
-		personLabelMenuItem.setContentAreaFilled(false);
-		personLabelMenuItem.addActionListener(e -> 
-				mapPanel.setShowPersonLabels(!mapPanel.isShowPersonLabels()));
-		popMenu.add(personLabelMenuItem);
-
-		// Create person label menu item.
-		var robotLabelMenuItem = new JCheckBoxMenuItem(
-				Msg.getString("SettlementWindow.menu.robots"), mapPanel.isShowRobotLabels()); //$NON-NLS-1$
-		robotLabelMenuItem.setContentAreaFilled(false);
-		robotLabelMenuItem.addActionListener(e ->
-				mapPanel.setShowRobotLabels(!mapPanel.isShowRobotLabels()));
-		popMenu.add(robotLabelMenuItem);
+		// Create display option items
+		for(DisplayOption op : DisplayOption.values()) {
+			popMenu.add(createDisplayToggle(Msg.getString("SettlementWindow.menu." + op.name().toLowerCase()),
+				op));
+		}
 
 		popMenu.pack();
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementWindow.java
@@ -53,7 +53,7 @@ public class SettlementWindow extends ToolWindow implements ConfigurableWindow {
 	private static final String WHITESPACES_2 = " ";
 	private static final String CLOSE_PARENT = ") ";
 	private static final String WITHIN_BLDG = " Building: (";
-	private static final String SETTLEMENT_MAP = " Map: (";
+	private static final String SETTLEMENT_MAP = " Map: ";
 	private static final String PIXEL_MAP = " Window: (";
 
 	private JLabel buildingXYLabel;
@@ -158,34 +158,20 @@ public class SettlementWindow extends ToolWindow implements ConfigurableWindow {
 	 * Sets the x/y pixel label of the settlement window.
 	 *
 	 * @param point
-	 * @param blank
 	 */
-	void setPixelXYCoord(double x, double y, boolean blank) {
-		if (blank) {
-			windowXYLabel.setText("");
-		}
-		else {
-			StringBuilder sb = new StringBuilder();
-			sb.append(PIXEL_MAP).append(format1(x, y)).append(CLOSE_PARENT);
-			windowXYLabel.setText(sb.toString());
-		}
+	void setPixelXYCoord(double x, double y) {
+		StringBuilder sb = new StringBuilder();
+		sb.append(PIXEL_MAP).append(format1(x, y)).append(CLOSE_PARENT);
+		windowXYLabel.setText(sb.toString());
 	}
 
 	/**
 	 * Sets the label of the settlement map coordinates.
 	 *
 	 * @param point
-	 * @param blank
 	 */
-	void setMapXYCoord(LocalPosition point, boolean blank) {
-		if (blank) {
-			mapXYLabel.setText("");
-		}
-		else {
-			StringBuilder sb = new StringBuilder();
-			sb.append(SETTLEMENT_MAP).append(point.getShortFormat()).append(CLOSE_PARENT);
-			mapXYLabel.setText(sb.toString());
-		}
+	void setMapXYCoord(LocalPosition point) {
+		mapXYLabel.setText(SETTLEMENT_MAP + point.getShortFormat());
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementWindow.java
@@ -12,7 +12,6 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GridLayout;
-import java.awt.Point;
 import java.util.Properties;
 
 import javax.swing.BorderFactory;
@@ -134,10 +133,6 @@ public class SettlementWindow extends ToolWindow implements ConfigurableWindow {
 		setVisible(true);
 	}
 
-	private String format0(double x, double y) {
-		return Math.round(x*100.00)/100.00 + ", " + Math.round(y*100.00)/100.00;
-	}
-
 	private String format1(double x, double y) {
 		return (int)x + ", " + (int)y;
 	}
@@ -145,17 +140,16 @@ public class SettlementWindow extends ToolWindow implements ConfigurableWindow {
 	/**
 	 * Sets the label of the coordinates within a building.
 	 *
-	 * @param x
-	 * @param y
+	 * @param pos
 	 * @param blank
 	 */
-	void setBuildingXYCoord(double x, double y, boolean blank) {
+	void setBuildingXYCoord(LocalPosition pos, boolean blank) {
 		if (blank) {
 			buildingXYLabel.setText("");
 		}
 		else {
 			StringBuilder sb = new StringBuilder();
-			sb.append(WITHIN_BLDG).append(format0(x, y)).append(CLOSE_PARENT);
+			sb.append(WITHIN_BLDG).append(pos.getShortFormat()).append(CLOSE_PARENT);
 			buildingXYLabel.setText(sb.toString());
 		}
 	}
@@ -183,13 +177,13 @@ public class SettlementWindow extends ToolWindow implements ConfigurableWindow {
 	 * @param point
 	 * @param blank
 	 */
-	void setMapXYCoord(Point.Double point, boolean blank) {
+	void setMapXYCoord(LocalPosition point, boolean blank) {
 		if (blank) {
 			mapXYLabel.setText("");
 		}
 		else {
 			StringBuilder sb = new StringBuilder();
-			sb.append(SETTLEMENT_MAP).append(format0(point.getX(), point.getY())).append(CLOSE_PARENT);
+			sb.append(SETTLEMENT_MAP).append(point.getShortFormat()).append(CLOSE_PARENT);
 			mapXYLabel.setText(sb.toString());
 		}
 	}
@@ -240,7 +234,6 @@ public class SettlementWindow extends ToolWindow implements ConfigurableWindow {
     public void displayVehicle(Vehicle vv) {
 		if (vv.isInSettlement()) {
 			refocusMap(vv.getSettlement(), vv.getPosition());
-			mapPanel.setShowVehicleLabels(true);
 		}
     }
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/VehicleMapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/VehicleMapLayer.java
@@ -23,6 +23,7 @@ import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.vehicle.LightUtilityVehicle;
 import com.mars_sim.core.vehicle.Vehicle;
 import com.mars_sim.core.vehicle.task.LoadingController;
+import com.mars_sim.ui.swing.tool.settlement.SettlementMapPanel.DisplayOption;
 import com.mars_sim.ui.swing.tool.svg.SVGMapUtil;
 
 /**
@@ -54,11 +55,12 @@ public class VehicleMapLayer extends AbstractMapLayer {
 
 		// Save original graphics transforms.
 		AffineTransform saveTransform = viewpoint.prepareGraphics();
+		boolean drawLabel = mapPanel.isOptionDisplayed(DisplayOption.VEHICLE_LABELS);
 
 		// Draw all parked vehicles at this settlement location
 		for (Vehicle v : CollectionUtils.getVehiclesInSettlementVicinity(settlement)) {
 			if (v.isReady())
-				drawVehicle(v, mapPanel.isShowVehicleLabels(), viewpoint);
+				drawVehicle(v, drawLabel, viewpoint);
 		}
 
 		// Restore original graphic transforms.


### PR DESCRIPTION
Clean up the selection logic in the Settlement map window

- Label/layer control is governed by an extendable approach based on an enum instead of a set explicit booleans
- Selection of Unit from mouse position is based on the Settlement LocalPosition

close #1371