### PR TITLE
Remove the "owner" attribute from the Holder interfaces

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/BinHolder.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/BinHolder.java
@@ -9,23 +9,12 @@ package com.mars_sim.core.equipment;
 import java.util.Collection;
 import java.util.Set;
 
-import com.mars_sim.core.Unit;
-
 /**
  * Represents an entity that can hold resources.
  *
  */
 public interface BinHolder {
 
-//	/**
-//	 * Adds an amount resource container to this container holder
-//	 * 
-//	 * @param container
-//	 * @param type
-//	 * @param resource
-//	 */
-//	void addAmountResourceContainer(AmountResourceContainer container, ContainerType type, int resource);
-	
 	/**
 	 * Finds the number of bins of a particular type.
 	 *
@@ -127,13 +116,6 @@ public interface BinHolder {
 	 * @return resource id
 	 */
 	int getAmountResource(BinType type, int id);
-
-	/**
-	 * Gets the owner unit instance.
-	 *
-	 * @return
-	 */
-	public Unit getOwner();
 
 	/**
 	 * Adds a bin to be owned by the settlement.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuit.java
@@ -83,7 +83,7 @@ public class EVASuit extends Equipment
 	private static final SimLogger logger = SimLogger.getLogger(EVASuit.class.getName());
 
 	// Static members
-	public final String EVA = "EVA";
+	public static final String EVA = "EVA";
 	
 	/** String name of an EVA suit. */	
 	public static final String TYPE = SystemType.EVA_SUIT.getName();
@@ -411,8 +411,8 @@ public class EVASuit extends Equipment
 						+ " kg O2 left at partial pressure of " + Math.round(pp*1000.0)/1000.0 + " kPa.");
 			return pp;
 		}
