### PR TITLE
Create a SuppliesManifest

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/CommandHelper.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/CommandHelper.java
@@ -376,10 +376,12 @@ public class CommandHelper {
 			LoadingController lp = tm.getLoadingPlan();
 			if ((lp != null) && !lp.isCompleted()) {
 				response.appendText("Loading from " + lp.getSettlement().getName() + " :");
-				outputResources("Resources", response, lp.getResourcesManifest());	
-				outputResources("Optional Resources", response, lp.getOptionalResourcesManifest());	
-				outputEquipment("Equipment", response, lp.getEquipmentManifest());	
-				outputEquipment("Optional Equipment", response, lp.getOptionalEquipmentManifest());	
+				outputAmounts("Amount Resources", response, lp.getAmountManifest(true));	
+				outputAmounts("Optional Amounts", response, lp.getAmountManifest(false));
+				outputItems("Items", response, lp.getItemManifest(true));	
+				outputItems("Optional Items", response, lp.getItemManifest(false));	
+				outputEquipment("Equipment", response, lp.getEquipmentManifest(true));	
+				outputEquipment("Optional Equipment", response, lp.getEquipmentManifest(false));	
 			}
 		}
 	}
@@ -406,34 +408,48 @@ public class CommandHelper {
 	}
 
 	/**
-	 * Outputs the resources in use.
+	 * Outputs the amount resources in use.
 	 * 
 	 * @param title
 	 * @param response
 	 * @param resourcesManifest
 	 */
