### PR TITLE
Use Worker in TaskManager

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/Equipment.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/Equipment.java
@@ -25,14 +25,14 @@ import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.building.Building;
 import com.mars_sim.core.structure.building.Indoor;
 import com.mars_sim.core.structure.building.task.MaintainBuilding;
-import com.mars_sim.core.unit.MobileUnit;
+import com.mars_sim.core.unit.AbstractMobileUnit;
 import com.mars_sim.core.vehicle.Vehicle;
 
 /**
  * The Equipment class is an abstract class that represents a useful piece of
  * equipment, such as a kit, a container, an EVA suit or a medpack.
  */
-public abstract class Equipment extends MobileUnit implements Indoor, Salvagable {
+public abstract class Equipment extends AbstractMobileUnit implements Indoor, Salvagable {
 
 	/** Default serial id. */
 	private static final long serialVersionUID = 1L;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
@@ -79,7 +79,7 @@ import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.MarsTime;
 import com.mars_sim.core.time.Temporal;
 import com.mars_sim.core.tool.RandomUtil;
-import com.mars_sim.core.unit.MobileUnit;
+import com.mars_sim.core.unit.AbstractMobileUnit;
 import com.mars_sim.core.vehicle.Crewable;
 import com.mars_sim.core.vehicle.Rover;
 import com.mars_sim.core.vehicle.Vehicle;
@@ -88,7 +88,7 @@ import com.mars_sim.core.vehicle.Vehicle;
  * The Person class represents a person on Mars. It keeps track of everything
  * related to that person and provides information about him/her.
  */
-public class Person extends MobileUnit implements Worker, Temporal, Appraiser {
+public class Person extends AbstractMobileUnit implements Worker, Temporal, Appraiser {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/PersonTaskManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/PersonTaskManager.java
@@ -240,12 +240,9 @@ public class PersonTaskManager extends TaskManager {
 		return selectedMissionRating;
 	}
 	
-	
-	@Override
 	public void reinit() {
 		person = mind.getPerson();
-		worker = person;
-		super.reinit();
+		super.reinit(person);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/TaskManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/TaskManager.java
@@ -13,7 +13,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import com.mars_sim.core.Simulation;
 import com.mars_sim.core.SimulationConfig;
-import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitEventType;
 import com.mars_sim.core.data.History;
 import com.mars_sim.core.data.RatingLog;
@@ -43,7 +42,7 @@ public abstract class TaskManager implements Serializable {
 	private static MasterClock master;
 
 	/**The worker **/
-	protected transient Unit worker;
+	private transient Worker worker;
 	/** The current task the worker is doing. */
 	private Task currentTask;
 	private RatingScore currentScore;
@@ -51,7 +50,6 @@ public abstract class TaskManager implements Serializable {
 	/** The last task the person was doing. */
 	private Task lastTask;
 
-//	private transient TaskCache taskProbCache = null;
 	private transient CacheCreator<TaskJob> taskProbCache = null;
 
 
@@ -65,7 +63,7 @@ public abstract class TaskManager implements Serializable {
 	 * 
 	 * @param worker
 	 */
-	protected TaskManager(Unit worker) {
+	protected TaskManager(Worker worker) {
 		this.worker = worker;
 		allActivities = new History<>(150);   // Equivalent of 3 days
 		pendingTasks = new CopyOnWriteArrayList<>();
@@ -231,7 +229,7 @@ public abstract class TaskManager implements Serializable {
 		if (currentTask != null) {
 			currentTask.endTask();
 			currentTask = null;
-			worker.fireUnitUpdate(UnitEventType.TASK_EVENT);
+			worker.fireUnitUpdate(UnitEventType.TASK_EVENT, null);
 		}
 	}
 
@@ -699,11 +697,12 @@ public abstract class TaskManager implements Serializable {
 	/**
 	 * Re-initializes instances when loading from a saved sim
 	 */
-	public void reinit() {
+	protected void reinit(Worker worker) {
 		if (currentTask != null)		
 			currentTask.reinit();
 		if (lastTask != null)
 			lastTask.reinit();
+		this.worker = worker;
 	}
 	
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/Worker.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/Worker.java
@@ -7,22 +7,20 @@
 
 package com.mars_sim.core.person.ai.task.util;
 
+import com.mars_sim.core.UnitEventType;
 import com.mars_sim.core.UnitIdentifer;
 import com.mars_sim.core.UnitListener;
 import com.mars_sim.core.UnitType;
 import com.mars_sim.core.equipment.EquipmentOwner;
-import com.mars_sim.core.map.location.Coordinates;
-import com.mars_sim.core.map.location.LocalPosition;
 import com.mars_sim.core.person.ai.NaturalAttributeManager;
 import com.mars_sim.core.person.ai.SkillOwner;
 import com.mars_sim.core.person.ai.mission.Mission;
 import com.mars_sim.core.structure.Settlement;
-import com.mars_sim.core.structure.building.Building;
 import com.mars_sim.core.structure.building.function.ActivitySpot;
 import com.mars_sim.core.structure.building.function.ActivitySpot.AllocatedSpot;
-import com.mars_sim.core.vehicle.Vehicle;
+import com.mars_sim.core.unit.MobileUnit;
 
-public interface Worker extends UnitIdentifer, EquipmentOwner, SkillOwner {
+public interface Worker extends UnitIdentifer, EquipmentOwner, SkillOwner, MobileUnit {
 
 	/**
 	 * Returns a reference to the Worker natural attribute manager
@@ -30,7 +28,6 @@ public interface Worker extends UnitIdentifer, EquipmentOwner, SkillOwner {
 	 * @return the person's natural attribute manager
 	 */
 	public NaturalAttributeManager getNaturalAttributeManager();
-
 
 	/**
 	 * Gets the workers name.
@@ -47,60 +44,11 @@ public interface Worker extends UnitIdentifer, EquipmentOwner, SkillOwner {
 	public String getTaskDescription();
 
 	/**
-	 * Gets the coordinates on Mars surface.
-	 * 
-	 * @return
-	 */
-	public Coordinates getCoordinates();
-
-	/**
-	 * Is the worker in a vehicle ?
-	 *
-	 * @return true if the worker in a vehicle
-	 */
-	public boolean isInVehicle();
-
-	/**
-	 * Gets vehicle worker is in, null if member is not in vehicle/
-	 *
-	 * @return the worker's vehicle
-	 */
-	public Vehicle getVehicle();
-
-	/**
 	 * Is the worker inside a vehicle in a garage ?
 	 * 
 	 * @return
 	 */
 	public boolean isInVehicleInGarage();
-	
-	/**
-	 * Is the worker in a settlement ?
-	 *
-	 * @return true if the worker in a settlement
-	 */
-	public boolean isInSettlement();
-
-	/**
-	 * Gets the current Settlement of the worker; may be different from the associated Settlement.
-	 * 
-	 * @return
-	 */
-	public Settlement getSettlement();
-	
-	/**
-	 * Gets the Worker's building.
-	 * 
-	 * @return building
-	 */
-	public Building getBuildingLocation();
-	
-	/**
-	 * Is the Worker outside ?
-	 *
-	 * @return true if the worker is on the MarsSurface
-	 */
-	public boolean isOutside();
 
 	/**
 	 * Is the worker outside of a settlement but within its vicinity ?
@@ -130,7 +78,6 @@ public interface Worker extends UnitIdentifer, EquipmentOwner, SkillOwner {
 	 */
 	public void removeUnitListener(UnitListener oldListener);
 
-
 	/**
 	 * What is the Mission this Worker is performing.
 	 * 
@@ -144,27 +91,6 @@ public interface Worker extends UnitIdentifer, EquipmentOwner, SkillOwner {
 	 * @param newMission the new mission
 	 */
 	public void setMission(Mission newMission);
-
-	/**
-	 * Gets the Worker's position within the Settlement/Vehicle.
-	 * 
-	 * @return
-	 */
-	public LocalPosition getPosition();
-	
-	/**
-	 * Sets the worker's position at a settlement.
-	 *
-	 * @param position
-	 */
-	public void setPosition(LocalPosition position);
-
-	/**
-	 * Sets the building the worker is located at.
-	 *
-	 * @param position
-	 */
-	public void setCurrentBuilding(Building building);
 
 	/**
 	 * Gets the manager of the Worker's Tasks.
@@ -193,4 +119,12 @@ public interface Worker extends UnitIdentifer, EquipmentOwner, SkillOwner {
 	 * @return
 	 */
 	public AllocatedSpot getActivitySpot();
+
+	/**
+	 * Fires a unit update event.
+	 *
+	 * @param updateType the update type.
+	 * @param target     the event target object or null if none.
+	 */
+	public void fireUnitUpdate(UnitEventType updateType, Object target);
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/robot/Robot.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/robot/Robot.java
@@ -52,13 +52,13 @@ import com.mars_sim.core.structure.building.function.SystemType;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.Temporal;
 import com.mars_sim.core.tool.RandomUtil;
-import com.mars_sim.core.unit.MobileUnit;
+import com.mars_sim.core.unit.AbstractMobileUnit;
 import com.mars_sim.core.vehicle.Crewable;
 
 /**
  * The robot class represents operating a robot on Mars.
  */
-public class Robot extends MobileUnit implements Salvagable, Temporal, Malfunctionable, Worker {
+public class Robot extends AbstractMobileUnit implements Salvagable, Temporal, Malfunctionable, Worker {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
@@ -214,14 +214,12 @@ public class Robot extends MobileUnit implements Salvagable, Temporal, Malfuncti
         return LocationStateType.SETTLEMENT_VICINITY == currentStateType;
     }
 
-	// TODO: allow parts to be recycled
-	public void toBeSalvaged() {
+	private void toBeSalvaged() {
 		((Settlement)getContainerUnit()).removeOwnedRobot(this);
 		isInoperable = true;
 	}
 
-	// TODO: allow robot parts to be stowed in storage
-	void setInoperable() {
+	private  void setInoperable() {
 		// set description for this robot
 		super.setDescription(getDescription().replace(OPERABLE, INOPERABLE));
 		botMind.setInactive();
@@ -386,22 +384,13 @@ public class Robot extends MobileUnit implements Salvagable, Temporal, Malfuncti
 	}
 
 	/**
-	 * Gets the name of the vehicle operator
-	 *
-	 * @return vehicle operator name.
-	 */
-	public String getOperatorName() {
-		return getName();
-	}
-
-	/**
 	 * Gets a collection of people affected by this malfunction bots
 	 *
 	 * @return person collection
 	 */
+	@Override
 	public Collection<Person> getAffectedPeople() {
 		return getBuildingLocation().getAffectedPeople();
-		// TODO: associate each bot with its owner
 	}
 
 	/**
@@ -555,8 +544,6 @@ public class Robot extends MobileUnit implements Salvagable, Temporal, Malfuncti
 	 */
 	@Override
 	public double getMass() {
-		// TODO because the PErson is not fully initialised in the constructor this
-		// can be null. The initialise method is the culprit.
 		return (eqmInventory != null ? eqmInventory.getStoredMass() : 0) + getBaseMass();
 
 	}
@@ -957,7 +944,7 @@ public class Robot extends MobileUnit implements Salvagable, Temporal, Malfuncti
 
 		// Check if the origin is a vehicle
 		if (ut == UnitType.VEHICLE) {
-			if (cu instanceof Crewable c) { //!((Vehicle)cu instanceof Drone)) {
+			if (cu instanceof Crewable c) {
 				transferred = c.removeRobot(this);
 			}
 			else {
@@ -983,7 +970,7 @@ public class Robot extends MobileUnit implements Salvagable, Temporal, Malfuncti
 		else {
 			// Check if the destination is a vehicle
 			if (destination.getUnitType() == UnitType.VEHICLE) {
-				if (destination instanceof Crewable c) { //!((Vehicle)destination instanceof Drone)) {
+				if (destination instanceof Crewable c) {
 					transferred = c.addRobot(this);
 				}
 				else {
@@ -1001,7 +988,7 @@ public class Robot extends MobileUnit implements Salvagable, Temporal, Malfuncti
 				transferred = ((Building)destination).getSettlement().addRobotsWithin(this);
 				// Turn a building destination to a settlement to avoid 
 				// casting issue with making containerUnit a building instance
-				destination = (((Building)destination)).getSettlement();
+				destination = ((Building)destination).getSettlement();
 			}
 
 			if (!transferred) {
@@ -1026,6 +1013,7 @@ public class Robot extends MobileUnit implements Salvagable, Temporal, Malfuncti
 	 *
 	 * @return hash code.
 	 */
+	@Override
 	public int hashCode() {
 		int hashCode = getIdentifier();
 		hashCode *= getRobotType().hashCode();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/robot/ai/task/BotTaskManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/robot/ai/task/BotTaskManager.java
@@ -202,12 +202,10 @@ public class BotTaskManager extends TaskManager {
 		return true;
 	}
 	
-	@Override
 	public void reinit() {
-		super.reinit();
 
 		robot = botMind.getRobot();
-		worker = robot;
+		super.reinit(robot);
 	}
 	
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/unit/AbstractMobileUnit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/unit/AbstractMobileUnit.java
@@ -1,0 +1,245 @@
+/*
+ * Mars Simulation Project
+ * MobileUnit.java
+ * @date 2024-09-15
+ * @author Barry Evans
+ */
+package com.mars_sim.core.unit;
+
+import com.mars_sim.core.Unit;
+import com.mars_sim.core.UnitType;
+import com.mars_sim.core.location.LocationStateType;
+import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.LocalPosition;
+import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.core.structure.building.Building;
+import com.mars_sim.core.vehicle.Vehicle;
+
+/**
+ * Represent a Unit that can move around the surface
+ */
+public abstract class AbstractMobileUnit extends Unit
+	implements MobileUnit  {
+    
+    private Settlement owner;
+    private LocalPosition localPosn = LocalPosition.DEFAULT_POSITION;
+    private int currentBuildingInt;
+
+    /**
+	 * Constructor.
+	 * 
+	 * @param name the name of the unit
+	 * @param owner the unit's location
+	 */
+	protected AbstractMobileUnit(String name, Settlement owner) {
+		super(name, owner.getCoordinates()); 
+        this.owner = owner;
+
+		setContainer(owner);
+	}
+
+	/**
+	 * Set the container of this mobile unit
+	 * @param destination New destination of container
+	 */
+	protected void setContainer(Unit destination) {
+		setContainerID(destination.getIdentifier());
+	}
+
+	/**
+	 * Gets the position at a settlement.
+	 *
+	 * @return distance (meters) from the settlement's center.
+	 */
+	public LocalPosition getPosition() {
+		return localPosn;
+	}
+
+	/**
+	 * Sets the settlement-wide position.
+	 *
+	 * @param position
+	 */
+	public void setPosition(LocalPosition position) {
+		this.localPosn = position;
+	}
+
+    /**
+	 * Computes the building the person is currently located at.
+	 * Returns null if outside of a settlement.
+	 *
+	 * @return building
+	 */
+	@Override
+	public Building getBuildingLocation() {
+		if (currentBuildingInt == -1)
+			return null;
+		return unitManager.getBuildingByID(currentBuildingInt);
+	}
+
+	/**
+	 * Computes the building the person is currently located at.
+	 * Returns null if outside of a settlement.
+	 *
+	 * @return building
+	 */
+	public void setCurrentBuilding(Building building) {
+		if (building == null) {
+			currentBuildingInt = -1;
+		}
+		else {
+			currentBuildingInt = building.getIdentifier();
+		}
+	}
+
+
+	/**
+	 * Gets the unit's location.
+	 *
+	 * @return the unit's location
+	 */
+	@Override
+	public Coordinates getCoordinates() {
+		Unit cu = getContainerUnit();
+		if (cu.getUnitType() == UnitType.MARS) {	
+			// Since Mars surface has no coordinates, 
+			// Get from its previously setting location
+			return super.getCoordinates();
+		}
+		
+		// Unless it's on Mars surface, get its container unit's coordinates
+		return cu.getCoordinates();
+	}
+
+    /**
+	 * This method assumes the Unit could be movable and change container. It identifies the
+	 * appropriate container it can use. Ideally this method should be moved to a 
+	 * new subclass called 'MovableUnit' that encapsulates some positioning methods 
+	 * not applicable to Structures.
+	 */
+	public String getContext() {
+		// Check vehicle first because could be in a Vehicle in a Settlement
+		if (isInVehicle()) {
+			return getVehicle().getChildContext();
+		}
+		else if (isInSettlement()) {
+			var b = getBuildingLocation();
+			if (b != null) {
+				return b.getContext();
+			}
+			else {
+				return getAssociatedSettlement().getName();
+			}
+		}
+		else if (isOutside()) {
+			return getCoordinates().getFormattedString();
+		}
+		else {
+			return getContainerUnit().getName();
+		}
+	}
+
+    /**
+     * Settlement that is associated with this Unit.
+     */
+    @Override
+    public Settlement getAssociatedSettlement() {
+        return owner;
+    }   
+    
+    /**
+	 * Gets the settlement the Unit is at.
+	 * Returns null if unit is not at a settlement.
+	 *
+	 * @return the settlement
+	 */
+	public Settlement getSettlement() {
+
+		if (getContainerID() <= Unit.MARS_SURFACE_UNIT_ID)
+			return null;
+
+		var c = getContainerUnit();
+
+		if (c instanceof Settlement s) {
+			return s;
+		}
+
+		else if (c instanceof Vehicle v) {
+			// Will see if vehicle is inside a garage or not
+			return (v.isInVehicleInGarage() ? v.getSettlement() : null);
+		}
+
+		else if (c instanceof FixedUnit b) {
+			return b.getAssociatedSettlement();
+		}
+		else if (c instanceof AbstractMobileUnit m) {
+			return m.getSettlement();
+		}
+
+		return null;
+	}
+
+    /**
+	 * Is this unit inside a settlement ?
+	 *
+	 * @return true if the unit is inside a settlement
+	 */
+	@Override
+	public boolean isInSettlement() {
+		return (getSettlement() != null);
+	}
+
+    
+	/**
+	 * Gets vehicle person is in, null if person is not in vehicle.
+	 *
+	 * @return the person's vehicle
+	 */
+	@Override
+	public Vehicle getVehicle() {
+		if (getLocationStateType() == LocationStateType.INSIDE_VEHICLE) {
+			return (Vehicle) getContainerUnit();
+		}
+
+		return null;
+	}
+    
+	/**
+	 * Is this unit inside a vehicle ?
+	 *
+	 * @return true if the unit is inside a vehicle
+	 */
+	@Override
+	public boolean isInVehicle() {
+		if (LocationStateType.INSIDE_VEHICLE == currentStateType)
+			return true;
+
+		if (LocationStateType.ON_PERSON_OR_ROBOT == currentStateType)
+			return getContainerUnit().isInVehicle();
+
+		return false;
+	}
+
+	
+    /**
+	 * Updates the location state type of a person.
+	 *
+	 * @param newContainer
+	 */
+	protected void updateLocationState(Unit newContainer) {
+		if (newContainer == null) {
+			currentStateType = LocationStateType.UNKNOWN;
+			return;
+		}
+
+		currentStateType = switch (newContainer.getUnitType()) {
+            case SETTLEMENT -> LocationStateType.INSIDE_SETTLEMENT;
+            case BUILDING -> LocationStateType.INSIDE_SETTLEMENT;
+            case VEHICLE -> LocationStateType.INSIDE_VEHICLE;
+            case CONSTRUCTION -> LocationStateType.MARS_SURFACE;
+            case PERSON -> LocationStateType.ON_PERSON_OR_ROBOT;
+            case MARS -> LocationStateType.MARS_SURFACE;
+            default -> null;
+        };
+	}
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/unit/MobileUnit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/unit/MobileUnit.java
@@ -1,15 +1,5 @@
-/*
- * Mars Simulation Project
- * MobileUnit.java
- * @date 2024-09-15
- * @author Barry Evans
- */
 package com.mars_sim.core.unit;
 
-import com.mars_sim.core.Unit;
-import com.mars_sim.core.UnitEventType;
-import com.mars_sim.core.UnitType;
-import com.mars_sim.core.location.LocationStateType;
 import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.map.location.LocalPosition;
 import com.mars_sim.core.structure.Settlement;
@@ -17,242 +7,76 @@ import com.mars_sim.core.structure.building.Building;
 import com.mars_sim.core.vehicle.Vehicle;
 
 /**
- * Represent a Unit that can move around the surface
+ * Represents an entity that can be mobile.
  */
-public abstract class MobileUnit extends Unit  {
+public interface MobileUnit {
+	/**
+	 * Gets the coordinates on Mars surface.
+	 * 
+	 * @return
+	 */
+	public Coordinates getCoordinates();
+
+	/**
+	 * Is the worker in a vehicle ?
+	 *
+	 * @return true if the worker in a vehicle
+	 */
+	public boolean isInVehicle();
+
+	/**
+	 * Gets vehicle worker is in, null if member is not in vehicle/
+	 *
+	 * @return the worker's vehicle
+	 */
+	public Vehicle getVehicle();
+    	
+	/**
+	 * Is the worker in a settlement ?
+	 *
+	 * @return true if the worker in a settlement
+	 */
+	public boolean isInSettlement();
     
-    private Settlement owner;
-    private LocalPosition localPosn = LocalPosition.DEFAULT_POSITION;
-    private int currentBuildingInt;
-    private Coordinates surfacePosn;
+	/**
+	 * Gets the current Settlement of the worker; may be different from the associated Settlement.
+	 * 
+	 * @return
+	 */
+	public Settlement getSettlement();
 
     /**
-	 * Constructor.
+	 * Gets the Worker's building.
 	 * 
-	 * @param name the name of the unit
-	 * @param owner the unit's location
+	 * @return building
 	 */
-	protected MobileUnit(String name, Settlement owner) {
-		super(name, owner.getCoordinates()); // TODO Unit constructor needs to drop coordinates from params
-        this.surfacePosn = owner.getCoordinates();
-        this.owner = owner;
-
-		setContainer(owner);
-	}
-
+	public Building getBuildingLocation();
+	
 	/**
-	 * Set the container of this mobile unit
-	 * @param destination New destination of container
-	 */
-	protected void setContainer(Unit destination) {
-		setContainerID(destination.getIdentifier());
-	}
-
-	/**
-	 * Gets the position at a settlement.
-	 *
-	 * @return distance (meters) from the settlement's center.
-	 */
-	public LocalPosition getPosition() {
-		return localPosn;
-	}
-
-	/**
-	 * Sets the settlement-wide position.
+	 * Sets the building the worker is located at.
 	 *
 	 * @param position
 	 */
-	public void setPosition(LocalPosition position) {
-		this.localPosn = position;
-	}
-
-    /**
-	 * Computes the building the person is currently located at.
-	 * Returns null if outside of a settlement.
-	 *
-	 * @return building
-	 */
-	@Override
-	public Building getBuildingLocation() {
-		if (currentBuildingInt == -1)
-			return null;
-		return unitManager.getBuildingByID(currentBuildingInt);
-	}
+	public void setCurrentBuilding(Building building);
 
 	/**
-	 * Computes the building the person is currently located at.
-	 * Returns null if outside of a settlement.
-	 *
-	 * @return building
+	 * Gets the Worker's position within the Settlement/Vehicle.
+	 * 
+	 * @return
 	 */
-	public void setCurrentBuilding(Building building) {
-		if (building == null) {
-			currentBuildingInt = -1;
-		}
-		else {
-			currentBuildingInt = building.getIdentifier();
-		}
-	}
-
-
-	/**
-	 * Gets the unit's location.
-	 *
-	 * @return the unit's location
-	 */
-	public Coordinates getCoordinates() {
-		Unit cu = getContainerUnit();
-		if (cu.getUnitType() == UnitType.MARS) {	
-			// Since Mars surface has no coordinates, 
-			// Get from its previously setting location
-			return surfacePosn;
-		}
-		
-		// Unless it's on Mars surface, get its container unit's coordinates
-		return cu.getCoordinates();
-	}
-
-	/**
-	 * Sets unit's location coordinates.
-	 *
-	 * @param newLocation the new location of the unit
-	 */
-	public void setCoordinates(Coordinates newLocation) {
-        // TODO the null check can be removed once Unit stop managing coordinates
-		if ((surfacePosn == null) || !surfacePosn.equals(newLocation)) {
-			surfacePosn = newLocation;
-			fireUnitUpdate(UnitEventType.LOCATION_EVENT, newLocation);
-		}
-	}
-    
-    /**
-	 * This method assumes the Unit could be movable and change container. It identifies the
-	 * appropriate container it can use. Ideally this method should be moved to a 
-	 * new subclass called 'MovableUnit' that encapsulates some positioning methods 
-	 * not applicable to Structures.
-	 */
-	public String getContext() {
-		// Check vehicle first because could be in a Vehicle in a Settlement
-		if (isInVehicle()) {
-			return getVehicle().getChildContext();
-		}
-		else if (isInSettlement()) {
-			var b = getBuildingLocation();
-			if (b != null) {
-				return b.getContext();
-			}
-			else {
-				return getAssociatedSettlement().getName();
-			}
-		}
-		else if (isOutside()) {
-			return getCoordinates().getFormattedString();
-		}
-		else {
-			return getContainerUnit().getName();
-		}
-	}
-
-    /**
-     * Settlement that is associated with this Unit.
-     */
-    @Override
-    public Settlement getAssociatedSettlement() {
-        return owner;
-    }   
-    
-    /**
-	 * Gets the settlement the Unit is at.
-	 * Returns null if unit is not at a settlement.
-	 *
-	 * @return the settlement
-	 */
-	public Settlement getSettlement() {
-
-		if (getContainerID() <= Unit.MARS_SURFACE_UNIT_ID)
-			return null;
-
-		var c = getContainerUnit();
-
-		if (c instanceof Settlement s) {
-			return s;
-		}
-
-		else if (c instanceof Vehicle v) {
-			// Will see if vehicle is inside a garage or not
-			return (v.isInVehicleInGarage() ? v.getSettlement() : null);
-		}
-
-		else if (c instanceof FixedUnit b) {
-			return b.getAssociatedSettlement();
-		}
-		else if (c instanceof MobileUnit m) {
-			return m.getSettlement();
-		}
-
-		return null;
-	}
-
-    /**
-	 * Is this unit inside a settlement ?
-	 *
-	 * @return true if the unit is inside a settlement
-	 */
-	@Override
-	public boolean isInSettlement() {
-		return (getSettlement() != null);
-	}
-
-    
-	/**
-	 * Gets vehicle person is in, null if person is not in vehicle.
-	 *
-	 * @return the person's vehicle
-	 */
-	@Override
-	public Vehicle getVehicle() {
-		if (getLocationStateType() == LocationStateType.INSIDE_VEHICLE) {
-			return (Vehicle) getContainerUnit();
-		}
-
-		return null;
-	}
-    
-	/**
-	 * Is this unit inside a vehicle ?
-	 *
-	 * @return true if the unit is inside a vehicle
-	 */
-	public boolean isInVehicle() {
-		if (LocationStateType.INSIDE_VEHICLE == currentStateType)
-			return true;
-
-		if (LocationStateType.ON_PERSON_OR_ROBOT == currentStateType)
-			return getContainerUnit().isInVehicle();
-
-		return false;
-	}
-
+	public LocalPosition getPosition();
 	
-    /**
-	 * Updates the location state type of a person.
+	/**
+	 * Sets the worker's position at a settlement.
 	 *
-	 * @param newContainer
+	 * @param position
 	 */
-	protected void updateLocationState(Unit newContainer) {
-		if (newContainer == null) {
-			currentStateType = LocationStateType.UNKNOWN;
-			return;
-		}
+	public void setPosition(LocalPosition position);
 
-		currentStateType = switch (newContainer.getUnitType()) {
-            case SETTLEMENT -> LocationStateType.INSIDE_SETTLEMENT;
-            case BUILDING -> LocationStateType.INSIDE_SETTLEMENT;
-            case VEHICLE -> LocationStateType.INSIDE_VEHICLE;
-            case CONSTRUCTION -> LocationStateType.MARS_SURFACE;
-            case PERSON -> LocationStateType.ON_PERSON_OR_ROBOT;
-            case MARS -> LocationStateType.MARS_SURFACE;
-            default -> null;
-        };
-	}
+	/**
+	 * Is the Worker outside ?
+	 *
+	 * @return true if the worker is on the MarsSurface
+	 */
+	public boolean isOutside();
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
@@ -64,7 +64,7 @@ import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.MarsTime;
 import com.mars_sim.core.time.Temporal;
 import com.mars_sim.core.tool.RandomUtil;
-import com.mars_sim.core.unit.MobileUnit;
+import com.mars_sim.core.unit.AbstractMobileUnit;
 import com.mars_sim.core.vehicle.task.LoadingController;
 
 /**
@@ -72,7 +72,7 @@ import com.mars_sim.core.vehicle.task.LoadingController;
  * information about the vehicle. This class needs to be subclassed to represent
  * a specific type of vehicle.
  */
-public abstract class Vehicle extends MobileUnit
+public abstract class Vehicle extends AbstractMobileUnit
 		implements Malfunctionable, Salvagable, Temporal, Indoor,
 		LocalBoundedObject, EquipmentOwner, ItemHolder, Towed {
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/TestContainment.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/TestContainment.java
@@ -19,7 +19,7 @@ import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.building.Building;
 import com.mars_sim.core.structure.building.BuildingManager;
 import com.mars_sim.core.structure.building.function.VehicleGarage;
-import com.mars_sim.core.unit.MobileUnit;
+import com.mars_sim.core.unit.AbstractMobileUnit;
 import com.mars_sim.core.vehicle.Rover;
 import com.mars_sim.core.vehicle.Vehicle;
 
@@ -45,7 +45,7 @@ public class TestContainment extends AbstractMarsSimUnitTest {
 		assertEquals("Parent container", container, source.getContainerUnit());
 	}
 
-	private static void assertInsideSettlement(String msg, MobileUnit source, Settlement base) {
+	private static void assertInsideSettlement(String msg, AbstractMobileUnit source, Settlement base) {
 		assertEquals(msg + ": Location state type", LocationStateType.INSIDE_SETTLEMENT, source.getLocationStateType());
 		assertEquals(msg + ": Settlement", base, source.getSettlement());
 		
@@ -137,7 +137,7 @@ public class TestContainment extends AbstractMarsSimUnitTest {
 		assertEquals(msg + ": Container", vehicle, source.getContainerUnit());
 	}
 	
-	private void assertWithinSettlementVicinity(String msg, MobileUnit source) {
+	private void assertWithinSettlementVicinity(String msg, AbstractMobileUnit source) {
 		
 		assertFalse(msg + ": InSettlement", source.isInSettlement());
 		assertNull(msg + ": Settlement", source.getSettlement());
@@ -153,7 +153,7 @@ public class TestContainment extends AbstractMarsSimUnitTest {
 	/*
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
-	public void testPersonInGarage() throws Exception {
+	public void testPersonInGarage() {
 		Person person = Person.create("Worker One", settlement, GenderType.MALE).build();
 		unitManager.addUnit(person);
 
@@ -167,7 +167,7 @@ public class TestContainment extends AbstractMarsSimUnitTest {
 	/*
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
-	public void testVehicleInGarage() throws Exception {
+	public void testVehicleInGarage() {
 		Vehicle vehicle = buildRover(settlement, "Garage Rover", new LocalPosition(1,1));
         
 		assertVehicleParked("Initial Vehicle", vehicle, settlement);
@@ -181,7 +181,7 @@ public class TestContainment extends AbstractMarsSimUnitTest {
 	/*
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
-	public void testVehicleNearSettlement() throws Exception {
+	public void testVehicleNearSettlement() {
 		Vehicle vehicle = buildRover(settlement, "Near Rover", new LocalPosition(1,1));
 
 		vehicle.setContainerUnitAndID(settlement);
@@ -192,7 +192,7 @@ public class TestContainment extends AbstractMarsSimUnitTest {
 	/*
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
-	public void testVehicleOnSurface() throws Exception {
+	public void testVehicleOnSurface() {
 		Vehicle vehicle = buildRover(settlement, "Garage Rover", new LocalPosition(1,1));
 
 		assertTrue("Transfer to Mars surface but still within settlement vicinity", vehicle.transfer(surface));
@@ -203,7 +203,7 @@ public class TestContainment extends AbstractMarsSimUnitTest {
 	/*
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
-	public void testBagOnSurface() throws Exception {
+	public void testBagOnSurface() {
 
 		Equipment bag = EquipmentFactory.createEquipment(EquipmentType.BAG, settlement);
 		
@@ -220,7 +220,7 @@ public class TestContainment extends AbstractMarsSimUnitTest {
 	/*
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
-	public void testBagOnVehicle() throws Exception {
+	public void testBagOnVehicle() {
 
 		Equipment bag = EquipmentFactory.createEquipment(EquipmentType.BAG, settlement);
 		
@@ -243,7 +243,7 @@ public class TestContainment extends AbstractMarsSimUnitTest {
 	/*
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
-	public void testPersonOnVehicle() throws Exception {
+	public void testPersonOnVehicle() {
 
 		Person person = buildPerson("Test Person", settlement);
 		
@@ -273,8 +273,6 @@ public class TestContainment extends AbstractMarsSimUnitTest {
 		assertEquals("Person's location state type is INSIDE_VEHICLE", LocationStateType.INSIDE_VEHICLE, person.getLocationStateType());
 		
 		assertFalse("Vehicle has left garage", vehicle.isInGarage());
-
-//		assertNull("Person in a vehicle. Vehicle is not in settlement", person.getSettlement());
 		
 		assertInVehicle("In vehicle", person, vehicle);
 		assertTrue("Person in crew", vehicle.getCrew().contains(person));
@@ -288,7 +286,7 @@ public class TestContainment extends AbstractMarsSimUnitTest {
 	/*
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
-//	public void testEVAOnPerson() throws Exception {
+//	public void testEVAOnPerson() {
 //		Person person = new Person("Worker Two", settlement);
 //		person.initialize(); // TODO This is bad. Why do we have to call a 2nd method after the constructor ???
 //        unitManager.addUnit(person);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/search/SearchWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/search/SearchWindow.java
@@ -43,6 +43,7 @@ import com.mars_sim.core.UnitType;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.robot.Robot;
 import com.mars_sim.core.tool.Msg;
+import com.mars_sim.core.unit.MobileUnit;
 import com.mars_sim.core.vehicle.Vehicle;
 import com.mars_sim.ui.swing.MainDesktopPane;
 import com.mars_sim.ui.swing.MarsPanelBorder;
@@ -259,8 +260,8 @@ extends ToolWindow {
 				nw.updateCoordsMaps(unit.getCoordinates());
 			}
 			
-			if (settlementCheck.isSelected())
-				openUnit(unit);
+			if (settlementCheck.isSelected() && (unit instanceof MobileUnit mu))
+				openMobileUnit(mu);
 			
 			if (!history.contains(selectedUnitName))
 				history.add(selectedUnitName);
@@ -277,11 +278,11 @@ extends ToolWindow {
 	}
 
 	/**
-	 * Opens the unit in Mars Navigator or Settlement Map.
+	 * Opens the mbile unit in Mars Navigator or Settlement Map.
 	 * 
 	 * @param u
 	 */
-	public void openUnit(Unit u) {
+	private void openMobileUnit(MobileUnit u) {
 		
 		if (u.isInSettlement()) {
 			showPersonRobot(u);
@@ -327,16 +328,14 @@ extends ToolWindow {
 	 * 
 	 * @param u
 	 */
-	private void showPersonRobot(Unit u) {
+	private void showPersonRobot(MobileUnit u) {
 		// person just happens to step outside the settlement at its
 		// vicinity temporarily
 		SettlementWindow sw = (SettlementWindow) desktop.openToolWindow(SettlementWindow.NAME);
-		if (u.getUnitType() == UnitType.PERSON) {
-			Person p = (Person) u;
+		if (u instanceof Person p) {
 			sw.displayPerson(p);
 		} 
-		else if (u.getUnitType() == UnitType.ROBOT) {
-			Robot r = (Robot)u;
+		else if (u instanceof Robot r) {
 			sw.displayRobot(r);
 		}
 	}


### PR DESCRIPTION
This PR covers changes to the Worker interface so it can be used in the abstract Task manager. This involves creating a MobileUnit interface that captures all movement methods.
The Task manager now is based on the Worker instead of Unit. This reduces the coupling to Unit.

close #1466