### PR TITLE
Add ability to queue manufacturing & salvage processes

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/UnitEventType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/UnitEventType.java
@@ -174,6 +174,7 @@ public enum UnitEventType {
 		return this.name;
 	}
 
+	@Override
 	public String toString() {
 		return this.name;
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/manufacture/ManufactureUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/manufacture/ManufactureUtil.java
@@ -320,6 +320,41 @@ public final class ManufactureUtil {
 	 * @return true if process can be started.
 	 * @throws Exception if error determining if process can be started.
 	 */
+	public static boolean canProcessBeQueued(ManufactureProcessInfo process, Manufacture workshop) {
+
+		// Q: Are the numbers of 3D printers available for another processes ?
+		// Check for workshop.getNumPrintersInUse()
+		// NOTE: create a map to show which process has a 3D printer in use and which doesn't
+
+		// Check to see if process tech level is above workshop tech level.
+		if (workshop.getTechLevel() < process.getTechLevelRequired()) {
+			return false;
+		}
+
+		Settlement settlement = workshop.getBuilding().getSettlement();
+
+		// Check to see if process input items are available at settlement.
+        if (!areProcessInputsAvailable(process, settlement)) {
+			return false;
+		}
+
+		// Check to see if room for process output items at settlement.
+		if (!canProcessOutputsBeStored(process, settlement)) {
+			return false;
+		}
+
+		return true;
+    }
+	
+	/**
+	 * Checks to see if a manufacturing process can be started at a given
+	 * manufacturing building.
+	 *
+	 * @param process  the manufacturing process to start.
+	 * @param workshop the manufacturing building.
+	 * @return true if process can be started.
+	 * @throws Exception if error determining if process can be started.
+	 */
 	public static boolean canProcessBeStarted(ManufactureProcessInfo process, Manufacture workshop) {
 		// Check to see if this workshop can accommodate another process.
 		if (workshop.getMaxProcesses() < workshop.getCurrentTotalProcesses()) {
@@ -351,6 +386,30 @@ public final class ManufactureUtil {
 		return true;
     }
 
+	/**
+	 * Checks to see if a salvage process can be started at a given manufacturing
+	 * building.
+	 *
+	 * @param process  the salvage process to start.
+	 * @param workshop the manufacturing building.
+	 * @return true if salvage process can be started.
+	 * @throws Exception if error determining if salvage process can be started.
+	 */
+	public static boolean canSalvageProcessBeQueued(SalvageProcessInfo process, Manufacture workshop) {
+
+        // Check to see if process tech level is above workshop tech level.
+		if (workshop.getTechLevel() < process.getTechLevelRequired()) {
+			return false;
+		}
+
+		// Check to see if a salvagable unit is available at the settlement.
+		if (findUnitForSalvage(process, workshop.getBuilding().getSettlement()) == null) {
+			return false;
+		}
+
+		return true;
+	}
+
 
 	/**
 	 * Checks to see if a salvage process can be started at a given manufacturing
@@ -362,7 +421,12 @@ public final class ManufactureUtil {
 	 * @throws Exception if error determining if salvage process can be started.
 	 */
 	public static boolean canSalvageProcessBeStarted(SalvageProcessInfo process, Manufacture workshop) {
-
+		// Check to see if this workshop can accommodate another process.
+		if (workshop.getMaxProcesses() < workshop.getCurrentTotalProcesses()) {
+			// NOTE: create a map to show which process has a 3D printer in use and which doesn't
+			return false;
+		}
+		
         // Check to see if process tech level is above workshop tech level.
 		if (workshop.getTechLevel() < process.getTechLevelRequired()) {
 			return false;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/SalvageGood.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/SalvageGood.java
@@ -59,6 +59,7 @@ public class SalvageGood extends Task {
 
 	/**
 	 * Constructor.
+	 * 
 	 * @param person the person to perform the task
 	 */
 	public SalvageGood(Person person) {
@@ -107,7 +108,8 @@ public class SalvageGood extends Task {
 	}
 
 	/**
-	 * Perform the salvaging phase.
+	 * Performs the salvaging phase.
+	 * 
 	 * @param time the time to perform (millisols)
 	 * @return remaining time after performing (millisols)
 	 */
@@ -161,6 +163,7 @@ public class SalvageGood extends Task {
 	/**
 	 * Gets an available manufacturing building that the person can use.
 	 * Returns null if no manufacturing building is currently available.
+	 * 
 	 * @param person the person
 	 * @return available manufacturing building
 	 */
@@ -193,6 +196,7 @@ public class SalvageGood extends Task {
 	/**
 	 * Gets a list of manufacturing buildings needing work from a list of buildings
 	 * with the manufacture function.
+	 * 
 	 * @param buildingList list of buildings with the manufacture function.
 	 * @param skill the materials science skill level of the person.
 	 * @return list of manufacture buildings needing work.
@@ -216,6 +220,7 @@ public class SalvageGood extends Task {
 
 	/**
 	 * Gets a subset list of manufacturing buildings with salvage processes requiring work.
+	 * 
 	 * @param buildingList the original building list.
 	 * @param skill the materials science skill level of the person.
 	 * @return subset list of buildings with processes requiring work, or original list if none found.
@@ -244,6 +249,7 @@ public class SalvageGood extends Task {
 
 	/**
 	 * Checks if manufacturing building has any salvage processes requiring work.
+	 * 
 	 * @param manufacturingBuilding the manufacturing building.
 	 * @param skill the materials science skill level of the person.
 	 * @return true if processes requiring work.
@@ -261,6 +267,20 @@ public class SalvageGood extends Task {
 			boolean skillRequired = (process.getInfo().getSkillLevelRequired() <= skill);
 			if (workRequired && skillRequired) {
 				result = true;
+				break;
+			}
+		}
+		
+		if (!result) {
+			Iterator<SalvageProcess> j = manufacturingFunction.getQueueSalvageProcesses().iterator();
+			while (j.hasNext()) {
+				SalvageProcess process = j.next();
+				boolean workRequired = (process.getWorkTimeRemaining() > 0D);
+				boolean skillRequired = (process.getInfo().getSkillLevelRequired() <= skill);
+				if (workRequired && skillRequired) {
+					result = true;
+					break;
+				}
 			}
 		}
 
@@ -270,6 +290,7 @@ public class SalvageGood extends Task {
 	/**
 	 * Gets a subset list of manufacturing buildings with the highest tech level from a list of buildings
 	 * with the manufacture function.
+	 * 
 	 * @param buildingList list of buildings with the manufacture function.
 	 * @return subset list of highest tech level buildings.
 	 */
@@ -303,6 +324,7 @@ public class SalvageGood extends Task {
 	/**
 	 * Gets the highest salvaging process goods value for the person and the
 	 * manufacturing building.
+	 * 
 	 * @param person the person to perform manufacturing.
 	 * @param manufacturingBuilding the manufacturing building.
 	 * @return highest process good value.
@@ -339,6 +361,7 @@ public class SalvageGood extends Task {
 	/**
 	 * Checks if a process type is currently running at a manufacturing
 	 * building.
+	 * 
 	 * @param processInfo the process type.
 	 * @param manufactureBuilding the manufacturing building.
 	 * @return true if process is running.
@@ -360,6 +383,7 @@ public class SalvageGood extends Task {
 
 	/**
 	 * Gets an available running salvage process.
+	 * 
 	 * @return process or null if none.
 	 */
 	private SalvageProcess getRunningSalvageProcess() {
@@ -373,14 +397,29 @@ public class SalvageGood extends Task {
 			if ((p.getInfo().getSkillLevelRequired() <= skillLevel) &&
 					(p.getWorkTimeRemaining() > 0D)) {
 				result = p;
+				break;
 			}
 		}
 
+		if (result == null) {
+			Iterator<SalvageProcess> j = workshop.getQueueSalvageProcesses().iterator();
+			while (i.hasNext() && (result == null)) {
+				SalvageProcess process = j.next();
+				if ((process.getInfo().getSkillLevelRequired() <= skillLevel) && (process.getWorkTimeRemaining() > 0D)) {
+					result = process;
+					workshop.loadFromSalvageQueue(process);
+					break;
+				}
+			}
+		}
+		
+		
 		return result;
 	}
 
 	/**
 	 * Creates a new salvage process if possible.
+	 * 
 	 * @return the new salvage process or null if none.
 	 */
 	private SalvageProcess createNewSalvageProcess() {
@@ -423,6 +462,7 @@ public class SalvageGood extends Task {
 
 	/**
 	 * Determines a salvage process used for the task.
+	 * 
 	 * @return salvage process or null if none determined.
 	 */
 	private SalvageProcess determineSalvageProcess() {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/task/ManufactureGood.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/task/ManufactureGood.java
@@ -272,8 +272,21 @@ public class ManufactureGood extends Task {
 		for (ManufactureProcess process : manufacturingBuilding.getManufacture().getProcesses()) {
 			boolean workRequired = (process.getWorkTimeRemaining() > 0D);
 			boolean skillRequired = (process.getInfo().getSkillLevelRequired() <= skill);
-			if (workRequired && skillRequired)
+			if (workRequired && skillRequired) {
 				result = true;
+				break;
+			}
+		}
+		
+		if (!result) {
+			for (ManufactureProcess process : manufacturingBuilding.getManufacture().getQueueManuProcesses()) {
+				boolean workRequired = (process.getWorkTimeRemaining() > 0D);
+				boolean skillRequired = (process.getInfo().getSkillLevelRequired() <= skill);
+				if (workRequired && skillRequired) {
+					result = true;
+					break;
+				}
+			}
 		}
 
 		return result;
@@ -427,7 +440,7 @@ public class ManufactureGood extends Task {
 				// Create a probability map and pick a process
 				process = createNewManufactureProcess();
 			}
-				
+			
 			if (process == null) {
 				endTask();
 			}
@@ -454,9 +467,22 @@ public class ManufactureGood extends Task {
 			ManufactureProcess process = i.next();
 			if ((process.getInfo().getSkillLevelRequired() <= skillLevel) && (process.getWorkTimeRemaining() > 0D)) {
 				result = process;
+				break;
 			}
 		}
 
+		if (result == null) {
+			Iterator<ManufactureProcess> j = workshop.getQueueManuProcesses().iterator();
+			while (i.hasNext() && (result == null)) {
+				ManufactureProcess process = j.next();
+				if ((process.getInfo().getSkillLevelRequired() <= skillLevel) && (process.getWorkTimeRemaining() > 0D)) {
+					result = process;
+					workshop.loadFromManuQueue(process);
+					break;
+				}
+			}
+		}
+		
 		return result;
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/task/ManufactureGoodMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/task/ManufactureGoodMeta.java
@@ -182,7 +182,7 @@ public class ManufactureGoodMeta extends MetaTask
                 	work = 100;
                 }
                 
-                RatingScore score = new RatingScore(100 + work);
+                RatingScore score = new RatingScore(100.0 + work);
                 
 	            score = applyCommerceFactor(score, settlement, CommerceType.MANUFACTURING);
 


### PR DESCRIPTION
09.11.2024

In Manufacture,
- new: add queueManuProcesses and queueSalvageProcesses
- new: add getQueueSalvageProcesses and getQueueManuProcesses

In SalvageGoodMeta,
- change: rework getTaskJobs() to call hasSalvageProcessRequiringWork()

In ManufactureGood,
- change: rework getRunningManufactureProcess() to load queue process

In TabPanelManufacture and BuildingPanelManufacture,
- change: rework createNewProcess(), getManufactureProcesses() getSalvageProcesses(), update()

In ManufactureGood,
- change: revise hasProcessRequiringWork()

In SalvageGood,
- change: revise hasSalvageProcessRequiringWork()

in SalvageGoodMeta,
- change: comment out checking for override

Relates to
1. https://github.com/mars-sim/mars-sim/issues/1410
2. https://github.com/mars-sim/mars-sim/issues/1236