-	private static void outputResources(String title, StructuredResponse response,
-			Map<Integer, Number> resourcesManifest) {
+	private static void outputAmounts(String title, StructuredResponse response,
+			Map<Integer, Double> resourcesManifest) {
 		if (!resourcesManifest.isEmpty()) {
 			response.appendText(title);
 			response.appendTableHeading(ITEM, 30, ITEM);
 			
-			for(Entry<Integer, Number> item : resourcesManifest.entrySet()) {
+			for(Entry<Integer, Double> item : resourcesManifest.entrySet()) {
 				int id = item.getKey();
-				String quantity;
-				String name;
-				if (id < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
-					name = ResourceUtil.findAmountResourceName(id);
-					quantity = String.format(KG_FORMAT, item.getValue().doubleValue());
-				}
-				else {
-					name = ItemResourceUtil.findItemResource(id).getName();
-					quantity = Integer.toString(item.getValue().intValue());
-				}	
+				var name = ResourceUtil.findAmountResourceName(id);
+				var quantity = String.format(KG_FORMAT, item.getValue());
 				response.appendTableRow(name, quantity);
 			}
 			response.appendBlankLine();
+		}
+	}
 
+	/**
+	 * Outputs the items in use.
+	 * 
+	 * @param title
+	 * @param response
+	 * @param resourcesManifest
+	 */
+	private static void outputItems(String title, StructuredResponse response,
+			Map<Integer, Integer> resourcesManifest) {
+		if (!resourcesManifest.isEmpty()) {
+			response.appendText(title);
+			response.appendTableHeading(ITEM, 30, ITEM);
+			
+			for(Entry<Integer, Integer> item : resourcesManifest.entrySet()) {
+				int id = item.getKey();
+				var name = ItemResourceUtil.findItemResource(id).getName();
+				var quantity = Integer.toString(item.getValue().intValue());	
+				response.appendTableRow(name, quantity);
+			}
+			response.appendBlankLine();
 		}
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionBoardVehicleStep.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionBoardVehicleStep.java
@@ -20,6 +20,7 @@ import com.mars_sim.core.person.ai.task.Sleep;
 import com.mars_sim.core.person.ai.task.Walk;
 import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.project.Stage;
+import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.robot.Robot;
 import com.mars_sim.core.vehicle.Crewable;
 import com.mars_sim.core.vehicle.Vehicle;
@@ -218,7 +219,7 @@ public class MissionBoardVehicleStep extends MissionStep {
 	 * @param addOptionals Any optional spares
      */
     @Override
-    void getRequiredResources(MissionManifest manifest, boolean addOptionals) {
+    void getRequiredResources(SuppliesManifest manifest, boolean addOptionals) {
 		MissionVehicleProject mvp = (MissionVehicleProject) getMission();
 		
 		// Get the estimated duration

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionLoadVehicleStep.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionLoadVehicleStep.java
@@ -12,6 +12,7 @@ import com.mars_sim.core.person.ai.mission.VehicleMission;
 import com.mars_sim.core.person.ai.task.util.Task;
 import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.project.Stage;
+import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.robot.Robot;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.tool.RandomUtil;
@@ -49,12 +50,8 @@ public class MissionLoadVehicleStep extends MissionStep {
         Vehicle v = vp.getVehicle();
         Settlement settlement = v.getSettlement();
 		if (loadingPlan == null) {
-            MissionManifest manifest = vp.getResources(true);
-			loadingPlan = new LoadingController(v.getSettlement(), v,
-												manifest.getResources(true),
-												manifest.getResources(false),
-                                                manifest.getEquipment(true),
-												manifest.getEquipment(false));	
+            SuppliesManifest manifest = vp.getResources(true);
+			loadingPlan = new LoadingController(v.getSettlement(), v, manifest);	
             
                                                 
             // Try and move the vehicle to garage

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionProject.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionProject.java
@@ -29,6 +29,7 @@ import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.project.Project;
 import com.mars_sim.core.project.ProjectStep;
 import com.mars_sim.core.project.Stage;
+import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.structure.ObjectiveType;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.time.MarsTime;
@@ -401,8 +402,8 @@ public abstract class MissionProject implements Mission {
      * Get the resources needed to complete the mission
      * @return
      */
-    public MissionManifest getResources(boolean includeOptionals) {
-        MissionManifest resources = new MissionManifest();
+    public SuppliesManifest getResources(boolean includeOptionals) {
+        SuppliesManifest resources = new SuppliesManifest();
         List<ProjectStep> steps = control.getRemainingSteps();
         for(ProjectStep ps : steps) {
             if (ps instanceof MissionStep ms) {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionStep.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionStep.java
@@ -82,13 +82,13 @@ public abstract class MissionStep extends ProjectStep {
     protected void addLifeSupportResource(int crew, double durationMSol, boolean ideal, SuppliesManifest manifest) {
         double personSols = (crew * durationMSol)/1000D; // Consumption rates are in Sols
         personSols *= (ideal ? Vehicle.getLifeSupportRangeErrorMargin() : 1D);
-        manifest.addResource(ResourceUtil.oxygenID,
+        manifest.addAmount(ResourceUtil.oxygenID,
                         PhysicalCondition.getOxygenConsumptionRate() * personSols, true);
 
-		manifest.addResource(ResourceUtil.waterID,
+		manifest.addAmount(ResourceUtil.waterID,
                         PhysicalCondition.getWaterConsumptionRate() * personSols, true);
 
-        manifest.addResource(ResourceUtil.foodID,
+        manifest.addAmount(ResourceUtil.foodID,
 		                PhysicalCondition.getFoodConsumptionRate() * personSols, true);
     }
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionStep.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionStep.java
@@ -16,6 +16,7 @@ import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.project.ProjectStep;
 import com.mars_sim.core.project.Stage;
 import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.robot.Robot;
 import com.mars_sim.core.time.MasterClock;
 import com.mars_sim.core.vehicle.Vehicle;
@@ -67,7 +68,7 @@ public abstract class MissionStep extends ProjectStep {
      * @param includeOptionals
      * @param resources
      */
-    void getRequiredResources(MissionManifest resources, boolean includeOptionals) {
+    void getRequiredResources(SuppliesManifest resources, boolean includeOptionals) {
        // Do nonthing; nothing to add
     }
 
@@ -78,7 +79,7 @@ public abstract class MissionStep extends ProjectStep {
      * @param ideal Calculate the ideal amount which will be more thn the minimum
      * @param manifest Place to hold the order
      */
-    protected void addLifeSupportResource(int crew, double durationMSol, boolean ideal, MissionManifest manifest) {
+    protected void addLifeSupportResource(int crew, double durationMSol, boolean ideal, SuppliesManifest manifest) {
         double personSols = (crew * durationMSol)/1000D; // Consumption rates are in Sols
         personSols *= (ideal ? Vehicle.getLifeSupportRangeErrorMargin() : 1D);
         manifest.addResource(ResourceUtil.oxygenID,

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionTravelStep.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionTravelStep.java
@@ -131,16 +131,16 @@ public class MissionTravelStep extends MissionStep {
 
         // Must use the same logic in all cases otherwise too few fuel will be loaded
         double amount = vehicle.getFuelNeededForTrip(distance, addOptionals);
-        manifest.addResource(vehicle.getFuelTypeID(), amount, true);
+        manifest.addAmount(vehicle.getFuelTypeID(), amount, true);
          
         if (vehicle.getFuelTypeID() == ResourceUtil.methanolID) {
             // if useMargin is true, include more oxygen
-            manifest.addResource(ResourceUtil.oxygenID, 
+            manifest.addAmount(ResourceUtil.oxygenID, 
             		VehicleController.RATIO_OXIDIZER_METHANOL * amount, true);
         }
         else if (vehicle.getFuelTypeID() == ResourceUtil.methaneID) {
             // if useMargin is true, include more oxygen
-            manifest.addResource(ResourceUtil.oxygenID, 
+            manifest.addAmount(ResourceUtil.oxygenID, 
             		VehicleController.RATIO_OXIDIZER_METHANE * amount, true);
         }
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionTravelStep.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionTravelStep.java
@@ -15,6 +15,7 @@ import com.mars_sim.core.person.ai.task.util.Task;
 import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.project.Stage;
 import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.vehicle.GroundVehicle;
 import com.mars_sim.core.vehicle.Vehicle;
@@ -122,7 +123,7 @@ public class MissionTravelStep extends MissionStep {
      * Gets the resources are needed for this travel. Should be vehicle fuel plus food and oxygen.
      */
     @Override
-    void getRequiredResources(MissionManifest manifest, boolean addOptionals) {
+    void getRequiredResources(SuppliesManifest manifest, boolean addOptionals) {
 
         Vehicle vehicle = getVehicle();
         double distance = destination.getPointToPointDistance() - getDistanceCovered();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/AbstractVehicleMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/AbstractVehicleMission.java
@@ -42,6 +42,7 @@ import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.project.Stage;
 import com.mars_sim.core.resource.ItemResourceUtil;
 import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.robot.Robot;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.time.ClockPulse;
@@ -319,11 +320,13 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 	protected LoadingController prepareLoadingPlan(Settlement loadingSite) {
 		if ((loadingPlan == null) || !loadingPlan.getSettlement().equals(loadingSite)) {
 			logger.info(vehicle, 10_000L, "Prepared a loading plan sourced from " + loadingSite.getName() + ".");
-			loadingPlan = new LoadingController(loadingSite, vehicle,
-												getRequiredResourcesToLoad(),
+			var manifest = new SuppliesManifest(getRequiredResourcesToLoad(),
 												getOptionalResourcesToLoad(),
 												getRequiredEquipmentToLoad(),
-												getOptionalEquipmentToLoad());			
+												getOptionalEquipmentToLoad());
+			loadingPlan = new LoadingController(loadingSite, vehicle, manifest);
+
+															
 		}
 		return loadingPlan;
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/resource/SuppliesManifest.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/resource/SuppliesManifest.java
@@ -14,13 +14,15 @@ import java.util.Map;
  */
 public class SuppliesManifest {
 
-    private Map<Integer, Number> mandatoryResources;
-    private Map<Integer, Number> optionalResources;
+    private Map<Integer, Double> mandatoryAmount;
+    private Map<Integer, Double> optionalAmount;
     private Map<Integer, Integer> mandatoryEqm;
     private Map<Integer, Integer> optionalEqm;
-
+    private Map<Integer, Integer> mandatoryItem;
+    private Map<Integer, Integer> optionalItem;
+    
     /**
-     * Preload the manifest
+     * Preload the manifest. This constructor is only used by the old AbstractVehicleMission class
      * @param mandatoryResources
      * @param optionalResources
      * @param mandatoryEqm
@@ -28,8 +30,28 @@ public class SuppliesManifest {
      */
     public SuppliesManifest(Map<Integer, Number> mandatoryResources, Map<Integer, Number> optionalResources,
             Map<Integer, Integer> mandatoryEqm, Map<Integer, Integer> optionalEqm) {
-        this.mandatoryResources = mandatoryResources;
-        this.optionalResources = optionalResources;
+        // Split the mandatory into seperate maps
+        this.mandatoryAmount = new HashMap<>();
+        this.mandatoryItem = new HashMap<>();
+        for(var m : mandatoryResources.entrySet())  {
+            int resourceId = m.getKey();
+            if (resourceId < ResourceUtil.FIRST_ITEM_RESOURCE_ID)
+                mandatoryAmount.put(resourceId, m.getValue().doubleValue());
+            else
+                mandatoryItem.put(resourceId, m.getValue().intValue());
+        }
+
+        this.optionalAmount = new HashMap<>();
+        this.optionalItem = new HashMap<>();
+        for(var m : optionalResources.entrySet())  {
+            int resourceId = m.getKey();
+            if (resourceId < ResourceUtil.FIRST_ITEM_RESOURCE_ID)
+                optionalAmount.put(resourceId, m.getValue().doubleValue());
+            else
+                optionalItem.put(resourceId, m.getValue().intValue());
+        }
+
+
         this.mandatoryEqm = mandatoryEqm;
         this.optionalEqm = optionalEqm;
     }
@@ -39,17 +61,21 @@ public class SuppliesManifest {
      * @param source Source manifest
      */
     public SuppliesManifest(SuppliesManifest source) {
-        this.mandatoryResources =  new HashMap<>(source.mandatoryResources);
-        this.optionalResources = new HashMap<>(source.optionalResources);
+        this.mandatoryAmount =  new HashMap<>(source.mandatoryAmount);
+        this.optionalAmount = new HashMap<>(source.optionalAmount);
         this.mandatoryEqm = new HashMap<>(source.mandatoryEqm);
         this.optionalEqm = new HashMap<>(source.optionalEqm);
+        this.mandatoryItem =  new HashMap<>(source.mandatoryItem);
+        this.optionalItem = new HashMap<>(source.optionalItem);
     }
 
     public SuppliesManifest() {
-        mandatoryResources = new HashMap<>();
-        optionalResources = new HashMap<>();
+        mandatoryAmount = new HashMap<>();
+        optionalAmount = new HashMap<>();
         mandatoryEqm = new HashMap<>();
         optionalEqm = new HashMap<>();
+        mandatoryItem = new HashMap<>();
+        optionalItem = new HashMap<>();
     }
 
     /**
@@ -59,8 +85,8 @@ public class SuppliesManifest {
      * @param amount Amount of resource to add
      * @param mandatory Is it mandatory
      */
-    public void addResource(int resourceId, double amount, boolean mandatory) {
-        Map<Integer, Number> selected = (mandatory ? mandatoryResources : optionalResources);
+    public void addAmount(int resourceId, double amount, boolean mandatory) {
+        Map<Integer, Double> selected = (mandatory ? mandatoryAmount : optionalAmount);
         selected.merge(resourceId, amount, (v1,v2) -> v1.doubleValue() + v2.doubleValue());
     }
 
@@ -72,7 +98,7 @@ public class SuppliesManifest {
      * @param mandatory Is it mandatory
      */
     public void addItem(int itemId, int count, boolean mandatory) {
-        Map<Integer, Number> selected = (mandatory ? mandatoryResources : optionalResources);
+        Map<Integer, Integer> selected = (mandatory ? mandatoryItem : optionalItem);
         selected.merge(itemId, count, (v1,v2) -> v1.intValue() + v2.intValue());
     }
 
@@ -88,14 +114,22 @@ public class SuppliesManifest {
         selected.merge(equipmentId, count, (v1,v2) -> Math.max(v1.intValue(), v2.intValue()));
     }
 
-
     /**
-     * The resources needed in the manifest.
+     * The amount resources needed in the manifest.
      * @param mandatory Get mandatory resoruces
      * @return
      */
-    public Map<Integer, Number> getResources(boolean mandatory) {
-        return (mandatory ? mandatoryResources : optionalResources);
+    public Map<Integer, Double> getAmounts(boolean mandatory) {
+        return (mandatory ? mandatoryAmount : optionalAmount);
+    }
+
+    /**
+     * The Items needed in the manifest.
+     * @param mandatory Get mandatory items
+     * @return
+     */
+    public Map<Integer, Integer> getItems(boolean mandatory) {
+        return (mandatory ? mandatoryItem : optionalItem);
     }
 
     /**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/resource/SuppliesManifest.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/resource/SuppliesManifest.java
@@ -1,23 +1,56 @@
 /**
  * Mars Simulation Project
- * MissionManifest.java
- * @date 2023-06-03
+ * SuppliesManifest.java
+ * @date 2024-09-01
  * @author Barry Evans
  */
-package com.mars_sim.core.mission;
+package com.mars_sim.core.resource;
 
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Manifest for a Mission covering mandatory and optional reources & items.
+ * Represents a manifest of Supplies covering mandatory and optional reources & items.
  */
-public class MissionManifest {
+public class SuppliesManifest {
 
-    private Map<Integer, Number> mandatoryResources = new HashMap<>();
-    private Map<Integer, Number> optionalResources = new HashMap<>();
-    private Map<Integer, Integer> mandatoryEqm = new HashMap<>();
-    private Map<Integer, Integer> optionalEqm = new HashMap<>();
+    private Map<Integer, Number> mandatoryResources;
+    private Map<Integer, Number> optionalResources;
+    private Map<Integer, Integer> mandatoryEqm;
+    private Map<Integer, Integer> optionalEqm;
+
+    /**
+     * Preload the manifest
+     * @param mandatoryResources
+     * @param optionalResources
+     * @param mandatoryEqm
+     * @param optionalEqm
+     */
+    public SuppliesManifest(Map<Integer, Number> mandatoryResources, Map<Integer, Number> optionalResources,
+            Map<Integer, Integer> mandatoryEqm, Map<Integer, Integer> optionalEqm) {
+        this.mandatoryResources = mandatoryResources;
+        this.optionalResources = optionalResources;
+        this.mandatoryEqm = mandatoryEqm;
+        this.optionalEqm = optionalEqm;
+    }
+
+    /**
+     * Deep copy of an existing manifest.
+     * @param source Source manifest
+     */
+    public SuppliesManifest(SuppliesManifest source) {
+        this.mandatoryResources =  new HashMap<>(source.mandatoryResources);
+        this.optionalResources = new HashMap<>(source.optionalResources);
+        this.mandatoryEqm = new HashMap<>(source.mandatoryEqm);
+        this.optionalEqm = new HashMap<>(source.optionalEqm);
+    }
+
+    public SuppliesManifest() {
+        mandatoryResources = new HashMap<>();
+        optionalResources = new HashMap<>();
+        mandatoryEqm = new HashMap<>();
+        optionalEqm = new HashMap<>();
+    }
 
     /**
      * Add an amount of resource to the manifest. This is cummulative and will increase what resoruce
@@ -29,9 +62,6 @@ public class MissionManifest {
     public void addResource(int resourceId, double amount, boolean mandatory) {
         Map<Integer, Number> selected = (mandatory ? mandatoryResources : optionalResources);
         selected.merge(resourceId, amount, (v1,v2) -> v1.doubleValue() + v2.doubleValue());
-
-        // Number existing = selected.getOrDefault(resourceId, 0D);
-        // selected.put(resourceId, existing.doubleValue() + amount);
     }
 
     /**
@@ -44,8 +74,6 @@ public class MissionManifest {
     public void addItem(int itemId, int count, boolean mandatory) {
         Map<Integer, Number> selected = (mandatory ? mandatoryResources : optionalResources);
         selected.merge(itemId, count, (v1,v2) -> v1.intValue() + v2.intValue());
-        // Could take the largest Item demand
-        //selected.merge(itemId, count, (v1,v2) -> Math.max(v1.intValue(), v2.intValue()));
     }
 
     /**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/LoadingController.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/LoadingController.java
@@ -26,6 +26,7 @@ import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.resource.ItemResourceUtil;
 import com.mars_sim.core.resource.Part;
 import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.vehicle.StatusType;
 import com.mars_sim.core.vehicle.Vehicle;
@@ -80,24 +81,18 @@ public class LoadingController implements Serializable {
 	 * Load a vehicle with a manifest from a Settlement
 	 * @param settlement Source of resources for the load
 	 * @param vehicle Vehicle to load
-	 * @param resources Mandatory resources needed
-	 * @param optionalResources Optional resources needed
-	 * @param equipment Mandatory equipment needed
-	 * @param optionalEquipment Optional equipment needed
+	 * @param manifest Defines what supplies are to be loaded
 	 */
 	public LoadingController(Settlement settlement, Vehicle vehicle,
-							 Map<Integer, Number> resources,
-							 Map<Integer, Number> optionalResources,
-							 Map<Integer, Integer> equipment,
-							 Map<Integer, Integer> optionalEquipment) {
+							 SuppliesManifest manifest) {
 		this.settlement = settlement;
 		this.vehicle = vehicle;
 
 		// Take copies to form the manifest as the quantities will be reduced
-		this.resourcesManifest = new HashMap<>(resources);
-		this.optionalResourcesManifest = new HashMap<>(optionalResources);
-		this.equipmentManifest = new HashMap<>(equipment);
-		this.optionalEquipmentManifest = new HashMap<>(optionalEquipment);
+		this.resourcesManifest = new HashMap<>(manifest.getResources(true));
+		this.optionalResourcesManifest = new HashMap<>(manifest.getResources(false));
+		this.equipmentManifest = new HashMap<>(manifest.getEquipment(true));
+		this.optionalEquipmentManifest = new HashMap<>(manifest.getEquipment(false));
 
 		// Reduce what is already in the Vehicle
 		removeVehicleResources(resourcesManifest);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/LoadingController.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/LoadingController.java
@@ -14,12 +14,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Map.Entry;
 
 import com.mars_sim.core.equipment.Equipment;
 import com.mars_sim.core.equipment.EquipmentType;
-import com.mars_sim.core.goods.Good;
-import com.mars_sim.core.goods.GoodsUtil;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.person.ai.NaturalAttributeType;
 import com.mars_sim.core.person.ai.task.util.Worker;
@@ -65,10 +62,12 @@ public class LoadingController implements Serializable {
 	/** default logger. */
 	private static SimLogger logger = SimLogger.getLogger(LoadingController.class.getName());
 
-	private Map<Integer, Number> resourcesManifest;
-	private Map<Integer, Number> optionalResourcesManifest;
+	private Map<Integer, Double> amountManifest;
+	private Map<Integer, Double> optionalAmountManifest;
 	private Map<Integer, Integer> equipmentManifest;
 	private Map<Integer, Integer> optionalEquipmentManifest;
+	private Map<Integer, Integer> itemManifest;
+	private Map<Integer, Integer> optionalItemManifest;
 	private Settlement settlement;
 	private Vehicle vehicle;
 
@@ -89,16 +88,20 @@ public class LoadingController implements Serializable {
 		this.vehicle = vehicle;
 
 		// Take copies to form the manifest as the quantities will be reduced
-		this.resourcesManifest = new HashMap<>(manifest.getResources(true));
-		this.optionalResourcesManifest = new HashMap<>(manifest.getResources(false));
+		this.amountManifest = new HashMap<>(manifest.getAmounts(true));
+		this.optionalAmountManifest = new HashMap<>(manifest.getAmounts(false));
 		this.equipmentManifest = new HashMap<>(manifest.getEquipment(true));
 		this.optionalEquipmentManifest = new HashMap<>(manifest.getEquipment(false));
+		this.itemManifest = new HashMap<>(manifest.getItems(true));
+		this.optionalItemManifest = new HashMap<>(manifest.getItems(false));
 
 		// Reduce what is already in the Vehicle
-		removeVehicleResources(resourcesManifest);
-		removeVehicleResources(optionalResourcesManifest);
+		removeVehicleAmounts(amountManifest);
+		removeVehicleAmounts(optionalAmountManifest);
 		removeVehicleEquipment(equipmentManifest);
 		removeVehicleEquipment(optionalEquipmentManifest);
+		removeVehicleItems(itemManifest);
+		removeVehicleItems(optionalItemManifest);
 	}
 
 	/*
@@ -123,37 +126,49 @@ public class LoadingController implements Serializable {
 	}
 
 	/*
-	 * Remove any resources the Vehicle has from the manifest. Resource completely loaded
+	 * Remove any amount resources the Vehicle has from the manifest. Resource completely loaded
 	 * in the vehicle will be removed from the manifest.
 	 */
-	private void removeVehicleResources(Map<Integer, Number> resources) {
+	private void removeVehicleAmounts(Map<Integer, Double> resources) {
 		Set<Integer> ids = new HashSet<>(resources.keySet());
 		for (Integer resourceId : ids) {
-			double amountLoaded;
-			if (resourceId < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
-				// Load amount resources
-				amountLoaded = vehicle.getAmountResourceStored(resourceId);
-				double capacity = vehicle.getAmountResourceCapacity(resourceId);
-				double amountRequired = resources.get(resourceId).doubleValue();
-				if (capacity < amountRequired) {
-					// So the vehicle can not handle the Manifest volume
-					// Adjust the manifest down
-					resources.put(resourceId, (capacity - amountLoaded));
-					logger.warning(vehicle, "Could not hold "
-							+ amountRequired + " kg "
-							+ ResourceUtil.findAmountResourceName(resourceId)
-							+ " from the manifest "
-							+ "(Capacity: " + capacity + " kg).");
-					amountLoaded = 0;
-				}
-			}
-			else {
-				// Load item resources
-				amountLoaded = vehicle.getItemResourceStored(resourceId);
+			double amountLoaded = vehicle.getAmountResourceStored(resourceId);
+			double capacity = vehicle.getAmountResourceCapacity(resourceId);
+			double amountRequired = resources.get(resourceId).doubleValue();
+			if (capacity < amountRequired) {
+				// So the vehicle can not handle the Manifest volume
+				// Adjust the manifest down
+				resources.put(resourceId, (capacity - amountLoaded));
+				logger.warning(vehicle, "Could not hold "
+						+ amountRequired + " kg "
+						+ ResourceUtil.findAmountResourceName(resourceId)
+						+ " from the manifest "
+						+ "(Capacity: " + capacity + " kg).");
+				amountLoaded = 0;
 			}
 
 			if (amountLoaded > 0) {
 				double newAmount = resources.get(resourceId).doubleValue() - amountLoaded;
+				if (newAmount <= 0D) {
+					resources.remove(resourceId);
+				}
+				else {
+					resources.put(resourceId, newAmount);
+				}
+			}
+		}
+	}
+
+	/*
+	 * Remove any Items the Vehicle has from the manifest. Items completely loaded
+	 * in the vehicle will be removed from the manifest.
+	 */
+	private void removeVehicleItems(Map<Integer, Integer> resources) {
+		Set<Integer> ids = new HashSet<>(resources.keySet());
+		for (Integer resourceId : ids) {
+			int amountLoaded = vehicle.getItemResourceStored(resourceId);
+			if (amountLoaded > 0) {
+				int newAmount = resources.get(resourceId).intValue() - amountLoaded;
 				if (newAmount <= 0D) {
 					resources.remove(resourceId);
 				}
@@ -184,22 +199,24 @@ public class LoadingController implements Serializable {
 			settlement.removeVicinityParkedVehicle(vehicle);
 		}
 
-		// Load equipment
+		// Load mandatory first
 		if ((amountLoading > 0D) && !equipmentManifest.isEmpty()) {
 			amountLoading = loadEquipment(amountLoading, equipmentManifest, true);
 		}
-
-		// Load resources
-		if ((amountLoading > 0D) && !resourcesManifest.isEmpty()) {
-			amountLoading = loadResources(worker, amountLoading, resourcesManifest, true);
+		if ((amountLoading > 0D) && !amountManifest.isEmpty()) {
+			amountLoading = loadAmounts(worker, amountLoading, amountManifest, true);
+		}
+		if ((amountLoading > 0D) && !itemManifest.isEmpty()) {
+			amountLoading = loadItems(worker, amountLoading, itemManifest, true);
 		}
 
 		// Load optionals last
-		if ((amountLoading > 0D) && !optionalResourcesManifest.isEmpty()) {
-			amountLoading = loadResources(worker, amountLoading, optionalResourcesManifest, false);
+		if ((amountLoading > 0D) && !optionalAmountManifest.isEmpty()) {
+			amountLoading = loadAmounts(worker, amountLoading, optionalAmountManifest, false);
 		}
-
-		// Load optional equipment
+		if ((amountLoading > 0D) && !optionalItemManifest.isEmpty()) {
+			amountLoading = loadItems(worker, amountLoading, optionalItemManifest, false);
+		}
 		if ((amountLoading > 0D) && !optionalEquipmentManifest.isEmpty()) {
 			amountLoading = loadEquipment(amountLoading, optionalEquipmentManifest, false);
 		}
@@ -230,15 +247,16 @@ public class LoadingController implements Serializable {
 		return (amountLoading > 0D) || completed;
 	}
 
+	
 	/**
-	 * Loads the vehicle with required resources from the settlement.
+	 * Loads the vehicle with required items from the settlement.
 	 *
 	 * @param amountLoading the amount (kg) the person can load in this time period.
 	 * @param manifest Manfiest to load from
 	 * @return the remaining amount (kg) the person can load in this time period.
 	 * @throws Exception if problem loading resources.
 	 */
-	private double loadResources(Worker loader, double amountLoading, Map<Integer, Number> manifest, boolean mandatory) {
+	private double loadItems(Worker loader, double amountLoading, Map<Integer, Integer> manifest, boolean mandatory) {
 
 		String  loaderName = loader.getName();
 
@@ -246,14 +264,36 @@ public class LoadingController implements Serializable {
 		// manifest
 		Set<Integer> resources = new HashSet<>(manifest.keySet());
 		for(Integer resource : resources) {
-			if (resource < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
-				// Load amount resources
-				amountLoading = loadAmountResource(loaderName, amountLoading, resource, manifest, mandatory);
+			// Load amount resources
+			amountLoading = loadItemResource(loaderName, amountLoading, resource, manifest, mandatory);
+
+			// Exhausted the loading amount
+			if (amountLoading <= 0D) {
+				return 0;
 			}
-			else {
-				// Load item resources
-				amountLoading = loadItemResource(loaderName, amountLoading, resource, manifest, mandatory);
-			}
+		}
+		// Return remaining amount that can be loaded by person this time period.
+		return amountLoading;
+	}
+
+	/**
+	 * Loads the vehicle with required amount resources from the settlement.
+	 *
+	 * @param amountLoading the amount (kg) the person can load in this time period.
+	 * @param manifest Manfiest to load from
+	 * @return the remaining amount (kg) the person can load in this time period.
+	 * @throws Exception if problem loading resources.
+	 */
+	private double loadAmounts(Worker loader, double amountLoading, Map<Integer, Double> manifest, boolean mandatory) {
+
+		String  loaderName = loader.getName();
+
+		// Load required resources. Take a cope as load will change the
+		// manifest
+		Set<Integer> resources = new HashSet<>(manifest.keySet());
+		for(Integer resource : resources) {
+			// Load amount resources
+			amountLoading = loadAmountResource(loaderName, amountLoading, resource, manifest, mandatory);
 
 			// Exhausted the loading amount
 			if (amountLoading <= 0D) {
@@ -276,7 +316,7 @@ public class LoadingController implements Serializable {
 	 * @return the remaining amount (kg) the person can load in this time period.
 	 */
 	private double loadAmountResource(String loader, double amountLoading, Integer resource,
-									  Map<Integer, Number> manifest, boolean mandatory) {
+									  Map<Integer, Double> manifest, boolean mandatory) {
 
 		String resourceName = ResourceUtil.findAmountResourceName(resource);
 
@@ -367,7 +407,7 @@ public class LoadingController implements Serializable {
 	 *                      optional.
 	 * @return the remaining amount (kg) the person can load in this time period.
 	 */
-	private double loadItemResource(String loader, double amountLoading, Integer id, Map<Integer, Number> manifest, boolean mandatory) {
+	private double loadItemResource(String loader, double amountLoading, Integer id, Map<Integer, Integer> manifest, boolean mandatory) {
 
 		Part p = ItemResourceUtil.findItemResource(id);
 		boolean usedSupply = false;
@@ -518,9 +558,9 @@ public class LoadingController implements Serializable {
 	public void backgroundLoad(double amountLoading) {
 
 		for (Integer id: BACKGROUND_RESOURCES) {
-			if (resourcesManifest.containsKey(id)) {
+			if (amountManifest.containsKey(id)) {
 				// Load this resource
-				loadAmountResource("Background", amountLoading, id, resourcesManifest, true);
+				loadAmountResource("Background", amountLoading, id, amountManifest, true);
 			}
 		}
 	}
@@ -531,8 +571,9 @@ public class LoadingController implements Serializable {
 	 */
 	public boolean isCompleted() {
 		// Manifest is empty so complete
-		return (resourcesManifest.isEmpty() && equipmentManifest.isEmpty()
-				&& optionalResourcesManifest.isEmpty() && optionalEquipmentManifest.isEmpty())
+		return (amountManifest.isEmpty() && optionalAmountManifest.isEmpty()
+				&& equipmentManifest.isEmpty() && optionalEquipmentManifest.isEmpty()
+				&& itemManifest.isEmpty() && optionalItemManifest.isEmpty())
 				|| vehicleFull;
 	}
 
@@ -544,20 +585,16 @@ public class LoadingController implements Serializable {
 		return retryAttempts <= 0;
 	}
 
-	public Map<Integer, Number> getResourcesManifest() {
-		return Collections.unmodifiableMap(this.resourcesManifest);
+	public Map<Integer, Double> getAmountManifest(boolean mandatory) {
+		return Collections.unmodifiableMap(mandatory ? this.amountManifest : this.optionalAmountManifest);
 	}
 
-	public Map<Integer, Number> getOptionalResourcesManifest() {
-		return Collections.unmodifiableMap(this.optionalResourcesManifest);
+	public Map<Integer, Integer> getEquipmentManifest(boolean mandatory) {
+		return Collections.unmodifiableMap(mandatory ? this.equipmentManifest : this.optionalEquipmentManifest);
 	}
 
-	public Map<Integer, Integer> getEquipmentManifest() {
-		return Collections.unmodifiableMap(this.equipmentManifest);
-	}
-
-	public Map<Integer, Integer> getOptionalEquipmentManifest() {
-		return Collections.unmodifiableMap(this.optionalEquipmentManifest);
+	public Map<Integer, Integer> getItemManifest(boolean mandatory) {
+		return Collections.unmodifiableMap(mandatory ? this.itemManifest : this.optionalItemManifest);
 	}
 
 	/**
@@ -576,27 +613,4 @@ public class LoadingController implements Serializable {
     public Vehicle getVehicle() {
 		return vehicle;
     }
-
-	/**
-	 * Dumps a description of the contents into a String representation.
-	 * 
-	 * @return String description of contents.
-	 */
-	public String dumpContents() {
-		StringBuilder buffer = new StringBuilder();
-		buffer.append("Resources:");
-		outputResourceManifest(resourcesManifest, buffer);		
-		buffer.append("Optional Resources:");
-		outputResourceManifest(optionalResourcesManifest, buffer);	
-
-		return buffer.toString();
-	}
-
-	private static void outputResourceManifest(Map<Integer, Number> manifest, StringBuilder buffer) {
-		for (Entry<Integer, Number> i : manifest.entrySet()) {
-			Good g = GoodsUtil.getGood(i.getKey());
-			buffer.append(g.getName()).append("=").append(i.getValue().toString()).append(' ');
-		}
-		buffer.append("\n");
-	}
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mission/MissionProjectTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mission/MissionProjectTest.java
@@ -16,6 +16,7 @@ import com.mars_sim.core.person.ai.mission.MissionType;
 import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.project.Stage;
 import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.structure.Settlement;
 
 public class MissionProjectTest extends AbstractMarsSimUnitTest {
@@ -52,7 +53,7 @@ public class MissionProjectTest extends AbstractMarsSimUnitTest {
          * @return
          */
         @Override
-        void getRequiredResources(MissionManifest manifest, boolean optionl) {
+        void getRequiredResources(SuppliesManifest manifest, boolean optionl) {
             manifest.addResource(ResourceUtil.oxygenID, oxygen, true);
             manifest.addResource(ResourceUtil.foodID, food, true);
         }
@@ -88,7 +89,7 @@ public class MissionProjectTest extends AbstractMarsSimUnitTest {
         int numSteps = 3;
         TestMission mp = new TestMission(MISSION_NAME, leader, numSteps);
 
-        MissionManifest manifest = mp.getResources(true);
+        SuppliesManifest manifest = mp.getResources(true);
         Map<Integer,Number> needed = manifest.getResources(true);
         assertEquals("Oxygen needed", numSteps * OXYGEN_VALUE, needed.get(ResourceUtil.oxygenID));
         assertEquals("Food needed", numSteps * FOOD_VALUE, needed.get(ResourceUtil.foodID));

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mission/MissionProjectTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mission/MissionProjectTest.java
@@ -54,8 +54,8 @@ public class MissionProjectTest extends AbstractMarsSimUnitTest {
          */
         @Override
         void getRequiredResources(SuppliesManifest manifest, boolean optionl) {
-            manifest.addResource(ResourceUtil.oxygenID, oxygen, true);
-            manifest.addResource(ResourceUtil.foodID, food, true);
+            manifest.addAmount(ResourceUtil.oxygenID, oxygen, true);
+            manifest.addAmount(ResourceUtil.foodID, food, true);
         }
     }
 
@@ -90,7 +90,7 @@ public class MissionProjectTest extends AbstractMarsSimUnitTest {
         TestMission mp = new TestMission(MISSION_NAME, leader, numSteps);
 
         SuppliesManifest manifest = mp.getResources(true);
-        Map<Integer,Number> needed = manifest.getResources(true);
+        Map<Integer,Double> needed = manifest.getAmounts(true);
         assertEquals("Oxygen needed", numSteps * OXYGEN_VALUE, needed.get(ResourceUtil.oxygenID));
         assertEquals("Food needed", numSteps * FOOD_VALUE, needed.get(ResourceUtil.foodID));
         assertEquals("Number of resources needed", 2, needed.size());

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mission/predefined/TestDriveMissionTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mission/predefined/TestDriveMissionTest.java
@@ -59,7 +59,7 @@ public class TestDriveMissionTest extends AbstractMarsSimUnitTest {
         // Check the plan has content
         LoadingController plan = mp.getLoadingPlan();
         assertNotNull("Loading plan created", plan);
-        Map<Integer, Number> resources = plan.getResourcesManifest();
+        Map<Integer, Double> resources = plan.getAmountManifest(true);
         assertTrue("Plan has Oxygen", resources.get(ResourceUtil.oxygenID).doubleValue() > 0D);
     }
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/resource/SuppliesManifestTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/resource/SuppliesManifestTest.java
@@ -1,0 +1,65 @@
+package com.mars_sim.core.resource;
+
+
+import com.mars_sim.core.AbstractMarsSimUnitTest;
+import com.mars_sim.core.equipment.EquipmentType;
+
+public class SuppliesManifestTest extends AbstractMarsSimUnitTest{
+
+    public void testAddResources() {
+        final double OPT = 20D;
+        final double MAND = 10D;
+        var manifest = new SuppliesManifest();
+
+        manifest.addResource(ResourceUtil.argonID, MAND, true);
+        manifest.addResource(ResourceUtil.oxygenID, MAND, true);
+        manifest.addResource(ResourceUtil.nitrogenID, OPT, false);
+
+        var mand = manifest.getResources(true);
+        assertEquals("Mandatory Resources", 2, mand.size());
+        assertEquals("Argon amount", MAND, mand.get(ResourceUtil.argonID));
+        assertEquals("Oxygen amount", MAND, mand.get(ResourceUtil.oxygenID));
+
+        var opt = manifest.getResources(false);
+        assertEquals("Optional Resources", 1, opt.size());
+        assertEquals("Nitrogen amount", OPT, opt.get(ResourceUtil.nitrogenID));
+    }
+
+    public void testAddItem() {
+        final int OPT = 5;
+        final int MAND = 4;
+        var manifest = new SuppliesManifest();
+
+        manifest.addItem(ItemResourceUtil.backhoeID, MAND, true);
+        manifest.addItem(ItemResourceUtil.printerID, MAND, true);
+        manifest.addItem(ItemResourceUtil.pneumaticDrillID, OPT, false);
+
+        var mand = manifest.getResources(true);
+        assertEquals("Mandatory Items", 2, mand.size());
+        assertEquals("Backhoe amount", MAND, mand.get(ItemResourceUtil.backhoeID));
+        assertEquals("Printer amount", MAND, mand.get(ItemResourceUtil.printerID));
+
+        var opt = manifest.getResources(false);
+        assertEquals("Optional Items", 1, opt.size());
+        assertEquals("Drill amount", OPT, opt.get(ItemResourceUtil.pneumaticDrillID));
+    }
+
+    public void testAddEquipment() {
+        final int OPT = 5;
+        final int MAND = 4;
+        var manifest = new SuppliesManifest();
+
+        manifest.addEquipment(EquipmentType.getResourceID(EquipmentType.BAG), MAND, true);
+        manifest.addEquipment(EquipmentType.getResourceID(EquipmentType.BARREL), MAND, true);
+        manifest.addEquipment(EquipmentType.getResourceID(EquipmentType.EVA_SUIT), OPT, false);
+
+        var mand = manifest.getEquipment(true);
+        assertEquals("Mandatory Equipment", 2, mand.size());
+        assertEquals("Argon amount", MAND, mand.get(EquipmentType.getResourceID(EquipmentType.BAG)).intValue());
+        assertEquals("Oxygen amount", MAND, mand.get(EquipmentType.getResourceID(EquipmentType.BARREL)).intValue());
+
+        var opt = manifest.getEquipment(false);
+        assertEquals("Optional entries", 1, opt.size());
+        assertEquals("Nitrogen amount", OPT, opt.get(EquipmentType.getResourceID(EquipmentType.EVA_SUIT)).intValue());
+    }
+}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/resource/SuppliesManifestTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/resource/SuppliesManifestTest.java
@@ -11,16 +11,16 @@ public class SuppliesManifestTest extends AbstractMarsSimUnitTest{
         final double MAND = 10D;
         var manifest = new SuppliesManifest();
 
-        manifest.addResource(ResourceUtil.argonID, MAND, true);
-        manifest.addResource(ResourceUtil.oxygenID, MAND, true);
-        manifest.addResource(ResourceUtil.nitrogenID, OPT, false);
+        manifest.addAmount(ResourceUtil.argonID, MAND, true);
+        manifest.addAmount(ResourceUtil.oxygenID, MAND, true);
+        manifest.addAmount(ResourceUtil.nitrogenID, OPT, false);
 
-        var mand = manifest.getResources(true);
+        var mand = manifest.getAmounts(true);
         assertEquals("Mandatory Resources", 2, mand.size());
         assertEquals("Argon amount", MAND, mand.get(ResourceUtil.argonID));
         assertEquals("Oxygen amount", MAND, mand.get(ResourceUtil.oxygenID));
 
-        var opt = manifest.getResources(false);
+        var opt = manifest.getAmounts(false);
         assertEquals("Optional Resources", 1, opt.size());
         assertEquals("Nitrogen amount", OPT, opt.get(ResourceUtil.nitrogenID));
     }
@@ -34,14 +34,14 @@ public class SuppliesManifestTest extends AbstractMarsSimUnitTest{
         manifest.addItem(ItemResourceUtil.printerID, MAND, true);
         manifest.addItem(ItemResourceUtil.pneumaticDrillID, OPT, false);
 
-        var mand = manifest.getResources(true);
+        var mand = manifest.getItems(true);
         assertEquals("Mandatory Items", 2, mand.size());
-        assertEquals("Backhoe amount", MAND, mand.get(ItemResourceUtil.backhoeID));
-        assertEquals("Printer amount", MAND, mand.get(ItemResourceUtil.printerID));
+        assertEquals("Backhoe amount", MAND, mand.get(ItemResourceUtil.backhoeID).intValue());
+        assertEquals("Printer amount", MAND, mand.get(ItemResourceUtil.printerID).intValue());
 
-        var opt = manifest.getResources(false);
+        var opt = manifest.getItems(false);
         assertEquals("Optional Items", 1, opt.size());
-        assertEquals("Drill amount", OPT, opt.get(ItemResourceUtil.pneumaticDrillID));
+        assertEquals("Drill amount", OPT, opt.get(ItemResourceUtil.pneumaticDrillID).intValue());
     }
 
     public void testAddEquipment() {

--- a/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadControllerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadControllerTest.java
@@ -7,7 +7,6 @@
 
 package com.mars_sim.core.vehicle.task;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -23,6 +22,7 @@ import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.NaturalAttributeType;
 import com.mars_sim.core.resource.ItemResourceUtil;
 import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.structure.MockSettlement;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.vehicle.Rover;
@@ -89,17 +89,14 @@ extends TestCase {
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.LoadingPhase(double)'
 	 */
 	public void testBackgroundLoading() {
-		Map<Integer, Number> requiredResourcesMap = new HashMap<>();
-		requiredResourcesMap.put(ResourceUtil.oxygenID, 20D);
-		requiredResourcesMap.put(ResourceUtil.methanolID, 10D);
+		var requiredResourcesMap = new SuppliesManifest();
+		requiredResourcesMap.addResource(ResourceUtil.oxygenID, 20D, true);
+		requiredResourcesMap.addResource(ResourceUtil.methanolID, 10D, true);
 
-		loadSettlementResources(settlement, requiredResourcesMap);
+		loadSettlement(settlement, requiredResourcesMap);
 
 		LoadingController controller = new LoadingController(settlement, vehicle,
-															 requiredResourcesMap,
-															 Collections.emptyMap(),
-															 Collections.emptyMap(),
-															 Collections.emptyMap());
+															 requiredResourcesMap);
 		int loadingCount = 0;
 		while (loadingCount < 100) {
 			controller.backgroundLoad(80);
@@ -114,57 +111,49 @@ extends TestCase {
 	 * Test method loading Equipment
 	 */
 	public void testLoadRequiredEquipment() {
-		Map<Integer, Integer> requiredEquipMap = new HashMap<>();
-		requiredEquipMap.put(EquipmentType.getResourceID(EquipmentType.BARREL), 10);
-		requiredEquipMap.put(EquipmentType.getResourceID(EquipmentType.SPECIMEN_BOX), 5);
-
+		var manifest = new SuppliesManifest();
+		manifest.addEquipment(EquipmentType.getResourceID(EquipmentType.BARREL), 10, true);
+		manifest.addEquipment(EquipmentType.getResourceID(EquipmentType.SPECIMEN_BOX), 5, true);
 
 		// Load the manifest
-		testLoading(100, Collections.emptyMap(), Collections.emptyMap(),
-				requiredEquipMap, Collections.emptyMap());
+		testLoading(100, manifest);
 	}
 
 	/*
 	 * Test method loading Equipment
 	 */
 	public void testLoadOptionalEquipment() {
-		Map<Integer, Integer> requiredEquipMap = new HashMap<>();
-		requiredEquipMap.put(EquipmentType.getResourceID(EquipmentType.BARREL), 10);
-		requiredEquipMap.put(EquipmentType.getResourceID(EquipmentType.SPECIMEN_BOX), 5);
+		var manifest = new SuppliesManifest();
+		manifest.addEquipment(EquipmentType.getResourceID(EquipmentType.BARREL), 10, true);
+		manifest.addEquipment(EquipmentType.getResourceID(EquipmentType.SPECIMEN_BOX), 5, true);
 
-		Map<Integer, Integer> optionalEquipMap = new HashMap<>();
-		optionalEquipMap.put(EquipmentType.getResourceID(EquipmentType.GAS_CANISTER), 10);
+		manifest.addEquipment(EquipmentType.getResourceID(EquipmentType.GAS_CANISTER), 10, false);
 
 		// Load the manifest
-		testLoading(100, Collections.emptyMap(), Collections.emptyMap(),
-				requiredEquipMap, optionalEquipMap);
+		testLoading(100, manifest);
 	}
 
 	/*
 	 * Test method loading Equipment
 	 */
 	public void testLoadMissingOptionalEquipment() {
-		Map<Integer, Integer> requiredEquipMap = new HashMap<>();
-		requiredEquipMap.put(EquipmentType.getResourceID(EquipmentType.BARREL), 10);
-		requiredEquipMap.put(EquipmentType.getResourceID(EquipmentType.SPECIMEN_BOX), 5);
+		var manifest = new SuppliesManifest();
+		manifest.addEquipment(EquipmentType.getResourceID(EquipmentType.BARREL), 10, true);
+		manifest.addEquipment(EquipmentType.getResourceID(EquipmentType.SPECIMEN_BOX), 5, true);
 
-		Map<Integer, Integer> optionalEquipMap = new HashMap<>();
-		optionalEquipMap.put(EquipmentType.getResourceID(EquipmentType.GAS_CANISTER), 10);
+		manifest.addEquipment(EquipmentType.getResourceID(EquipmentType.GAS_CANISTER), 10, false);
 
-		loadSettlementEquipment(settlement, requiredEquipMap);
-		loadSettlementEquipment(settlement, optionalEquipMap);
+		loadSettlement(settlement, manifest);
 
 		// Add an extra resource that will not be present
 		int missingId = EquipmentType.getResourceID(EquipmentType.LARGE_BAG);
-		var extraOptionalEquipment = new HashMap<>(optionalEquipMap);
-		extraOptionalEquipment.put(missingId, 10);
+		var expanded = new SuppliesManifest(manifest);
+		expanded.addEquipment(missingId, 10, false);
 
-		loadIt(100, Collections.emptyMap(), Collections.emptyMap(),
-				requiredEquipMap, extraOptionalEquipment);
+		loadIt(100, expanded);
 
 		// Check Equipment that was present in settlement
-		checkVehicleEquipment(vehicle, requiredEquipMap);
-		checkVehicleEquipment(vehicle, optionalEquipMap);
+		checkVehicleInventory(vehicle, manifest);
 
 		EquipmentType eType = EquipmentType.convertID2Type(missingId);
 		long optionalLoaded = vehicle.getEquipmentSet().stream()
@@ -179,44 +168,39 @@ extends TestCase {
 	 * Test method loading Resource Items
 	 */
 	public void testLoadRequiredItemResources() {
-		Map<Integer, Number> requiredResourcesMap = new HashMap<>();
-		requiredResourcesMap.put(fireExtinguisherID, 1);
-		requiredResourcesMap.put(smallHammerID, 2);
+		var manifest = new SuppliesManifest();
+		manifest.addItem(fireExtinguisherID, 1, true);
+		manifest.addItem(smallHammerID, 2, true);
 
 		// Load the manifest
-		testLoading(100, requiredResourcesMap, Collections.emptyMap(),
-					   Collections.emptyMap(), Collections.emptyMap());
+		testLoading(100, manifest);
 	}
 
 	/*
 	 * Test method loading Resource Items
 	 */
 	public void testLoadOptionalItemResources() {
-		Map<Integer, Number> requiredResourcesMap = new HashMap<>();
-		requiredResourcesMap.put(fireExtinguisherID, 1);
-		requiredResourcesMap.put(smallHammerID, 2);
+		var manifest = new SuppliesManifest();
+		manifest.addItem(fireExtinguisherID, 1, true);
+		manifest.addItem(smallHammerID, 2, true);
 
-		Map<Integer, Number> optionalResourcesMap = new HashMap<>();
-		optionalResourcesMap.put(pipeWrenchID, 10D);
+		manifest.addItem(pipeWrenchID, 10, false);
 
 		// Load the manifest
-		testLoading(100, requiredResourcesMap, optionalResourcesMap,
-					   Collections.emptyMap(), Collections.emptyMap());
+		testLoading(100,manifest);
 	}
 
 	/*
 	 * Load with optional resource present
 	 */
 	public void testLoadMissingOptionalItemResources() {
-		Map<Integer, Number> requiredResourcesMap = new HashMap<>();
-		requiredResourcesMap.put(fireExtinguisherID, 1);
-		requiredResourcesMap.put(smallHammerID, 2);
+		var manifest = new SuppliesManifest();
+		manifest.addItem(fireExtinguisherID, 1, true);
+		manifest.addItem(smallHammerID, 2, true);
 
-		Map<Integer, Number> optionalResourcesMap = new HashMap<>();
-		optionalResourcesMap.put(pipeWrenchID, 10D);
+		manifest.addItem(pipeWrenchID, 10, false);
 
-		testLoadOptionalResources(100, requiredResourcesMap,
-								  optionalResourcesMap,
+		testLoadOptionalResources(100, manifest,
 								  ItemResourceUtil.printerID);
 	}
 
@@ -224,13 +208,12 @@ extends TestCase {
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.LoadingPhase(double)'
 	 */
 	public void testLoadRequiredAmountResources() {
-		Map<Integer, Number> requiredResourcesMap = new HashMap<>();
-		requiredResourcesMap.put(ResourceUtil.foodID, 30D);
-		requiredResourcesMap.put(ResourceUtil.waterID, 10D);
+		var manifest = new SuppliesManifest();
+		manifest.addResource(ResourceUtil.foodID, 30D, true);
+		manifest.addResource(ResourceUtil.waterID, 10D, true);
 
 		// Load the manifest
-		testLoading(200, requiredResourcesMap, Collections.emptyMap(),
-					   Collections.emptyMap(), Collections.emptyMap());
+		testLoading(200, manifest);
 	}
 
 
@@ -238,13 +221,12 @@ extends TestCase {
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.LoadingPhase(double)'
 	 */
 	public void testLoadFailedAmountResources() {
-		Map<Integer, Number> requiredResourcesMap = new HashMap<>();
+		var requiredResourcesMap = new SuppliesManifest();
 		// Add 2000kg food to the manifest
-		requiredResourcesMap.put(ResourceUtil.foodID, 50D);
+		requiredResourcesMap.addResource(ResourceUtil.foodID, 50D, true);
 
 		LoadingController controller = new LoadingController(settlement, vehicle,
-				requiredResourcesMap, Collections.emptyMap(),
-				Collections.emptyMap(), Collections.emptyMap());
+				requiredResourcesMap);
 
 		// Run the loader but do not load an resources into the settlement
 		for(int i = 0 ; i < (LoadingController.MAX_SETTLEMENT_ATTEMPTS - 1); i++) {
@@ -265,30 +247,26 @@ extends TestCase {
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.LoadingPhase(double)'
 	 */
 	public void testLoadOptionalAmountResources() {
-		Map<Integer, Number> requiredResourcesMap = new HashMap<>();
-		requiredResourcesMap.put(ResourceUtil.foodID, 20D);
-		requiredResourcesMap.put(ResourceUtil.waterID, 10D);
+		var manifest = new SuppliesManifest();
+		manifest.addResource(ResourceUtil.foodID, 20D, true);
+		manifest.addResource(ResourceUtil.waterID, 10D, true);
 
-		Map<Integer, Number> optionalResourcesMap = new HashMap<>();
-		optionalResourcesMap.put(ResourceUtil.co2ID, 4D);
+		manifest.addResource(ResourceUtil.co2ID, 4D, false);
 
 		// Load the manifest
-		testLoading(200, requiredResourcesMap, optionalResourcesMap,
-					   Collections.emptyMap(), Collections.emptyMap());
+		testLoading(200, manifest);
 	}
 
 	/*
 	 * Load with optional resource present
 	 */
 	public void testLoadMissingOptionalAmountResources() {
-		Map<Integer, Number> requiredResourcesMap = new HashMap<>();
-		requiredResourcesMap.put(ResourceUtil.foodID, 100D);
+		var manifest = new SuppliesManifest();
+		manifest.addResource(ResourceUtil.foodID, 100D, true);
 
-		Map<Integer, Number> optionalResourcesMap = new HashMap<>();
-		optionalResourcesMap.put(ResourceUtil.co2ID, 4D);
+		manifest.addResource(ResourceUtil.co2ID, 4D, false);
 
-		testLoadOptionalResources(100, requiredResourcesMap,
-								  optionalResourcesMap,
+		testLoadOptionalResources(100, manifest,
 								  ResourceUtil.nitrogenID);
 	}
 
@@ -296,58 +274,50 @@ extends TestCase {
 	 * Test method loading Equipment
 	 */
 	public void testLoadFull() {
-		Map<Integer, Integer> requiredEquipMap = new HashMap<>();
-		requiredEquipMap.put(EquipmentType.getResourceID(EquipmentType.BARREL), 5);
-		requiredEquipMap.put(EquipmentType.getResourceID(EquipmentType.SPECIMEN_BOX), 5);
+		var manifest = new SuppliesManifest();
+		manifest.addEquipment(EquipmentType.getResourceID(EquipmentType.BARREL), 5, true);
+		manifest.addEquipment(EquipmentType.getResourceID(EquipmentType.SPECIMEN_BOX), 5, true);
 
-		Map<Integer, Integer> optionalEquipMap = new HashMap<>();
-		optionalEquipMap.put(EquipmentType.getResourceID(EquipmentType.GAS_CANISTER), 5);
+		manifest.addEquipment(EquipmentType.getResourceID(EquipmentType.GAS_CANISTER), 5, false);
 
-		Map<Integer, Number> requiredResourcesMap = new HashMap<>();
-		requiredResourcesMap.put(ResourceUtil.foodID, 100D);
-		requiredResourcesMap.put(fireExtinguisherID, 1);
-		requiredResourcesMap.put(smallHammerID, 2);
+		manifest.addResource(ResourceUtil.foodID, 100D, true);
+		manifest.addItem(fireExtinguisherID, 1, true);
+		manifest.addItem(smallHammerID, 2, true);
 
-		Map<Integer, Number> optionalResourcesMap = new HashMap<>();
-		optionalResourcesMap.put(ResourceUtil.co2ID, 4D);
-		optionalResourcesMap.put(pipeWrenchID, 5D);
+		manifest.addResource(ResourceUtil.co2ID, 4D, false);
+		manifest.addItem(pipeWrenchID, 5, false);
 
 		// Load the manifest
-		testLoading(200, requiredResourcesMap, optionalResourcesMap,
-				requiredEquipMap, optionalEquipMap);
+		testLoading(200, manifest);
 	}
 
 	/*
 	 * Executes a loading for a manifest and a batch of tests.
 	 */
-	private void testLoading(int maxCycles,
-			Map<Integer, Number> resourcesManifest,
-			Map<Integer, Number> optionalResourcesManifest,
-			Map<Integer, Integer> equipmentManifest,
-			Map<Integer, Integer> optionalEquipmentManifest) {
+	private void testLoading(int maxCycles, SuppliesManifest manifest) {
 
 		// Add resources to Settlement
-		loadSettlementResources(settlement, resourcesManifest);
-		loadSettlementResources(settlement, optionalResourcesManifest);
-		loadSettlementEquipment(settlement, equipmentManifest);
-		loadSettlementEquipment(settlement, optionalEquipmentManifest);
+		loadSettlement(settlement, manifest);
 
 		// Make sure Vehicle has capacity
-		setResourcesCapacity(vehicle, resourcesManifest);
-		setResourcesCapacity(vehicle, optionalResourcesManifest);
+		setVehicleCapacity(vehicle, manifest);
 
 		// Load the manifest
-		loadIt(maxCycles, resourcesManifest, optionalResourcesManifest,
-			   equipmentManifest, optionalEquipmentManifest);
-		checkVehicleResources(vehicle, resourcesManifest);
-		checkVehicleEquipment(vehicle, equipmentManifest);
-
-		checkVehicleResources(vehicle, optionalResourcesManifest);
-		checkVehicleEquipment(vehicle, optionalEquipmentManifest);
+		loadIt(maxCycles, manifest);
+		checkVehicleInventory(vehicle, manifest);
 
 		// Reload the same manifest which should complete immediately
-		reload(resourcesManifest, optionalResourcesManifest,
-				   equipmentManifest, optionalEquipmentManifest);
+		reload(manifest);
+	}
+
+	private void checkVehicleInventory(Vehicle v, SuppliesManifest manifest) {
+		checkVehicleEquipment(v, manifest);
+		checkVehicleResources(v, manifest);
+	}
+
+	private void setVehicleCapacity(Vehicle v, SuppliesManifest manifest) {
+		setResourcesCapacity(v, manifest.getResources(true));
+		setResourcesCapacity(v, manifest.getResources(false));
 	}
 
 	/**
@@ -355,7 +325,7 @@ extends TestCase {
 	 * @param settlement
 	 * @param manifest
 	 */
-	private void loadSettlementEquipment(Settlement settlement, Map<Integer, Integer> manifest) {
+	private static void loadSettlementEquipment(Settlement settlement, Map<Integer, Integer> manifest) {
 		for(Entry<Integer, Integer> item : manifest.entrySet()) {
 			EquipmentType type = EquipmentType.convertID2Type(item.getKey());
 			for(int i = 0; i < item.getValue(); i++) {
@@ -367,30 +337,22 @@ extends TestCase {
 	/**
 	 * Test loading optional resources where one is missiing
 	 * @param maxCycles
-	 * @param requiredResources Required resources to load
-	 * @param optionalResources Optional resources
+	 * @param manifest
 	 * @param missingId Missing resource that should not be loaded
 	 */
 	private void testLoadOptionalResources(int maxCycles,
-			Map<Integer, Number> requiredResources,
-			Map<Integer, Number> optionalResources, int missingId) {
+			SuppliesManifest manifest, int missingId) {
 
-		loadSettlementResources(settlement, requiredResources);
-		setResourcesCapacity(vehicle, requiredResources);
-
-		loadSettlementResources(settlement, optionalResources);
-		setResourcesCapacity(vehicle, optionalResources);
+		loadSettlement(settlement, manifest);
+		setVehicleCapacity(vehicle, manifest);
 
 		// Add an extra resource that will not be present
-		var extraOptionalResources = new HashMap<>(optionalResources);
-		extraOptionalResources.put(missingId, 10D);
+		var extraOptionalResources = new SuppliesManifest(manifest);
+		extraOptionalResources.addResource(missingId, 10D, false);
 
-		loadIt(maxCycles, requiredResources, extraOptionalResources,
-			 Collections.emptyMap(),
-			 Collections.emptyMap());
+		loadIt(maxCycles, manifest);
 
-		checkVehicleResources(vehicle, requiredResources);
-		checkVehicleResources(vehicle, optionalResources);
+		checkVehicleInventory(vehicle, manifest);
 
 		double optionalLoaded;
 		if (missingId < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
@@ -407,22 +369,13 @@ extends TestCase {
 	/**
 	 * Run a reload controller to load this manifest. This expects teh manifest
 	 * to be already satisified by the Vehicle
-	 * @param resourcesManifest
-	 * @param optionalResourcesManifest
-	 * @param equipmentManifest
-	 * @param optionalEquipmentManifest
+	 * @param manifest
 	 * @return
 	 */
-	private LoadingController reload(Map<Integer, Number> resourcesManifest,
-			Map<Integer, Number> optionalResourcesManifest,
-			Map<Integer, Integer> equipmentManifest,
-			Map<Integer, Integer> optionalEquipmentManifest) {
+	private LoadingController reload(SuppliesManifest manifest) {
 
 		LoadingController controller = new LoadingController(settlement, vehicle,
-						resourcesManifest,
-						optionalResourcesManifest,
-						equipmentManifest,
-						optionalEquipmentManifest);
+						manifest);
 
 		// Vehicle should already be loaded
 		assertTrue("Vehicle already loaded", controller.isCompleted());
@@ -439,17 +392,10 @@ extends TestCase {
 	 * @param optionalEquipmentManifest
 	 * @return
 	 */
-	private LoadingController loadIt(int maxCycles,
-				Map<Integer, Number> resourcesManifest,
-				Map<Integer, Number> optionalResourcesManifest,
-				Map<Integer, Integer> equipmentManifest,
-				Map<Integer, Integer> optionalEquipmentManifest) {
+	private LoadingController loadIt(int maxCycles, SuppliesManifest manifest) {
 
 		LoadingController controller = new LoadingController(settlement, vehicle,
-				resourcesManifest,
-				optionalResourcesManifest,
-				equipmentManifest,
-				optionalEquipmentManifest);
+				manifest);
 
 		int loadingCount = 0;
 		boolean loaded = false;
@@ -467,11 +413,14 @@ extends TestCase {
 
 	/**
 	 * Check if a vehicle has the required Equipment
-	 * @param vehicle2
+	 * @param source
 	 * @param equipmentManifest
 	 */
-	private void checkVehicleEquipment(Vehicle source, Map<Integer, Integer> manifest) {
-		for(Entry<Integer, Integer> item : manifest.entrySet()) {
+	private void checkVehicleEquipment(Vehicle source, SuppliesManifest manifest) {
+		var eqm = new HashMap<>(manifest.getEquipment(true));
+		eqm.putAll(manifest.getEquipment(false));
+
+		for(Entry<Integer, Integer> item : eqm.entrySet()) {
 			EquipmentType eType = EquipmentType.convertID2Type(item.getKey());
 			long stored = source.getEquipmentSet().stream()
 					.filter(e -> (e.getEquipmentType() == eType))
@@ -485,10 +434,12 @@ extends TestCase {
 	/**
 	 * Check if the Vehicle has the Resources defined by a manifest
 	 * @param source
-	 * @param requiredResourcesMap
+	 * @param manifest
 	 */
-	private void checkVehicleResources(Vehicle source, Map<Integer, Number> requiredResourcesMap) {
+	private void checkVehicleResources(Vehicle source, SuppliesManifest manifest) {
 
+		var requiredResourcesMap = new HashMap<>(manifest.getResources(true));
+		requiredResourcesMap.putAll(manifest.getResources(false));
 		for (Entry<Integer, Number> resource : requiredResourcesMap.entrySet()) {
 			int key = resource.getKey();
 			if (key < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
@@ -535,9 +486,15 @@ extends TestCase {
 	 * @param target
 	 * @param requiredResourcesMap
 	 */
-	private void loadSettlementResources(Settlement target, Map<Integer, Number> requiredResourcesMap) {
+	public static void loadSettlement(Settlement target, SuppliesManifest requiredResourcesMap) {
+		loadSettlementResources(target, requiredResourcesMap.getResources(true));
+		loadSettlementResources(target, requiredResourcesMap.getResources(false));
+		loadSettlementEquipment(target, requiredResourcesMap.getEquipment(true));
+		loadSettlementEquipment(target, requiredResourcesMap.getEquipment(false));
+	}
 
-		for (Entry<Integer, Number> resource : requiredResourcesMap.entrySet()) {
+	private static void loadSettlementResources(Settlement target, Map<Integer, Number> resourcesMap) {
+		for (Entry<Integer, Number> resource : resourcesMap.entrySet()) {
 			int key = resource.getKey();
 			if (key < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
 				// Add extra to the stored to give a tolerance

--- a/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadVehicleEVATest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadVehicleEVATest.java
@@ -1,15 +1,12 @@
 package com.mars_sim.core.vehicle.task;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import com.mars_sim.core.AbstractMarsSimUnitTest;
 import com.mars_sim.core.map.location.LocalPosition;
 import com.mars_sim.core.person.ai.SkillType;
 import com.mars_sim.core.person.ai.job.util.JobType;
 import com.mars_sim.core.person.ai.task.EVAOperationTest;
 import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.SuppliesManifest;
 
 public class LoadVehicleEVATest extends AbstractMarsSimUnitTest {
     public void testCreateTask() {
@@ -22,15 +19,12 @@ public class LoadVehicleEVATest extends AbstractMarsSimUnitTest {
         var eva = EVAOperationTest.prepareForEva(this, p);
 
         // Create a loading plan and preload Settlement
-        Map<Integer, Number> resources = new HashMap<>();
-        resources.put(ResourceUtil.oxygenID, 10D);
-        resources.put(ResourceUtil.waterID, 10D);
-        resources.put(ResourceUtil.foodID, 10D);
-        for(var entry : resources.entrySet()) {
-            s.storeAmountResource(entry.getKey(), entry.getValue().doubleValue() * 1.1D);
-        }
-        LoadingController lc = new LoadingController(s, v, resources, Collections.emptyMap(),
-                                        Collections.emptyMap(), Collections.emptyMap());
+        var resources = new SuppliesManifest();
+        resources.addResource(ResourceUtil.oxygenID, 10D, true);
+        resources.addResource(ResourceUtil.waterID, 10D, true);
+        resources.addResource(ResourceUtil.foodID, 10D, true);
+        LoadControllerTest.loadSettlement(s, resources);
+        LoadingController lc = new LoadingController(s, v, resources);
 
         var task = new LoadVehicleEVA(p, lc);
         assertFalse("Task created", task.isDone()); 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadVehicleEVATest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadVehicleEVATest.java
@@ -20,9 +20,9 @@ public class LoadVehicleEVATest extends AbstractMarsSimUnitTest {
 
         // Create a loading plan and preload Settlement
         var resources = new SuppliesManifest();
-        resources.addResource(ResourceUtil.oxygenID, 10D, true);
-        resources.addResource(ResourceUtil.waterID, 10D, true);
-        resources.addResource(ResourceUtil.foodID, 10D, true);
+        resources.addAmount(ResourceUtil.oxygenID, 10D, true);
+        resources.addAmount(ResourceUtil.waterID, 10D, true);
+        resources.addAmount(ResourceUtil.foodID, 10D, true);
         LoadControllerTest.loadSettlement(s, resources);
         LoadingController lc = new LoadingController(s, v, resources);
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadVehicleGarageTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadVehicleGarageTest.java
@@ -20,9 +20,9 @@ public class LoadVehicleGarageTest extends AbstractMarsSimUnitTest {
 
         // Create a loading plan and preload Settlement
         var resources = new SuppliesManifest();
-        resources.addResource(ResourceUtil.oxygenID, 10D, true);
-        resources.addResource(ResourceUtil.waterID, 10D, true);
-        resources.addResource(ResourceUtil.foodID, 10D, true);
+        resources.addAmount(ResourceUtil.oxygenID, 10D, true);
+        resources.addAmount(ResourceUtil.waterID, 10D, true);
+        resources.addAmount(ResourceUtil.foodID, 10D, true);
         LoadControllerTest.loadSettlement(s, resources);
         LoadingController lc = new LoadingController(s, v, resources);
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadVehicleGarageTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadVehicleGarageTest.java
@@ -1,14 +1,11 @@
 package com.mars_sim.core.vehicle.task;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import com.mars_sim.core.AbstractMarsSimUnitTest;
 import com.mars_sim.core.map.location.LocalPosition;
 import com.mars_sim.core.person.ai.SkillType;
 import com.mars_sim.core.person.ai.job.util.JobType;
 import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.structure.building.function.FunctionType;
 
 public class LoadVehicleGarageTest extends AbstractMarsSimUnitTest {
@@ -22,15 +19,12 @@ public class LoadVehicleGarageTest extends AbstractMarsSimUnitTest {
         p.getSkillManager().addNewSkill(SkillType.MECHANICS, 10); // Skilled
 
         // Create a loading plan and preload Settlement
-        Map<Integer, Number> resources = new HashMap<>();
-        resources.put(ResourceUtil.oxygenID, 10D);
-        resources.put(ResourceUtil.waterID, 10D);
-        resources.put(ResourceUtil.foodID, 10D);
-        for(var entry : resources.entrySet()) {
-            s.storeAmountResource(entry.getKey(), entry.getValue().doubleValue() * 1.1D);
-        }
-        LoadingController lc = new LoadingController(s, v, resources, Collections.emptyMap(),
-                                        Collections.emptyMap(), Collections.emptyMap());
+        var resources = new SuppliesManifest();
+        resources.addResource(ResourceUtil.oxygenID, 10D, true);
+        resources.addResource(ResourceUtil.waterID, 10D, true);
+        resources.addResource(ResourceUtil.foodID, 10D, true);
+        LoadControllerTest.loadSettlement(s, resources);
+        LoadingController lc = new LoadingController(s, v, resources);
 
         var task = new LoadVehicleGarage(p, lc);
         assertFalse("Task created", task.isDone()); 


### PR DESCRIPTION
This PR reworks the ```MissionManifest``` to a more generic ```SuppliesManifest```. The latter allows Amounts, Equipment & Items to be separately added to a manifest as either mandatory or optional.

The ```LoadingController``` uses the manifest as the source of the loading instead of a combination of separate Maps. The controller also explicitly manages the loading of Items & Amounts.

The objective is to improve the clarity of the code and simplify the loading.