### PR TITLE
Remove the displayUnit concept from UnitManager

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/UnitManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/UnitManager.java
@@ -140,7 +140,7 @@ public class UnitManager implements Serializable, Temporal {
 	 * @return
 	 */
 	private Map<Integer, ? extends Unit> getUnitMap(UnitType type) {
-		Map<Integer, ? extends Unit> map = switch (type) {
+		return switch (type) {
 			case PERSON -> lookupPerson;
 			case VEHICLE -> lookupVehicle;
 			case SETTLEMENT -> lookupSettlement;
@@ -150,7 +150,6 @@ public class UnitManager implements Serializable, Temporal {
 			case CONSTRUCTION -> lookupSite;
 			default -> throw new IllegalArgumentException("No Unit map for type " + type);
 		};
-        return map;
 	}
 
 	/**
@@ -326,16 +325,6 @@ public class UnitManager implements Serializable, Temporal {
 			default -> throw new IllegalArgumentException(
 					"Cannot store unit type:" + unit.getUnitType());
 		}
-			// switch (unit.getUnitType()) {
-			// 	case SETTLEMENT -> {
-			// 		lookupSettlement.put(unitIdentifier, (Settlement) unit);
-			// 		addDisplayUnit(unit);
-			// 	}
-
-			// 	case VEHICLE -> {
-			// 		lookupVehicle.put(unitIdentifier, (Vehicle) unit);
-			// 		addDisplayUnit(unit);
-			// 	}
 	}
 
 	/**
@@ -593,9 +582,6 @@ public class UnitManager implements Serializable, Temporal {
 		}
 		synchronized(listeners) {
 			listeners.computeIfAbsent(source, k -> new HashSet<>()).add(newListener);
-
-			// Over adding listeners?
-			//logger.info("Added Listener " + source + " #" + listeners.get(source).size() + " : " + newListener.toString());
 		}
 	}
 
@@ -732,17 +718,6 @@ public class UnitManager implements Serializable, Temporal {
 		setupTasks();
 	}
 
-//	/**
-//	 * Reinitializes instances after deserialization.
-//	 * 
-//	 * @param in
-//	 * @throws IOException
-//	 * @throws ClassNotFoundException
-//	 */
-//	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-//		in.defaultReadObject();
-//	}
-
 	/**
 	 * Prepares object for garbage collection.
 	 */
@@ -796,7 +771,6 @@ public class UnitManager implements Serializable, Temporal {
 
 		marsSurface = null;
 
-//		listeners.clear();
 		listeners = null;
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/UnitManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/UnitManager.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.mars_sim.core.authority.Authority;
-import com.mars_sim.core.data.UnitSet;
 import com.mars_sim.core.environment.MarsSurface;
 import com.mars_sim.core.environment.OuterSpace;
 import com.mars_sim.core.equipment.Equipment;
@@ -85,8 +84,6 @@ public class UnitManager implements Serializable, Temporal {
 	private transient Set<SettlementTask> settlementTasks = new HashSet<>();
 	/** Map of equipment types and their numbers. */
 	private Map<String, Integer> unitCounts = new HashMap<>();
-	/** A map of all map display units (settlements and vehicles). */
-	private Set<Unit> displayUnits;
 	/** A map of settlements with its unit identifier. */
 	private Map<Integer, Settlement> lookupSettlement;
 	/** A map of sites with its unit identifier. */
@@ -315,28 +312,30 @@ public class UnitManager implements Serializable, Temporal {
 	public synchronized void addUnit(Unit unit) {
 		int unitIdentifier = unit.getIdentifier();
 
-		if (unit != null) { // is it necessary?
-			switch (unit.getUnitType()) {
-				case SETTLEMENT -> {
-					lookupSettlement.put(unitIdentifier, (Settlement) unit);
-					addDisplayUnit(unit);
-				}
-				case PERSON -> lookupPerson.put(unitIdentifier, (Person) unit);
-				case ROBOT -> lookupRobot.put(unitIdentifier, (Robot) unit);
-				case VEHICLE -> {
-					lookupVehicle.put(unitIdentifier, (Vehicle) unit);
-					addDisplayUnit(unit);
-				}
-                case CONTAINER, EVA_SUIT -> lookupEquipment.put(unitIdentifier, (Equipment) unit);
-				case BUILDING -> lookupBuilding.put(unitIdentifier, (Building) unit);
-				case CONSTRUCTION -> lookupSite.put(unitIdentifier, (ConstructionSite) unit);
-				case MARS -> marsSurface = (MarsSurface) unit;
-				case OUTER_SPACE -> outerSpace = (OuterSpace) unit;
-				case MOON -> moon = (Moon) unit;
-				default -> throw new IllegalArgumentException(
-						"Cannot store unit type:" + unit.getUnitType());
-			}
+		switch(unit) {
+			case Settlement s -> lookupSettlement.put(unitIdentifier, s);
+			case Person p -> lookupPerson.put(unitIdentifier, p);
+			case Robot r -> lookupRobot.put(unitIdentifier, r);
+			case Vehicle v -> lookupVehicle.put(unitIdentifier, v);
+			case Equipment e -> lookupEquipment.put(unitIdentifier, e);
+			case Building b -> lookupBuilding.put(unitIdentifier, b);
+			case ConstructionSite c -> lookupSite.put(unitIdentifier, c);
+			case MarsSurface ms -> marsSurface = ms;
+			case OuterSpace os -> outerSpace = os;
+			case Moon m -> moon = m;
+			default -> throw new IllegalArgumentException(
+					"Cannot store unit type:" + unit.getUnitType());
 		}
+			// switch (unit.getUnitType()) {
+			// 	case SETTLEMENT -> {
+			// 		lookupSettlement.put(unitIdentifier, (Settlement) unit);
+			// 		addDisplayUnit(unit);
+			// 	}
+
+			// 	case VEHICLE -> {
+			// 		lookupVehicle.put(unitIdentifier, (Vehicle) unit);
+			// 		addDisplayUnit(unit);
+			// 	}
 	}
 
 	/**
@@ -580,27 +579,6 @@ public class UnitManager implements Serializable, Temporal {
 		return lookupEquipment.values().stream()
 				.filter(e -> e.getUnitType() == UnitType.EVA_SUIT)
 				.collect(Collectors.toSet());
-	}
-
-	/**
-	 * Adds the unit for display.
-	 *
-	 * @param unit
-	 */
-	private void addDisplayUnit(Unit unit) {
-		if (displayUnits == null)
-			displayUnits = new UnitSet<>();
-
-		displayUnits.add(unit);
-	}
-
-	/**
-	 * Obtains the settlement and vehicle units for map display.
-	 *
-	 * @return
-	 */
-	public Set<Unit> getDisplayUnits() {
-		return displayUnits;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/map/IntegerMapData.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/map/IntegerMapData.java
@@ -127,7 +127,7 @@ import com.mars_sim.core.map.location.Coordinates;
 			logger.config("GPU OpenCL accel enabled.");
 		} catch(Exception e) {
 			hardwareAccel = false;
-			logger.log(Level.SEVERE, "Exception with GPU OpenCL accel when loading kernel program. " + e.getMessage());
+			logger.log(Level.SEVERE, "Exception with GPU OpenCL accel when loading kernel program.", e);
 		}
  	}
 
@@ -372,16 +372,17 @@ import com.mars_sim.core.map.location.Coordinates;
  		
  		// Create an array of int RGB color values to create the map image from.
  		int[] mapArray = new int[mapBoxWidth * mapBoxHeight];
- 
+		var rendered = hardwareAccel;
 		if (hardwareAccel) {
 			try {
 				gpu(centerPhi, centerTheta, mapBoxWidth, mapBoxHeight, newRho, mapArray);
 			} catch(Exception e) {
 				hardwareAccel = false;
+				rendered = false; // Fallback to CPU
 				logger.log(Level.SEVERE, "Exception with GPU OpenCL accel when running gpu(). " + e.getMessage());
 			}
 		}
-		else {
+		if (!rendered) {
 			cpu0(centerPhi, centerTheta, mapBoxWidth, mapBoxHeight, newRho, mapArray);
 		}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionTravelStep.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionTravelStep.java
@@ -8,7 +8,6 @@ package com.mars_sim.core.mission;
 
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.map.location.Coordinates;
-import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.mission.NavPoint;
 import com.mars_sim.core.person.ai.mission.VehicleMission;
 import com.mars_sim.core.person.ai.task.util.Task;
@@ -74,7 +73,8 @@ public class MissionTravelStep extends MissionStep {
 
 		// Choose a driver
         boolean workedOn = false;
-        if (vehicle.getOperator() == null) {
+        var driver = vehicle.getOperator();
+        if ((driver == null) || driver.equals(worker)) {
             Task operateVehicleTask = createOperateVehicleTask(vehicle, worker);
             workedOn = assignTask(worker, operateVehicleTask);
         }
@@ -109,7 +109,7 @@ public class MissionTravelStep extends MissionStep {
     private Task createOperateVehicleTask(Vehicle vehicle, Worker worker) {
         if (vehicle instanceof GroundVehicle gv) {
             double coveredSoFar = getDistanceCovered();
-            return new DriveGroundVehicle((Person) worker, gv, destination.getLocation(),
+            return new DriveGroundVehicle(worker, gv, destination.getLocation(),
                                             getMission().getPhaseStartTime(), coveredSoFar);
         }
         else {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
@@ -1843,8 +1843,7 @@ public abstract class Vehicle extends MobileUnit
 	 * @return true if yes
 	 */
 	public boolean isOutsideOnMarsMission() {
-		return LocationStateType.MARS_SURFACE == currentStateType
-				|| LocationStateType.VEHICLE_VICINITY == currentStateType;
+		return (mission != null);
 	}
 
 	/**

--- a/mars-sim-core/src/test/java/com/mars_sim/core/TestSaving.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/TestSaving.java
@@ -8,10 +8,13 @@ import java.util.ArrayList;
 
 import com.mars_sim.core.configuration.Scenario;
 import com.mars_sim.core.configuration.ScenarioConfig;
+import com.mars_sim.core.equipment.EquipmentFactory;
+import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.health.Complaint;
 import com.mars_sim.core.person.health.ComplaintType;
 import com.mars_sim.core.person.health.MedicalManager;
+import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.SettlementBuilder;
 
 import junit.framework.TestCase;
@@ -43,6 +46,10 @@ public class TestSaving extends TestCase implements SimulationListener {
         Scenario bootstrap = config.getItem("Single Settlement");
         builder.createInitialSettlements(bootstrap);
         
+        // Add Equipment
+        Settlement s = (new ArrayList<>(sim.getUnitManager().getSettlements())).get(0);
+        EquipmentFactory.createEquipment(EquipmentType.BAG, s);
+
         // Find a person and add a medical complaint
         Complaint complaint = sim.getMedicalManager().getComplaintByName(ComplaintType.APPENDICITIS);
         Person p = (new ArrayList<>(sim.getUnitManager().getPeople())).get(0);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/equipment/EquipmentFactoryTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/equipment/EquipmentFactoryTest.java
@@ -12,6 +12,7 @@ public class EquipmentFactoryTest extends AbstractMarsSimUnitTest {
             var e = EquipmentFactory.createEquipment(et, s);
             assertTrue(et.name() + " created in Settlement", s.getEquipmentSet().contains(e));
             assertEquals(et.name() + " equipment type", et, e.getEquipmentType());
+            assertEquals(et.name() + " found in UnitManager", e, unitManager.getEquipmentByID(e.getIdentifier()));
         }
     }
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapMouseListener.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapMouseListener.java
@@ -1,0 +1,136 @@
+/*
+ * Mars Simulation Project
+ * MapMouseListener.java
+ * @date 2024-09-29
+ * @author Barry Evans
+ */
+package com.mars_sim.ui.swing.tool.map;
+
+import java.awt.Cursor;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.List;
+
+import javax.swing.SwingUtilities;
+
+import com.mars_sim.core.Unit;
+import com.mars_sim.core.UnitManager;
+import com.mars_sim.core.environment.Landmark;
+import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.ui.swing.MainDesktopPane;
+import com.mars_sim.ui.swing.unit_display_info.UnitDisplayInfo;
+import com.mars_sim.ui.swing.unit_display_info.UnitDisplayInfoFactory;
+
+/**
+ * This is a listener to mouse event on a MapPanel. It changes the cursor when hovered over a 
+ * surface unit or a landmark.
+ * If clicked the appropriate detailed window is shown.
+ */
+public class MapMouseListener extends MouseAdapter {
+
+    private UnitManager unitManager;
+    private MapPanel mapPanel;
+    private MainDesktopPane desktop;
+    	
+	private List<Landmark> landmarks;
+
+
+    public MapMouseListener(MainDesktopPane desktop, MapPanel mapPanel) {
+        var sim = desktop.getSimulation();
+        this.unitManager = sim.getUnitManager();
+        this.mapPanel = mapPanel;
+        this.desktop = desktop;
+        this.landmarks = sim.getConfig().getLandmarkConfiguration().getLandmarkList();
+    }
+
+    @Override
+    public void mouseClicked(MouseEvent event) {
+        if (SwingUtilities.isRightMouseButton(event) && event.getClickCount() == 1) {
+            checkClick(mapPanel.getMouseCoordinates(event.getX(), event.getY()));
+        }
+    }
+
+    /**
+	 * Checks the click location.
+	 * 
+	 * @param event
+	 */
+	private void checkClick(Coordinates clickedPosition) {
+
+		Unit foundMatch = findUnitUnderMouse(clickedPosition);
+		if (foundMatch != null) {
+			mapPanel.setCursor(new Cursor(Cursor.CROSSHAIR_CURSOR));
+			desktop.showDetails(foundMatch);
+		}
+		else
+			mapPanel.setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
+	}
+
+    @Override
+    public void mouseMoved(MouseEvent event) {
+        checkHover(mapPanel.getMouseCoordinates(event.getX(), event.getY()));
+    }
+
+    /**
+	 * Checks if the mouse is hovering over a map.
+	 * 
+	 * @param event
+	 */
+	protected void checkHover(Coordinates pos) {
+        // Check if over a object
+		Unit unit = findUnitUnderMouse(pos);
+		if (unit != null) {
+			mapPanel.setCursor(new Cursor(Cursor.CROSSHAIR_CURSOR));
+			return;
+		}
+
+		// FUTURE: how to avoid overlapping labels ?		
+		// Change mouse cursor if hovering over a landmark on the map
+		for(Landmark landmark : landmarks) {
+			double clickRange = Coordinates.computeDistance(landmark.getLandmarkCoord(), pos);
+			double unitClickRange = 20;
+			if (clickRange < unitClickRange) {
+				mapPanel.setCursor(new Cursor(Cursor.CROSSHAIR_CURSOR));
+				return;
+			}
+		}
+
+		mapPanel.setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
+	}
+
+	private Unit findUnitUnderMouse(Coordinates clickedPosition) {
+		// Check Settlements first
+		for(var s : unitManager.getSettlements()) {
+			if (isUnitAtPosition(s, clickedPosition)) {
+				return s;
+			}
+		}
+
+		// Check vehicles on surface
+		for(var v : unitManager.getVehicles()) {
+			if (v.isOutsideOnMarsMission() && isUnitAtPosition(v, clickedPosition)) {
+				return v;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Sets the cursor and open detail window of a unit.
+	 * 
+	 * @param unit
+	 * @param clickedPosition
+	 */
+	private boolean isUnitAtPosition(Unit unit, Coordinates clickedPosition) {
+		UnitDisplayInfo displayInfo = UnitDisplayInfoFactory.getUnitDisplayInfo(unit);
+		if (displayInfo != null && displayInfo.isMapDisplayed(unit)) {
+			Coordinates unitCoords = unit.getCoordinates();
+			double clickRange = unitCoords.getDistance(clickedPosition);
+			double unitClickRange = displayInfo.getMapClickRange();
+			if (clickRange < unitClickRange) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapPanel.java
@@ -230,16 +230,7 @@ public class MapPanel extends JPanel implements MouseWheelListener {
 		    g.drawRoundRect(0, 6, w, 6, 6, 6);
 		});
 
-        zoomSlider = new JSlider(SwingConstants.VERTICAL, 0, MAX_SLIDER, 25) {
-					// @Override
-					// public String getToolTipText() {
-					// 	if (marsMap == null)
-					// 		return "No map";
-					// 	return "Rho:" + marsMap.getRho() + " Scale:" + getScale()
-					// 			+ " Range:" + marsMap.getRhoRange()
-					// 			+ " default:" + marsMap.getRhoDefault();
-					// }
-				};
+        zoomSlider = new JSlider(SwingConstants.VERTICAL, 0, MAX_SLIDER, 25);
         zoomSlider.setLayout(new FlowLayout(FlowLayout.RIGHT, 5, 100));
         zoomSlider.setPreferredSize(new Dimension(60, 400));
         zoomSlider.setSize(new Dimension(60, 400));
@@ -648,8 +639,9 @@ public class MapPanel extends JPanel implements MouseWheelListener {
 	                	// Say if the location of a vehicle is updated
 	                	// it doesn't have to redraw the marsMap.
 	                	// It only have to redraw its map layer below
-	                	Iterator<MapLayer> i = mapLayers.iterator();
-	                	while (i.hasNext()) i.next().displayLayer(centerCoords, marsMap, g);
+	                	for( var i : mapLayers) {
+	                		i.displayLayer(centerCoords, marsMap, g);
+						}
               		
 		        		g2d.setBackground(Color.BLACK);
 	                }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/UnitMapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/UnitMapLayer.java
@@ -4,15 +4,12 @@
  * @date 2023-04-29
  * @author Scott Davis
  */
-
 package com.mars_sim.ui.swing.tool.map;
 
 import java.awt.Graphics;
-import java.util.ArrayList;
 import java.util.Collection;
 
 import com.mars_sim.core.Unit;
-import com.mars_sim.core.UnitType;
 import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.tool.SimulationConstants;
@@ -30,7 +27,7 @@ abstract class UnitMapLayer implements MapLayer, SimulationConstants {
 	private static long blinkTime = 0L;
 	private Collection<Settlement> unitsToDisplay;
 
-	public UnitMapLayer() {
+	protected UnitMapLayer() {
 		blinkFlag = false;
 	}
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/MiningSitePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/MiningSitePanel.java
@@ -32,11 +32,11 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 
-import com.mars_sim.core.Unit;
 import com.mars_sim.core.environment.ExploredLocation;
 import com.mars_sim.core.environment.SurfaceFeatures;
 import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.map.location.IntPoint;
+import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.ui.swing.MarsPanelBorder;
 import com.mars_sim.ui.swing.NumberCellRenderer;
 import com.mars_sim.ui.swing.StyleManager;
@@ -107,7 +107,7 @@ public class MiningSitePanel extends WizardPanel {
 		JPanel centerPane = new JPanel(new BorderLayout(0, 0));
 		centerPane.setAlignmentX(Component.CENTER_ALIGNMENT);
 		centerPane.setMaximumSize(new Dimension(Short.MAX_VALUE, 350));
-		add(centerPane);//, BorderLayout.CENTER);
+		add(centerPane);
 
 		JPanel mapPanel = new JPanel(new BorderLayout(0, 0));//FlowLayout(FlowLayout.CENTER, 0, 0));
 		mapPanel.setBorder(new MarsPanelBorder());
@@ -205,7 +205,7 @@ public class MiningSitePanel extends WizardPanel {
 		
 		JPanel bottomPane = new JPanel(new FlowLayout(FlowLayout.CENTER, 0, 0));
 		bottomPane.setAlignmentX(Component.CENTER_ALIGNMENT);
-		add(bottomPane);//, BorderLayout.SOUTH);
+		add(bottomPane);
 		
 		// Create vertical glue.
 		bottomPane.add(Box.createVerticalGlue());
@@ -278,7 +278,7 @@ public class MiningSitePanel extends WizardPanel {
 	 */
 	void updatePanel() {
 		try {
-			Collection<Unit> unitsToDisplay = new ArrayList<Unit>(1);
+			Collection<Settlement> unitsToDisplay = new ArrayList<>(1);
 			unitsToDisplay.add(getWizard().getMissionData().getStartingSettlement());
 			unitIconLayer.setUnitsToDisplay(unitsToDisplay);
 			unitLabelLayer.setUnitsToDisplay(unitsToDisplay);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/navigator/NavigatorWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/navigator/NavigatorWindow.java
@@ -9,7 +9,6 @@ package com.mars_sim.ui.swing.tool.navigator;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
@@ -17,9 +16,6 @@ import java.awt.GridLayout;
 import java.awt.Image;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseMotionAdapter;
 import java.awt.image.MemoryImageSource;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -57,13 +53,10 @@ import com.formdev.flatlaf.extras.components.FlatToggleButton;
 import com.mars_sim.core.GameManager;
 import com.mars_sim.core.GameManager.GameMode;
 import com.mars_sim.core.Simulation;
-import com.mars_sim.core.SimulationConfig;
-import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitManager;
 import com.mars_sim.core.UnitManagerEventType;
 import com.mars_sim.core.UnitManagerListener;
 import com.mars_sim.core.UnitType;
-import com.mars_sim.core.environment.Landmark;
 import com.mars_sim.core.environment.TerrainElevation;
 import com.mars_sim.core.map.IntegerMapData;
 import com.mars_sim.core.map.MapDataFactory;
@@ -72,7 +65,6 @@ import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.tool.Msg;
-import com.mars_sim.core.vehicle.Vehicle;
 import com.mars_sim.ui.swing.ConfigurableWindow;
 import com.mars_sim.ui.swing.JComboBoxMW;
 import com.mars_sim.ui.swing.MainDesktopPane;
@@ -82,6 +74,7 @@ import com.mars_sim.ui.swing.tool.map.ExploredSiteMapLayer;
 import com.mars_sim.ui.swing.tool.map.LandmarkMapLayer;
 import com.mars_sim.ui.swing.tool.map.MapDisplay;
 import com.mars_sim.ui.swing.tool.map.MapLayer;
+import com.mars_sim.ui.swing.tool.map.MapMouseListener;
 import com.mars_sim.ui.swing.tool.map.MapPanel;
 import com.mars_sim.ui.swing.tool.map.MineralMapLayer;
 import com.mars_sim.ui.swing.tool.map.NavpointMapLayer;
@@ -90,8 +83,6 @@ import com.mars_sim.ui.swing.tool.map.UnitIconMapLayer;
 import com.mars_sim.ui.swing.tool.map.UnitLabelMapLayer;
 import com.mars_sim.ui.swing.tool.map.VehicleTrailMapLayer;
 import com.mars_sim.ui.swing.tool_window.ToolWindow;
-import com.mars_sim.ui.swing.unit_display_info.UnitDisplayInfo;
-import com.mars_sim.ui.swing.unit_display_info.UnitDisplayInfoFactory;
 
 /**
  * The NavigatorWindow is a tool window that displays a map and a globe showing
@@ -189,8 +180,6 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 	
 	private transient UnitManagerListener umListener;
 	
-	private List<Landmark> landmarks;
-	
 	/** The map panel class for holding all the map layers. */
 	private MapPanel mapPanel;
 
@@ -211,7 +200,6 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 		super(NAME, TITLE, desktop);
 
 		Simulation sim = desktop.getSimulation();
-		this.landmarks = SimulationConfig.instance().getLandmarkConfiguration().getLandmarkList();
 		this.unitManager = sim.getUnitManager();
 	
 		// Prepare content pane		
@@ -231,8 +219,17 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 		mapPanel.setPreferredSize(new Dimension(MAP_BOX_WIDTH, MAP_BOX_WIDTH));
 		
 		mapPanel.setMouseDragger(true);
-		mapPanel.addMouseListener(new MouseListener());
-		mapPanel.addMouseMotionListener(new MouseMotionListener());
+
+		// Create a mouse listener to show Units. But update status bar on hover
+		var mapListner = new MapMouseListener(desktop, mapPanel) {
+			@Override
+			protected void checkHover(Coordinates clickedPosition) {
+				updateStatusBar(clickedPosition);
+				super.checkHover(clickedPosition);
+			}
+		};
+		mapPanel.addMouseListener(mapListner);
+		mapPanel.addMouseMotionListener(mapListner);
 		
 		// Create map layers.
 		createMapLayer(DAYLIGHT_LAYER, 0, new ShadingMapLayer(mapPanel));
@@ -654,14 +651,16 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 	/**
 	 * Updates the labels on the status bar.
 	 * 
-	 * @param scale
-	 * @param phi
-	 * @param theta
-	 * @param rho
-	 * @param height
-	 * @param coord
+	 * @param pos New positional Coordinate
 	 */
-	private void updateStatusBar(double scale, double phi, double theta, double rho, double height, String coord) {
+	private void updateStatusBar(Coordinates pos) {
+		double phi = pos.getPhi();
+		double theta = pos.getTheta();			
+		double height = TerrainElevation.getMOLAElevation(phi, theta);
+		double scale = mapPanel.getScale();
+		var coord = pos.getFormattedString();
+		double rho = mapPanel.getRho();
+
 		coordLabel.setText(WHITESPACE + coord);
 
 		phiLabel.setText(PHI + StyleManager.DECIMAL_PLACES3.format(phi));
@@ -1033,145 +1032,6 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 		Image image = displayComponent.createImage(new MemoryImageSource(10, 10, imageArray, 0, 10));
 		return new ImageIcon(image);
 	}
-
-	private class MouseListener extends MouseAdapter {
-		@Override
-		public void mouseClicked(MouseEvent event) {
-			if (SwingUtilities.isRightMouseButton(event) && event.getClickCount() == 1) {
-				checkClick(event);
-            }
-		}
-	}
-
-	private class MouseMotionListener extends MouseMotionAdapter {
-		@Override
-		public void mouseMoved(MouseEvent event) {
-			checkHover(event);
-		}
-	}
-
-	/**
-	 * Checks the click location.
-	 * 
-	 * @param event
-	 */
-	public void checkClick(MouseEvent event) {
-
-		Coordinates mapCenter = mapPanel.getCenterLocation();
-		if (mapCenter == null) {
-			return;
-		}
-		
-		Coordinates clickedPosition = mapPanel.getMouseCoordinates(event.getX(), event.getY());
-
-		Iterator<Unit> i = unitManager.getDisplayUnits().iterator();
-
-		// Open window if unit is clicked on the map
-		while (i.hasNext()) {
-			Unit unit = i.next();
-			
-			if ((unit.getUnitType() == UnitType.VEHICLE) && ((Vehicle)unit).isOutsideOnMarsMission()) {
-				// Proceed to below to set cursor
-				setCursorOpenWindow(unit, clickedPosition);
-			}
-		}
-	}
-
-	/**
-	 * Sets the cursor and open detail window of a unit.
-	 * 
-	 * @param unit
-	 * @param clickedPosition
-	 */
-	private void setCursorOpenWindow(Unit unit, Coordinates clickedPosition) {
-		UnitDisplayInfo displayInfo = UnitDisplayInfoFactory.getUnitDisplayInfo(unit);
-		if (displayInfo != null && displayInfo.isMapDisplayed(unit)) {
-			Coordinates unitCoords = unit.getCoordinates();
-			double clickRange = unitCoords.getDistance(clickedPosition);
-			double unitClickRange = displayInfo.getMapClickRange();
-			if (clickRange < unitClickRange) {
-				mapPanel.setCursor(new Cursor(Cursor.CROSSHAIR_CURSOR));
-				desktop.showDetails(unit);
-			} else
-				mapPanel.setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
-		}
-	}
-	
-	/**
-	 * Checks if the mouse is hovering over a map.
-	 * 
-	 * @param event
-	 */
-	public void checkHover(MouseEvent event) {
-
-		Coordinates mapCenter = mapPanel.getCenterLocation();
-		if (mapCenter == null) {
-			return;
-		}
-		
-		Coordinates pos = mapPanel.getMouseCoordinates(event.getX(), event.getY());
-
-		double phi = pos.getPhi();
-		double theta = pos.getTheta();			
-		double h0 = TerrainElevation.getMOLAElevation(phi, theta);
-		double scale = mapPanel.getScale();
-		
-		updateStatusBar(scale, phi, theta, mapPanel.getRho(), h0, pos.getFormattedString());
-
-		checkOnTarget(pos);
-	}
-
-	/**
-	 * Finds a target.
-	 * 
-	 * @param pos
-	 */
-	private void checkOnTarget(Coordinates pos) {
-		boolean onTarget = false;
-
-		Iterator<Unit> i = unitManager.getDisplayUnits().iterator();
-
-		// Change mouse cursor if hovering over an unit on the map
-		while (i.hasNext()) {
-			Unit unit = i.next();
-			if (unit.getUnitType() == UnitType.VEHICLE) {
-				if (((Vehicle)unit).isOutsideOnMarsMission()) {
-					// Proceed to below to set cursor
-					mapPanel.setCursor(new Cursor(Cursor.CROSSHAIR_CURSOR));
-				}
-				else 
-					continue;
-			}
-			
-			UnitDisplayInfo displayInfo = UnitDisplayInfoFactory.getUnitDisplayInfo(unit);
-			if (displayInfo != null && displayInfo.isMapDisplayed(unit)) {
-				double clickRange = Coordinates.computeDistance(unit.getCoordinates(), pos);
-				double unitClickRange = displayInfo.getMapClickRange();
-				if (clickRange < unitClickRange) {
-					mapPanel.setCursor(new Cursor(Cursor.CROSSHAIR_CURSOR));
-					onTarget = true;
-				}
-			}
-		}
-
-		// FUTURE: how to avoid overlapping labels ?
-		
-		// Change mouse cursor if hovering over a landmark on the map
-		Iterator<Landmark> j = landmarks.iterator();
-		while (j.hasNext()) {
-			Landmark landmark = j.next();
-			double clickRange = Coordinates.computeDistance(landmark.getLandmarkCoord(), pos);
-			double unitClickRange = 20;
-			if (clickRange < unitClickRange) {
-				mapPanel.setCursor(new Cursor(Cursor.CROSSHAIR_CURSOR));
-				onTarget = true;
-			}
-		}
-
-		if (!onTarget) {
-			mapPanel.setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
-		}
-	}
 	
 	/**
 	 * Updates the map with time pulse.
@@ -1252,7 +1112,6 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 		thetaLabel = null;
 
 		mapLayers  = null;
-		landmarks = null;
 		mapPanel = null;
 		mineralLayer = null;
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_display_info/SettlementDisplayInfoBean.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_display_info/SettlementDisplayInfoBean.java
@@ -22,7 +22,7 @@ import java.awt.Font;
 class SettlementDisplayInfoBean implements UnitDisplayInfo {
 
     // Navigator click range in km.
-    private static double SETTLEMENT_CLICK_RANGE = 50D;
+    private static final double SETTLEMENT_CLICK_RANGE = 20D;
         
     private Icon buttonIcon;
     private Font mapLabelFont;

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_display_info/VehicleDisplayInfoBean.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_display_info/VehicleDisplayInfoBean.java
@@ -27,7 +27,7 @@ import com.mars_sim.ui.swing.ImageLoader;
 abstract class VehicleDisplayInfoBean implements UnitDisplayInfo {
     
     // Navigator click range in km.
-    private static double VEHICLE_CLICK_RANGE = 40D;
+    private static final double VEHICLE_CLICK_RANGE = 20D;
     
     // Data members
     private Icon blackMapIcon;


### PR DESCRIPTION
This removes the displayUnit concept from the ```UnitManager```. This is a UI concept and should not be in the core module.
The specific layers that use display units now explicitly render Settlements and Vehicles.

A new ```MapMouseListener```class  is created that centralises the mouse selection logic in the Navigator window and NavPointPanel. 

close #1408 