### PR TITLE
Prep 3.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,12 @@
 name: Create Release
 
+# This workflow is triggered on user request
 on:
-  push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  workflow_dispatch:
+
+# Make sure the GITHUB_TOKEN has permission to upload to our releases
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -22,25 +24,16 @@ jobs:
       run:
         mvn  --file pom.xml -B package
     - name: Extract build version
-      run: echo "MARS_SIM_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+      run: echo "POM_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+    - name: Create tag
+      run: |
+        git tag v${{ env.POM_VERSION }}
+        git push origin tag v${{ env.POM_VERSION }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
+      run: |
+        cd ${{github.workspace}}
+        gh release create v${{ env.POM_VERSION }} ./mars-sim-dist/target/mars-sim-${{ env.POM_VERSION }}.zip --verify-tag --draft --title 'Release v${{ env.POM_VERSION }}' --notes-file ./RELEASE.md     
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref_name }}
-        body_path: ./RELEASE.md
-        draft: true
-        prerelease: false
-    - name: Upload Release Asset
-      id: upload-release-asset 
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: ./mars-sim-dist/target/mars-sim-${{ env.MARS_SIM_VERSION }}.zip
-        asset_name: mars-sim-${{ github.ref_name }}.zip
-        asset_content_type: application/zip

--- a/mars-sim-console/pom.xml
+++ b/mars-sim-console/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.mars-sim</groupId>
     <artifactId>mars-sim</artifactId>
-    <version>pre-3.9.0</version>
+    <version>3.9.0</version>
   </parent>
   <artifactId>mars-sim-console</artifactId>
   <name>mars-sim-console</name>

--- a/mars-sim-core/pom.xml
+++ b/mars-sim-core/pom.xml
@@ -90,7 +90,7 @@
 		<repository>
 			<id>jogamp-remote</id>
 			<name>jogamp mirror</name>
-			<url>https://www.jogamp.org/deployment/maven/</url>
+			<url>https://jogamp.org/deployment/maven/</url>
 		</repository>
 	</repositories>
    <build>

--- a/mars-sim-core/pom.xml
+++ b/mars-sim-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>mars-sim</artifactId>
 		<groupId>com.mars-sim</groupId>
-		<version>pre-3.9.0</version>
+		<version>3.9.0</version>
 	</parent>
 	<artifactId>mars-sim-core</artifactId>
 	<name>mars-sim-core</name>

--- a/mars-sim-dist/pom.xml
+++ b/mars-sim-dist/pom.xml
@@ -6,7 +6,7 @@
   <parent>
 	<artifactId>mars-sim</artifactId>
 	<groupId>com.mars-sim</groupId>
-	<version>pre-3.9.0</version>
+	<version>3.9.0</version>
   </parent>
   <artifactId>mars-sim-dist</artifactId>
   <name>mars-sim-dist</name>

--- a/mars-sim-fxgl/pom.xml
+++ b/mars-sim-fxgl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.mars-sim</groupId>
     <artifactId>mars-sim</artifactId>
-    <version>pre-3.9.0</version>
+    <version>3.9.0</version>
   </parent>
   <artifactId>mars-sim-fxgl</artifactId>
   <name>mars-sim-fxgl</name>

--- a/mars-sim-headless/pom.xml
+++ b/mars-sim-headless/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.mars-sim</groupId>
 		<artifactId>mars-sim</artifactId>
-		<version>pre-3.9.0</version>
+		<version>3.9.0</version>
 	</parent>
 	<artifactId>mars-sim-headless</artifactId>
 	<name>mars-sim-headless</name>

--- a/mars-sim-javafx/pom.xml
+++ b/mars-sim-javafx/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.github.mars-sim</groupId>
     <artifactId>mars-sim</artifactId>
-    <version>pre-3.9.0</version>
+    <version>3.9.0</version>
   </parent>
   <artifactId>mars-sim-javafx</artifactId>
   <name>mars-sim-javafx</name>

--- a/mars-sim-libgdx/pom.xml
+++ b/mars-sim-libgdx/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.mars-sim</groupId>
     <artifactId>mars-sim</artifactId>
-    <version>pre-3.9.0</version>
+    <version>3.9.0</version>
   </parent>
   <artifactId>mars-sim-libgdx</artifactId>
   <name>mars-sim-libgdx</name>

--- a/mars-sim-tools/pom.xml
+++ b/mars-sim-tools/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.mars-sim</groupId>
     <artifactId>mars-sim</artifactId>
-    <version>pre-3.9.0</version>
+    <version>3.9.0</version>
   </parent>
   <artifactId>mars-sim-tools</artifactId>
   <dependencies>

--- a/mars-sim-ui/pom.xml
+++ b/mars-sim-ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.mars-sim</groupId>
 		<artifactId>mars-sim</artifactId>
-		<version>pre-3.9.0</version>
+		<version>3.9.0</version>
 	</parent>
 	<artifactId>mars-sim-ui</artifactId>
 	<name>mars-sim-ui</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.mars-sim</groupId>
 	<artifactId>mars-sim</artifactId>
 	<packaging>pom</packaging>
-	<version>pre-3.9.0</version>
+	<version>3.9.0</version>
 	<name>mars-sim</name>
 	<url>https://github.com/mars-sim/mars-sim</url>
 	<inceptionYear>2009</inceptionYear>


### PR DESCRIPTION
Some changes in preparation of release 3.9.0

- Advance Maven version to 3.9.0
- Change the GitHub Create Release action to automatically create tag and identify the release number from the Maven project