### PR TITLE
Correct Sonarqube

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   sonarqube:
@@ -18,7 +16,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     
-    # Setup java 17
+    # Setup java 21
     - name: Setup Java JDK
       uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
This will prevent errors when a PR comes from a remote fork repo which does not have access to the security tokens