-//		Note: the outside ambient air pressure is weather.getAirPressure(getCoordinates());
-		return NOMINAL_O2_PRESSURE;// * (malfunctionManager.getAirPressureModifier() / 100D);
+//		Note: the outside ambient air pressure is weather.getAirPressure(getCoordinates())
+		return NOMINAL_O2_PRESSURE;
 	}
 
 	/**
@@ -422,7 +422,7 @@ public class EVASuit extends Equipment
 	 */
 	@Override
 	public double getTemperature() {
-		return NORMAL_TEMP;// * (malfunctionManager.getTemperatureModifier() / 100D);
+		return NORMAL_TEMP;
 //		double ambient = weather.getTemperature(getCoordinates());
 
 //		if (result < ambient) {
@@ -578,11 +578,6 @@ public class EVASuit extends Equipment
 	@Override
 	public int retrieveItemResource(int resource, int quantity) {
 		return microInventory.retrieveItemResource(resource, quantity);
-	}
-
-	@Override
-	public Unit getHolder() {
-		return this;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuitUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuitUtil.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.logging.Level;
 
 import com.mars_sim.core.Unit;
-import com.mars_sim.core.UnitType;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.mission.Mission;
@@ -26,10 +25,14 @@ import com.mars_sim.core.vehicle.Vehicle;
 /**
  * A utility class for finding an EVA suit from an inventory
  */
-public class EVASuitUtil {
+public final class EVASuitUtil {
 
 	/** default logger. */
 	private static final SimLogger logger = SimLogger.getLogger(EVASuitUtil.class.getName());
+
+	private EVASuitUtil() {
+		// Static helper class
+	}
 
 	/**
 	 * Take off EVA suit, puts on the garment and get back the thermal bottle.
@@ -54,13 +57,9 @@ public class EVASuitUtil {
 			// Doff this suit.
 			boolean success = suit.transfer((Unit)housing);
 			
-			if (success) {
-				; //logger.log((Unit)housing, person, Level.INFO, 4_000, "Just transferred back " + suit.getName() 
-//						+ " to " + (Unit)housing + ".");
-			}
-			else {
+			if (!success) {
 				logger.warning(person, 4_000,
-						"Could not transfer " + suit + " from " + person + " to " + ((Unit)housing).getName() + ".");
+						"Could not transfer " + suit + " from " + person + " to " + housing.getName() + ".");
 			}
 		}
 		
@@ -207,10 +206,10 @@ public class EVASuitUtil {
 	 */
 	private static boolean hasEnoughResourcesForSuit(EquipmentOwner owner, EVASuit suit) {
 		int otherPeopleNum = 0;
-		if (owner.getHolder().getUnitType() == UnitType.SETTLEMENT)
-			otherPeopleNum = ((Settlement) owner).getIndoorPeopleCount() - 1;
-		else 
-			otherPeopleNum = ((Crewable) owner).getCrewNum();
+		if (owner instanceof Settlement s)
+			otherPeopleNum = s.getIndoorPeopleCount() - 1;
+		else if (owner instanceof Crewable c)
+			otherPeopleNum = c.getCrewNum();
 		
 		// Check if enough oxygen.
 		double neededOxygen = suit.getAmountResourceRemainingCapacity(ResourceUtil.oxygenID);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentInventory.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentInventory.java
@@ -7,7 +7,6 @@
 
 package com.mars_sim.core.equipment;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -28,7 +27,7 @@ import com.mars_sim.core.resource.ResourceUtil;
  * basic capacity management.
  */
 public class EquipmentInventory
-		implements EquipmentOwner, ItemHolder, BinHolder, Serializable {
+		implements EquipmentOwner, ItemHolder, BinHolder {
 
 	private static final long serialVersionUID = 1L;
 
@@ -678,7 +677,6 @@ public class EquipmentInventory
 	/**
 	 * Sets the resource capacities.
 	 *
-	 * TODO should be keyed on resourceID not string.
 	 * @param capacities
 	 */
 	public void setResourceCapacityMap(Map<Integer, Double> capacities) {
@@ -731,16 +729,6 @@ public class EquipmentInventory
 	 */
 	public void removeCapacity(int resource, double capacity) {
 		microInventory.removeCapacity(resource, capacity);
-	}
-
-	/**
-	 * Gets the holder's unit instance.
-	 *
-	 * @return the holder's unit instance
-	 */
-	@Override
-	public Unit getHolder() {
-		return owner.getContainerUnit();
 	}
 
 	/**
@@ -934,17 +922,22 @@ public class EquipmentInventory
 		
 		return 0;
 	}
+	
+	@Override
+	public String getName() {
+		return owner.getName();
+	}
 
 	@Override
-	public Unit getOwner() {
-		return owner;
-	}
-	
+	public String getContext() {
+		return owner.getDescription();
+	}	
+
 	public void destroy() {
 		containerSet.clear();
 		containerSet = null;
 		suitSet.clear();
 		suitSet = null;
 		microInventory = null;
-	}	
+	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/GenericContainer.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/GenericContainer.java
@@ -11,7 +11,6 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
 
-import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitType;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.resource.AmountResource;
@@ -297,16 +296,6 @@ class GenericContainer extends Equipment implements Container {
 		}
 
 		return resourceHeld == -1;
-	}
-
-	/**
-	 * Gets the holder's unit instance.
-	 *
-	 * @return the holder's unit instance
-	 */
-	@Override
-	public Unit getHolder() {
-		return this;
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/ItemHolder.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/ItemHolder.java
@@ -8,8 +8,6 @@ package com.mars_sim.core.equipment;
 
 import java.util.Set;
 
-import com.mars_sim.core.Unit;
-
 /**
  * Represents an entity that can hold item resources.
  *
@@ -63,11 +61,4 @@ public interface ItemHolder {
 	 * @return quantity that cannot be retrieved
 	 */
 	int retrieveItemResource(int resource, int quantity);
-
-	/**
-	 * Gets the holder's unit instance
-	 *
-	 * @return the holder's unit instance
-	 */
-	public Unit getHolder();
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/ResourceHolder.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/ResourceHolder.java
@@ -8,13 +8,13 @@ package com.mars_sim.core.equipment;
 
 import java.util.Set;
 
-import com.mars_sim.core.Unit;
+import com.mars_sim.core.Entity;
 
 /**
  * Represents an entity that can hold resources.
  *
  */
-public interface ResourceHolder {
+public interface ResourceHolder extends Entity {
 
 	/**
 	 * Gets the amount resource stored
@@ -88,13 +88,6 @@ public interface ResourceHolder {
 	 * @return a collection of resource ids
 	 */
 	Set<Integer> getAllAmountResourceIDs();
-	
-	/**
-	 * Gets the holder's unit instance
-	 *
-	 * @return the holder's unit instance
-	 */
-	public Unit getHolder();
 	
 	/**
 	 * Does it have unused space or capacity for a particular resource ?

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
@@ -1689,16 +1689,6 @@ public class Person extends MobileUnit implements Worker, Temporal, Appraiser {
 	}
 
 	/**
-	 * Gets the holder's unit instance.
-	 *
-	 * @return the holder's unit instance
-	 */
-	@Override
-	public Unit getHolder() {
-		return this;
-	}
-
-	/**
 	 * Does this person have a set of clothing ?
 	 */
 	public boolean hasGarment() {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/robot/Robot.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/robot/Robot.java
@@ -1037,16 +1037,6 @@ public class Robot extends MobileUnit implements Salvagable, Temporal, Malfuncti
 		return UnitType.ROBOT;
 	}
 
-	/**
-	 * Gets the holder's unit instance
-	 *
-	 * @return the holder's unit instance
-	 */
-	@Override
-	public Unit getHolder() {
-		return this;
-	}
-
 	/** 
 	 * Returns the current amount of energy in kWh. 
 	 */

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -3536,11 +3536,6 @@ public class Settlement extends Unit implements Temporal,
 		return eqmInventory.getAmountResource(type, id);
 	}
 
-	@Override
-	public Unit getOwner() {
-		return eqmInventory.getOwner();
-	}
-	
 	/**
 	 * Gets the EquipmentInventory instance.
 	 * 
@@ -3609,16 +3604,6 @@ public class Settlement extends Unit implements Temporal,
 		return false;
 	}
 
-	/**
-	 * Gets the holder's unit instance.
-	 *
-	 * @return the holder's unit instance
-	 */
-	@Override
-	public Unit getHolder() {
-		return this;
-	}
-	
 	/**
 	 * Gets the preference that this Settlement influences.
 	 * 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/Building.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/Building.java
@@ -17,7 +17,6 @@ import java.util.logging.Level;
 
 import com.mars_sim.core.Simulation;
 import com.mars_sim.core.SimulationConfig;
-import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitEventType;
 import com.mars_sim.core.UnitType;
 import com.mars_sim.core.air.AirComposition;
@@ -88,7 +87,6 @@ import com.mars_sim.core.unit.FixedUnit;
 
 /**
  * The Building class is a settlement's building.
- * TODO Is the Item & ResoruceHolder needed if it is delegated to Settlement
  */
 public class Building extends FixedUnit implements Malfunctionable,
 	 InsidePathLocation, Temporal, ResourceHolder, ItemHolder {
@@ -120,7 +118,7 @@ public class Building extends FixedUnit implements Malfunctionable,
 	private int baseLevel;
 
 	/** Default : 22.5 deg celsius. */
-	private double presetTemperature = 0;//22.5D;
+	private double presetTemperature = 0; //22.5D
 	private double width;
 	// Q: how to handle the indefinite length of hallway/tunnel ?
 	// "-1" if it doesn't exist.
@@ -692,8 +690,7 @@ public class Building extends FixedUnit implements Malfunctionable,
 	/**
 	 * Gets the building type.
 	 *
-	 * @return building type as a String. TODO internationalize building names for
-	 *         display in user interface.
+	 * @return building type as a String.
 	 */
 	public String getBuildingType() {
 		return buildingType;
@@ -1210,9 +1207,6 @@ public class Building extends FixedUnit implements Malfunctionable,
 		if (!isValid(pulse)) {
 			return false;
 		}
-		
-		// DEBUG: Calculate the real time elapsed [in milliseconds]
-//		long tnow = System.currentTimeMillis();
 
 		// Send time to each building function.
 		for (Function f : functions)
@@ -1568,16 +1562,6 @@ public class Building extends FixedUnit implements Malfunctionable,
 	@Override
 	public Set<Integer> getAllAmountResourceIDs() {
 		return getAssociatedSettlement().getAllAmountResourceIDs();
-	}
-
-	/**
-	 * Gets the holder's unit instance.
-	 *
-	 * @return the holder's unit instance
-	 */
-	@Override
-	public Unit getHolder() {
-		return this;
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/Storage.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/Storage.java
@@ -207,7 +207,7 @@ public class Storage extends Function {
 				return true;
 			}
 			else if (excess > 0) {
-				logger.log(rh.getHolder(), Level.INFO, 60_000, method
+				logger.log(rh, Level.INFO, 60_000, method
 		    		+ "Storage full for "
 		    		+ ResourceUtil.findAmountResourceName(id) 
 		    		+ ". To store: "
@@ -226,7 +226,7 @@ public class Storage extends Function {
 			result = false;
 			if (!method.equals(""))
 				method = " at " + method;
-				logger.log(rh.getHolder(), Level.SEVERE, 10_000,
+				logger.log(rh, Level.SEVERE, 10_000,
 					"Attempting to store non-positive amount of "
 					+ ResourceUtil.findAmountResourceName(id) + method);
 		}
@@ -270,7 +270,7 @@ public class Storage extends Function {
 					if (isRetrieving) {
 						rh.retrieveAmountResource(id, amount);
 					}
-					logger.warning(rh.getHolder(), 30_000,
+					logger.warning(rh, 30_000,
 							"Ran out of "
 							+ ResourceUtil.findAmountResourceName(id) + "."
 							);
@@ -283,13 +283,13 @@ public class Storage extends Function {
 					result = true;
 				}
 			} catch (Exception e) {
-				logger.severe(rh.getHolder(),10_000,
+				logger.severe(rh,10_000,
 						"Issues with retrieveAnResource(ar) on "
 						+ ResourceUtil.findAmountResourceName(id) + " : " + e.getMessage(), e);
 			}
 		} else {
 			result = false;
-			logger.severe(rh.getHolder(), 10_000,
+			logger.severe(rh, 10_000,
 					"Attempting to retrieve non-positive amount of "
 					+ ResourceUtil.findAmountResourceName(id));
 		}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
@@ -294,7 +294,6 @@ public abstract class Vehicle extends MobileUnit
 	/**
 	 * Gets the base image for this Vehicle.
 	 * 
-	 * @todo This needs refactoring to avoid copying out VehicleSpec properties
 	 * @return Name of base image for this vehicle
 	 */
 	public String getBaseImage() {
@@ -1859,16 +1858,6 @@ public abstract class Vehicle extends MobileUnit
 	@Override
 	public UnitType getUnitType() {
 		return UnitType.VEHICLE;
-	}
-
-	/**
-	 * Gets the holder's unit instance.
-	 *
-	 * @return the holder's unit instance
-	 */
-	@Override
-	public Unit getHolder() {
-		return this;
 	}
 
 	/**


### PR DESCRIPTION
Change the Holder interfaces to use Entity so they can be used directly in logging. Goal is to reduce the dependency on Unit

Changes:
- BinHolder, ResourceHolder, ItemHolder & EquipmentHolder drops getOwner method
- ResourceHolder now implements Entity to support logging
- EquipmentInventory class implements Entity methods and delegates to the owner Unit
- Building, Vehicle, Settlement, Person, Robot, EVASuit & GenericContainer removed for dropped interface methods
- EVASuitUtil in method hasEnoughResourcesForSuit uses instance of holder directly

close #1467