### PR TITLE
Better use of Salvagable interface

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
@@ -483,9 +483,6 @@ public class Simulation implements ClockListener, Serializable {
 		// Re-initialize ScientificStudyUtil
 		ScientificStudyUtil.initializeInstances(unitManager);
 		
-	
-        // Initialize ManufactureUtil
-        new ManufactureUtil();
         // Initialize RoleUtil
         new RoleUtil();
         // Initialize RoleUtil
@@ -613,9 +610,7 @@ public class Simulation implements ClockListener, Serializable {
 		ScientificStudy.initializeInstances(masterClock, simulationConfig.getScienceConfig());
 		// Re-nitialize ScientificStudyUtil
 		ScientificStudyUtil.initializeInstances(unitManager);
-		
-		// Initialize ManufactureUtil
-        new ManufactureUtil();
+	
         // Initialize RoleUtil
         new RoleUtil();
         // Initialize RoleUtil

--- a/mars-sim-core/src/main/java/com/mars_sim/core/goods/AmountResourceGood.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/goods/AmountResourceGood.java
@@ -782,8 +782,8 @@ class AmountResourceGood extends Good {
 		double demand = 0D;
 
 		// Get highest manufacturing tech level in settlement.
-		if (ManufactureUtil.doesSettlementHaveManufacturing(settlement)) {
-			int techLevel = ManufactureUtil.getHighestManufacturingTechLevel(settlement);
+		int techLevel = ManufactureUtil.getHighestManufacturingTechLevel(settlement);
+		if (techLevel >= 0) {
 			for (ManufactureProcessInfo i : ManufactureUtil.getManufactureProcessesForTechLevel(techLevel)) {
 				double manufacturingDemand = getResourceManufacturingProcessDemand(owner, settlement, i);
 				demand += manufacturingDemand / 1000D;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/goods/CommerceUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/goods/CommerceUtil.java
@@ -8,12 +8,10 @@ package com.mars_sim.core.goods;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitManager;
 import com.mars_sim.core.equipment.Container;
 import com.mars_sim.core.equipment.ContainerUtil;
@@ -388,9 +386,7 @@ public final class CommerceUtil {
 			case VEHICLE:
 				int count = 0;
 				VehicleType vehicleType = VehicleType.convertNameToVehicleType(good.getName());
-				Iterator<Unit> i = settlement.getVehicleTypeUnit(vehicleType).iterator();
-				while (i.hasNext()) {
-					Vehicle vehicle = (Vehicle) i.next();
+				for(Vehicle vehicle : settlement.getVehicleTypeUnit(vehicleType)) {
 					boolean isEmpty = vehicle.isEmpty();
 					if (vehicle.getDescription().equalsIgnoreCase(good.getName()) && !vehicle.isReserved() && isEmpty) {
 						count++;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/goods/PartGood.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/goods/PartGood.java
@@ -610,12 +610,10 @@ public class PartGood extends Good {
 		double base = 0D;
 
 		// Get highest manufacturing tech level in settlement.
-		if (ManufactureUtil.doesSettlementHaveManufacturing(settlement)) {
-			int techLevel = ManufactureUtil.getHighestManufacturingTechLevel(settlement);
-			Iterator<ManufactureProcessInfo> i = ManufactureUtil.getManufactureProcessesForTechLevel(techLevel)
-					.iterator();
-			while (i.hasNext()) {
-				double manufacturingDemand = getPartManufacturingProcessDemand(owner, settlement, part, i.next());
+		int techLevel = ManufactureUtil.getHighestManufacturingTechLevel(settlement);
+		if (techLevel >= 0) {
+			for(ManufactureProcessInfo found : ManufactureUtil.getManufactureProcessesForTechLevel(techLevel)) {
+				double manufacturingDemand = getPartManufacturingProcessDemand(owner, settlement, part, found);
 				base += manufacturingDemand * (1 + techLevel);
 			}
 		}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/manufacture/ManufactureUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/manufacture/ManufactureUtil.java
@@ -387,7 +387,7 @@ public final class ManufactureUtil {
 
 	/**
 	 * Checks to see if a salvage process can be started at a given manufacturing
-	 * building.
+	 * building. This also means it coud be queued
 	 *
 	 * @param process  the salvage process to start.
 	 * @param workshop the manufacturing building.
@@ -400,14 +400,9 @@ public final class ManufactureUtil {
 			// NOTE: create a map to show which process has a 3D printer in use and which doesn't
 			return false;
 		}
-		
-        // Check to see if process tech level is above workshop tech level.
-		if (workshop.getTechLevel() < process.getTechLevelRequired()) {
-			return false;
-		}
-
-		// Check to see if a salvagable unit is available at the settlement.
-		return findUnitForSalvage(process, workshop.getBuilding().getSettlement()) != null;
+	
+		// To start it the same queue condition must be met
+		return canSalvageProcessBeQueued(process, workshop);
 	}
 
 	/**
@@ -525,7 +520,7 @@ public final class ManufactureUtil {
 			// Take any non-empty and unreserved vehicles
 			salvagableUnits = settlement.getVehicleTypeUnit(type).stream()
 								.filter(v -> (v.isEmpty() && !v.isReserved()))
-								.filter(v2 -> (v2.getContainerUnit() != settlement))
+								.filter(v2 -> (v2.getContainerUnit().equals(settlement)))
 								.map(Salvagable.class::cast)
 								.toList();
 		} 
@@ -533,7 +528,7 @@ public final class ManufactureUtil {
 		else if (info.getType() == ItemType.EQUIPMENT) {
 			EquipmentType eType = EquipmentType.convertName2Enum(info.getItemName());
 			salvagableUnits = settlement.getContainerSet(eType).stream()
-								.filter(v2 -> (v2.getContainerUnit() != settlement))
+								.filter(v2 -> (v2.getContainerUnit().equals(settlement)))
 								.map(Salvagable.class::cast)
 								.toList();
 		} 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/manufacture/Salvagable.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/manufacture/Salvagable.java
@@ -7,10 +7,12 @@
 
 package com.mars_sim.core.manufacture;
 
+import com.mars_sim.core.Entity;
+
 /**
  * An interface for salvagable items.
  */
-public interface Salvagable {
+public interface Salvagable extends Entity {
 
     /**
      * Checks if the item is salvaged.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/manufacture/SalvageProcess.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/manufacture/SalvageProcess.java
@@ -6,7 +6,6 @@
  */
 package com.mars_sim.core.manufacture;
 
-import com.mars_sim.core.Unit;
 import com.mars_sim.core.structure.building.function.Manufacture;
 
 import java.io.Serializable;
@@ -22,7 +21,7 @@ public class SalvageProcess implements Serializable {
     private double workTimeRemaining;
     private double averageSkillLevel;
     
-    private Unit salvagedUnit;
+    private Salvagable salvagedUnit;
     
     private Manufacture workshop;
     private SalvageProcessInfo info;
@@ -33,7 +32,7 @@ public class SalvageProcess implements Serializable {
      * @param info information about the salvage process.
      * @param workshop the manufacturing workshop where the salvage is taking place.
      */
-    public SalvageProcess(SalvageProcessInfo info, Manufacture workshop, Unit salvagedUnit) {
+    public SalvageProcess(SalvageProcessInfo info, Manufacture workshop, Salvagable salvagedUnit) {
         this.info = info;
         this.workshop = workshop;
         this.salvagedUnit = salvagedUnit;
@@ -92,7 +91,7 @@ public class SalvageProcess implements Serializable {
      * 
      * @return salvaged unit.
      */
-    public Unit getSalvagedUnit() {
+    public Salvagable getSalvagedUnit() {
         return salvagedUnit;
     }
     

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/SalvageGood.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/SalvageGood.java
@@ -11,7 +11,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import com.mars_sim.core.Unit;
 import com.mars_sim.core.data.UnitSet;
 import com.mars_sim.core.malfunction.Malfunctionable;
 import com.mars_sim.core.manufacture.ManufactureUtil;
@@ -404,10 +403,10 @@ public class SalvageGood extends Task {
 		if (result == null) {
 			Iterator<SalvageProcess> j = workshop.getQueueSalvageProcesses().iterator();
 			while (i.hasNext() && (result == null)) {
-				SalvageProcess process = j.next();
-				if ((process.getInfo().getSkillLevelRequired() <= skillLevel) && (process.getWorkTimeRemaining() > 0D)) {
-					result = process;
-					workshop.loadFromSalvageQueue(process);
+				SalvageProcess queuedProcess = j.next();
+				if ((queuedProcess.getInfo().getSkillLevelRequired() <= skillLevel) && (queuedProcess.getWorkTimeRemaining() > 0D)) {
+					result = queuedProcess;
+					workshop.loadFromSalvageQueue(queuedProcess);
 					break;
 				}
 			}
@@ -448,7 +447,7 @@ public class SalvageGood extends Task {
 			SalvageProcessInfo selectedProcess = RandomUtil.getWeightedRandomObject(processValues);
 
 			if (selectedProcess != null) {
-				Unit salvagedUnit = ManufactureUtil.findUnitForSalvage(selectedProcess,
+				var salvagedUnit = ManufactureUtil.findUnitForSalvage(selectedProcess,
 						person.getSettlement());
 				if (salvagedUnit != null) {
 					result = new SalvageProcess(selectedProcess, workshop, salvagedUnit);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -2089,10 +2089,9 @@ public class Settlement extends Unit implements Temporal,
 	 *
 	 * @return Collection of Unit
 	 */
-	public Collection<Unit> getVehicleTypeUnit(VehicleType vehicleType) {
+	public Collection<Vehicle> getVehicleTypeUnit(VehicleType vehicleType) {
 		return ownedVehicles.stream()
 				.filter(v -> v.getVehicleType() == vehicleType)
-				.map(Unit.class::cast)
 				.toList();
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/Manufacture.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/function/Manufacture.java
@@ -422,26 +422,26 @@ public class Manufacture extends Function {
 		}
 
 		ongoingSalvages.add(process);
+		Settlement settlement = building.getSettlement();
 
 		// Retrieve salvaged unit and remove from unit manager.
-		Unit salvagedUnit = process.getSalvagedUnit();
+		var salvagedUnit = process.getSalvagedUnit();
 		if (salvagedUnit != null) {
-			if (salvagedUnit.getUnitType() == UnitType.CONTAINER
-					|| salvagedUnit.getUnitType() == UnitType.EVA_SUIT) {
-				building.getSettlement().removeEquipment((Equipment)salvagedUnit);
-			} else if (salvagedUnit.getUnitType() == UnitType.VEHICLE) {
-				building.getSettlement().removeOwnedVehicle((Vehicle)salvagedUnit);
-				building.getSettlement().removeVicinityParkedVehicle((Vehicle)salvagedUnit);
-			} else if (salvagedUnit.getUnitType() == UnitType.ROBOT) {
-				building.getSettlement().removeOwnedRobot((Robot)salvagedUnit);
+			switch(salvagedUnit) {
+				case Equipment e: settlement.removeEquipment(e); break;
+				case Robot r: settlement.removeOwnedRobot(r); break;
+				case Vehicle v:
+					settlement.removeOwnedVehicle(v);
+					settlement.removeVicinityParkedVehicle(v);
+					break;
+				default: throw new IllegalStateException("Salvage process can not remote target");
 			}
 		} else
 			throw new IllegalStateException("Salvaged unit is null");
 
-		Settlement settlement = building.getSettlement();
 
 		// Set the salvage process info for the salvaged unit.
-		((Salvagable) salvagedUnit).startSalvage(process.getInfo(), settlement.getIdentifier());
+		salvagedUnit.startSalvage(process.getInfo(), settlement.getIdentifier());
 
 		// Recalculate settlement good value for salvaged unit.
 		Good salvagedGood = null;
@@ -775,9 +775,8 @@ public class Manufacture extends Function {
 
 			// Determine the salvage chance based on the wear condition of the item.
 			double salvageChance = 50D;
-			Unit salvagedUnit = process.getSalvagedUnit();
-			if (salvagedUnit instanceof Malfunctionable) {
-				Malfunctionable malfunctionable = (Malfunctionable) salvagedUnit;
+			var salvagedUnit = process.getSalvagedUnit();
+			if (salvagedUnit instanceof Malfunctionable malfunctionable) {
 				double wearCondition = malfunctionable.getMalfunctionManager().getWearCondition();
 				salvageChance = (wearCondition * .25D) + 25D;
 			}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/manufacture/ManufactureUtilTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/manufacture/ManufactureUtilTest.java
@@ -1,6 +1,8 @@
 package com.mars_sim.core.manufacture;
 
 import com.mars_sim.core.AbstractMarsSimUnitTest;
+import com.mars_sim.core.equipment.EquipmentFactory;
+import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.map.location.LocalPosition;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.building.Building;
@@ -70,5 +72,28 @@ public class ManufactureUtilTest extends AbstractMarsSimUnitTest {
         assertFalse("No salvage on low skill found", found.contains(selection));
         found = ManufactureUtil.getSalvageProcessesForTechSkillLevel(selection.getTechLevelRequired(), selection.getSkillLevelRequired());
         assertTrue("Salvage on low skill found", found.contains(selection));
+    }
+
+    public void testCanSalvageBarrel() {
+        var s = buildSettlement();
+        var w = buildManufacture(s);
+        var manu = w.getManufacture();
+
+        SalvageProcessInfo selected = null;
+        var found = ManufactureUtil.getSalvageProcessesForTechLevel(manu.getTechLevel());
+        for(var p : found) {
+            if (p.getItemName().equals("barrel")) {
+                selected = p;
+                break;
+            }
+        }
+
+        assertNotNull("Found barrel salvage", selected);
+        var canstart = ManufactureUtil.canSalvageProcessBeStarted(selected, manu);
+        assertFalse("Cannot start barrel salvage witout barrels", canstart);
+
+        EquipmentFactory.createEquipment(EquipmentType.BARREL, s);
+        canstart = ManufactureUtil.canSalvageProcessBeStarted(selected, manu);
+        assertTrue("Can start barrel salvage with barrel", canstart);
     }
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/manufacture/ManufactureUtilTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/manufacture/ManufactureUtilTest.java
@@ -1,0 +1,74 @@
+package com.mars_sim.core.manufacture;
+
+import com.mars_sim.core.AbstractMarsSimUnitTest;
+import com.mars_sim.core.map.location.LocalPosition;
+import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.core.structure.building.Building;
+import com.mars_sim.core.structure.building.BuildingCategory;
+import com.mars_sim.core.structure.building.function.FunctionType;
+
+public class ManufactureUtilTest extends AbstractMarsSimUnitTest {
+
+    private Building buildManufacture(Settlement s) {
+        return buildFunction(s.getBuildingManager(), "Workshop", BuildingCategory.PROCESSING,
+							FunctionType.MANUFACTURE,  LocalPosition.DEFAULT_POSITION, 0D, true);
+    }
+    
+    public void testGetHighestManufacturingTechLevel() {
+        var s = buildSettlement();
+        
+        int highest = ManufactureUtil.getHighestManufacturingTechLevel(s);
+        assertEquals("No manufacturing", -1, highest);
+
+        var w = buildManufacture(s);
+        highest = ManufactureUtil.getHighestManufacturingTechLevel(s);
+
+        assertEquals("Highest tech level found", w.getManufacture().getTechLevel(), highest);
+    }
+
+    public void testGetManufactureProcessesForTechLevel() {
+
+        var highList = ManufactureUtil.getManufactureProcessesForTechLevel(5);
+        assertTrue("High tech processes", !highList.isEmpty());
+
+        var lowList = ManufactureUtil.getManufactureProcessesForTechLevel(1);
+        assertTrue("Low tech processes", !lowList.isEmpty());
+
+        assertTrue("More high processes than low", highList.size() > lowList.size());
+        assertTrue("Low are in high", highList.containsAll(lowList));
+
+        var selection = highList.get(0);
+        var found = ManufactureUtil.getManufactureProcessesForTechSkillLevel(selection.getTechLevelRequired(), selection.getSkillLevelRequired()-1);
+        assertFalse("No process on low skill found", found.contains(selection));
+        found = ManufactureUtil.getManufactureProcessesForTechSkillLevel(selection.getTechLevelRequired(), selection.getSkillLevelRequired());
+        assertTrue("Process on low skill found", found.contains(selection));
+    }
+
+    public void testGetManufactureProcessesWithGivenOutput() {
+        var results = ManufactureUtil.getManufactureProcessesWithGivenOutput("barrel");
+
+        // Should just be 1 on the current manufacturing,xml
+        assertFalse("No barrel processes found", results.isEmpty());
+
+        var selection = results.get(0);
+        assertTrue("Output for barrel process", selection.getOutputNames().contains("barrel"));
+    }
+
+    public void testGetSalvageProcessesForTechLevel() {
+
+        var highList = ManufactureUtil.getSalvageProcessesForTechLevel(5);
+        assertTrue("High tech salvage", !highList.isEmpty());
+    
+        var lowList = ManufactureUtil.getSalvageProcessesForTechLevel(1);
+        assertTrue("Low tech salvage", !lowList.isEmpty());
+    
+        assertTrue("More high salvage than low", highList.size() > lowList.size());
+        assertTrue("Low are in high", highList.containsAll(lowList));
+    
+        var selection = highList.get(0);
+        var found = ManufactureUtil.getSalvageProcessesForTechSkillLevel(selection.getTechLevelRequired(), selection.getSkillLevelRequired()-1);
+        assertFalse("No salvage on low skill found", found.contains(selection));
+        found = ManufactureUtil.getSalvageProcessesForTechSkillLevel(selection.getTechLevelRequired(), selection.getSkillLevelRequired());
+        assertTrue("Salvage on low skill found", found.contains(selection));
+    }
+}


### PR DESCRIPTION
This PR makes the ```SalvageProcess``` use the ```Salvagable``` as the target instead of a Unit. This simplifies the logic of the processing and make the future changes in Unit hierarchy easier to deliver.

The ManufactureUtil class has bene updated to make it more efficient and aligned with the new Salvagable approach. There is a new UnitTest provides to check the logic on the util class.

close #1471