### PR TITLE
Extract exploration logic out of Settlement

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
@@ -68,6 +68,7 @@ import com.mars_sim.core.science.ScientificStudy;
 import com.mars_sim.core.science.ScientificStudyManager;
 import com.mars_sim.core.science.ScientificStudyUtil;
 import com.mars_sim.core.structure.Airlock;
+import com.mars_sim.core.structure.ExplorationManager;
 import com.mars_sim.core.structure.building.BuildingConfig;
 import com.mars_sim.core.structure.building.BuildingManager;
 import com.mars_sim.core.structure.building.function.Function;
@@ -387,6 +388,7 @@ public class Simulation implements ClockListener, Serializable {
 
 
 		BuildingManager.initializeInstances(simulationConfig, masterClock, unitManager);
+		ExplorationManager.initialise(surfaceFeatures);
 
 		AbstractMission.initializeInstances(this, eventManager, unitManager,
 			surfaceFeatures, missionManager, simulationConfig.getPersonConfig());
@@ -545,7 +547,7 @@ public class Simulation implements ClockListener, Serializable {
 		SalvageValues.initializeInstances(unitManager, masterClock);
 		
 		BuildingManager.initializeInstances(simulationConfig, masterClock, unitManager);
-
+		ExplorationManager.initialise(surfaceFeatures);
 		
 		doneInitializing = true;
 		
@@ -676,6 +678,7 @@ public class Simulation implements ClockListener, Serializable {
 
 		// Re-initialize Structure related class
 		BuildingManager.initializeInstances(simulationConfig, masterClock, unitManager);
+		ExplorationManager.initialise(surfaceFeatures);
 	
 		// Start a chain of calls to set instances
 		// Warning: must call this at the end of this method

--- a/mars-sim-core/src/main/java/com/mars_sim/core/configuration/ConfigHelper.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/configuration/ConfigHelper.java
@@ -388,12 +388,18 @@ public class ConfigHelper {
 	 * max equals min * defaultSpan.
 	 * 
 	 * @param element
-	 * @param defaultSpan
+	 * @param defaultSpan If =1 then the MAx must be specified
 	 * @return
 	 */
 	public static Range parseRange(Element element, double defaultSpan) {
 		double min = getAttributeDouble(element, MIN);
-		double max = getOptionalAttributeDouble(element, MAX, min * defaultSpan);
+		double max;
+		if (defaultSpan < 0) {
+			max = getAttributeDouble(element, MAX);
+		}
+		else {
+			max = getOptionalAttributeDouble(element, MAX, min * defaultSpan);
+		}
 
 		return new Range(min, max);
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/environment/SurfaceFeatures.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/environment/SurfaceFeatures.java
@@ -540,16 +540,13 @@ public class SurfaceFeatures implements Serializable, Temporal {
 		}
 		
 		ExploredLocation result = null;
-		
-		var mineralTypes = mineralMap.getTypes();
-		
-		Map<String, Double> initialMineralEstimations = new HashMap<>();
-		
+				
+		Map<String, Double> initialMineralEstimations = new HashMap<>();		
 		double totalConc = 0;
 		
-		for (var m : mineralTypes) {
-			var mineralType = m.getName();
-			double initialEst = mineralMap.getMineralConcentration(mineralType, location);
+		for (var m : mineralMap.getAllMineralConcentrations(location).entrySet()) {
+			var mineralType = m.getKey();
+			double initialEst = m.getValue();
 
 			if (initialEst <= 0) {
 				continue;
@@ -579,9 +576,6 @@ public class SurfaceFeatures implements Serializable, Temporal {
 			result = new ExploredLocation(location, skill, initialMineralEstimations, settlement);
 			
 			regionOfInterestLocations.add(result);
-		}
-		else {
-			logger.info(settlement, "Initially found no mineral concentrations in " + location.getFormattedString() + ".");
 		}
 		
 		return result;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mineral/MineralMap.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mineral/MineralMap.java
@@ -189,11 +189,10 @@ public class MineralMap implements Serializable {
 	 * 
 	 * @param startingLocation the starting location.
 	 * @param range            the distance range (km).
-	 * @param sol			the mission sol
 	 * @param foundLocations
 	 * @return location and distance pair
 	 */
-	public Map.Entry<Coordinates, Double> findRandomMineralLocation(Coordinates startingLocation, double range, int sol,
+	public Map.Entry<Coordinates, Double> findRandomMineralLocation(Coordinates startingLocation, double range,
 			Collection<Coordinates> foundLocations) {
 
 		Map<Coordinates, Double> locales = generateMineralLocations(startingLocation, range, foundLocations);
@@ -211,7 +210,7 @@ public class MineralMap implements Serializable {
 				continue;
 			}
 			double prob = 0;
-			double delta = range - distance + Math.max(0, 100 - sol);
+			double delta = range - distance + 100;
 			if (delta > 0) {
 				prob = delta * delta / range / range;
 			}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/Mining.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/Mining.java
@@ -67,7 +67,7 @@ public class Mining extends EVAMission
 	public static final int NUMBER_OF_LARGE_BAGS = 4;
 
 	/** The good value factor of a site. */
-	static final double MINERAL_GOOD_VALUE_FACTOR = 500;
+	public static final double MINERAL_GOOD_VALUE_FACTOR = 500;
 	
 	/** The averge good value of a site. */
 	static final double AVERAGE_RESERVE_GOOD_VALUE = 50_000;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMeta.java
@@ -12,7 +12,6 @@ import com.mars_sim.core.data.RatingScore;
 import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.goods.GoodsManager.CommerceType;
 import com.mars_sim.core.person.Person;
-import com.mars_sim.core.person.ai.SkillType;
 import com.mars_sim.core.person.ai.job.util.JobType;
 import com.mars_sim.core.person.ai.mission.Exploration;
 import com.mars_sim.core.person.ai.mission.Mission;
@@ -75,14 +74,13 @@ public class ExplorationMeta extends AbstractMetaMission {
 				}
 
 				missionProbability = new RatingScore(1);
-				
-				int skill = person.getSkillManager().getEffectiveSkillLevel(SkillType.AREOLOGY);
-				
+								
 				// Get available rover.
 				Rover rover = RoverMission.getVehicleWithGreatestRange(settlement, false);
 				if (rover != null) {
 					// Check if any mineral locations within rover range and obtain their concentration
-					missionProbability.addModifier(MINERALS, Math.min(MAX, settlement.getTotalMineralValue(rover, skill)) / VALUE);
+					missionProbability.addModifier(MINERALS, Math.min(MAX,
+									settlement.getExplorations().getTotalMineralValue(rover)) / VALUE);
 				}
 
 				// Job modifier.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/AnalyzeMapDataMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/AnalyzeMapDataMeta.java
@@ -75,14 +75,14 @@ public class AnalyzeMapDataMeta extends FactoryMetaTask {
         	return EMPTY_TASKLIST;
 		}
 		
-		int unclaimedSites = person.getAssociatedSettlement().numDeclaredLocation(false);
+		var eMgr = person.getAssociatedSettlement().getExplorations();
+		int unclaimedSites = eMgr.numDeclaredLocation(false);
 			
-		Set<Coordinates> nearbySites = person.getAssociatedSettlement()
-				.getNearbyMineralLocations();	
+		Set<Coordinates> nearbySites = eMgr.getNearbyMineralLocations();	
 	
 		int numNearby = nearbySites.size();
 		
-		Set<ExploredLocation> minableLocs = person.getAssociatedSettlement().getDeclaredLocations()
+		Set<ExploredLocation> minableLocs = eMgr.getDeclaredLocations()
 				.stream()
 				.filter(el -> el != null && el.isMinable())
 				.collect(Collectors.toSet());

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/ExplorationManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/ExplorationManager.java
@@ -1,0 +1,420 @@
+/*
+ * Mars Simulation Project
+ * ExplorationManager.java
+ * @date 2024-12-07
+ * @author Barry Evans
+ */
+package com.mars_sim.core.structure;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.mars_sim.core.environment.ExploredLocation;
+import com.mars_sim.core.environment.SurfaceFeatures;
+import com.mars_sim.core.logging.SimLogger;
+import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.mineral.MineralMap;
+import com.mars_sim.core.person.ai.mission.Mining;
+import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.time.MarsTime;
+import com.mars_sim.core.tool.RandomUtil;
+import com.mars_sim.core.vehicle.Rover;
+
+/**
+ * This class managers Exploration sites that are local to a Settlement.
+ * It interacts with the central SurfaceFeatures.
+ */
+public class ExplorationManager implements Serializable {
+    /**
+     * This is the statistics output for a category of explored locations.
+     */
+    public record ExploredStats(double mean, double sd) {}
+
+    private static SurfaceFeatures surfaceFeatures;
+
+    /** default logger. */
+	private static final SimLogger logger = SimLogger.getLogger(ExplorationManager.class.getName());
+
+    private static final double AVERAGE_SITE_TIME = 250D;
+    private static final int AVERAGE_SITE_VISITS = 3;
+
+    public static final int CLAIMED_STAT = 0;
+    public static final int UNCLAIMED_STAT = 1;
+    public static final int SITE_STAT = 2;
+
+	/** A set of nearby mineral locations. */
+	private Map<Coordinates, Double> nearbyMineralLocations = new HashMap<>();
+	/** A list of nearby mineral locations. */
+	private Set<ExploredLocation> declaredMineralLocations = new HashSet<>();
+
+    private Settlement base;
+    
+    /** The extra search radius [in km] to be added. */
+	private double extraKM = 0D;
+
+    ExplorationManager(Settlement base) {
+        this.base = base;
+    }
+
+    /**
+	 * Adds a nearby mineral location in random.
+	 * 
+	 * @param limit
+	 * @param sol
+	 */
+	public Coordinates acquireNearbyMineralLocation(double limit) {
+		
+		var pair = surfaceFeatures.getMineralMap().
+				findRandomMineralLocation(base.getCoordinates(), limit + extraKM, nearbyMineralLocations.keySet());
+		
+		if (pair == null) {
+			logger.warning(base, "No nearby mineral locations found within " + Math.round(limit + extraKM) + " km.");
+			extraKM = extraKM + 0.3;
+			return null;
+		}
+		
+		nearbyMineralLocations.put(pair.getKey(), pair.getValue());
+		
+		return pair.getKey();
+	}
+	
+    
+	/**
+	 * Gets the next closest mineral location.
+	 * 
+	 * @param limit
+	 * @return
+	 */
+	public Coordinates getNextClosestMineralLoc(double limit) {
+		
+		acquireNearbyMineralLocation(limit);
+				
+		double shortestDist = 1000;
+		Coordinates chosen = null;
+
+		for(var c : nearbyMineralLocations.entrySet()) {
+			double dist = c.getValue();
+			if (!surfaceFeatures.isDeclaredARegionOfInterest(c.getKey(), base, false)
+			    && (shortestDist >= dist)) {
+				shortestDist = dist;
+				chosen = c.getKey();
+			}
+		}	
+		
+		return chosen;
+	}
+	
+	/**
+	 * Gets a set of nearby potential mineral locations.
+	 */
+	public Set<Coordinates> getNearbyMineralLocations() {
+		return nearbyMineralLocations.keySet();
+	}
+	
+	/**
+	 * Gets the number of nearby potential mineral location.
+	 * 
+	 * @return
+	 */
+	public int numNearbyMineralLocations() {
+		return nearbyMineralLocations.size();
+	}
+	
+	/**
+	 * Gets one of the existing nearby mineral location that has not been declared yet.
+	 *
+	 * @return
+	 */
+	public Coordinates getExistingNearbyMineralLocation() {
+
+		for (Coordinates c : nearbyMineralLocations.keySet()) {
+			for (ExploredLocation el : declaredMineralLocations) {
+				if (!c.equals(el.getLocation())) {
+					return c;
+				}
+			}
+		}
+		
+		return null;
+	}
+    
+	
+	/**
+	 * Gets a random nearby mineral location that can be reached by any rover.
+	 * 
+	 * @param closest is selecting to return one of the closest locations
+	 * @param limit
+	 * @param skill
+	 * @return
+	 */
+	public Coordinates getARandomNearbyMineralLocation(boolean closest, double limit) {
+		
+		double newRange = limit;
+		
+		if (limit == -1) {		
+			return getNextClosestMineralLoc(limit);
+		}
+		
+		logger.info(base, "nearbyMineralLocations: " + nearbyMineralLocations.size());
+		
+		Map<Coordinates, Double> weightedMap = new HashMap<>();
+		for (var c : nearbyMineralLocations.entrySet()) {
+			// If an undeclared location
+			if (declaredMineralLocations.stream().noneMatch(e -> e.getCoordinates().equals(c.getKey()))) {
+				double distance = c.getValue();
+				double prob = 0;
+				double delta = newRange - distance + 100;
+				if (delta > 0) {
+					continue;
+				}
+					
+				if (closest) {		
+					prob = delta * delta / newRange / newRange;
+				}
+				else {
+					prob = delta / newRange;
+				}
+				
+				if (distance >= MineralMap.MIN_DISTANCE && prob > 0) {
+					// Fill up the weight map
+					weightedMap.put(c.getKey(), prob);
+				}
+			}
+		}
+
+		// Choose one with weighted randomness 
+		Coordinates chosen = RandomUtil.getWeightedRandomObject(weightedMap);
+
+		if (weightedMap.isEmpty() || chosen == null) {
+			logger.info(base, 30_000, "No ROIs found within " + Math.round(limit + extraKM) + " km.");
+			extraKM = extraKM + 0.3;
+			return null;
+		}
+		
+		return chosen;
+	}
+
+	/**
+	 * Returns number of locations being claimed or not being claimed as a Region Of Interest (ROI).
+	 * 
+	 * @param isClaimed
+	 * @return
+	 */
+	public int numDeclaredLocation(boolean isClaimed) {	
+		int num = 0;
+		for (Coordinates c: nearbyMineralLocations.keySet()) {
+			if (surfaceFeatures.isDeclaredARegionOfInterest(c, base, isClaimed))
+				num++;
+		}
+		return num;
+	}
+	
+	/**
+	 * Returns number of locations being claimed or not being claimed as a Region Of Interest (ROI).
+	 * 
+	 * @return
+	 */
+	public int numDeclaredLocation() {	
+		return declaredMineralLocations.size();
+	}
+	
+	/**
+	 * Returns list of declared locations of Region Of Interest (ROI).
+	 * 
+	 * @return
+	 */
+	public Set<ExploredLocation> getDeclaredLocations() {	
+		return declaredMineralLocations;
+	}
+
+    
+	/**
+	 * Computes the mineral sites statistics.
+	 * 
+	 * @param status The type of statistics to requet
+	 * @return
+	 */
+	public ExploredStats getStatistics(int status) {
+		List<Double> list = new ArrayList<>();
+		for (var e : nearbyMineralLocations.entrySet()) {
+			Coordinates c = e.getKey();	
+            var locn = e.getValue();
+
+            switch(status) {
+                case SITE_STAT: 
+                    list.add(locn);
+                    break;
+                
+                case CLAIMED_STAT:
+                    if (surfaceFeatures.isDeclaredARegionOfInterest(c, base, true)) {
+                        list.add(locn);
+                    }
+                    break;
+                
+                case UNCLAIMED_STAT:
+                    if (surfaceFeatures.isDeclaredARegionOfInterest(c, base, false)) {
+                        list.add(locn);
+                    }
+                    break;
+                
+                default:
+                    break;
+            }	
+		}
+		
+	    double mean = 0.0;
+	    double sd = 0.0;
+	    
+        double sum = list.stream().mapToDouble(Double::doubleValue).sum();
+        int size = list.size();
+		if (size != 0) {
+			mean = sum / size;
+ 
+            final double m = mean;
+            double total = list.stream()
+                        .mapToDouble(d -> Math.pow((d - m), 2))
+                        .sum();
+	        var variance = total / size;
+	        sd = Math.sqrt(variance);
+		}
+		
+        return new ExploredStats(mean, sd);
+	}
+	
+	/**
+	 * Creates a Region of Interest (ROI) at a given location and
+	 * estimate its mineral concentrations.
+	 * 
+	 * @param siteLocation
+	 * @param skill
+	 * @return ExploredLocation
+	 */
+	public ExploredLocation createARegionOfInterest(Coordinates siteLocation, int skill) {
+		ExploredLocation el = surfaceFeatures.createARegionOfInterest(siteLocation, base, skill);
+		if (el != null) {
+			declaredMineralLocations.add(el);
+			return el;
+		}
+		return null;
+	}
+	
+	/**
+	 * Checks if there are any mineral locations within rover/mission range.
+	 * Note: Called by getTotalMineralValue()
+	 *
+	 * @param rover          the rover to use.
+	 * @return true if mineral locations.
+	 * @throws Exception if error determining mineral locations.
+	 */
+	private Map<String, Integer> getNearbyMineral(Rover rover) {
+				
+		double roverRange = rover.getEstimatedRange();
+		double tripTimeLimit = rover.getTotalTripTimeLimit(true);
+		double tripRange = getTripTimeRange(tripTimeLimit, rover.getBaseSpeed() / 1.25D);
+		double range = roverRange;
+		if (tripRange < range)
+			range = tripRange;
+
+		Map<Coordinates, Double> weightedMap = new HashMap<>();
+		
+		for (var c : nearbyMineralLocations.entrySet()) {
+			double distance = c.getValue();
+			double prob = 0;
+			double delta = range - distance + 100;
+			if (delta > 0) {
+				prob = delta * delta / range / range;
+			}
+			
+			if (distance >= MineralMap.MIN_DISTANCE && prob > 0) {
+				// Fill up the weight map
+				weightedMap.put(c.getKey(), prob);
+			}
+		}
+		
+		// Choose one with weighted randomness 
+		Coordinates chosen = RandomUtil.getWeightedRandomObject(weightedMap);
+
+		if (weightedMap.isEmpty() || chosen == null) {
+			logger.info(base, 30_000, "No mineral site of interest found within " + Math.round(range + extraKM) + " km.");
+			return Collections.emptyMap();
+		}
+		
+		double chosenDist = weightedMap.get(chosen);
+		
+		logger.info(base, 30_000L, 
+				"Investigating a mineral site at " + chosen + " (" + Math.round(chosenDist * 10.0)/10.0 + " km away).");
+		
+		return surfaceFeatures.getMineralMap().getAllMineralConcentrations(chosen);
+	}
+	
+	
+	/**
+	 * Gets the total mineral value, based on the range of a given rover.
+	 * 
+	 * @param rover
+	 * @return
+	 */
+	public int getTotalMineralValue(Rover rover) {
+        // Check if any mineral locations within rover range and obtain their
+        // concentration
+        var minerals = getNearbyMineral(rover);
+        if (!minerals.isEmpty()) {
+            return getTotalMineralValue(base, minerals);
+        }
+	
+		return 0;
+	}
+
+    /**
+	 * Gets the estimated total mineral value of a mining site.
+	 *
+	 * @param site       the mining site.
+	 * @param settlement the settlement valuing the minerals.
+	 * @return estimated value of the minerals at the site (VP).
+	 * @throws MissionException if error determining the value.
+	 */
+	private static int getTotalMineralValue(Settlement settlement, Map<String, Integer> minerals) {
+
+		double result = 0D;
+
+		for (var entry : minerals.entrySet()) {
+		    String mineralType = entry.getKey();
+		    double concentration = entry.getValue();
+			int mineralResource = ResourceUtil.findIDbyAmountResourceName(mineralType);
+			double mineralValue = settlement.getGoodsManager().getGoodValuePoint(mineralResource);
+			double mineralAmount = (concentration / 100) * Mining.MINERAL_GOOD_VALUE_FACTOR;
+			result += mineralValue * mineralAmount;
+		}
+		
+		result = Math.round(result * 100.0)/100.0;
+		
+		logger.info(settlement, "A site has an Exploration Value of " + result + ".");
+		return (int)result;
+	}
+    	
+	public static void initialise(SurfaceFeatures sf) {
+		surfaceFeatures = sf;
+	}
+
+	/**
+	 * Gets the range of a trip based on its time limit and exploration sites.
+	 *
+	 * @param tripTimeLimit time (millisols) limit of trip.
+	 * @param averageSpeed  the average speed of the vehicle.
+	 * @return range (km) limit.
+	 */
+	private static double getTripTimeRange(double tripTimeLimit, double averageSpeed) {
+		
+		double tripTimeTravellingLimit = tripTimeLimit - (AVERAGE_SITE_VISITS * AVERAGE_SITE_TIME);
+		double millisolsInHour = MarsTime.convertSecondsToMillisols(60D * 60D);
+		double averageSpeedMillisol = averageSpeed / millisolsInHour;
+		return tripTimeTravellingLimit * averageSpeedMillisol;
+	}
+	
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementConfig.java
@@ -18,6 +18,7 @@ import org.jdom2.Element;
 
 import com.mars_sim.core.activities.GroupActivityInfo;
 import com.mars_sim.core.configuration.ConfigHelper;
+import com.mars_sim.core.data.Range;
 import com.mars_sim.core.person.ai.shift.ShiftPattern;
 import com.mars_sim.core.person.ai.shift.ShiftSpec;
 import com.mars_sim.core.person.ai.task.util.ExperienceImpact;
@@ -37,19 +38,18 @@ public class SettlementConfig {
 	private static final String ROVER_LIFE_SUPPORT_RANGE_ERROR_MARGIN = "rover-life-support-range-error-margin";
 	private static final String ROVER_FUEL_RANGE_ERROR_MARGIN = "rover-fuel-range-error-margin";
 	private static final String MISSION_CONTROL = "mission-control";
+
 	private static final String LIFE_SUPPORT_REQUIREMENTS = "life-support-requirements";
 	private static final String TOTAL_PRESSURE = "total-pressure";
 	private static final String PARTIAL_PRESSURE_OF_O2 = "partial-pressure-of-oxygen"; 
 	private static final String PARTIAL_PRESSURE_OF_N2 = "partial-pressure-of-nitrogen";
 	private static final String PARTIAL_PRESSURE_OF_CO2 = "partial-pressure-of-carbon-dioxide"; 
-	private static final String TEMPERATURE = "temperature";
+	public static final String TEMPERATURE = "temperature";
 	private static final String RELATIVE_HUMIDITY = "relative-humidity"; 
 	private static final String VENTILATION = "ventilation";
-	private static final String LOW = "low";
-	private static final String HIGH = "high";
+
+
 	private static final String NAME = "name";
-
-
 	private static final String TYPE = "type";
 	private static final String VALUE = "value";
 	private static final String RESOURCE = "resource";
@@ -83,13 +83,14 @@ public class SettlementConfig {
 	private static final String CALENDAR = "calendar";
 
 	private double[] roverValues = new double[] { 0, 0 };
-	private double[][] lifeSupportValues = new double[2][7];
+	private Map<String,Range> lifeSupportValues = new HashMap<>();
 	
 	private List<ShiftPattern> shiftDefinitions = new ArrayList<>();
 
 	private Map<Integer, ResourceLimits> resLimits = new HashMap<>();
 
 	private List<GroupActivitySchedule> rulesets = new ArrayList<>();
+	
 	/**
 	 * Constructor.
 	 *
@@ -335,11 +336,10 @@ public class SettlementConfig {
 	/**
 	 * Loads the life support requirements from the XML document.
 	 *
-	 * @return an array of double.
-	 * @throws Exception if error reading XML document.
+	 * @return range of values for the parameter
 	 */
-	public double[][] getLifeSupportRequirements() {
-		return lifeSupportValues;
+	public Range getLifeSupportRequirements(String name) {
+		return lifeSupportValues.get(name);
 	}
 
 	/**
@@ -349,11 +349,6 @@ public class SettlementConfig {
 	 * @throws Exception if error reading XML document.
 	 */
 	private void loadLifeSupportRequirements(Element req) {
-		if (lifeSupportValues[0][0] != 0) {
-			// testing only the value at [0][0]
-			return;
-		}
-
 		String[] types = new String[] {
 				TOTAL_PRESSURE,
 				PARTIAL_PRESSURE_OF_O2,
@@ -363,19 +358,9 @@ public class SettlementConfig {
 				RELATIVE_HUMIDITY,
 				VENTILATION};
 
-		for (int j = 0; j < 2; j++) {
-			for (int i = 0; i < types.length; i++) {
-				double [] t = getLowHighValues(req, types[i]);
-				lifeSupportValues[j][i] = t[j];
-			}
+		for (var t : types) {
+			var r = ConfigHelper.parseRange(req.getChild(t), -1);
+			lifeSupportValues.put(t, r);
 		}
-	}
-
-	private double[] getLowHighValues(Element element, String name) {
-		Element el = element.getChild(name);
-		double a = Double.parseDouble(el.getAttributeValue(LOW));
-		double b = Double.parseDouble(el.getAttributeValue(HIGH));
-
-		return new double[] { a, b };
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Rover.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Rover.java
@@ -17,6 +17,7 @@ import com.mars_sim.core.LifeSupportInterface;
 import com.mars_sim.core.LocalAreaUtil;
 import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.air.AirComposition;
+import com.mars_sim.core.data.Range;
 import com.mars_sim.core.data.UnitSet;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.map.location.Coordinates;
@@ -33,6 +34,7 @@ import com.mars_sim.core.robot.Robot;
 import com.mars_sim.core.structure.Airlock;
 import com.mars_sim.core.structure.Lab;
 import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.core.structure.SettlementConfig;
 import com.mars_sim.core.structure.building.function.SystemType;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.tool.Msg;
@@ -81,6 +83,8 @@ public class Rover extends GroundVehicle implements Crewable,
 	private static final double GAS_RATIO;
 	/** The minimum required O2 partial pressure. At 11.94 kPa (1.732 psi) */
 	private static final double MIN_O2_PRESSURE;
+
+	private static Range tempRange;
 	
 	// Data members
 	/** The rover's capacity for crew members. */
@@ -130,6 +134,7 @@ public class Rover extends GroundVehicle implements Crewable,
 		GAS_RATIO = cO2Expelled/o2Consumed;
 		
 		MIN_O2_PRESSURE = simulationConfig.getPersonConfig().getMinSuitO2Pressure();
+		tempRange = simulationConfig.getSettlementConfiguration().getLifeSupportRequirements(SettlementConfig.TEMPERATURE);
 	}
 	
 	/**
@@ -461,8 +466,8 @@ public class Rover extends GroundVehicle implements Crewable,
 		}
 
 		double t = getTemperature();
-		if (t < Settlement.getLifeSupportValues(0, 4) - Settlement.SAFE_TEMPERATURE_RANGE
-				|| t > Settlement.getLifeSupportValues(1, 4) + Settlement.SAFE_TEMPERATURE_RANGE) {
+		if (t < tempRange.min() - Settlement.SAFE_TEMPERATURE_RANGE
+				|| t > tempRange.max() + Settlement.SAFE_TEMPERATURE_RANGE) {
 			logger.log(this, Level.WARNING, 10_000,
 					"Out-of-range overall temperature at " + Math.round(t * 100.0D) / 100.0D
 						+ " " + Msg.getString("temperature.sign.degreeCelsius") + " detected.");

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/UnloadVehicleGarage.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/UnloadVehicleGarage.java
@@ -67,8 +67,10 @@ public class UnloadVehicleGarage extends Task {
 		// Use Task constructor.
 		super("Unloading vehicle", worker, false, IMPACT,
 					RandomUtil.getRandomDouble(40D) + 10D);
+		
+		settlement = worker.getSettlement();
 
-		if (worker.isOutside()) {
+		if (worker.isOutside() || (settlement == null)) {
 			endTask();
 			return;
 		}
@@ -79,8 +81,6 @@ public class UnloadVehicleGarage extends Task {
 			return;
 		}
 		
-		settlement = worker.getSettlement();
-
 		if (isFullyUnloaded(vehicle)) {
 			clearTask(vehicle.getName() + " already unloaded.");
 			return;

--- a/mars-sim-core/src/main/resources/xml/settlements.xml
+++ b/mars-sim-core/src/main/resources/xml/settlements.xml
@@ -13,26 +13,26 @@
 	partial-pressure-of-nitrogen, partial-pressure-of-carbon-dioxide, temperature,
 	relative-humidity, ventilation)>
 	<!ELEMENT total-pressure EMPTY>
-	<!ATTLIST total-pressure low CDATA #REQUIRED>
-	<!ATTLIST total-pressure high CDATA #REQUIRED>
+	<!ATTLIST total-pressure min CDATA #REQUIRED>
+	<!ATTLIST total-pressure max CDATA #REQUIRED>
 	<!ELEMENT partial-pressure-of-oxygen EMPTY>
-	<!ATTLIST partial-pressure-of-oxygen low CDATA #REQUIRED>
-	<!ATTLIST partial-pressure-of-oxygen high CDATA #REQUIRED>
+	<!ATTLIST partial-pressure-of-oxygen min CDATA #REQUIRED>
+	<!ATTLIST partial-pressure-of-oxygen max CDATA #REQUIRED>
 	<!ELEMENT partial-pressure-of-nitrogen EMPTY>
-	<!ATTLIST partial-pressure-of-nitrogen low CDATA #REQUIRED>
-	<!ATTLIST partial-pressure-of-nitrogen high CDATA #REQUIRED>
+	<!ATTLIST partial-pressure-of-nitrogen min CDATA #REQUIRED>
+	<!ATTLIST partial-pressure-of-nitrogen max CDATA #REQUIRED>
 	<!ELEMENT partial-pressure-of-carbon-dioxide EMPTY>
-	<!ATTLIST partial-pressure-of-carbon-dioxide low CDATA #REQUIRED>
-	<!ATTLIST partial-pressure-of-carbon-dioxide high CDATA #REQUIRED>
+	<!ATTLIST partial-pressure-of-carbon-dioxide min CDATA #REQUIRED>
+	<!ATTLIST partial-pressure-of-carbon-dioxide max CDATA #REQUIRED>
 	<!ELEMENT temperature EMPTY>
-	<!ATTLIST temperature low CDATA #REQUIRED>
-	<!ATTLIST temperature high CDATA #REQUIRED>
+	<!ATTLIST temperature min CDATA #REQUIRED>
+	<!ATTLIST temperature max CDATA #REQUIRED>
 	<!ELEMENT relative-humidity EMPTY>
-	<!ATTLIST relative-humidity low CDATA #REQUIRED>
-	<!ATTLIST relative-humidity high CDATA #REQUIRED>
+	<!ATTLIST relative-humidity min CDATA #REQUIRED>
+	<!ATTLIST relative-humidity max CDATA #REQUIRED>
 	<!ELEMENT ventilation EMPTY>
-	<!ATTLIST ventilation low CDATA #REQUIRED>
-	<!ATTLIST ventilation high CDATA #REQUIRED>
+	<!ATTLIST ventilation min CDATA #REQUIRED>
+	<!ATTLIST ventilation max CDATA #REQUIRED>
 
 	<!ELEMENT essential-resources (resource*)>
 	<!ELEMENT resource EMPTY>
@@ -125,22 +125,22 @@
 	<life-support-requirements>
 
 		<!-- recommended range of total air pressure in kPa -->
-		<total-pressure low="32" high="36" />
+		<total-pressure min="32" max="36" />
 		<!-- recommended range of partial pressure for O2 in kPa -->
-		<partial-pressure-of-oxygen low="18"
-			high="22" />
+		<partial-pressure-of-oxygen min="18"
+			max="22" />
 		<!-- recommended range of partial pressure for NO2 in kPa -->
-		<partial-pressure-of-nitrogen low="10"
-			high="14" />
+		<partial-pressure-of-nitrogen min="10"
+			max="14" />
 		<!-- recommended range of partial pressure for CO2 in kPa -->
 		<partial-pressure-of-carbon-dioxide
-			low="0.03" high="0.07" />
+			min="0.03" max="0.07" />
 		<!-- recommended range of temperatures [in degree celsius] -->
-		<temperature low="18" high="26" />
+		<temperature min="18" max="26" />
 		<!-- humidity in % -->
-		<relative-humidity low="30" high="70" />
+		<relative-humidity min="30" max="70" />
 		<!-- ventilation in m/s -->
-		<ventilation low="0.076" high="0.203" />
+		<ventilation min="0.076" max="0.203" />
 
 	</life-support-requirements>
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/ExplorationManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/ExplorationManagerTest.java
@@ -1,0 +1,71 @@
+package com.mars_sim.core.structure;
+
+
+import java.util.Collections;
+
+import com.mars_sim.core.AbstractMarsSimUnitTest;
+import com.mars_sim.core.mineral.RandomMineralFactory;
+
+public class ExplorationManagerTest extends AbstractMarsSimUnitTest {
+    public void testCreateARegionOfInterest() {
+        var s = buildSettlement();
+
+        var eMgr = new ExplorationManager(s);
+
+        // Find a random location within 20K with minerals
+        var mm = getSim().getSurfaceFeatures().getMineralMap();
+        RandomMineralFactory.createLocalConcentration(mm, s.getCoordinates());
+        var found = mm.findRandomMineralLocation(s.getCoordinates(), 20, Collections.emptyList());
+
+        assertTrue("No declared locations", eMgr.getDeclaredLocations().isEmpty());
+
+        // Create a site 1KM from the base
+        var siteLocn = found.getKey();
+        var newRoI = eMgr.createARegionOfInterest(siteLocn, 100);
+
+        assertNotNull("New RoI created", newRoI);
+        assertEquals("New ROI coordinates", siteLocn, newRoI.getCoordinates());
+        assertEquals("New RoI settlement", s, newRoI.getSettlement());
+        assertFalse("New RoI not claimed", newRoI.isClaimed());
+        assertEquals("Declared locations", 1, eMgr.getDeclaredLocations().size());
+
+        newRoI.setClaimed(true);
+        assertTrue("New RoI claimed", newRoI.isClaimed());
+    }
+
+    public void testStatistics() {
+        var s = buildSettlement();
+
+        var eMgr = new ExplorationManager(s);
+
+        // Find a random location within 20K with minerals
+        var mm = getSim().getSurfaceFeatures().getMineralMap();
+        RandomMineralFactory.createLocalConcentration(mm, s.getCoordinates());
+
+        var place = eMgr.acquireNearbyMineralLocation(100);
+        eMgr.createARegionOfInterest(place, 100);
+        var dist1 = place.getDistance(s.getCoordinates());
+
+        place = eMgr.acquireNearbyMineralLocation(100);
+        var newRoI2 = eMgr.createARegionOfInterest(place, 100);
+        newRoI2.setClaimed(true);
+        var dist2 = place.getDistance(s.getCoordinates());
+
+        assertEquals("Nearby locations", 2, eMgr.getNearbyMineralLocations().size());
+        assertEquals("Declared locations", 2, eMgr.getDeclaredLocations().size());
+
+        var claimedStats = eMgr.getStatistics(ExplorationManager.CLAIMED_STAT);
+        assertEquals("Claimed mean", dist2, claimedStats.mean());
+
+        var unclaimedStats = eMgr.getStatistics(ExplorationManager.UNCLAIMED_STAT);
+        assertEquals("Unclaimed mean", dist1, unclaimedStats.mean());
+
+        var siteStats = eMgr.getStatistics(ExplorationManager.SITE_STAT);
+        assertEquals("Site mean", (dist1 + dist2)/2, siteStats.mean());
+
+        assertEquals("Number of Declared", 2, eMgr.numDeclaredLocation());
+        assertEquals("Number of Claimed", 1, eMgr.numDeclaredLocation(true));
+        assertEquals("Number of Unclaimed", 1, eMgr.numDeclaredLocation(false));
+
+    }
+}


### PR DESCRIPTION
This PR focuses on reducing the logic in the Settlement class to support the unit changes actively elsewhere. It contains 2 changes:
- Creation of an ```ExplorationManager``` with unit tests to handle all exploration logic in Settlement
- Use ```Range``` class to simplify the configuration of life support tolerances in Settlements.

Part of #773