### PR TITLE
Improve EquipmentFactory

### DIFF
--- a/mars-sim-core/src/test/java/com/mars_sim/core/equipment/EquipmentFactoryTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/equipment/EquipmentFactoryTest.java
@@ -1,0 +1,25 @@
+package com.mars_sim.core.equipment;
+
+import static org.junit.Assert.assertNotEquals;
+
+import com.mars_sim.core.AbstractMarsSimUnitTest;
+
+public class EquipmentFactoryTest extends AbstractMarsSimUnitTest {
+    public void testCreateEquipment() {
+        var s = buildSettlement("Eqm");
+
+        for(EquipmentType et : EquipmentType.values()) {
+            var e = EquipmentFactory.createEquipment(et, s);
+            assertTrue(et.name() + " created in Settlement", s.getEquipmentSet().contains(e));
+            assertEquals(et.name() + " equipment type", et, e.getEquipmentType());
+        }
+    }
+
+    public void testGetEquipmentMass() {
+
+        for(EquipmentType et : EquipmentType.values()) {
+            var m = EquipmentFactory.getEquipmentMass(et);
+            assertNotEquals(et.name() + " valid mass", EquipmentFactory.DEFAULT_MASS, m);
+        }
+    }
+}


### PR DESCRIPTION
Rework the ```EquipmentFactory``` class to improve the code quality.

The logic is fragile because it depends upon certain Manufacturing Processes that are found by name. This may break if the name of the process is changed or when internationalise of configurations is applied. To protect against this there is a new UnitTest that flags if the mappings are broken.