### PR TITLE
Enable loading and projecting gray maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ Check out the most recent release or pre-release build in GitHub
 [Releases](https://github.com/mars-sim/mars-sim/releases) page.
 
 Alternatively, see all our previous and current official release versions at SourceForge
-[Repo](https://sourceforge.net/projects/mars-sim/files/mars-sim/3.6.2/).
+[Repo](https://sourceforge.net/projects/mars-sim/files/mars-sim/3.8.0/).
 
 > [!NOTE]
 > If you prefer, click SF's button below to automatically sense the correct OS platform to download.

--- a/mars-sim-core/src/main/resources/mapdata.properties
+++ b/mars-sim-core/src/main/resources/mapdata.properties
@@ -15,28 +15,27 @@ elevation = memory, megt90n000eb.img
 
 # Each user map entry must contain 
 # 1. the map type
-# 2. the true or false flag for colourized
+# 2. the true or false flag for being a colourized map (as opposed to a gray map)
 # 3. the file name of the 1st image (level 0: the lowest resolution)
 # 4. the file name of the 2nd image (level 1)
 # 5. the file name of the nth image (level n: the highest resolution)
 #
 # Format: the parameters are separated by a comma with or without whitespaces. e.g. ",  "
 #
-# Note that currently the gray maps could NOT be loaded properly.
-# grayDEM       = Gray MOLA HRSC DEM, false, Mars_HRSC_MOLA_BlendDEM_Global_200mp_1024.jpg
-# grayShaded    = Gray MOLA HRSC Shaded Relief, false, Mars_HRSC_MOLA_BlendShade_Global_200mp_1024.jpg
-# molaGray      = MOLA Shade, false, jmars_MOLA_128ppd_shade_ne_-_1024_x_512.png, jmars_MOLA_128ppd_shade_ne_-_4096_x_2048.png
+grayDEM       = (Gray) MOLA HRSC DEM, false, Mars_HRSC_MOLA_BlendDEM_Global_200mp_1024.jpg
+grayShaded    = (Gray) MOLA HRSC Shaded Relief, false, Mars_HRSC_MOLA_BlendShade_Global_200mp_1024.jpg
+molaGray      = (Gray) jMars MOLA Shade, false, jmars_MOLA_128ppd_shade_ne_-_1024_x_512.png, jmars_MOLA_128ppd_shade_ne_-_4096_x_2048.png
 
-vertRoughness    		= MOLA Vertical Roughness, true, MOLA_Vertical_Roughness_1200.jpg, MOLA_Vertical_Roughness_8ppd_2800.jpg
-marinerGeo    			= Mariner 9 Geology, true, Mars_Global_Geology_Mariner9_1024.jpg, Mars_Global_Geology_Mariner9_12ppd.jpg
-geoTexture    			= Geo Texture, true, geo_texture_2880.jpg, geo_texture_5760.jpg
-geoRegion     			= Geo Region, true, geo_region_1200.jpg, geo_region_2880.jpg, geo_region_5760.jpg
-vikingGeo     			= Viking Geologic, true, jmars_viking_geologic_map_skinner_et_al_2006_-_1024_x_512.png, jmars_viking_geologic_map_skinner_et_al_2006_-_2048_x_1024.png, jmars_viking_geologic_map_skinner_et_al_2006_-_4096_x_2048.png
-landing       			= MRO CTX Human EZ Landing, true, AA_CTX_Human_EZ_1024.jpg, AA_CTX_Human_EZ_2880.jpg
-topoRegion    			= Colorized Topo Region, true, Colorized_topo_region_names_1200.jpg, Colorized_topo_region_names_2880.jpg, Colorized_topo_region_names_5760.jpg
-molaColor     			= MOLA Color Shaded Relief Topo, true, Mars_MGS_colorhillshade_mola_2865.jpg, Mars_MGS_colorhillshade_mola_4096.jpg, Mars_MGS_colorhillshade_mola_8192.jpg, Mars_MGS_MOLA_ClrShade_merge_global_18000.jpg
-surfaceRegion 			= Blended Surface Region, true, Orange_blended_surface_height_region_names_1200.jpg, Orange_blended_surface_height_region_names_2880.jpg, Orange_blended_surface_height_region_names_5760.jpg
-vikingMDIM    			= Viking Colorized Global Mosaic MDIM 2.1, true, Mars_Viking_MDIM21_ClrMosaic_1200.jpg, Mars_Viking_MDIM21_ClrMosaic_2880.jpg, Mars_Viking_MDIM21_ClrMosaic_2500m.jpg, Mars_Viking_MDIM21_ClrMosaic_1km.jpg
+vertRoughness   = MOLA Vertical Roughness, true, MOLA_Vertical_Roughness_1200.jpg, MOLA_Vertical_Roughness_8ppd_2800.jpg
+marinerGeo    	= Mariner 9 Geology, true, Mars_Global_Geology_Mariner9_1024.jpg, Mars_Global_Geology_Mariner9_12ppd.jpg
+geoTexture    	= Geo Texture, true, geo_texture_2880.jpg, geo_texture_5760.jpg
+geoRegion     	= Geo Region, true, geo_region_1200.jpg, geo_region_2880.jpg, geo_region_5760.jpg
+vikingGeo     	= Viking Geologic, true, jmars_viking_geologic_map_skinner_et_al_2006_-_1024_x_512.png, jmars_viking_geologic_map_skinner_et_al_2006_-_2048_x_1024.png, jmars_viking_geologic_map_skinner_et_al_2006_-_4096_x_2048.png
+landing       	= MRO CTX Human EZ Landing, true, AA_CTX_Human_EZ_1024.jpg, AA_CTX_Human_EZ_2880.jpg
+topoRegion    	= Colorized Topo Region, true, Colorized_topo_region_names_1200.jpg, Colorized_topo_region_names_2880.jpg, Colorized_topo_region_names_5760.jpg
+molaColor     	= MOLA Color Shaded Relief Topo, true, Mars_MGS_colorhillshade_mola_2865.jpg, Mars_MGS_colorhillshade_mola_4096.jpg, Mars_MGS_colorhillshade_mola_8192.jpg, Mars_MGS_MOLA_ClrShade_merge_global_18000.jpg
+surfaceRegion 	= Blended Surface Region, true, Orange_blended_surface_height_region_names_1200.jpg, Orange_blended_surface_height_region_names_2880.jpg, Orange_blended_surface_height_region_names_5760.jpg
+vikingMDIM    	= Viking Colorized Global Mosaic MDIM 2.1, true, Mars_Viking_MDIM21_ClrMosaic_1200.jpg, Mars_Viking_MDIM21_ClrMosaic_2880.jpg, Mars_Viking_MDIM21_ClrMosaic_2500m.jpg, Mars_Viking_MDIM21_ClrMosaic_1km.jpg
 
 # Note: vikingMDIM maps are actually in YCbCr mode
 


### PR DESCRIPTION
09.01.2024

- fix: adopt an approach to render gray image in setRGB() in IntegerMapData for loading and projecting gray map in Mars Navigator

Relates to https://github.com/mars-sim/mars-sim/issues/1394