### PR TITLE
Goods Manage Buy & Sell list are no longer transient

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/TradeCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/TradeCommand.java
@@ -36,8 +36,8 @@ public class TradeCommand extends AbstractSettlementCommand {
 	public static final ChatCommand TRADE = new TradeCommand();
 	private static final int COST_WIDTH = 10;
 	private static final String DEALS = "deals";
-	private static final String BUYING = "buying";
-	private static final String SELLING = "selling";
+	private static final String BUYING = "buy";
+	private static final String SELLING = "sell";
 
 	private TradeCommand() {
 		super("tr", "trade", "Trade deals of a Settlement");
@@ -81,8 +81,8 @@ public class TradeCommand extends AbstractSettlementCommand {
 		Collections.sort(ordered);						
 		for(Good good : ordered) {
 			ShoppingItem item = list.get(good);
-			response.appendTableRow(good.getName(), item.getQuantity(),
-						String.format(CommandHelper.MONEY_FORMAT, item.getPrice()));
+			response.appendTableRow(good.getName(), item.quantity(),
+						String.format(CommandHelper.MONEY_FORMAT, item.price()));
 		}
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/goods/CommerceUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/goods/CommerceUtil.java
@@ -57,7 +57,7 @@ public final class CommerceUtil {
 	 * Private constructor for utility class.
 	 */
 	private CommerceUtil() {
-	};
+	}
 
 	/**
 	 * Gets the best trade deal for a given settlement.
@@ -133,25 +133,20 @@ public final class CommerceUtil {
 	 * @return true if current trade mission between settlements.
 	 */
 	private static boolean hasCurrentCommerceMission(Settlement settlement1, Settlement settlement2) {
-		boolean result = false;
 
 		for(Mission mission : missionManager.getMissions()) {
 			if (mission instanceof CommerceMission) {
 				CommerceMission tradeMission = (CommerceMission) mission;
 				Settlement startingSettlement = tradeMission.getStartingSettlement();
 				Settlement tradingSettlement = tradeMission.getTradingSettlement();
-				if (startingSettlement.equals(settlement1) && tradingSettlement.equals(settlement2)) {
-					result = true;
-					break;
-				}
-				else if (startingSettlement.equals(settlement2) && tradingSettlement.equals(settlement1)) {
-					result = true;
-					break;
+				if ((startingSettlement.equals(settlement1) && tradingSettlement.equals(settlement2))
+					|| (startingSettlement.equals(settlement2) && tradingSettlement.equals(settlement1))) {
+					return true;
 				}
 			}
 		}
 
-		return result;
+		return false;
 	}
 
 	/**
@@ -272,11 +267,11 @@ public final class CommerceUtil {
 		for(Good good : unionGoods) {
 			ShoppingItem buy = buyList.get(good);
 			ShoppingItem sell = sellList.get(good);
-			if (buy.getPrice() <= sell.getPrice()) {
+			if (buy.price() <= sell.price()) {
 				continue;
 			}
 
-			int amountToTrade = Math.min(buy.getQuantity(), sell.getQuantity());
+			int amountToTrade = Math.min(buy.quantity(), sell.quantity());
 
 			boolean isAmountResource = good.getCategory() == GoodCategory.AMOUNT_RESOURCE;
 
@@ -311,7 +306,7 @@ public final class CommerceUtil {
 
 			extraMass += (good.getMassPerItem() * amountToTrade);
 			if (extraMass < massCapacity) {
-				costValue += buy.getPrice() * amountToTrade;
+				costValue += buy.price() * amountToTrade;
 				massCapacity -= extraMass;
 				if (tradeList.containsKey(good)) {
 					amountToTrade += tradeList.get(good);
@@ -357,7 +352,7 @@ public final class CommerceUtil {
 			if (prices != null) {
 				ShoppingItem sItem = prices.get(item.getKey());
 				if (sItem != null) {
-					itemPrice = sItem.getPrice();
+					itemPrice = sItem.price();
 				}
 			}
 			if (itemPrice == 0) {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/goods/GoodsManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/goods/GoodsManager.java
@@ -128,8 +128,6 @@ public class GoodsManager implements Serializable {
 	/** Initialized logger. */
 	private static SimLogger logger = SimLogger.getLogger(GoodsManager.class.getName());
 
-	private static final int CHECK_RESOURCES = 30;
-
 	// Number modifiers for outstanding repair and maintenance parts and EVA parts.
 	private static final int BASE_REPAIR_PART = 150;
 	private static final int BASE_MAINT_PART = 15;
@@ -172,8 +170,8 @@ public class GoodsManager implements Serializable {
 	/** A standard list of resources to be excluded in buying negotiation. */
 	private static Set<Good> unsellableGoods = null;
 	/** A standard list of buying resources in buying negotiation. */
-	private transient Map<Good, ShoppingItem> buyList =  Collections.emptyMap();
-	private transient Map<Good, ShoppingItem> sellList = Collections.emptyMap();
+	private Map<Good, ShoppingItem> buyList =  Collections.emptyMap();
+	private Map<Good, ShoppingItem> sellList = Collections.emptyMap();
 
 	private Set<Integer> reviewedEssentials = new HashSet<>();
 
@@ -876,11 +874,8 @@ public class GoodsManager implements Serializable {
 	public void destroy() {
 
 		settlement = null;
-		goodsValues.clear();
 		goodsValues = null;
-		demandCache.clear();
 		demandCache = null;
-		tradeCache.clear();
 		tradeCache = null;
 
 		deflationIndexMap = null;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/goods/ShoppingItem.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/goods/ShoppingItem.java
@@ -6,23 +6,11 @@
  */
 package com.mars_sim.core.goods;
 
+import java.io.Serializable;
+
 /**
  * An item in the shopping list holding the value and quantity
  */
-public class ShoppingItem {
-    private int quantity;
-    private double price;
-
-    ShoppingItem(int quantity, double price) {
-        this.quantity = quantity;
-        this.price = price;
-    }
-
-    public int getQuantity() {
-        return quantity;
-    }
-
-    public double getPrice() {
-        return price;
-    }
-}
+public record ShoppingItem(int quantity, double price) implements Serializable
+{}
+   


### PR DESCRIPTION
GoodsManager remembers the buy & sell lists during a save operation.  This means the lists re immediately available when a simulation is restored. Important if a commerce mission is active.

close #1118 