### PR TITLE
Loading of vehicles is independent of VehicleMission

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/CommandHelper.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/CommandHelper.java
@@ -373,15 +373,18 @@ public class CommandHelper {
 			}
 	
 			// Vehicle mission has a loading
-			LoadingController lp = tm.getLoadingPlan();
-			if ((lp != null) && !lp.isCompleted()) {
-				response.appendText("Loading from " + lp.getSettlement().getName() + " :");
-				outputAmounts("Amount Resources", response, lp.getAmountManifest(true));	
-				outputAmounts("Optional Amounts", response, lp.getAmountManifest(false));
-				outputItems("Items", response, lp.getItemManifest(true));	
-				outputItems("Optional Items", response, lp.getItemManifest(false));	
-				outputEquipment("Equipment", response, lp.getEquipmentManifest(true));	
-				outputEquipment("Optional Equipment", response, lp.getEquipmentManifest(false));	
+			Vehicle v = tm.getVehicle();
+			if (v != null) {
+				LoadingController lp = v.getLoadingPlan();
+				if ((lp != null) && !lp.isCompleted()) {
+					response.appendText("Loading from " + lp.getSettlement().getName() + " :");
+					outputAmounts("Amount Resources", response, lp.getAmountManifest(true));	
+					outputAmounts("Optional Amounts", response, lp.getAmountManifest(false));
+					outputItems("Items", response, lp.getItemManifest(true));	
+					outputItems("Optional Items", response, lp.getItemManifest(false));	
+					outputEquipment("Equipment", response, lp.getEquipmentManifest(true));	
+					outputEquipment("Optional Equipment", response, lp.getEquipmentManifest(false));	
+				}
 			}
 		}
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/environment/DustStorm.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/environment/DustStorm.java
@@ -79,6 +79,8 @@ public class DustStorm implements Serializable {
 
 	private DustStormType type;
 
+	private String description;
+
 	/**
 	 * Constructor.
 	 * 
@@ -87,7 +89,7 @@ public class DustStorm implements Serializable {
 	 * @param weather
 	 * @param origin
 	 */
-	public DustStorm(DustStormType type, int id, Weather weather,
+	DustStorm(DustStormType type, int id, Weather weather,
 					 Settlement origin) {
 		this.id = id;
 		this.settlementId = origin.getIdentifier();
@@ -107,6 +109,8 @@ public class DustStorm implements Serializable {
 			speed = RandomUtil.getRandomInt(10);
 			size = 1 + RandomUtil.getRandomInt(3); 
 		}
+
+		updateDescription();
 	}
 
 	public String getName() {
@@ -126,24 +130,6 @@ public class DustStorm implements Serializable {
 		return startTime;
 	}
 	
-//	/**
-//     * Gets the distance to the destination.
-//     * 
-//     * @return distance (km)
-//     */
-//    protected double getDistanceToDestination() {
-//    	return getCoordinates().getDistance(destination);
-//    }
-//    
-//	public void travel(double millisols) {
-//	
-//        // Find the distance to destination.
-//        double dist2Dest = getDistanceToDestination();
-//        
-//        // Find current direction and update vehicle.
-//        setDirection(getCoordinates().getDirectionToPoint(destination));	
-//	}
-
 	// Almost all of the planet-encircling storms have been observed to start in one
 	// of two regions (a-d, e) on Mars:
 	// Coordinates from http://planetarynames.wr.usgs.gov/Feature/5954
@@ -221,7 +207,7 @@ public class DustStorm implements Serializable {
 			// Mars year
 			// is 33% based on Earth-based observational record in 1956, 1971, 1973, 1977
 			// (two), and 1982.
-			// TODO: how to incorporate this 33% into the algorithm here?
+			// how to incorporate this 33% into the algorithm here?
 
 			// if there are already 2 planet encircling dust storm,
 			// do not create the next one and reduce it to 3900
@@ -277,6 +263,7 @@ public class DustStorm implements Serializable {
 		size = newSize;
 		speed = newSpeed;
 
+		updateDescription();
 		return size;
 	}
 
@@ -314,4 +301,22 @@ public class DustStorm implements Serializable {
 	public Coordinates getCoordinates() {
 		return location;
 	}
+
+	/**
+	 * Get the description of this storm
+	 * @return
+	 */
+	public String getDescription() {
+		return description;
+	}
+
+	/**
+	 * Update the desxcription which is based on size & speed
+	 * @return Updated description
+	 */
+    private void updateDescription() {
+		description = name
+				+ " (size " + size + " with wind speed "
+				+ Math.round(speed * 10.0) / 10.0 + " m/s) was sighted.";
+    }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/environment/Weather.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/environment/Weather.java
@@ -919,20 +919,18 @@ public class Weather implements Serializable, Temporal {
 				.count() < 2);
 		
 		if (!dustStorms.isEmpty()) {
-			List<DustStorm> storms = new ArrayList<>(dustStorms);
-			for (DustStorm ds : storms) {
+			List<DustStorm> old = null;
+			for (DustStorm ds : dustStorms) {
 				if (ds.computeNewSize(allowPlantStorms) == 0) {
-					dustStorms.remove(ds);
-				} 
-		
-				if (ds.getSize() != 0) {
-					Settlement s = ds.getSettlement();
-					String msg = ds.getName()
-						+ " (size " + ds.getSize() + " with wind speed "
-						+ Math.round(ds.getSpeed() * 10.0) / 10.0 + " m/s) was sighted.";
-					s.setDustStormMsg(msg);
-					logger.info(s, 30_000, msg);
+					if (old == null) {
+						old = new ArrayList<>();
+					}
+					old.add(ds);
 				}
+			}
+
+			if (old != null) {
+				dustStorms.removeAll(old);
 			}
 		}
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionLoadVehicleStep.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionLoadVehicleStep.java
@@ -8,11 +8,9 @@ package com.mars_sim.core.mission;
 
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.mission.MissionStatus;
-import com.mars_sim.core.person.ai.mission.VehicleMission;
 import com.mars_sim.core.person.ai.task.util.Task;
 import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.project.Stage;
-import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.robot.Robot;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.tool.RandomUtil;
@@ -50,10 +48,8 @@ public class MissionLoadVehicleStep extends MissionStep {
         Vehicle v = vp.getVehicle();
         Settlement settlement = v.getSettlement();
 		if (loadingPlan == null) {
-            SuppliesManifest manifest = vp.getResources(true);
-			loadingPlan = new LoadingController(v.getSettlement(), v, manifest);	
-            
-                                                
+			loadingPlan = v.setLoading(vp.getResources(true));	
+                                                            
             // Try and move the vehicle to garage
 		    settlement.getBuildingManager().addToGarage(v);
 		}
@@ -85,15 +81,6 @@ public class MissionLoadVehicleStep extends MissionStep {
     }
 
     /**
-     * Gets the loading plan associated with the step.
-     * 
-     * @return
-     */
-    public LoadingController getLoadingPlan() {
-        return loadingPlan;
-    }
-
-    /**
      * Creates the most suitable Load Vehicle task if possible.
      * 
      * @param worker
@@ -102,17 +89,16 @@ public class MissionLoadVehicleStep extends MissionStep {
      */
     private Task createLoadTask(Worker worker, Vehicle vehicle) {
         boolean inGarage = vehicle.isInGarage();
-        VehicleMission target = (VehicleMission) getMission();
         if (worker.isInSettlement())
         	return null;
         if (worker instanceof Person p) {
             if (inGarage) {
-                return new LoadVehicleGarage(p, target.getLoadingPlan());
+                return new LoadVehicleGarage(p, vehicle);
             }
-            return new LoadVehicleEVA(p, target.getLoadingPlan());
+            return new LoadVehicleEVA(p, vehicle);
         }
         else if ((worker instanceof Robot r) && inGarage) {
-            return new LoadVehicleGarage(r, target.getLoadingPlan());
+            return new LoadVehicleGarage(r, vehicle);
         }
 
         return null;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionVehicleProject.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionVehicleProject.java
@@ -21,7 +21,6 @@ import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.time.MarsTime;
 import com.mars_sim.core.tool.RandomUtil;
 import com.mars_sim.core.vehicle.Vehicle;
-import com.mars_sim.core.vehicle.task.LoadingController;
 
 /**
  * This represents a MissionProject that specialises in Vehicle based Mission.
@@ -175,14 +174,6 @@ public class MissionVehicleProject extends MissionProject
     }
 
     @Override
-    public LoadingController getLoadingPlan() {
-        if (getCurrentStep() instanceof MissionLoadVehicleStep ls) {
-            return ls.getLoadingPlan();
-        }
-        return null;
-    }
-
-    @Override
     public MarsTime getLegETA() {
         return null;
     }
@@ -269,7 +260,7 @@ public class MissionVehicleProject extends MissionProject
 
 	@Override
 	public double getDistanceCurrentLegTravelled() {
-		// TODO Auto-generated method stub
+		// Auto-generated method stub
 		return 0;
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/AbstractVehicleMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/AbstractVehicleMission.java
@@ -300,16 +300,6 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 	public Vehicle getVehicle() {
 		return vehicle;
 	}
-	
-	/**
-	 * Gets the current loading plan for this Mission phase.
-	 * 
-	 * @return
-	 */
-	@Override
-	public LoadingController getLoadingPlan() {
-		return loadingPlan;
-	}
 
 	/**
 	 * Prepares a loading plan taking resources from a site. If a plan for the same
@@ -324,9 +314,7 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 												getOptionalResourcesToLoad(),
 												getRequiredEquipmentToLoad(),
 												getOptionalEquipmentToLoad());
-			loadingPlan = new LoadingController(loadingSite, vehicle, manifest);
-
-															
+			loadingPlan = vehicle.setLoading(manifest);													
 		}
 		return loadingPlan;
 	}
@@ -708,7 +696,7 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 				// This allows person to do other important things such as eating
 				&& RandomUtil.lessThanRandPercent(75)) {
 								
-				TaskJob job = LoadVehicleMeta.createLoadJob(this, settlement);
+				TaskJob job = LoadVehicleMeta.createLoadJob(vehicle, settlement);
 		        if (job != null) {
 		            Task task = null;
 		            // Create the Task ready for assignment

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/ConstructionMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/ConstructionMission.java
@@ -926,10 +926,6 @@ public class ConstructionMission extends AbstractMission
 						&& !luvTemp.isReserved() && (luvTemp.getCrewNum() == 0) && (luvTemp.getRobotCrewNum() == 0)) {
 					result = luvTemp;
 					luvTemp.setReservedForMission(true);
-
-					if (!settlement.removeVicinityParkedVehicle(luvTemp)) {
-						endMissionProblem(luvTemp, "Can not remove parked vehicle");
-					}
 				}
 			}
 		}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/EmergencySupply.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/EmergencySupply.java
@@ -408,7 +408,7 @@ public class EmergencySupply extends RoverMission {
 			// sometimes)
 			if (member.isInSettlement() && RandomUtil.lessThanRandPercent(50)) {
 
-				TaskJob job = LoadVehicleMeta.createLoadJob(this, emergencySettlement);
+				TaskJob job = LoadVehicleMeta.createLoadJob(getVehicle(), emergencySettlement);
 		        if (job != null) {
 		            Task task = null;
 		            // Create the Task ready for assignment

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/Exploration.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/Exploration.java
@@ -477,7 +477,8 @@ public class Exploration extends EVAMission
 	 * @return first exploration site or null if none.
 	 */
 	private Coordinates determineFirstSiteCoordinate(double limit, int areologySkill) {
-		return getStartingSettlement().determineFirstSiteCoordinate(limit, areologySkill);
+		// Get a random site that is one of the closest
+		return getStartingSettlement().getARandomNearbyMineralLocation(true, limit, areologySkill);
 	}
 	
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/SalvageMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/SalvageMission.java
@@ -555,10 +555,6 @@ public class SalvageMission extends AbstractMission
 					// Place light utility vehicles at random location in construction site.
 					LocalPosition settlementLocSite = LocalAreaUtil.getRandomLocalPos(constructionSite);
 					luvTemp.setParkedLocation(settlementLocSite, RandomUtil.getRandomDouble(360D));
-
-					if (!settlement.removeVicinityParkedVehicle(luvTemp)) {
-						endMissionProblem(luvTemp, "Can not remove parked vehicle");
-					}
 				}
 			}
 		}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/VehicleMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/VehicleMission.java
@@ -11,7 +11,6 @@ import java.util.List;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.time.MarsTime;
 import com.mars_sim.core.vehicle.Vehicle;
-import com.mars_sim.core.vehicle.task.LoadingController;
 
 public interface VehicleMission extends Mission {
 
@@ -50,13 +49,6 @@ public interface VehicleMission extends Mission {
      * Gets the remaining distance for the current travel leg.
      */
     double getDistanceCurrentLegTravelled();
-    
-    /**
-	 * Gets the current loading plan for this Mission phase.
-	 * 
-	 * @return
-	 */
-    LoadingController getLoadingPlan();
 
     /**
 	 * Gets the estimated time of arrival (ETA) for the current leg of the mission.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/ReviewMissionPlan.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/ReviewMissionPlan.java
@@ -419,8 +419,8 @@ public class ReviewMissionPlan extends Task {
 			Settlement settlement = person.getAssociatedSettlement();
 			
 			double score = mp.getScore();
-			
-			if (settlement.passMissionScore(score)) {
+			double minScore = settlement.getMinimumPassingScore();
+			if (score > minScore) {
 				// Approved
 				// Updates the mission plan status
 				missionManager.approveMissionPlan(mp, PlanType.APPROVED, settlement.getMinimumPassingScore());

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/MetaTaskUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/MetaTaskUtil.java
@@ -343,7 +343,6 @@ public class MetaTaskUtil {
 	 */
     static void initialiseInstances(Simulation sim) {
 		MetaTask.initialiseInstances(sim);
-		LoadVehicleMeta.initialiseInstances(sim);
 		UnloadVehicleMeta.initialiseInstances(sim);
 		ExamineBodyMeta.initialiseInstances(sim.getMedicalManager());
 		ReviewMissionPlanMeta.initialiseInstances(sim.getMissionManager());

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -2133,10 +2133,10 @@ public class Settlement extends Structure implements Temporal,
 	 * @return numbers of vehicles on mission.
 	 */
 	public int getMissionVehicleNum() {
-		return Math.toIntExact(ownedVehicles
+		return (int) ownedVehicles
 				.stream()
 				.filter(v -> v.getMission() != null)
-				.collect(Collectors.counting()));
+				.count();
 	}
 
 	/**
@@ -2145,9 +2145,8 @@ public class Settlement extends Structure implements Temporal,
 	 * @return Collection of parked or garaged drones
 	 */
 	public Collection<Drone> getParkedGaragedDrones() {
-		return ownedVehicles.stream()
+		return vicinityParkedVehicles.stream()
 				.filter(v -> VehicleType.isDrone(v.getVehicleType()))
-				.filter(v -> this.equals(v.getSettlement()))
 				.map(Drone.class::cast)
 				.toList();
 	}
@@ -2161,7 +2160,7 @@ public class Settlement extends Structure implements Temporal,
 		return ownedVehicles.stream()
 				.filter(v -> v.getVehicleType() == vehicleType)
 				.map(Unit.class::cast)
-				.collect(Collectors.toList());
+				.toList();
 	}
 
 	/**
@@ -2171,10 +2170,10 @@ public class Settlement extends Structure implements Temporal,
 	 * @return number of vehicles.
 	 */
 	public int findNumVehiclesOfType(VehicleType vehicleType) {
-		return Math.toIntExact(ownedVehicles
+		return (int)ownedVehicles
 					.stream()
 					.filter(v -> v.getVehicleType() == vehicleType)
-					.collect(Collectors.counting()));
+					.count();
 	}
 
 	/**
@@ -2183,10 +2182,9 @@ public class Settlement extends Structure implements Temporal,
 	 * @return number of parked rovers
 	 */
 	public int findNumParkedRovers() {
-		return (int)ownedVehicles
+		return (int)vicinityParkedVehicles
 					.stream()
 					.filter(v -> VehicleType.isRover(v.getVehicleType()))
-					.filter(v -> this.equals(v.getSettlement()))
 					.count();
 	}
 
@@ -2197,9 +2195,7 @@ public class Settlement extends Structure implements Temporal,
 	 */
 	public Collection<Vehicle> getParkedGaragedVehicles() {
 		// Get all Vehicles that are back home
-		return 	ownedVehicles.stream()
-					.filter(v -> this.equals(v.getSettlement()))
-					.toList();
+		return 	vicinityParkedVehicles;
 	}
 
 	/**
@@ -2208,9 +2204,7 @@ public class Settlement extends Structure implements Temporal,
 	 * @return parked vehicles number
 	 */
 	public int getNumParkedVehicles() {
-		return (int)ownedVehicles.stream()
-				.filter(v -> this.equals(v.getSettlement()))
-				.count();
+		return vicinityParkedVehicles.size();
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementBuilder.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementBuilder.java
@@ -320,7 +320,7 @@ public final class SettlementBuilder {
 		RobotDemand demand = new RobotDemand(settlement);
 
 		// Note : need to call updateAllAssociatedRobots() first to compute numBots in Settlement
-		while (settlement.getIndoorRobotsCount() < target) {
+		while (settlement.getNumBots() < target) {
 			// Get a robotType randomly
 			RobotType robotType = demand.getBestNewRobot();
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Drone.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Drone.java
@@ -10,13 +10,11 @@ import java.util.Collection;
 
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.person.ai.mission.Mission;
-import com.mars_sim.core.person.ai.mission.VehicleMission;
 import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.resource.AmountResource;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.time.ClockPulse;
-import com.mars_sim.core.vehicle.task.LoadingController;
 
 public class Drone extends Flyer {
 
@@ -77,19 +75,6 @@ public class Drone extends Flyer {
 						// Question: why would the mission be null for this member in the first place after loading from a saved sim
 						logger.info(this, m.getName() + " reregistered for " + mission + ".");
 						m.setMission(mission);
-					}
-				}
-
-				if (isInSettlement()
-					&& mission instanceof VehicleMission vm) {
-						LoadingController lp = vm.getLoadingPlan();
-
-					if ((lp != null) && !lp.isCompleted()) {
-						double time = pulse.getElapsed();
-						double transferSpeed = 10; // Assume 10 kg per msol
-						double amountLoading = time * transferSpeed;
-
-						lp.backgroundLoad(amountLoading);
 					}
 				}
 			}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Rover.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Rover.java
@@ -786,18 +786,6 @@ public class Rover extends GroundVehicle implements Crewable,
 				}
 
 				if (isInSettlement()) {
-					if (mission instanceof VehicleMission) {
-						LoadingController lp = ((VehicleMission)mission).getLoadingPlan();
-
-						if ((lp != null) && !lp.isCompleted()) {
-							double time = pulse.getElapsed();
-							double transferSpeed = 10; // Assume 10 kg per msol
-							double amountLoading = time * transferSpeed;
-
-							lp.backgroundLoad(amountLoading);
-						}
-					}
-
 					plugInTemperature(pulse.getElapsed());
 					plugInAirPressure(pulse.getElapsed());
 				}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/StatusType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/StatusType.java
@@ -15,33 +15,30 @@ import com.mars_sim.core.tool.Msg;
  */
 public enum StatusType {
 	
-	GARAGED 				(Msg.getString("StatusType.garaged"), true), //$NON-NLS-1$
-	HOVERING 				(Msg.getString("StatusType.hovering"), true), //$NON-NLS-1$
-	MAINTENANCE 			(Msg.getString("StatusType.maintenance"), false), //$NON-NLS-1$
-	MALFUNCTION 			(Msg.getString("StatusType.malfunction"), false), //$NON-NLS-1$
-	MOVING 					(Msg.getString("StatusType.moving"), true), //$NON-NLS-1$
-	OUT_OF_BATTERY_POWER	(Msg.getString("StatusType.outOfBatteryPower"),false), //$NON-NLS-1$
-	OUT_OF_FUEL 			(Msg.getString("StatusType.outOfFuel"),false), //$NON-NLS-1$
-	OUT_OF_OXIDIZER 		(Msg.getString("StatusType.outOfOxidizer"),false), //$NON-NLS-1$
-	PARKED 					(Msg.getString("StatusType.parked"), true), //$NON-NLS-1$
-	STUCK					(Msg.getString("StatusType.stuck"), false), //$NON-NLS-1$
-	TOWED 					(Msg.getString("StatusType.towed"), false), //$NON-NLS-1$	
-	TOWING 					(Msg.getString("StatusType.towing"), false), //$NON-NLS-1$	
+	GARAGED 				(true),
+	HOVERING 				(true),
+	LOADING		 			(false),
+	MAINTENANCE 			(false),
+	MALFUNCTION 			(false),
+	MOVING 					(true),
+	OUT_OF_BATTERY_POWER	(false),
+	OUT_OF_FUEL 			(false),
+	OUT_OF_OXIDIZER 		(false),
+	PARKED 					(true),
+	STUCK					(false),
+	TOWED 					(false),	
+	TOWING 					(false),	
 	;
 	
 	private String name;
 	private boolean primary;
 
-	private StatusType(String name, boolean primary) {
-		this.name = name;
+	private StatusType(boolean primary) {
+		this.name = Msg.getString("StatusType." + name().toLowerCase());
 		this.primary = primary;
 	}
 
 	public String getName() {
-		return this.name;
-	}
-	
-	public String toString() {
 		return this.name;
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
@@ -50,6 +50,7 @@ import com.mars_sim.core.person.ai.task.util.Task;
 import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.person.health.RadiationExposure;
 import com.mars_sim.core.project.Stage;
+import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.robot.Robot;
 import com.mars_sim.core.structure.RadiationStatus;
 import com.mars_sim.core.structure.Settlement;
@@ -64,6 +65,7 @@ import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.MarsTime;
 import com.mars_sim.core.time.Temporal;
 import com.mars_sim.core.tool.RandomUtil;
+import com.mars_sim.core.vehicle.task.LoadingController;
 import com.mars_sim.core.vehicle.task.MaintainVehicleMeta;
 
 /**
@@ -120,10 +122,6 @@ public abstract class Vehicle extends Unit
 	/** Vehicle's associated Settlement. */
 	private int associatedSettlementID;
 	
-//	/** The average road load power of the vehicle [kph]. */
-//	private double averageRoadLoadSpeed;
-//	/** The average road load power of the vehicle [kW]. */
-//	private double averageRoadLoadPower;		
 	/** Parked facing (degrees clockwise from North). */
 	private double facingParked;
 	/** The Base Lifetime Wear in msols **/
@@ -198,6 +196,8 @@ public abstract class Vehicle extends Unit
 	private MSolDataLogger<Integer> roadSpeedHistory = new MSolDataLogger<>(MAX_NUM_SOLS);
 	/** The vehicle's road power history. */	
 	private MSolDataLogger<Integer> roadPowerHistory = new MSolDataLogger<>(MAX_NUM_SOLS);
+
+	private LoadingController loadingController;
 	
 	static {
 		lifeSupportRangeErrorMargin = simulationConfig.getSettlementConfiguration()
@@ -364,6 +364,32 @@ public abstract class Vehicle extends Unit
 		return facingParked;
 	}
 
+	/**
+	 * Get the loading plan associated with this Vehicle
+	 */
+	public LoadingController getLoadingPlan() {
+		return loadingController;
+	}
+
+	/**
+	 * Change the loading status of this loading
+	 * @param manifest Supplies to load; if this is null then stop the loading
+	 */
+    public LoadingController setLoading(SuppliesManifest manifest) {
+		if (manifest == null) {
+			removeSecondaryStatus(StatusType.LOADING);
+			loadingController = null;
+		}
+        else if (statusTypes.contains(StatusType.LOADING)) {
+			logger.warning(this, "Is already in the loading status");
+		}
+		else {
+			loadingController = new LoadingController(getSettlement(), this, manifest);
+			addSecondaryStatus(StatusType.LOADING);
+		}
+		return loadingController;
+    }
+	
 	/**
 	 * Gets a list of operator activity spots.
 	 *
@@ -1451,24 +1477,11 @@ public abstract class Vehicle extends Unit
 		// if it's malfunction (outside or inside settlement) 
 		// whether it's in a garage or not
 		else if (haveStatusType(StatusType.MALFUNCTION)
-				&& malfunctionManager.getMalfunctions().size() == 0) {
+				&& malfunctionManager.getMalfunctions().isEmpty()) {
 			// Remove the malfunction status
 			removeSecondaryStatus(StatusType.MALFUNCTION);
 		}
-		
-//		// Regardless being outside or inside settlement,
-//		// if it's still reportedly under maintenance
-//		// but maintenance just got done	
-//		else if (haveStatusType(StatusType.MAINTENANCE) 
-//			&& malfunctionManager.getEffectiveTimeSinceLastMaintenance() <= 0D) {
-//			// Make sure reservedForMaintenance is false since vehicle now needs no maintenance.
-//			setReservedForMaintenance(false);
-//			// Remove the malfunction status
-//			removeSecondaryStatus(StatusType.MAINTENANCE);
-//			// If the vehicle is in a garage, remove from garage
-//			BuildingManager.removeFromGarage(this);
-//		}
-		
+
 		// Regardless being outside or inside settlement,
 		// NOT under maintenance
 		else {
@@ -1487,18 +1500,18 @@ public abstract class Vehicle extends Unit
 			
 		}
 
+		// Bckground loading check
+		if (haveStatusType(StatusType.LOADING) && isInSettlement()
+				&& !loadingController.isCompleted()) {
+			double time = pulse.getElapsed();
+			double transferSpeed = 10; // Assume 10 kg per msol
+			double amountLoading = time * transferSpeed;
+
+			loadingController.backgroundLoad(amountLoading);
+		}
+
 		// Check once per msol (millisol integer)
 		if (pulse.isNewIntMillisol()) {
-			
-//			if (primaryStatus == StatusType.PARKED && isReserved()){
-//				// If the vehicle is reserved and is not in a garage, add to  garage
-//				addToAGarage();
-//			}
-			
-//			if (primaryStatus == StatusType.GARAGED && !isReserved()) {
-//				// If the vehicle is not reserved and is in a garage, remove from garage
-//				BuildingManager.removeFromGarage(this);
-//			}
 			
 			// Sample a data point every SAMPLE_FREQ (in msols)
 			int msol = pulse.getMarsTime().getMillisolInt();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/LoadVehicleEVA.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/LoadVehicleEVA.java
@@ -51,9 +51,9 @@ public class LoadVehicleEVA extends EVAOperation {
 	 * Constructor
 	 * 
 	 * @param person            the person performing the task.
-	 * @param loadingPlan Plan to execute the load
+	 * @param vehicle           vehicle to load via EVA
 	 */
-	public LoadVehicleEVA(Person person, LoadingController loadingPlan) {
+	public LoadVehicleEVA(Person person, Vehicle vehicle) {
 		// Use Task constructor.
 		super(NAME, person, 20D + RandomUtil.getRandomInt(5) - RandomUtil.getRandomInt(5), LOADING);
 
@@ -67,15 +67,15 @@ public class LoadVehicleEVA extends EVAOperation {
 		if (unitManager == null)
 			unitManager = Simulation.instance().getUnitManager();
 		
-		settlement = unitManager.findSettlement(person.getCoordinates());
+		settlement = person.getSettlement();
 		if (settlement == null) {
 			endTask();
 			return;
 		}
 
-		this.loadingPlan = loadingPlan;		
-		vehicle = loadingPlan.getVehicle();
-		if (vehicle == null) {
+		this.vehicle = vehicle;
+		this.loadingPlan = vehicle.getLoadingPlan();
+		if (loadingPlan == null) {
 			// Mission must be done
 			checkLocation("Vehicle is null.");
 			return;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/LoadVehicleGarage.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/LoadVehicleGarage.java
@@ -67,9 +67,9 @@ public class LoadVehicleGarage extends Task {
 	 * Constructor.
 	 * 
 	 * @param person            the person performing the task.
-	 * @param loadingController           the vehicle to be loaded.
+	 * @param vehicle           the vehicle to be loaded.
 	 */
-	public LoadVehicleGarage(Worker worker, LoadingController loadingController) {
+	public LoadVehicleGarage(Worker worker, Vehicle vehicle) {
 		// Use Task constructor.
 		super(NAME, worker, false, IMPACT,
 					RandomUtil.getRandomDouble(50D) + 10D);
@@ -80,8 +80,8 @@ public class LoadVehicleGarage extends Task {
 			return;
 		}
 
-		vehicle = loadingController.getVehicle();
-		this.loadController = loadingController;
+		this.vehicle = vehicle;
+		this.loadController = vehicle.getLoadingPlan();
  
 		// Rover may already be in the Garage
 		Building garage = vehicle.getGarage();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/LoadVehicleMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/LoadVehicleMeta.java
@@ -9,15 +9,11 @@ package com.mars_sim.core.vehicle.task;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.mars_sim.core.Simulation;
 import com.mars_sim.core.data.RatingScore;
 import com.mars_sim.core.goods.GoodsManager.CommerceType;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.fav.FavoriteType;
 import com.mars_sim.core.person.ai.job.util.JobType;
-import com.mars_sim.core.person.ai.mission.Mission;
-import com.mars_sim.core.person.ai.mission.MissionManager;
-import com.mars_sim.core.person.ai.mission.VehicleMission;
 import com.mars_sim.core.person.ai.task.util.MetaTask;
 import com.mars_sim.core.person.ai.task.util.SettlementMetaTask;
 import com.mars_sim.core.person.ai.task.util.SettlementTask;
@@ -30,6 +26,7 @@ import com.mars_sim.core.robot.RobotType;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.tool.Msg;
 import com.mars_sim.core.vehicle.Rover;
+import com.mars_sim.core.vehicle.StatusType;
 import com.mars_sim.core.vehicle.Vehicle;
 
 /**
@@ -42,16 +39,12 @@ public class LoadVehicleMeta extends MetaTask
 
 		private static final long serialVersionUID = 1L;
 
-		private VehicleMission vehicleMission;
+		private Vehicle vehicle;
 		
-        private LoadJob(SettlementMetaTask owner, VehicleMission target, boolean eva, RatingScore score) {
+        private LoadJob(SettlementMetaTask owner, Vehicle target, boolean eva, RatingScore score) {
             super(owner, "Load " + (eva ? "via EVA " : ""), target, score);
-            vehicleMission = target;
+            vehicle = target;
             setEVA(eva);
-        }
-
-        private VehicleMission getMission() {
-            return (VehicleMission) getFocus();
         }
 
         @Override
@@ -59,22 +52,20 @@ public class LoadVehicleMeta extends MetaTask
             if (!person.isInSettlement())
             	return null;
             if (isEVA()) {
-                return new LoadVehicleEVA(person, getMission().getLoadingPlan());
+                return new LoadVehicleEVA(person, vehicle);
             }
 	
-    		Vehicle vehicle = vehicleMission.getVehicle();
-
     		boolean hasGarage = vehicle.isInGarage(); 
     		if (hasGarage)
-    			return new LoadVehicleGarage(person, getMission().getLoadingPlan());
+    			return new LoadVehicleGarage(person, vehicle);
     			
     		boolean garageTask = MaintainVehicleMeta.hasGarageSpaces(
     				vehicle.getAssociatedSettlement(), vehicle instanceof Rover);
             
     		if (garageTask)
-    			return new LoadVehicleGarage(person, getMission().getLoadingPlan());
+    			return new LoadVehicleGarage(person, vehicle);
 			
-    		return new LoadVehicleEVA(person, getMission().getLoadingPlan());
+    		return new LoadVehicleEVA(person, vehicle);
         }
 
         @Override
@@ -83,7 +74,7 @@ public class LoadVehicleMeta extends MetaTask
 				// Should not happen
 				throw new IllegalStateException("Robots can not do EVA load vehicle");
 			}
-            return new LoadVehicleGarage(robot, getMission().getLoadingPlan());
+            return new LoadVehicleGarage(robot, vehicle);
         }
     }
 
@@ -92,9 +83,6 @@ public class LoadVehicleMeta extends MetaTask
             "Task.description.loadVehicle"); //$NON-NLS-1$
 
     private static final double GARAGE_DEFAULT_SCORE = 500D;
-
-    /** The static instance of the MissionManager */
-	private static MissionManager missionManager;
 
     public LoadVehicleMeta() {
 		super(NAME, WorkerType.BOTH, TaskScope.WORK_HOUR);
@@ -125,18 +113,18 @@ public class LoadVehicleMeta extends MetaTask
 	public List<SettlementTask> getSettlementTasks(Settlement settlement) {
 		List<SettlementTask> tasks = new ArrayList<>();
 
-        // Find all Vehicle missions with an active loading plan
-		for (Mission mission : missionManager.getMissions()) {
-			if (mission instanceof VehicleMission vehicleMission) {
-				LoadingController plan = vehicleMission.getLoadingPlan();
+        // Find all parked Vehicles with an active loading plan
+		for (var vehicle : settlement.getParkedGaragedVehicles()) {
+			if (vehicle.haveStatusType(StatusType.LOADING)) {
+				LoadingController plan = vehicle.getLoadingPlan();
 
 				// Must have a local Loading Plan that is not complete
 				if ((plan != null) && plan.getSettlement().equals(settlement) && !plan.isCompleted()) {
 					
 					boolean garageTask = MaintainVehicleMeta.hasGarageSpaces(
-							vehicleMission.getAssociatedSettlement(), vehicleMission.getVehicle() instanceof Rover);
+							settlement, vehicle instanceof Rover);
 							
-                    SettlementTask job = createLoadJob(vehicleMission, settlement, garageTask, this);
+                    SettlementTask job = createLoadJob(vehicle, settlement, garageTask, this);
                     if (job != null) {
                         tasks.add(job);
                     }
@@ -147,21 +135,17 @@ public class LoadVehicleMeta extends MetaTask
     }
 
     /**
-     * Creates the appropriate TaskJob to load a mission. This considers whether the vehicle is already in a garage.
+     * Creates the appropriate TaskJob to load a vehicle. This considers whether the vehicle is already in a garage.
      * and whether there is Garage space.
      * 
-     * @param vehicleMission Mission needing a load
+     * @param vehicle Vehicle to load
      * @param settlement Location the load is occurring
      * @param insideOnlyTasks Only inside tasks
      * @param owner 
      */
-    private static SettlementTask createLoadJob(VehicleMission vehicleMission, Settlement settlement,
+    private static SettlementTask createLoadJob(Vehicle vehicle, Settlement settlement,
                                         boolean insideOnlyTasks,
                                         SettlementMetaTask owner) {
-
-        Vehicle vehicle = vehicleMission.getVehicle();
-        if (vehicle == null)
-            return null; // Should not happen
 
         RatingScore score = new RatingScore(GARAGE_DEFAULT_SCORE);
         score = applyCommerceFactor(score, settlement, CommerceType.TRANSPORT);
@@ -172,28 +156,20 @@ public class LoadVehicleMeta extends MetaTask
                 score.addModifier(GARAGED_MODIFIER, 2);
             }
             // Note: owner can be null
-            return new LoadJob(owner, vehicleMission, false, score);
+            return new LoadJob(owner, vehicle, false, score);
         }
-     // Note: owner can be null
-        return new LoadJob(owner, vehicleMission, true, score);
+        return new LoadJob(owner, vehicle, true, score);
     }
 
     /**
-     * Creates the appropriate TaskJob to load a mission. This considers whether the vehicle is 
+     * Creates the appropriate TaskJob to load a Vehicle. This considers whether the vehicle is 
      * already in a garage and whether there is garage space.
      * 
-     * @param vehicleMission Mission needing a load
+     * @param vehicle Vehicle needing a load
      * @param settlement Location the load is occurring
      */
-    public static TaskJob createLoadJob(VehicleMission vehicleMission, Settlement settlement) {
+    public static TaskJob createLoadJob(Vehicle vehicle, Settlement settlement) {
     	// Question: will a null SettlementTask be causing any issues ?
-        return createLoadJob(vehicleMission, settlement, false, null);
+        return createLoadJob(vehicle, settlement, false, null);
     } 
-
-    /**
-	 * Attached to the common controlling classes.
-	 */
-	public static void initialiseInstances(Simulation sim) {
-		missionManager = sim.getMissionManager();
-	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/LoadingController.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/LoadingController.java
@@ -242,6 +242,7 @@ public class LoadingController implements Serializable {
 		if (completed) {
 			// Can remove assume fuel is reloaded
 			vehicle.removeSecondaryStatus(StatusType.OUT_OF_FUEL);
+			vehicle.setLoading(null);
 			logger.fine(vehicle, "Loading completed by " + worker.getName());
 		}
 		return (amountLoading > 0D) || completed;

--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -1405,13 +1405,14 @@ SplashWindow.title = Mars Simulation Project
 
 StatusType.garaged			= Garaged
 StatusType.hovering			= Hovering
+StatusType.loading  		= Loading
 StatusType.maintenance		= Maintenance
 StatusType.malfunction		= Malfunction
 StatusType.moving			= Moving
 StatusType.parked			= Parked
-StatusType.outOfBatteryPower= Out Of Battery Power
-StatusType.outOfFuel		= Out Of Fuel
-StatusType.outOfOxidizer	= Out Of Oxidizer
+StatusType.out_of_battery_power= Out Of Battery Power
+StatusType.out_of_fuel		= Out Of Fuel
+StatusType.out_of_oxidizer	= Out Of Oxidizer
 StatusType.stuck			= Stuck
 StatusType.towed			= Towed
 StatusType.towing			= Towing

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mission/predefined/TestDriveMissionTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mission/predefined/TestDriveMissionTest.java
@@ -57,7 +57,7 @@ public class TestDriveMissionTest extends AbstractMarsSimUnitTest {
         assertTrue("Initial stage completed", executeMission(leader, assigned, mp, 10));
 
         // Check the plan has content
-        LoadingController plan = mp.getLoadingPlan();
+        LoadingController plan = assigned.getLoadingPlan();
         assertNotNull("Loading plan created", plan);
         Map<Integer, Double> resources = plan.getAmountManifest(true);
         assertTrue("Plan has Oxygen", resources.get(ResourceUtil.oxygenID).doubleValue() > 0D);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadControllerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadControllerTest.java
@@ -26,6 +26,7 @@ import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.structure.MockSettlement;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.vehicle.Rover;
+import com.mars_sim.core.vehicle.StatusType;
 import com.mars_sim.core.vehicle.Vehicle;
 
 import junit.framework.TestCase;
@@ -95,8 +96,7 @@ extends TestCase {
 
 		loadSettlement(settlement, requiredResourcesMap);
 
-		LoadingController controller = new LoadingController(settlement, vehicle,
-															 requiredResourcesMap);
+		LoadingController controller = vehicle.setLoading(requiredResourcesMap);
 		int loadingCount = 0;
 		while (loadingCount < 100) {
 			controller.backgroundLoad(80);
@@ -225,8 +225,7 @@ extends TestCase {
 		// Add 2000kg food to the manifest
 		requiredResourcesMap.addAmount(ResourceUtil.foodID, 50D, true);
 
-		LoadingController controller = new LoadingController(settlement, vehicle,
-				requiredResourcesMap);
+		LoadingController controller = vehicle.setLoading(requiredResourcesMap);
 
 		// Run the loader but do not load an resources into the settlement
 		for(int i = 0 ; i < (LoadingController.MAX_SETTLEMENT_ATTEMPTS - 1); i++) {
@@ -374,8 +373,7 @@ extends TestCase {
 	 */
 	private LoadingController reload(SuppliesManifest manifest) {
 
-		LoadingController controller = new LoadingController(settlement, vehicle,
-						manifest);
+		LoadingController controller = vehicle.setLoading(manifest);
 
 		// Vehicle should already be loaded
 		assertTrue("Vehicle already loaded", controller.isCompleted());
@@ -394,8 +392,10 @@ extends TestCase {
 	 */
 	private LoadingController loadIt(int maxCycles, SuppliesManifest manifest) {
 
-		LoadingController controller = new LoadingController(settlement, vehicle,
-				manifest);
+
+		LoadingController controller = vehicle.setLoading(manifest);
+		assertTrue("Vehicle has of LOADING", vehicle.haveStatusType(StatusType.LOADING));
+		assertEquals("Vehicle of the controller", vehicle, controller.getVehicle());
 
 		int loadingCount = 0;
 		boolean loaded = false;
@@ -407,6 +407,7 @@ extends TestCase {
 		assertTrue("Load operation stopped on load complete", loaded);
 		assertFalse("Loading controller successful", controller.isFailure());
 		assertTrue("Loading controller complete", controller.isCompleted());
+		assertFalse("Vehicle clear of LOADING", vehicle.haveStatusType(StatusType.LOADING));
 
 		return controller;
 	}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadVehicleEVATest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadVehicleEVATest.java
@@ -24,9 +24,9 @@ public class LoadVehicleEVATest extends AbstractMarsSimUnitTest {
         resources.addAmount(ResourceUtil.waterID, 10D, true);
         resources.addAmount(ResourceUtil.foodID, 10D, true);
         LoadControllerTest.loadSettlement(s, resources);
-        LoadingController lc = new LoadingController(s, v, resources);
+        v.setLoading(resources);
 
-        var task = new LoadVehicleEVA(p, lc);
+        var task = new LoadVehicleEVA(p, v);
         assertFalse("Task created", task.isDone()); 
 
         // Move onsite
@@ -40,5 +40,30 @@ public class LoadVehicleEVATest extends AbstractMarsSimUnitTest {
         EVAOperationTest.executeEVAWalk(this, eva, task);
         assertTrue("Task completed", task.isDone()); 
 
+    }
+
+    public void testMetaTask() {
+        var s = buildSettlement("Vehicle base", true);
+
+        // Load the vehicle
+        var v = buildRover(s, "rover1", new LocalPosition(10, 10));
+        buildRover(s, "rover2", new LocalPosition(10, 13));
+
+        var mt = new LoadVehicleMeta();
+
+        // Check with no loading
+        var tasks = mt.getSettlementTasks(s);
+        assertTrue("No load tasks found", tasks.isEmpty());
+
+        // Set rover to be loading
+        var resources = new SuppliesManifest();
+        resources.addAmount(ResourceUtil.oxygenID, 10D, true);
+        v.setLoading(resources);
+
+        tasks = mt.getSettlementTasks(s);
+        assertEquals("One load tasks found", 1, tasks.size());
+        var t = tasks.get(0);
+        assertTrue("Load in eva", t.isEVA());
+        assertEquals("Correct vehicle selected", v, t.getFocus());
     }
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadVehicleGarageTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadVehicleGarageTest.java
@@ -24,9 +24,9 @@ public class LoadVehicleGarageTest extends AbstractMarsSimUnitTest {
         resources.addAmount(ResourceUtil.waterID, 10D, true);
         resources.addAmount(ResourceUtil.foodID, 10D, true);
         LoadControllerTest.loadSettlement(s, resources);
-        LoadingController lc = new LoadingController(s, v, resources);
+        v.setLoading(resources);
 
-        var task = new LoadVehicleGarage(p, lc);
+        var task = new LoadVehicleGarage(p, v);
         assertFalse("Task created", task.isDone()); 
 
         // Do maintenance and advance to return
@@ -35,5 +35,31 @@ public class LoadVehicleGarageTest extends AbstractMarsSimUnitTest {
 
         // Return to base
         assertTrue("Task completed", task.isDone()); 
+    }
+
+    public void testMetaTask() {
+        var s = buildSettlement("Vehicle base", true);
+        buildGarage(s.getBuildingManager(), LocalPosition.DEFAULT_POSITION, 0D, 0);
+
+        // Load the vehicle
+        var v = buildRover(s, "rover1", new LocalPosition(10, 10));
+        buildRover(s, "rover2", new LocalPosition(10, 13));
+
+        var mt = new LoadVehicleMeta();
+
+        // Check with no loading
+        var tasks = mt.getSettlementTasks(s);
+        assertTrue("No load tasks found", tasks.isEmpty());
+
+        // Set rover to be loading
+        var resources = new SuppliesManifest();
+        resources.addAmount(ResourceUtil.oxygenID, 10D, true);
+        v.setLoading(resources);
+
+        tasks = mt.getSettlementTasks(s);
+        assertEquals("One load tasks found", 1, tasks.size());
+        var t = tasks.get(0);
+        assertFalse("Load in not eva", t.isEVA());
+        assertEquals("Correct vehicle selected", v, t.getFocus());
     }
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementTransparentPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementTransparentPanel.java
@@ -539,9 +539,10 @@ public class SettlementTransparentPanel extends JComponent {
        		String resources = resourceCache.get(s);
        		if (resources == null)
        			resources = "";
-       		StringBuilder sb = new StringBuilder("");
-       		if (s.getDustStorm() != null) {
-       			sb.append(s.getDustStormMsg());
+       		StringBuilder sb = new StringBuilder();
+       		var ds = s.getDustStorm();
+			if (ds != null) {
+       			sb.append(ds.getDescription());
        		}
        		
        		sb.append(resources);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/VehicleMapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/VehicleMapLayer.java
@@ -16,13 +16,11 @@ import org.apache.batik.gvt.GraphicsNode;
 
 import com.mars_sim.core.CollectionUtils;
 import com.mars_sim.core.map.location.LocalBoundedObject;
-import com.mars_sim.core.person.ai.mission.Mission;
-import com.mars_sim.core.person.ai.mission.VehicleMission;
 import com.mars_sim.core.resource.Part;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.vehicle.LightUtilityVehicle;
+import com.mars_sim.core.vehicle.StatusType;
 import com.mars_sim.core.vehicle.Vehicle;
-import com.mars_sim.core.vehicle.task.LoadingController;
 import com.mars_sim.ui.swing.tool.settlement.SettlementMapPanel.DisplayOption;
 import com.mars_sim.ui.swing.tool.svg.SVGMapUtil;
 
@@ -95,7 +93,7 @@ public class VehicleMapLayer extends AbstractMapLayer {
 			}
 
 			// Draw overlay if the vehicle is being loaded or unloaded.
-			if (isVehicleLoading(vehicle)) {
+			if (vehicle.haveStatusType(StatusType.LOADING)) {
 				drawSVGLoading(vehicle, svg, viewpoint);
 			}
 
@@ -147,25 +145,6 @@ public class VehicleMapLayer extends AbstractMapLayer {
 		if ((maintOverlaySvg != null) && (vehicleSvg != null)) {
 			drawVehicleOverlay(vehicle, vehicleSvg, maintOverlaySvg, viewpoint);
 		}
-	}
-
-	/**
-	 * Checks if the vehicle is currently being loaded or unloaded.
-	 * 
-	 * @param vehicle the vehicle
-	 * @return true if vehicle is being loaded or unloaded.
-	 */
-	private boolean isVehicleLoading(Vehicle vehicle) {
-		boolean result = false;
-
-		// For vehicle missions, check if vehicle is loading or unloading for the mission.
-		Mission mission = vehicle.getMission();
-		if ((mission != null) && (mission instanceof VehicleMission vm)) {
-			LoadingController lp = vm.getLoadingPlan();
-			result = (lp != null) && !lp.isCompleted();
-		}
-
-		return result;
 	}
 
 	/**


### PR DESCRIPTION
This PR makes changes so the loading of a Vehicle is independent of a VehicleMission. This reduces the coupling of code and allow future change to load Vehicles without needing a mission. 

This is delivered by introducing a new StatusType of LOADING this signifies Vehicles ready for loading. Secondary benefit is the LOADING is recorded in the status log of the Vehicle.
When in the LOADING state, a Vehicle now has a ```LoadingController``` attached instead of it being on the ```VehicleMission```.

To support this, the definition of a parked vehicle is changed to include those visiting from other Settlements.

Complementary changes for unloading will follow.
This supersedes the PR #1357 which proved impossible to merge changes due to significant changes on the master branch.

In addition, ```DustStorm``` now supports a description instead of relying upon the Settlement.

Part of #1324