### PR TITLE
Prepare for change of Container

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
@@ -343,12 +343,12 @@ public class Simulation implements ClockListener, Serializable {
 		unitManager.addUnit(outerSpace);
 		
 		// Initialize Moon instance
-		Moon moon = new Moon(outerSpace);
+		Moon moon = new Moon();
 		// Add it to unitManager
 		unitManager.addUnit(moon);
 		
 		// Build planetary objects
-		MarsSurface marsSurface = new MarsSurface(outerSpace);
+		MarsSurface marsSurface = new MarsSurface();
 		// Add it to unitManager
 		unitManager.addUnit(marsSurface);
 	
@@ -456,12 +456,12 @@ public class Simulation implements ClockListener, Serializable {
 		unitManager.addUnit(outerSpace);
 		
 		// Initialize Moon instance
-		Moon moon = new Moon(outerSpace);
+		Moon moon = new Moon();
 		// Add it to unitManager
 		unitManager.addUnit(moon);
 		
 		// Initialize MarsSurface instance
-		MarsSurface marsSurface = new MarsSurface(outerSpace);
+		MarsSurface marsSurface = new MarsSurface();
 		// Add it to unitManager
 		unitManager.addUnit(marsSurface);
 		

--- a/mars-sim-core/src/main/java/com/mars_sim/core/Unit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Unit.java
@@ -37,8 +37,6 @@ public abstract class Unit implements UnitIdentifer, Comparable<Unit> {
 	public static final Integer UNKNOWN_UNIT_ID = -3;
 
 	// Data members
-	/** The unit containing this unit. */
-	protected Integer containerID = UNKNOWN_UNIT_ID;
 
 	// Unique Unit identifier
 	private int identifier;
@@ -111,13 +109,11 @@ public abstract class Unit implements UnitIdentifer, Comparable<Unit> {
 	 *
 	 * @param name     {@link String} the name of the unit
 	 * @param id Unit identifier
-	 * @param containerId Identifier of the container
 	 */
-	protected Unit(String name, int id, int containerId) {
+	protected Unit(String name, int id) {
 		// Initialize data members from parameters
 		this.name = name;
 		this.identifier = id;
-		this.containerID = containerId;
 	}
 
 	/**
@@ -135,30 +131,6 @@ public abstract class Unit implements UnitIdentifer, Comparable<Unit> {
 	
 			// Calculate the new Identifier for this type
 			identifier = unitManager.generateNewId(getUnitType());
-		}
-
-		// Define the default LocationStateType of an unit at the start of the sim
-		// Instantiate Inventory as needed. Still needs to be pushed to subclass
-		// constructors
-		switch (getUnitType()) {
-		case BUILDING, CONTAINER, EVA_SUIT, PERSON, ROBOT:
-			// Why no containerID ?
-			break;
-			
-		case VEHICLE:
-			containerID = MARS_SURFACE_UNIT_ID;
-			break;
-
-		case CONSTRUCTION, MARS, SETTLEMENT:
-			containerID = MARS_SURFACE_UNIT_ID;
-			break;
-
-		case MOON:
-			containerID = MOON_UNIT_ID;
-			break;
-			
-		default:
-			throw new IllegalStateException("Do not know Unittype " + getUnitType());
 		}
 
 		if (diagnosticFile != null) {
@@ -260,25 +232,6 @@ public abstract class Unit implements UnitIdentifer, Comparable<Unit> {
 		fireUnitUpdate(UnitEventType.NOTES_EVENT, notes);
 	}
 
-	/**
-	 * Gets the unit's container unit. Returns null if unit has no container unit.
-	 *
-	 * @return the unit's container unit
-	 */
-	public Unit getContainerUnit() {
-		if (unitManager == null) // for maven test
-			return null;
-		return unitManager.getUnitByID(containerID);
-	}
-
-	public int getContainerID() {
-		return containerID;
-	}
-
-	protected void setContainerID(Integer id) {
-		containerID = id;
-	}
-	
 	/**
 	 * Checks if it has a unit listener.
 	 * 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/Unit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Unit.java
@@ -15,10 +15,8 @@ import com.mars_sim.core.environment.Weather;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.person.ai.mission.MissionManager;
 import com.mars_sim.core.structure.Settlement;
-import com.mars_sim.core.structure.building.Building;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.MasterClock;
-import com.mars_sim.core.vehicle.Vehicle;
 
 /**
  * The Unit class is the abstract parent class to all units in the simulation.
@@ -359,51 +357,12 @@ public abstract class Unit implements UnitIdentifer, Comparable<Unit> {
 	}
 
 	/**
-	 * Gets the building this unit is at.
-	 *
-	 * @return the building
-	 */
-	public Building getBuildingLocation() {
-		return null;
-	}
-
-	/**
 	 * Gets the associated settlement this unit is with.
 	 *
 	 * @return the associated settlement
 	 */
 	public Settlement getAssociatedSettlement() {
 		return null;
-	}
-
-	/**
-	 * Gets the vehicle this unit is in, null if not in vehicle.
-	 *
-	 * @return the vehicle
-	 */
-	public Vehicle getVehicle() {
-		return null;
-	}
-
-	/**
-	 * Is this unit inside a settlement ?
-	 *
-	 * @return true if the unit is inside a settlement
-	 */
-	public abstract boolean isInSettlement();
-
-	/**
-	 * Is this unit inside a vehicle in a garage ?
-	 *
-	 * @return true if the unit is in a vehicle inside a garage
-	 */
-	public boolean isInVehicleInGarage() {
-		Unit cu = getContainerUnit();
-		if (cu.getUnitType() == UnitType.VEHICLE) {
-			// still inside the garage
-			return ((Vehicle)cu).isInGarage();
-		}
-		return false;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/environment/MarsSurface.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/environment/MarsSurface.java
@@ -21,8 +21,8 @@ public class MarsSurface extends PlanetaryEntity {
 
 	private static final String NAME = "Mars Surface";
 
-	public MarsSurface(Unit outerSpace) {
-		super(NAME, Unit.MARS_SURFACE_UNIT_ID, outerSpace.getIdentifier(), outerSpace, UnitType.MARS);
+	public MarsSurface() {
+		super(NAME, Unit.MARS_SURFACE_UNIT_ID, UnitType.MARS);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/environment/OuterSpace.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/environment/OuterSpace.java
@@ -21,7 +21,6 @@ public class OuterSpace extends PlanetaryEntity {
 	private static final String NAME = "Outer Space";
 
 	public OuterSpace() {
-		super(NAME, Unit.OUTER_SPACE_UNIT_ID, Unit.OUTER_SPACE_UNIT_ID, null,
-				UnitType.OUTER_SPACE);
+		super(NAME, Unit.OUTER_SPACE_UNIT_ID, UnitType.OUTER_SPACE);
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/environment/PlanetaryEntity.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/environment/PlanetaryEntity.java
@@ -26,16 +26,12 @@ public abstract class PlanetaryEntity extends Unit {
 
 	private Set<Unit> unitList;
 
-	private Unit owner;
-
 	private UnitType objectType;
 
-	protected PlanetaryEntity(String name, int id, int containerId, Unit owner,
-							UnitType objectType) {
-		super(name, id, containerId);
+	protected PlanetaryEntity(String name, int id, UnitType objectType) {
+		super(name, id);
 
 		unitList = new UnitSet<>();
-		this.owner = owner;
 		this.objectType = objectType;				
 	}
 
@@ -131,16 +127,6 @@ public abstract class PlanetaryEntity extends Unit {
 		synchronized (unitList) {
 			return unitList.remove(vehicle);
 		}
-	}
-
-	/**
-	 * Gets the unit's container unit.
-	 *
-	 * @return the unit's container unit
-	 */
-	@Override
-	public Unit getContainerUnit() {
-		return owner;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/environment/PlanetaryEntity.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/environment/PlanetaryEntity.java
@@ -144,17 +144,6 @@ public abstract class PlanetaryEntity extends Unit {
 	}
 
 	/**
-	 * Is this unit inside a settlement ?
-	 *
-	 * @return true if the unit is inside a settlement
-	 */
-	@Override
-	public boolean isInSettlement() {
-		return false;
-	}
-
-
-	/**
 	 * Gets the hash code for this object.
 	 *
 	 * @return hash code.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuit.java
@@ -430,7 +430,7 @@ public class EVASuit extends Equipment
 	 * @throws Exception if error during time.
 	 */
 	public void recordUsageTime(ClockPulse pulse) {
-		Unit container = getContainerUnit();
+		var container = getContainerUnit();
 		if ((container instanceof Person p)
 			&& p.isOutside() && !p.getPhysicalCondition().isDead()) {
 				malfunctionManager.activeTimePassing(pulse);
@@ -455,7 +455,7 @@ public class EVASuit extends Equipment
 
 	@Override
 	public void setContainer(Unit parent, LocationStateType newState) {
-		Unit cu = getContainerUnit();
+		var cu = getContainerUnit();
 		if (parent != cu) {
 			// Add new parent to owner history
 			if (locnHistory == null) {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuitUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuitUtil.java
@@ -95,13 +95,12 @@ public final class EVASuitUtil {
 		if (suit != null)
 			return suit;
 		
-		Unit cu = p.getContainerUnit();
-		if (!(cu instanceof EquipmentOwner)) {
-			logger.warning(p, "Can't find any EVA Suit from " + cu.getName() + ".");
-			return null;
+		var cu = p.getContainerUnit();
+		if (cu instanceof EquipmentOwner eo) {
+			return findEVASuitWithResources(eo, p);
 		}
-		
-		return findEVASuitWithResources((EquipmentOwner)cu, p);
+		logger.warning(p, "Can't find any EVA Suit from " + cu.getName() + ".");
+		return null;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/Equipment.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/Equipment.java
@@ -26,6 +26,7 @@ import com.mars_sim.core.structure.building.Building;
 import com.mars_sim.core.structure.building.Indoor;
 import com.mars_sim.core.structure.building.task.MaintainBuilding;
 import com.mars_sim.core.unit.AbstractMobileUnit;
+import com.mars_sim.core.unit.MobileUnit;
 import com.mars_sim.core.vehicle.Vehicle;
 
 /**
@@ -229,8 +230,9 @@ public abstract class Equipment extends AbstractMobileUnit implements Indoor, Sa
 		Unit container = getContainerUnit();
 		if (container instanceof Vehicle v)
 			return v;
-		if (container.getContainerUnit() instanceof Vehicle v)
-			return v;
+		if ((container instanceof MobileUnit mu)
+				&& mu.getContainerUnit() instanceof Vehicle vu)
+			return vu;
 
 		return null;
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/GenericContainer.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/GenericContainer.java
@@ -16,7 +16,6 @@ import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.resource.AmountResource;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.structure.Settlement;
-import com.mars_sim.core.structure.building.Building;
 
 /**
  * A container class for holding resources.
@@ -267,11 +266,6 @@ class GenericContainer extends Equipment implements Container {
 			return totalCapacity;
 		}
 		return 0;
-	}
-
-	@Override
-	public Building getBuildingLocation() {
-		return getContainerUnit().getBuildingLocation();
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/Kit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/Kit.java
@@ -78,11 +78,6 @@ public class Kit extends Equipment
 	}
 
 	@Override
-	public Settlement getAssociatedSettlement() {
-		return getContainerUnit().getAssociatedSettlement();
-	}
-
-	@Override
 	public double storeAmountResource(int resource, double quantity) {
 		return 0;
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/location/LocationTag.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/location/LocationTag.java
@@ -10,7 +10,6 @@ import java.io.Serializable;
 import java.util.Collection;
 
 import com.mars_sim.core.CollectionUtils;
-import com.mars_sim.core.Unit;
 import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.structure.Settlement;
@@ -66,7 +65,7 @@ public class LocationTag implements Serializable {
 				}
 			} break;
 			case ON_PERSON_OR_ROBOT: {
-				Unit container = unit.getContainerUnit();
+				var container = unit.getContainerUnit();
 				if (container instanceof AbstractMobileUnit w) {
 					result = w.getLocationTag().getImmediateLocation();
 				}
@@ -146,7 +145,7 @@ public class LocationTag implements Serializable {
 				}
 			} break;
 			case ON_PERSON_OR_ROBOT: {
-				Unit container = unit.getContainerUnit();
+				var container = unit.getContainerUnit();
 				if (container instanceof AbstractMobileUnit w) {
 					result = w.getLocationTag().getImmediateLocation();
 				}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/moon/Moon.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/moon/Moon.java
@@ -22,7 +22,7 @@ public class Moon extends PlanetaryEntity {
 	private static final String NAME = "Moon";
 
 
-	public Moon(Unit outerSpace) {
-		super(NAME, Unit.MOON_UNIT_ID, outerSpace.getIdentifier(), outerSpace, UnitType.MOON);
+	public Moon() {
+		super(NAME, Unit.MOON_UNIT_ID, UnitType.MOON);
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/EatDrinkMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/meta/EatDrinkMeta.java
@@ -8,8 +8,6 @@ package com.mars_sim.core.person.ai.task.meta;
 
 import java.util.List;
 
-import com.mars_sim.core.Unit;
-import com.mars_sim.core.UnitType;
 import com.mars_sim.core.data.RatingScore;
 import com.mars_sim.core.equipment.ResourceHolder;
 import com.mars_sim.core.person.Person;
@@ -66,7 +64,7 @@ public class EatDrinkMeta extends FactoryMetaTask {
 		double foodAmount = person.getAmountResourceStored(FOOD_ID);
 		double waterAmount = person.getAmountResourceStored(WATER_ID);
 		
-		Unit container = person.getContainerUnit();
+		var container = person.getContainerUnit();
 		if (container instanceof ResourceHolder rh) {
 			if (foodAmount == 0)
 				foodAmount = rh.getAmountResourceStored(FOOD_ID);
@@ -117,9 +115,7 @@ public class EatDrinkMeta extends FactoryMetaTask {
 		}
 		else if (person.isInVehicle()) {
 			
-			if (UnitType.VEHICLE == container.getUnitType()) {
-				Vehicle vehicle = (Vehicle)container;
-				
+			if (container instanceof Vehicle vehicle) {
 				if (vehicle.isInSettlement()) {
 					inSettlement = true;
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/science/task/StudyFieldSamplesMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/science/task/StudyFieldSamplesMeta.java
@@ -8,7 +8,6 @@ package com.mars_sim.core.science.task;
 
 import java.util.List;
 
-import com.mars_sim.core.Unit;
 import com.mars_sim.core.data.RatingScore;
 import com.mars_sim.core.equipment.ResourceHolder;
 import com.mars_sim.core.person.Person;
@@ -64,7 +63,7 @@ public class StudyFieldSamplesMeta extends FactoryMetaTask {
 		// Check that there are available field samples to study.
 		double mostStored = 0D;
 
-		Unit container = person.getContainerUnit();
+		var container = person.getContainerUnit();
 		if (container instanceof ResourceHolder rh) {
 			for (int i: ResourceUtil.rockIDs) {
 				double stored = rh.getAmountResourceStored(i);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -3587,18 +3587,6 @@ public class Settlement extends Unit implements Temporal,
 		return futureEvents;
 	}
 
-	/**
-	 * Gets the unit's container unit. Returns null if unit has no container unit.
-	 *
-	 * @return the unit's container unit
-	 */
-	@Override
-	public Unit getContainerUnit() {
-		if (unitManager == null) // for maven test
-			return null;
-		return unitManager.getMarsSurface();
-	}
-
 	@Override
 	public UnitType getUnitType() {
 		return UnitType.SETTLEMENT;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -3605,16 +3605,6 @@ public class Settlement extends Unit implements Temporal,
 	}
 
 	/**
-	 * Is this unit inside a settlement ?
-	 *
-	 * @return true if the unit is inside a settlement
-	 */
-	@Override
-	public boolean isInSettlement() {
-		return false;
-	}
-
-	/**
 	 * Gets the preference that this Settlement influences.
 	 * 
 	 * @return A read only copy of preferences

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/Building.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/building/Building.java
@@ -1428,12 +1428,6 @@ public class Building extends FixedUnit implements Malfunctionable,
 		return p * AirComposition.KPA_PER_ATM;
 	}
 
-	@Override
-	public Building getBuildingLocation() {
-		return this;
-	}
-
-
 	// TODO this is wrong as names can change. This is just used to identify if there are multiple floors.
 	public boolean isAHabOrHub() {
         return buildingType.contains(" Hab")

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/construction/ConstructionSite.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/construction/ConstructionSite.java
@@ -413,12 +413,9 @@ public class ConstructionSite extends FixedUnit {
     public boolean hasStage(ConstructionStageInfo stage) {
         if (stage == null) throw new IllegalArgumentException("stage cannot be null");
 
-        boolean result = false;
-        if ((foundationStage != null) && foundationStage.getInfo().equals(stage)) result = true;
-        else if ((frameStage != null) && frameStage.getInfo().equals(stage)) result = true;
-        else if ((buildingStage != null) && buildingStage.getInfo().equals(stage)) result = true;
-
-        return result;
+        return (((foundationStage != null) && foundationStage.getInfo().equals(stage))
+                    || ((frameStage != null) && frameStage.getInfo().equals(stage))
+                    || ((buildingStage != null) && buildingStage.getInfo().equals(stage)));
     }
 
     /**
@@ -499,17 +496,11 @@ public class ConstructionSite extends FixedUnit {
 	public UnitType getUnitType() {
 		return UnitType.CONSTRUCTION;
 	}
-
-	/**
-	 * Is this unit inside a settlement ?
-	 *
-	 * @return true if the unit is inside a settlement
-	 */
-	@Override
-	public boolean isInSettlement() {
-		return false;
-	}
 	
+    /**
+     * Get the dynamic description based on the current stage.
+     * @return Description of site
+     */
     @Override
     public String getDescription() {
 		StringBuilder result = new StringBuilder();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/unit/AbstractMobileUnit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/unit/AbstractMobileUnit.java
@@ -8,6 +8,7 @@ package com.mars_sim.core.unit;
 
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitEventType;
+import com.mars_sim.core.UnitType;
 import com.mars_sim.core.location.LocationStateType;
 import com.mars_sim.core.location.LocationTag;
 import com.mars_sim.core.map.location.Coordinates;
@@ -112,13 +113,18 @@ public abstract class AbstractMobileUnit extends Unit
 	}
 
     /**
-	 * Computes the building the person is currently located at.
+	 * Computes the building the unit is currently located at. Accounts for the mobile unit
+	 * being in another MobileUnit
 	 * Returns null if outside of a settlement.
 	 *
 	 * @return building
 	 */
 	@Override
 	public Building getBuildingLocation() {
+		if (getContainerUnit() instanceof MobileUnit mu) {
+			return mu.getBuildingLocation();
+		}
+	
 		if (currentBuildingInt == -1)
 			return null;
 		return unitManager.getBuildingByID(currentBuildingInt);
@@ -283,6 +289,20 @@ public abstract class AbstractMobileUnit extends Unit
 		if (LocationStateType.ON_PERSON_OR_ROBOT == locnState)
 			return ((Worker)getContainerUnit()).isInVehicle();
 
+		return false;
+	}
+
+	/**
+	 * Is this unit inside a vehicle in a garage ?
+	 *
+	 * @return true if the unit is in a vehicle inside a garage
+	 */
+	public boolean isInVehicleInGarage() {
+		Unit cu = getContainerUnit();
+		if (cu.getUnitType() == UnitType.VEHICLE) {
+			// still inside the garage
+			return ((Vehicle)cu).isInGarage();
+		}
 		return false;
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/unit/AbstractMobileUnit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/unit/AbstractMobileUnit.java
@@ -32,6 +32,7 @@ public abstract class AbstractMobileUnit extends Unit
 	private LocationTag tag;
 	private LocationStateType locnState;
 	private Coordinates location;
+	private Unit container;
 
     /**
 	 * Constructor.
@@ -48,13 +49,21 @@ public abstract class AbstractMobileUnit extends Unit
 	}
 
 	/**
+	 * Get the container of this mobile unit.
+	 * @return Should never be null
+	 */
+	public Unit getContainerUnit() {
+		return container;
+	}
+
+	/**
 	 * Set the container of this mobile unit
 	 * @param destination New destination of container
 	 * @param newState 
 	 */
 	protected void setContainer(Unit destination, LocationStateType newState) {
 		this.locnState = newState;
-		setContainerID(destination.getIdentifier());
+		container = destination;
 	}
 
 	/**
@@ -217,10 +226,8 @@ public abstract class AbstractMobileUnit extends Unit
 	 *
 	 * @return the settlement
 	 */
+	@Override
 	public Settlement getSettlement() {
-
-		if (getContainerID() <= Unit.MARS_SURFACE_UNIT_ID)
-			return null;
 
 		var c = getContainerUnit();
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/unit/FixedUnit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/unit/FixedUnit.java
@@ -59,17 +59,6 @@ public abstract class FixedUnit extends Unit
     }
 
     /**
-	 * Is this unit inside a settlement
-     * TODO This will be removed once completed
-	 *
-	 * @return true if the unit is inside a settlement
-	 */
-	@Override
-	public boolean isInSettlement() {
-		return true;
-	}
-
-    /**
 	 * This method return the context of this FixedUnit which is always the parent 
 	 */
 	@Override

--- a/mars-sim-core/src/main/java/com/mars_sim/core/unit/FixedUnit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/unit/FixedUnit.java
@@ -29,9 +29,6 @@ public abstract class FixedUnit extends Unit
 		super(name);
 
         this.owner = owner;
-
-        // TODO Place holder; once completed this can be removed
-		setContainerID(owner.getIdentifier());
 	}
 
     /**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
@@ -65,6 +65,7 @@ import com.mars_sim.core.time.MarsTime;
 import com.mars_sim.core.time.Temporal;
 import com.mars_sim.core.tool.RandomUtil;
 import com.mars_sim.core.unit.AbstractMobileUnit;
+import com.mars_sim.core.unit.MobileUnit;
 import com.mars_sim.core.vehicle.task.LoadingController;
 
 /**
@@ -982,11 +983,6 @@ public abstract class Vehicle extends AbstractMobileUnit
 		double estFE = getEstimatedFuelEconomy();
 		double estFC = getEstimatedFuelConsumption();
 		
-//		if (cumFE > 0 && cumFC > 0 && averageRoadLoadPower > 0 && averageRoadLoadSpeed > 0)
-//			// [km / kg]  / [Wh / km]  * [kW] / [km / h]
-//			// km / kg / Wh * km * kW / km * h = km / kg * k 
-//			return cumFE / cumFC * averageRoadLoadPower / averageRoadLoadSpeed ;
-		
 		if (estFE > 0 && estFC > 0)
 			// [km / kg]  / [Wh / km]  
 			// km / kg / Wh * km 
@@ -1318,17 +1314,14 @@ public abstract class Vehicle extends AbstractMobileUnit
 	@Override
 	public Settlement getSettlement() {
 
-		if (getContainerID() <= Unit.MARS_SURFACE_UNIT_ID)
-			return null;
-
 		Unit c = getContainerUnit();
 
-		if (c.getUnitType() == UnitType.SETTLEMENT)
-			return (Settlement) c;
+		if (c instanceof Settlement s)
+			return s;
 
 		// If this unit is an LUV and it is within a rover
-		if (c.getUnitType() == UnitType.VEHICLE)
-			return ((Vehicle)c).getSettlement();
+		if (c instanceof MobileUnit mu)
+			return mu.getSettlement();
 
 		return null;
 	}
@@ -2268,7 +2261,7 @@ public abstract class Vehicle extends AbstractMobileUnit
 	 */
 	@Override
 	public boolean isInSettlement() {
-		if (containerID <= MARS_SURFACE_UNIT_ID) {
+		if (getContainerUnit() instanceof MarsSurface) {
 			return false;
 		}
 
@@ -2276,7 +2269,7 @@ public abstract class Vehicle extends AbstractMobileUnit
 		boolean isVehicleInGarage = LocationStateType.INSIDE_SETTLEMENT == currentStateType;
 		boolean isVehicleInSettlementVicinity = LocationStateType.SETTLEMENT_VICINITY == currentStateType;
 		boolean isUnitTypeSettlement = getContainerUnit().getUnitType() == UnitType.SETTLEMENT;
-		boolean isVicinityParkedVehicle = ((Settlement)(getContainerUnit())).containsVicinityParkedVehicle(this);
+		boolean isVicinityParkedVehicle = (getContainerUnit() instanceof Settlement s) && s.containsVicinityParkedVehicle(this);
 
 		return isVehicleInGarage || isVehicleInSettlementVicinity || isUnitTypeSettlement || isVicinityParkedVehicle;
 	}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/equipment/EquipmentInventoryTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/equipment/EquipmentInventoryTest.java
@@ -10,7 +10,6 @@ package com.mars_sim.core.equipment;
 import java.util.Set;
 
 import com.mars_sim.core.AbstractMarsSimUnitTest;
-import com.mars_sim.core.Unit;
 import com.mars_sim.core.resource.ItemResourceUtil;
 import com.mars_sim.core.resource.Part;
 import com.mars_sim.core.resource.ResourceUtil;
@@ -37,95 +36,44 @@ public class EquipmentInventoryTest extends AbstractMarsSimUnitTest {
 	/*
 	 * Test method loading equipment with amount resources.
 	 */
-	public void testAmountInEquipmentLoading() throws Exception {
+	public void testAmountInEquipmentLoading() {
 		EquipmentInventory inv = new EquipmentInventory(settlement, CAPACITY_AMOUNT);
 		int co2 = ResourceUtil.co2ID;
 		int rock = ResourceUtil.rockSamplesID;
 		double co2Mass = CAPACITY_AMOUNT/10; // 100 kg
 		double rockMass = CAPACITY_AMOUNT/20; // 50 kg
-
-		double cargoCap = inv.getCargoCapacity();
-		System.out.println("1. Cargo Capacity: " + cargoCap + " kg.");
-		double stored = inv.getStoredMass();
-		System.out.println("1. Stored mass: " + stored + " kg.");
-		double remain = inv.getRemainingCargoCapacity();
-		System.out.println("1. Remaining Cargo Capacity: " + remain + " kg.");
 		
 		// Store some CO2 directly and then a Bag containing rocks
 		inv.storeAmountResource(co2, co2Mass);
-
-		cargoCap = inv.getCargoCapacity();
-		System.out.println("1.5 Cargo Capacity: " + cargoCap + " kg.");
-		stored = inv.getStoredMass();
-		System.out.println("1.5 Stored mass: " + stored + " kg.");
-		remain = inv.getRemainingCargoCapacity();
-		System.out.println("1.5 Remaining Cargo Capacity: " + remain + " kg.");
 		
 		Equipment bag = EquipmentFactory.createEquipment(EquipmentType.BAG, settlement);
-		boolean canStore = settlement.addEquipment(bag);
-		System.out.println("canStore: " + canStore);
-		
-		// Test if the bag is in the settlement
-		boolean hasIt = inv.containsEquipment(EquipmentType.BAG);
-		System.out.println("Is there a bag in the settlement: " + hasIt);
-		
-		int size = settlement.getEquipmentSet().size();
-		System.out.println("size: " + size);
-		
-		Unit unit = bag.getContainerUnit();
-		System.out.println(bag + "'s container unit: " + unit);
 		
 		double excess = ((Container)bag).storeAmountResource(rock, rockMass);
-		System.out.println("excess: " + excess);
 		
 		assertEquals("Bag cannot store the rock.", 0D, excess);
-		
-		double bagMass = bag.getMass();
-		System.out.println("bagMass: " + bagMass + " kg.");
-		
+				
 		assertEquals("CO2 stored.", co2Mass, inv.getAmountResourceStored(co2));
 		
 		// Note: rock is stored inside a bag and not in settlement
 		assertEquals("Rock stored.", 0D, inv.getAmountResourceStored(rock));
-
-		cargoCap = inv.getCargoCapacity();
-		System.out.println("2. Cargo Capacity: " + cargoCap + " kg.");
-		stored = inv.getStoredMass();
-		System.out.println("2. Stored mass: " + stored + " kg.");
-		remain = inv.getRemainingCargoCapacity();
-		System.out.println("2. Remaining Cargo Capacity: " + remain + " kg.");
-		
-		System.out.println("equipment set size: " + inv.getEquipmentSet().size());
-		
-		double expectedMass = co2Mass + rockMass + bag.getBaseMass();
-		System.out.println("Expected total stored mass: " + expectedMass + " kg.");
-		
-		// Note: It's unable to reconcile the presence of a bag (1 kg) with rock mass of (50 kg)
-//		assertEquals("Remaining cargo capacity after bag load.", CAPACITY_AMOUNT - expectedMass, remain);
-//		assertEquals("Total mass after bag load.", expectedMass, inv.getStoredMass());
-		
+						
 		assertEquals("Resources held in inventory.", Set.of(co2), inv.getAmountResourceIDs());
 
 		// Remove some rock from bag
 		bag.retrieveAmountResource(rock, rockMass/2);
-		expectedMass = co2Mass + rockMass/2 + bag.getBaseMass();
 		assertEquals("Rock after bag unload.", rockMass/2, bag.getAmountResourceStored(rock));
 		
-		// Note: It's unable to reconcile the presence of a bag (1 kg) with rock mass of (50 kg)
-//		assertEquals("Total mass after bag unload.", expectedMass, inv.getStoredMass());
-
 		// Remove the bag
 		inv.removeEquipment(bag);
 		assertEquals("Remaining capacity after bag remove.", CAPACITY_AMOUNT - co2Mass, inv.getAmountResourceRemainingCapacity(co2));
 		assertEquals("Total mass after bag remove.", co2Mass, inv.getStoredMass());
 		assertEquals("Resources held after bag remove.", Set.of(co2), inv.getAmountResourceIDs());
-
 	}
 
 	/*
 	 * Test method loading amount resources.
 	 */
-	public void testAmountLoading() throws Exception {
+	public void testAmountLoading() {
 		EquipmentInventory inv = new EquipmentInventory(settlement, CAPACITY_AMOUNT);
 		int resource = ResourceUtil.co2ID;
 
@@ -143,7 +91,7 @@ public class EquipmentInventoryTest extends AbstractMarsSimUnitTest {
 	/*
 	 * Test method loading parts.
 	 */
-	public void testPartsOverloading() throws Exception {
+	public void testPartsOverloading() {
 		Part drillPart = (Part) ItemResourceUtil.findItemResource(PNEUMATIC_DRILL);
 		int maxDrills = 2;
 		
@@ -164,7 +112,7 @@ public class EquipmentInventoryTest extends AbstractMarsSimUnitTest {
 	/*
 	 * Test method over-loading amount resources.
 	 */
-	public void testAmountOverloading() throws Exception {
+	public void testAmountOverloading() {
 		EquipmentInventory inv = new EquipmentInventory(settlement, CAPACITY_AMOUNT);
 		int resource = ResourceUtil.co2ID;
 
@@ -178,7 +126,7 @@ public class EquipmentInventoryTest extends AbstractMarsSimUnitTest {
 	/*
 	 * Test method unloading amount resources.
 	 */
-	public void testAmountUnloading() throws Exception {
+	public void testAmountUnloading() {
 		EquipmentInventory inv = new EquipmentInventory(settlement, CAPACITY_AMOUNT);
 		int resource = ResourceUtil.co2ID;
 
@@ -200,14 +148,14 @@ public class EquipmentInventoryTest extends AbstractMarsSimUnitTest {
 	/*
 	 * Test method loading combined amount resources.
 	 */
-	public void testMultiples() throws Exception {
+	public void testMultiples() {
 		EquipmentInventory inv = new EquipmentInventory(settlement, CAPACITY_AMOUNT);
 		int resource = ResourceUtil.co2ID;
 		int resource2  = ResourceUtil.oxygenID;
 
 		// if Using general/cargo capacity instead of the dedicated capacity for a resource
-		assertEquals("Remaining capacity 1st resource", CAPACITY_AMOUNT, inv.getRemainingCargoCapacity());//getAmountResourceRemainingCapacity(resource));
-		assertEquals("Remaining capacity 2nd resource", CAPACITY_AMOUNT, inv.getRemainingCargoCapacity());//getAmountResourceRemainingCapacity(resource2));
+		assertEquals("Remaining capacity 1st resource", CAPACITY_AMOUNT, inv.getRemainingCargoCapacity());
+		assertEquals("Remaining capacity 2nd resource", CAPACITY_AMOUNT, inv.getRemainingCargoCapacity());
 
 		inv.storeAmountResource(resource, CAPACITY_AMOUNT/2);
 		inv.storeAmountResource(resource2, CAPACITY_AMOUNT/4);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/EatDrinkTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/EatDrinkTest.java
@@ -1,0 +1,128 @@
+package com.mars_sim.core.person.ai.task;
+
+import com.mars_sim.core.AbstractMarsSimUnitTest;
+import com.mars_sim.core.equipment.EquipmentFactory;
+import com.mars_sim.core.equipment.EquipmentType;
+import com.mars_sim.core.equipment.ResourceHolder;
+import com.mars_sim.core.map.location.LocalPosition;
+import com.mars_sim.core.person.Person;
+import com.mars_sim.core.person.PhysicalCondition;
+import com.mars_sim.core.person.ai.job.util.JobType;
+import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.structure.building.Building;
+import com.mars_sim.core.structure.building.BuildingCategory;
+import com.mars_sim.core.structure.building.BuildingManager;
+import com.mars_sim.core.structure.building.function.FunctionType;
+
+public class EatDrinkTest extends AbstractMarsSimUnitTest {
+    
+    private static final double INITIAL_RESOURCE = 100D;
+
+    protected Building buildDining(BuildingManager buildingManager, LocalPosition pos, double facing) {
+        return buildFunction(buildingManager, "Lander Hab", BuildingCategory.LIVING,
+                                FunctionType.DINING,  pos, facing, true);
+    }
+
+    public void testSettlementWater() {
+        var s = buildSettlement();
+        var d = buildDining(s.getBuildingManager(), LocalPosition.DEFAULT_POSITION, 0);
+        var p = buildPerson("eater", s, JobType.ENGINEER, d, FunctionType.DINING);
+        s.storeAmountResource(ResourceUtil.waterID, INITIAL_RESOURCE);
+
+        testWater(p);
+        assertTrue("Water consumed", s.getAmountResourceStored(ResourceUtil.waterID) < INITIAL_RESOURCE);
+    }
+
+    public void testBottleWater() {
+        var s = buildSettlement();
+        var d = buildDining(s.getBuildingManager(), LocalPosition.DEFAULT_POSITION, 0);
+        var p = buildPerson("eater", s, JobType.ENGINEER, d, FunctionType.DINING);
+
+        // Create bottle and assign to person
+        var b = EquipmentFactory.createEquipment(EquipmentType.THERMAL_BOTTLE, s);
+        b.storeAmountResource(ResourceUtil.waterID, INITIAL_RESOURCE);
+        p.assignThermalBottle();
+
+        testWater(p);
+        assertTrue("Water consumed", b.getAmountResourceStored(ResourceUtil.waterID) < INITIAL_RESOURCE);
+    }
+
+    public void testVehicleWater() {
+        var s = buildSettlement();
+        var p = buildPerson("eater", s);
+        var v = buildRover(s, "R1", LocalPosition.DEFAULT_POSITION);
+        v.storeAmountResource(ResourceUtil.waterID, INITIAL_RESOURCE);
+
+        p.transfer(v);
+        assertTrue("In vehicle", p.isInVehicle());
+
+        testWater(p);
+        assertTrue("Water consumed", v.getAmountResourceStored(ResourceUtil.waterID) < INITIAL_RESOURCE);
+
+    }
+
+    private void testWater(Person p) {
+        var pc = p.getPhysicalCondition();
+        pc.setThirst(PhysicalCondition.MAX_THIRST);
+        var initialThirst = pc.getThirst();
+        assertTrue("Person is thirty", initialThirst > 0);
+
+        var t = new EatDrink(p);
+        assertFalse("EatDrink task not complete", t.isDone());
+
+        executeTask(p, t, 100);
+        assertTrue("Eatdrnk completed", t.isDone());
+        assertTrue("Person is less thirty", pc.getThirst() < initialThirst);
+    }
+
+    public void testSettlementFood() {
+        var s = buildSettlement();
+        var d = buildDining(s.getBuildingManager(), LocalPosition.DEFAULT_POSITION, 0);
+        var p = buildPerson("eater", s, JobType.ENGINEER, d, FunctionType.DINING);
+
+        testHunger(p, s);
+    }
+
+    public void testSettlementFoodWater() {
+        var s = buildSettlement();
+        var d = buildDining(s.getBuildingManager(), LocalPosition.DEFAULT_POSITION, 0);
+        var p = buildPerson("eater", s, JobType.ENGINEER, d, FunctionType.DINING);
+
+        var pc = p.getPhysicalCondition();
+        pc.setThirst(PhysicalCondition.MAX_THIRST);
+        var initialThirst = pc.getThirst();
+
+        testHunger(p, s);
+
+        assertTrue("Person is less thirsty", pc.getThirst() < initialThirst);
+
+    }
+
+    public void testVehicleFood() {
+        var s = buildSettlement();
+        var p = buildPerson("eater", s);
+        var v = buildRover(s, "R1", LocalPosition.DEFAULT_POSITION);
+
+        p.transfer(v);
+        assertTrue("In vehicle", p.isInVehicle());
+
+        testHunger(p, v);
+    }
+
+    private void testHunger(Person p, ResourceHolder rh) {
+        rh.storeAmountResource(ResourceUtil.foodID, INITIAL_RESOURCE);
+
+        var pc = p.getPhysicalCondition();
+        pc.setHunger(PhysicalCondition.HUNGER_THRESHOLD + 1);
+        pc.setThirst(0D);
+        assertTrue("Person is hungry", pc.isHungry());
+
+        var t = new EatDrink(p);
+        assertFalse("EatDrink task not complete", t.isDone());
+
+        executeTask(p, t, 1000);
+        assertTrue("Eatdrnk completed", t.isDone());
+        assertFalse("Person is not hungry", pc.isHungry());
+        assertTrue("Food consumed", rh.getAmountResourceStored(ResourceUtil.foodID) < INITIAL_RESOURCE);
+    }
+}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_display_info/VehicleDisplayInfoBean.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_display_info/VehicleDisplayInfoBean.java
@@ -15,8 +15,6 @@ import javax.swing.Icon;
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.environment.MarsSurface;
 import com.mars_sim.core.map.MapMetaData;
-import com.mars_sim.core.vehicle.Drone;
-import com.mars_sim.core.vehicle.Rover;
 import com.mars_sim.core.vehicle.StatusType;
 import com.mars_sim.core.vehicle.Vehicle;
 import com.mars_sim.ui.swing.ImageLoader;
@@ -52,12 +50,12 @@ abstract class VehicleDisplayInfoBean implements UnitDisplayInfo {
     @Override
     public boolean isMapDisplayed(Unit unit) {
         boolean result = true;
+        Vehicle vehicle = (Vehicle) unit;
         
-        Unit container = unit.getContainerUnit();
+        Unit container = vehicle.getContainerUnit();
 		if (container == null || container instanceof MarsSurface)
         	result = true;
         
-        Vehicle vehicle = (Vehicle) unit;
         if (vehicle.isSalvaged()) result = false;
         
         // Do not display towed vehicle on map.
@@ -130,15 +128,11 @@ abstract class VehicleDisplayInfoBean implements UnitDisplayInfo {
      */
     @Override
     public boolean isGlobeDisplayed(Unit unit) {
-        boolean result = true;
         
         Vehicle vehicle = (Vehicle) unit;
         
         // Show the vehicle only if it's on a mission outside
-        int containerID = vehicle.getContainerID();
-        result = (containerID == Unit.MARS_SURFACE_UNIT_ID || containerID == Unit.UNKNOWN_UNIT_ID)
-                && (vehicle instanceof Rover || vehicle instanceof Drone);
-		
+        boolean result = !vehicle.isInSettlement() && !vehicle.isInSettlementVicinity();
         if (vehicle.isSalvaged()) 
         	result = false;
         

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_display_info/VehicleDisplayInfoBean.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_display_info/VehicleDisplayInfoBean.java
@@ -52,7 +52,7 @@ abstract class VehicleDisplayInfoBean implements UnitDisplayInfo {
         boolean result = true;
         Vehicle vehicle = (Vehicle) unit;
         
-        Unit container = vehicle.getContainerUnit();
+        var container = vehicle.getContainerUnit();
 		if (container == null || container instanceof MarsSurface)
         	result = true;
         

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/LocationTabPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/LocationTabPanel.java
@@ -18,6 +18,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
 
+import com.mars_sim.core.Entity;
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.environment.TerrainElevation;
 import com.mars_sim.core.location.LocationStateType;
@@ -79,7 +80,7 @@ public class LocationTabPanel extends TabPanel {
 	private DisplayCircular gauge;
 
 	
-	private Unit containerCache;
+	private Entity containerCache;
 	private Building buildingCache;
 	private Coordinates locationCache = new Coordinates(0D, 0D);
 
@@ -223,7 +224,7 @@ public class LocationTabPanel extends TabPanel {
 		posnLabel.setText(mu.getPosition().getShortFormat());
 
 		// Update labels as necessary
-		Unit container = mu.getContainerUnit();
+		Entity container = mu.getContainerUnit();
 		if ((containerCache == null) || !containerCache.equals(container)) {
 			containerCache = container;
 			String n = container != null ? container.getName() : "";


### PR DESCRIPTION
This PR contains preparatory work for the introduction later of the new ```UnitOwner```:

- Management of container is move to ```AbstractMobileUnit```
- Base ```Unit``` no longer has a container
- Use of ```getContainerUnit``` uses a 'var' instead of 'Unit'
- ```EatDrinkTask``` is reworked to simplify and isolated from container. Also safe guarded with a new Unit test
- 

