### PR TITLE
Fix defect when restarting save sim

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/mineral/MineralMap.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mineral/MineralMap.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.map.location.SurfaceManager;
 import com.mars_sim.core.tool.RandomUtil;
@@ -87,14 +86,16 @@ public class MineralMap implements Serializable {
 	// A map of all mineral concentrations
 	private SurfaceManager<MineralDeposit> allMinerals;
 	
-	private transient MineralMapConfig mineralMapConfig;
+	private List<MineralType> types;
 	
 	/**
-	 * Constructor.
+	 * Create a mineral map that is based on a configuration
+	 * @param mineralMapConfig Defines details of map
 	 */
-	MineralMap() {
-		// A bit nasty
-		mineralMapConfig = SimulationConfig.instance().getMineralMapConfiguration();
+	MineralMap(MineralMapConfig mineralMapConfig) {
+		// Types are locked down when te map is created
+		types = mineralMapConfig.getMineralTypes();
+
 		allMinerals = new SurfaceManager<>();
 	}
 
@@ -151,7 +152,7 @@ public class MineralMap implements Serializable {
 	 * @return
 	 */
 	public List<MineralType> getTypes() {
-		return mineralMapConfig.getMineralTypes();
+		return types;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mineral/RandomMineralFactory.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mineral/RandomMineralFactory.java
@@ -102,7 +102,10 @@ public final class RandomMineralFactory {
 	 */
 	public static MineralMap createRandomMap() {
 	
-		var newMap = new MineralMap();
+		// Should be passed in as argument
+		var mineralMapConfig = SimulationConfig.instance().getMineralMapConfiguration();
+
+		var newMap = new MineralMap(mineralMapConfig);
 
 		// Add random mineral to the map using potential Location based on the type of mineral
 		addRandomMinerals(newMap, 0, 100, new LocationSelector());
@@ -123,10 +126,8 @@ public final class RandomMineralFactory {
 	private static void addRandomMinerals(MineralMap newMap, int lowerBaseCon, int highBaseConc,
 						Function<MineralType,List<Coordinates>> locator) {
 
-		// Should be passed in as argument
-		var mineralMapConfig = SimulationConfig.instance().getMineralMapConfiguration();
 		
-		List<MineralType> minerals = new ArrayList<>(mineralMapConfig.getMineralTypes());
+		List<MineralType> minerals = new ArrayList<>(newMap.getTypes());
 		
 		Collections.shuffle(minerals);
 		for(var mineralType : minerals) {		

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mineral/MineralMapTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mineral/MineralMapTest.java
@@ -15,7 +15,7 @@ public class MineralMapTest extends AbstractMarsSimUnitTest {
         var type2 = minerals.get(1);
         Set<String> all = Set.of(type1.getName(), type2.getName());
 
-        MineralMap newMap = new MineralMap();
+        MineralMap newMap = new MineralMap(config);
 
         var center = new Coordinates("3 S", "67 E");
         
@@ -37,7 +37,7 @@ public class MineralMapTest extends AbstractMarsSimUnitTest {
         var type2 = minerals.get(1);
         Set<String> all = Set.of(type1.getName(), type2.getName());
 
-        MineralMap newMap = new MineralMap();
+        MineralMap newMap = new MineralMap(config);
 
         var center = new Coordinates("3 S", "67 E");
         

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mineral/RandomMineralFactoryTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mineral/RandomMineralFactoryTest.java
@@ -7,7 +7,7 @@ import com.mars_sim.core.map.location.Coordinates;
 
 public class RandomMineralFactoryTest extends AbstractMarsSimUnitTest {
     public void testCreateLocalConcentration() {
-        var newMap = new MineralMap();
+        var newMap = new MineralMap(simConfig.getMineralMapConfiguration());
 
         var center = new Coordinates("30 N", "25 W");
         RandomMineralFactory.createLocalConcentration(newMap, center);


### PR DESCRIPTION
Problem is the MineralMap looses the handle to the MineralMapConfig. The mineral types should be locked down into the map when it is created.

Changes:
- MineralMap retains the minteral types and does not rely on config object
- Update tests

Relates to #1385