### PR TITLE
Make construction of simulation config explicit

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/CommanderProfile.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/CommanderProfile.java
@@ -80,7 +80,7 @@ public class CommanderProfile implements BiConsumer<TextIO, RunnerData> {
     	terminal = term.getTerminal();
 
     	// Get Country list from known PersonConfig
-        NationSpecConfig nameConfig = new NationSpecConfig();
+        NationSpecConfig nameConfig = new NationSpecConfig(config);
     	countryList = new ArrayList<>(nameConfig.getItemNames());
     	Collections.sort(countryList);
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
@@ -367,7 +367,7 @@ public class Simulation implements ClockListener, Serializable {
 		// Initialize ScientificStudyUtil
 		ScientificStudyUtil.initializeInstances(unitManager);
 
-		//Rover.initializeInstances(simulationConfig);
+		Rover.initializeInstances(simulationConfig);
 		Unit.initializeInstances(masterClock, unitManager, weather, missionManager);
 		
 		LocalAreaUtil.initializeInstances(unitManager, masterClock);
@@ -462,7 +462,7 @@ public class Simulation implements ClockListener, Serializable {
 		lunarColonyManager.addInitColonies();
 		
 		// Initialize Unit
-		//Rover.initializeInstances(simulationConfig);
+		Rover.initializeInstances(simulationConfig);
 		Unit.initializeInstances(masterClock, unitManager, weather, missionManager);
 	
 		PhysicalCondition.initializeInstances(masterClock, medicalManager,
@@ -588,7 +588,7 @@ public class Simulation implements ClockListener, Serializable {
 		
 		
 		// Re-initialize units prior to starting the unit manager
-		//Rover.initializeInstances(simulationConfig);
+		Rover.initializeInstances(simulationConfig);
 		Unit.initializeInstances(masterClock, unitManager, weather, missionManager);
 
 		PhysicalCondition.initializeInstances(masterClock, medicalManager,

--- a/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
@@ -73,7 +73,6 @@ import com.mars_sim.core.person.ai.task.util.MetaTaskUtil;
 import com.mars_sim.core.person.ai.task.util.TaskManager;
 import com.mars_sim.core.person.health.MedicalConfig;
 import com.mars_sim.core.person.health.MedicalManager;
-import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.science.ScientificStudy;
 import com.mars_sim.core.science.ScientificStudyManager;
 import com.mars_sim.core.science.ScientificStudyUtil;
@@ -85,6 +84,7 @@ import com.mars_sim.core.time.MasterClock;
 import com.mars_sim.core.time.SystemDateTime;
 import com.mars_sim.core.tool.CheckSerializedSize;
 import com.mars_sim.core.tool.Msg;
+import com.mars_sim.core.vehicle.Rover;
 
 /**
  * The Simulation class is the primary singleton class in the MSP simulation.
@@ -303,9 +303,7 @@ public class Simulation implements ClockListener, Serializable {
 	 * Initializes instance for the maven test.
 	 */
 	public void testRun() {
-		
-		ResourceUtil.getInstance().initializeInstances();
-		
+				
 		simulationConfig = SimulationConfig.instance();
 		
 		MedicalConfig mc = simulationConfig.getMedicalConfiguration();
@@ -369,7 +367,7 @@ public class Simulation implements ClockListener, Serializable {
 		// Initialize ScientificStudyUtil
 		ScientificStudyUtil.initializeInstances(unitManager);
 
-
+		//Rover.initializeInstances(simulationConfig);
 		Unit.initializeInstances(masterClock, unitManager, weather, missionManager);
 		
 		LocalAreaUtil.initializeInstances(unitManager, masterClock);
@@ -399,8 +397,6 @@ public class Simulation implements ClockListener, Serializable {
 	 */
 	private void initializeIntransientData(int timeRatio) {
 
-		// Initialize resources
-		ResourceUtil.getInstance().initializeInstances();
 
 		// Gets config file instances
 		simulationConfig = SimulationConfig.instance();
@@ -466,6 +462,7 @@ public class Simulation implements ClockListener, Serializable {
 		lunarColonyManager.addInitColonies();
 		
 		// Initialize Unit
+		//Rover.initializeInstances(simulationConfig);
 		Unit.initializeInstances(masterClock, unitManager, weather, missionManager);
 	
 		PhysicalCondition.initializeInstances(masterClock, medicalManager,
@@ -551,8 +548,6 @@ public class Simulation implements ClockListener, Serializable {
 	 *  Recreates a few instances after loading from a saved sim.
 	 */
 	public void recreateSomeInstances(int userTimeRatio) {
-		// Initialize resources
-		ResourceUtil.getInstance().initializeInstances();
 		// Gets config file instances
 		simulationConfig = SimulationConfig.instance();
 		// Clock is always first
@@ -570,9 +565,6 @@ public class Simulation implements ClockListener, Serializable {
 		Simulation sim = instance();
 		
 		simulationConfig = SimulationConfig.instance();
-	
-		// Re-initialize the resources for the saved sim
-		ResourceUtil.getInstance().initializeInstances();
 
 		// Gets config file instances
 		BuildingConfig bc = simulationConfig.getBuildingConfiguration();
@@ -596,6 +588,7 @@ public class Simulation implements ClockListener, Serializable {
 		
 		
 		// Re-initialize units prior to starting the unit manager
+		//Rover.initializeInstances(simulationConfig);
 		Unit.initializeInstances(masterClock, unitManager, weather, missionManager);
 
 		PhysicalCondition.initializeInstances(masterClock, medicalManager,
@@ -1085,7 +1078,6 @@ public class Simulation implements ClockListener, Serializable {
       	StringBuilder sb = new StringBuilder();
 
 		List<Serializable> list = Arrays.asList(
-				ResourceUtil.getInstance(),
 				malfunctionFactory,
 				orbitInfo,
 				weather,

--- a/mars-sim-core/src/main/java/com/mars_sim/core/SimulationBuilder.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/SimulationBuilder.java
@@ -244,9 +244,7 @@ public class SimulationBuilder {
 		
 		// Load xml files but not until arguments parsed since it may change 
 		// the data directory
-		SimulationConfig simConfig = SimulationConfig.instance();
-		simConfig.loadConfig();
-		
+		SimulationConfig simConfig = SimulationConfig.loadConfig();
 		Simulation sim = Simulation.instance();
 			
 		boolean loaded = false;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/SimulationConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/SimulationConfig.java
@@ -673,7 +673,7 @@ public class SimulationConfig {
 		raFactory = new AuthorityFactory(parseXMLFileAsJDOMDocument(GOVERNANCE_FILE, true));
 		resourceConfig = new AmountResourceConfig(parseXMLFileAsJDOMDocument(RESOURCE_FILE, true));
 		partConfig = new PartConfig(parseXMLFileAsJDOMDocument(PART_FILE, true));
-		PartPackageConfig partPackageConfig = new PartPackageConfig(parseXMLFileAsJDOMDocument(PART_PACKAGE_FILE, true));
+		PartPackageConfig partPackageConfig = new PartPackageConfig(parseXMLFileAsJDOMDocument(PART_PACKAGE_FILE, true), partConfig);
 		buildingPackageConfig = new BuildingPackageConfig(parseXMLFileAsJDOMDocument(BUILDING_PACKAGE_FILE, true));
 		personConfig = new PersonConfig(parseXMLFileAsJDOMDocument(PEOPLE_FILE, true));
 		medicalConfig = new MedicalConfig(parseXMLFileAsJDOMDocument(MEDICAL_FILE, true));
@@ -689,7 +689,7 @@ public class SimulationConfig {
 		settlementConfig = new SettlementConfig(parseXMLFileAsJDOMDocument(SETTLEMENT_FILE, true));
 		settlementTemplateConfig = new SettlementTemplateConfig(parseXMLFileAsJDOMDocument(
 				SETTLEMENT_TEMPLATE_FILE, true), partPackageConfig, buildingPackageConfig,
-				resupplyConfig, settlementConfig, raFactory);
+				resupplyConfig, this);
 
 
 		constructionConfig = new ConstructionConfig(parseXMLFileAsJDOMDocument(CONSTRUCTION_FILE, true));

--- a/mars-sim-core/src/main/java/com/mars_sim/core/SimulationConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/SimulationConfig.java
@@ -13,8 +13,6 @@ import java.time.format.DateTimeFormatter;
 
 import javax.xml.XMLConstants;
 
-import com.mars_sim.core.structure.SettlementTemplateConfig;
-import org.apache.commons.io.FileUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -43,6 +41,7 @@ import com.mars_sim.core.resourceprocess.ResourceProcessConfig;
 import com.mars_sim.core.robot.RobotConfig;
 import com.mars_sim.core.science.ScienceConfig;
 import com.mars_sim.core.structure.SettlementConfig;
+import com.mars_sim.core.structure.SettlementTemplateConfig;
 import com.mars_sim.core.time.MasterClock;
 import com.mars_sim.core.tool.ResourceCache;
 import com.mars_sim.core.vehicle.VehicleConfig;
@@ -104,8 +103,7 @@ public class SimulationConfig {
 	private static final String EVA_LIGHT = "min-eva-light";
 	private static final String CONTENT_URL = "content-url";
 
-	private static final String OLD_BACKUP = "backup";
-
+	private static SimulationConfig instance = null;
 
 	private String marsStartDate = null;
 	private String earthStartDate = null;
@@ -120,7 +118,6 @@ public class SimulationConfig {
 	private int numberOfAutoSaves = 0;
 	private int averageTransitTime = 0;
 	private int unusedCores = 0;	
-	private boolean loaded = false;
 	
 	/*
 	 * -----------------------------------------------------------------------------
@@ -163,28 +160,33 @@ public class SimulationConfig {
 
 	/** hidden constructor. */
 	private SimulationConfig(String xmlLoc) {
+		logger.info("Loading simulation configuration from " + xmlLoc);
 		cachedResources = new ResourceCache(new File(xmlLoc), true);
+
+		readConfig();
 	}
 
 	/**
-	 * Initializes an inner static helper class for Bill Pugh Singleton Pattern
-	 * Note: as soon as the instance() method is called the first time, the class is
-	 * loaded into memory and an instance gets created. Advantage: it supports
-	 * multiple threads calling instance() simultaneously with no synchronized
-	 * keyword needed (which slows down the VM)
+	 * Load a new instance of the simulation configuration for the default XML files.
+	 * @return
 	 */
-	private static class SingletonHelper {
-		private static final SimulationConfig INSTANCE = new SimulationConfig(SimulationRuntime.getXMLDir());
+	public static SimulationConfig loadConfig() {
+		if (instance == null) {
+			instance = new SimulationConfig(SimulationRuntime.getXMLDir());
+		}
+		return instance;
 	}
 
 	/**
-	 * Gets a Bill Pugh Singleton instance of the SimulationConfig.
+	 * Gets the previously loaded config
 	 *
 	 * @return SimulationConfig instance
 	 */
 	public static SimulationConfig instance() {
-		// NOTE: SimulationConfig.instance() is accessible on any threads or by any threads
-		return SingletonHelper.INSTANCE;
+		if (instance == null) {
+			throw new IllegalStateException("SimulationConfig has not been loaded.");
+		}
+		return instance;
 	}
 
 	/**
@@ -192,19 +194,9 @@ public class SimulationConfig {
 	 *
 	 * @throws Exception if error loading or parsing configuration files.
 	 */
-	public void loadConfig() {
-		if (loaded) {
-			return;
-		}
-		
-		try {
-			// Remove legacy backupDIR
-			var backupDir = new File(SimulationRuntime.getDataDir(), OLD_BACKUP);
-			if (backupDir.exists()) {
-				logger.info("Deleting legacy backup directory");
-				FileUtils.deleteDirectory(backupDir); 
-			}
+	private void readConfig() {
 
+		try {
 			// Load simulation document
 			Document simulationDoc = parseXMLFileAsJDOMDocument(SIMULATION_FILE, true);
 
@@ -236,22 +228,10 @@ public class SimulationConfig {
 
 			loadDefaultConfiguration();
 
-			loaded = true;
-
 		} catch (RuntimeException | JDOMException | IOException rte) {
           	logger.severe("Cannot load default config : " + rte.getMessage(), rte);
 			throw new IllegalStateException("Cannot load the configurations", rte);
 		}
-	}
-
-	/**
-	 * Reloads the configurations from the XML files including
-	 * re-checking the XML versions.
-	 * Should need to be used if the files have changed as Config
-	 * objects should be immutable.
-	 */
-	public void reloadConfig() {
-		loadConfig();
 	}
 
 	/**
@@ -660,21 +640,20 @@ public class SimulationConfig {
 		}
 	}
 
-
 	/**
 	 * load the default config files
 	 * @throws IOException
 	 * @throws JDOMException
 	 */
 	private void loadDefaultConfiguration() throws JDOMException, IOException {
-  BuildingPackageConfig buildingPackageConfig;
 
 		// Load subset configuration classes.
 		raFactory = new AuthorityFactory(parseXMLFileAsJDOMDocument(GOVERNANCE_FILE, true));
 		resourceConfig = new AmountResourceConfig(parseXMLFileAsJDOMDocument(RESOURCE_FILE, true));
 		partConfig = new PartConfig(parseXMLFileAsJDOMDocument(PART_FILE, true));
-		PartPackageConfig partPackageConfig = new PartPackageConfig(parseXMLFileAsJDOMDocument(PART_PACKAGE_FILE, true), partConfig);
-		buildingPackageConfig = new BuildingPackageConfig(parseXMLFileAsJDOMDocument(BUILDING_PACKAGE_FILE, true));
+		PartPackageConfig partPackageConfig = new PartPackageConfig(parseXMLFileAsJDOMDocument(PART_PACKAGE_FILE, true),
+																	partConfig);
+		BuildingPackageConfig buildingPackageConfig = new BuildingPackageConfig(parseXMLFileAsJDOMDocument(BUILDING_PACKAGE_FILE, true));
 		personConfig = new PersonConfig(parseXMLFileAsJDOMDocument(PEOPLE_FILE, true));
 		medicalConfig = new MedicalConfig(parseXMLFileAsJDOMDocument(MEDICAL_FILE, true));
 		landmarkConfig = new LandmarkConfig(parseXMLFileAsJDOMDocument(LANDMARK_FILE, true));
@@ -698,7 +677,5 @@ public class SimulationConfig {
 						cropConfig, personConfig);
 		robotConfig = new RobotConfig(parseXMLFileAsJDOMDocument(ROBOT_FILE, true));
 		scienceConfig = new ScienceConfig();
-
-		logger.config("Done loading all xml config files.");
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/Unit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Unit.java
@@ -51,8 +51,6 @@ public abstract class Unit implements UnitIdentifer, Comparable<Unit> {
 	/** Unit listeners. */
 	private transient Set<UnitListener> listeners;
 
-	protected static SimulationConfig simulationConfig = SimulationConfig.instance();
-
 	protected static MasterClock masterClock;
 
 	protected static UnitManager unitManager;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/configuration/ScenarioConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/configuration/ScenarioConfig.java
@@ -22,6 +22,7 @@ import java.util.zip.ZipOutputStream;
 import org.jdom2.Document;
 import org.jdom2.Element;
 
+import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.SimulationRuntime;
 import com.mars_sim.core.authority.Authority;
 import com.mars_sim.core.interplanetary.transport.settlement.ArrivingSettlement;
@@ -37,9 +38,6 @@ import com.mars_sim.core.tool.RandomUtil;
  */
 public class ScenarioConfig extends UserConfigurableConfig<Scenario> {
 	
-	/** default logger. */
-	// may add back SimLogger logger = SimLogger.getLogger(ScenarioConfig.class.getName());
-
 	
 	private static final String PREFIX = "scenario";
 	private static final String INITIAL_SETTLEMENT_LIST = "initial-settlement-list";
@@ -62,10 +60,10 @@ public class ScenarioConfig extends UserConfigurableConfig<Scenario> {
 	// Default scenario
 	public static final String[] PREDEFINED_SCENARIOS = {"Default", "Single Settlement"};	
 	
-	public ScenarioConfig() {
+	public ScenarioConfig(SimulationConfig config) {
 		super(PREFIX);
 
-		setXSDName("scenario.xsd");
+		setXSDName("scenario.xsd", config);
 		
 		loadDefaults(PREDEFINED_SCENARIOS);
 		loadUserDefined();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/configuration/UserConfigurableConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/configuration/UserConfigurableConfig.java
@@ -88,11 +88,11 @@ public abstract class UserConfigurableConfig<T extends UserConfigurable> {
 		this.itemPrefix = itemPrefix;
 	}
 
-	protected void setXSDName(String xsd) {
+	protected void setXSDName(String xsd, SimulationConfig config) {
 		this.xsdName = xsd;
 
 		// Have to pull it out of bundle
-		SimulationConfig.instance().getBundledXML(itemPrefix + "/" + xsdName);
+		config.getBundledXML(itemPrefix + "/" + xsdName);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/CrewConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/CrewConfig.java
@@ -17,6 +17,7 @@ import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
 
+import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.configuration.ConfigHelper;
 import com.mars_sim.core.configuration.UserConfigurableConfig;
 import com.mars_sim.core.person.ai.SkillType;
@@ -67,11 +68,12 @@ public class CrewConfig extends UserConfigurableConfig<Crew> {
 	
 	/**
 	 * Constructor.
+	 * @param config 
 	 */
-	public CrewConfig() {
+	public CrewConfig(SimulationConfig config) {
 		super(CREW_PREFIX);
 		
-		setXSDName(CREW_XSD);
+		setXSDName(CREW_XSD, config);
 		
 		loadDefaults(PREDEFINED_CREWS);
 		loadUserDefined();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/NationSpecConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/NationSpecConfig.java
@@ -11,6 +11,8 @@ import java.util.List;
 
 import org.jdom2.Document;
 import org.jdom2.Element;
+
+import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.authority.Nation;
 import com.mars_sim.core.configuration.ConfigHelper;
 import com.mars_sim.core.configuration.UserConfigurableConfig;
@@ -21,27 +23,27 @@ import com.mars_sim.core.configuration.UserConfigurableConfig;
  */
 public class NationSpecConfig extends UserConfigurableConfig<NationSpec> {
 
-	private static final String COUNTRY_XSD = "country.xsd";
-	
-	private static final String COUNTRY = "country";
+    private static final String COUNTRY_XSD = "country.xsd";
+    
+    private static final String COUNTRY = "country";
 
-	private static final String ECONOMICS_DATA = "economics-data";
+    private static final String ECONOMICS_DATA = "economics-data";
 
-	private static final String LAST_NAME_LIST = "last-name-list";
-	private static final String FIRST_NAME_LIST = "first-name-list";	
-	private static final String MALE = "male";
-	private static final String FEMALE = "female";
-	private static final String LAST_NAME = "last-name";
-	private static final String FIRST_NAME = "first-name";
-	private static final String GENDER = "gender";
+    private static final String LAST_NAME_LIST = "last-name-list";
+    private static final String FIRST_NAME_LIST = "first-name-list";	
+    private static final String MALE = "male";
+    private static final String FEMALE = "female";
+    private static final String LAST_NAME = "last-name";
+    private static final String FIRST_NAME = "first-name";
+    private static final String GENDER = "gender";
     private static final String NAME = "name";
     private static final String VALUE = "value";
     private static final String POPULATION_CHARS = "characteristics";
 
     // Note: each of the predefined country below has a xml file
     private static final String[] COUNTRIES = {
-    					"Austria",  "Belgium", "Brazil", 
-    					"Canada", "China", "Czech Republic",
+                        "Austria",  "Belgium", "Brazil", 
+                        "Canada", "China", "Czech Republic",
                         "Denmark", "Estonia", "Finland", "France", 
                         "Germany", "Greece",
                         "Hungary", "India", "Ireland", "Italy", 
@@ -55,12 +57,12 @@ public class NationSpecConfig extends UserConfigurableConfig<NationSpec> {
                         "United Kingdom", "United States"};
 
 
-	private static List<Nation> nations = new ArrayList<>();
-	
-    public NationSpecConfig() {
+    private static List<Nation> nations = new ArrayList<>();
+    
+    public NationSpecConfig(SimulationConfig config) {
         super(COUNTRY);
 
-        setXSDName(COUNTRY_XSD);
+        setXSDName(COUNTRY_XSD, config);
 
         for (String name: COUNTRIES) {
         	Nation nation = new Nation(name);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
@@ -107,15 +107,6 @@ public class Person extends AbstractMobileUnit implements Worker, Temporal, Unit
 
 	private static final String EARTHLING = "Earthling";
 
-	private static double averageWeight;
-	private static double averageHeight;
-
-	static {
-		var pc = SimulationConfig.instance().getPersonConfig();
-
-		averageHeight = pc.getDefaultPhysicalChars().getAverageHeight();
-		averageWeight = pc.getDefaultPhysicalChars().getAverageWeight();
-	}
 
 	// Transient data members
 	/** The extrovert score of a person. */
@@ -1966,13 +1957,4 @@ public class Person extends AbstractMobileUnit implements Worker, Temporal, Unit
 		skillManager.destroy();
 		skillManager = null;
 	}
-
-	public static double getAverageWeight() {
-		return averageWeight;
-	}
-
-    public static double getAverageHeight() {
-        return averageHeight;
-    }
-
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/resource/AmountResourceConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/resource/AmountResourceConfig.java
@@ -36,8 +36,8 @@ public class AmountResourceConfig {
 	private static int nextID = ResourceUtil.FIRST_AMOUNT_RESOURCE_ID;
 
 	// Data members.
-	private transient Set<AmountResource> resourceSet = new TreeSet<>();
-	private transient Set<Integer> tissueCultureSet = new TreeSet<>();
+	private Set<AmountResource> resourceSet = new TreeSet<>();
+	private Set<Integer> tissueCultureSet = new TreeSet<>();
 
 	/**
 	 * Constructor
@@ -47,6 +47,7 @@ public class AmountResourceConfig {
 	 */
 	public AmountResourceConfig(Document amountResourceDoc) {
 		loadAmountResources(amountResourceDoc);
+		ResourceUtil.registerResources(resourceSet);
 	}
 
 	/**
@@ -83,7 +84,7 @@ public class AmountResourceConfig {
 			double demand = 0;
 			String demandString = resourceElement.getAttributeValue(DEMAND);
 			if (demandString != null)
-			demand = Double.parseDouble(demandString);
+				demand = Double.parseDouble(demandString);
 			
 			// Get life support
 			Boolean lifeSupport = Boolean.parseBoolean(resourceElement.getAttributeValue(LIFE_SUPPORT));
@@ -136,9 +137,5 @@ public class AmountResourceConfig {
 
 	public Set<Integer> getTissueCultures() {
 		return tissueCultureSet;
-	}
-
-	public int getNextID() {
-		return nextID;
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/resource/ItemResourceUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/resource/ItemResourceUtil.java
@@ -7,27 +7,20 @@
 
 package com.mars_sim.core.resource;
 
-import java.io.Serializable;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.goods.GoodType;
 import com.mars_sim.core.logging.SimLogger;
-import com.mars_sim.core.manufacture.ManufactureConfig;
 import com.mars_sim.core.manufacture.ManufactureProcessInfo;
 import com.mars_sim.core.process.ProcessItem;
 
-public class ItemResourceUtil implements Serializable {
+public class ItemResourceUtil {
 
-	/** default serial id. */
-	private static final long serialVersionUID = 1L;
 	
 	/** default logger. */
 	private static SimLogger logger = SimLogger.getLogger(ItemResourceUtil.class.getName());
@@ -62,10 +55,6 @@ public class ItemResourceUtil implements Serializable {
 	private static Map<String, Part> itemResourceMap;
 	private static Map<Integer, Part> itemResourceIDMap;
 	private static Set<Part> partSet;
-	private static List<Part> sortedParts;
-
-	private static PartConfig partConfig = SimulationConfig.instance().getPartConfiguration();
-	private static ManufactureConfig manufactureConfig = SimulationConfig.instance().getManufactureConfiguration();
 	
 	public static Set<Integer> evaSuitPartIDs;
 
@@ -75,8 +64,15 @@ public class ItemResourceUtil implements Serializable {
 	/**
 	 * Constructor.
 	 */
-	public ItemResourceUtil() {
-		partSet = getItemResources();
+	private ItemResourceUtil() {
+	}
+
+	/**
+	 * Register the parts of the simulation.
+	 * @param parts
+	 */
+	public static void registerParts(Set<Part> parts) {
+		partSet = parts;
 		createMaps();
 		createIDs();
 	}
@@ -100,8 +96,7 @@ public class ItemResourceUtil implements Serializable {
 
 			ManufactureProcessInfo manufactureProcessInfo = null;
 			
-			if (manufactureConfig == null)
-				manufactureConfig = SimulationConfig.instance().getManufactureConfiguration();
+			var manufactureConfig = SimulationConfig.instance().getManufactureConfiguration();
 			
 			for (ManufactureProcessInfo info : manufactureConfig.getManufactureProcessList()) {
 				if (info.getName().equals(ASSEMBLE_EVA_SUIT)) {
@@ -136,7 +131,7 @@ public class ItemResourceUtil implements Serializable {
 	/**
 	 * Prepares the id's of a few item resources.
 	 */
-	public static void createIDs() {
+	private static void createIDs() {
 
 		// Create item ids reference
 		garmentID = findIDbyItemResourceName(GARMENT);
@@ -179,15 +174,13 @@ public class ItemResourceUtil implements Serializable {
 	 */
 	private static void createMaps() {
 		itemResourceMap = new HashMap<>();
-		sortedParts = new CopyOnWriteArrayList<>(partSet);
-		Collections.sort(sortedParts);
 
-		for (Part p : sortedParts) {
+		for (Part p : partSet) {
 			itemResourceMap.put(p.getName().toLowerCase(), p);
 		}
 
 		itemResourceIDMap = new HashMap<>();
-		for (Part p : sortedParts) {
+		for (Part p : partSet) {
 			itemResourceIDMap.put(p.getID(), p);
 		}
 	}
@@ -237,22 +230,7 @@ public class ItemResourceUtil implements Serializable {
 	 * @return
 	 */
 	public static Set<Part> getItemResources() {
-		if (partConfig == null)
-			partConfig = SimulationConfig.instance().getPartConfiguration();
-		if (partSet == null)
-			partSet = Collections.unmodifiableSet(partConfig.getPartSet());
 		return partSet;
-	}
-
-	/**
-	 * Gets a list of sorted parts.
-	 *
-	 * @return
-	 */
-	public static List<Part> getSortedParts() {
-		sortedParts = new CopyOnWriteArrayList<>(partSet);
-		Collections.sort(sortedParts);
-		return sortedParts;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/resource/PartConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/resource/PartConfig.java
@@ -6,7 +6,6 @@
  */
 package com.mars_sim.core.resource;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,35 +32,28 @@ import com.mars_sim.core.vehicle.VehicleType;
  * Provides configuration information about parts. Uses a DOM document to get
  * the information.
  */
-public final class PartConfig implements Serializable {
+public final class PartConfig  {
 
-	/** default serial id. */
-	private static final long serialVersionUID = 1L;
-
-	/** default logger. */
-	// May add back private static SimLogger logger = SimLogger.getLogger(PartConfig.class.getName())
-	
 	// Element names
-	public static final String PART = "part";
-	public static final String DESCRIPTION = "description";
-	public static final String NAME = "name";
-	public static final String TYPE = "type";
-	public static final String MASS = "mass";
-	public static final String STORABLE = "storable";
-	public static final String MAINTENANCE_ENTITY_LIST = "maintenance-entity-list";
-	public static final String ENTITY = "entity";
-	public static final String PROBABILITY = "probability";
-	public static final String MAX_NUMBER = "max-number";
+	private static final String PART = "part";
+	private static final String DESCRIPTION = "description";
+	private static final String NAME = "name";
+	private static final String TYPE = "type";
+	private static final String MASS = "mass";
+	private static final String MAINTENANCE_ENTITY_LIST = "maintenance-entity-list";
+	private static final String ENTITY = "entity";
+	private static final String PROBABILITY = "probability";
+	private static final String MAX_NUMBER = "max-number";
 
 	/** The next global part ID. */
 	private int nextID;
 	
 	/** The set of parts. */
-	private transient Set<Part> partSet;
+	private Set<Part> partSet;
 	/** The map of maintenance scopes. */
-	private transient Map<String, List<MaintenanceScope>> scopes = new HashMap<>();
+	private Map<String, List<MaintenanceScope>> scopes = new HashMap<>();
 	/** The collection of standard scopes. */
-	private transient Set<String> STANDARD_SCOPES = new TreeSet<>();
+	private Set<String> standarsScopes = new TreeSet<>();
 	
 	/**
 	 * Constructor.
@@ -74,13 +66,15 @@ public final class PartConfig implements Serializable {
 		nextID = ResourceUtil.FIRST_ITEM_RESOURCE_ID;
 
 		loadItemResources(itemResourceDoc);
+
+		ItemResourceUtil.registerParts(partSet);
 	}
 
 	/**
 	 * The collection of standard scopes.
 	 */
 	public Set<String> getScopes() {
-		return STANDARD_SCOPES;	 
+		return standarsScopes;	 
 	}
 	
 	
@@ -89,37 +83,37 @@ public final class PartConfig implements Serializable {
 	 */
 	private void createStandardScope() {
 		for (VehicleType type: VehicleType.values()) {
-			if (!STANDARD_SCOPES.contains(type.getName()))
-				STANDARD_SCOPES.add(type.getName());
+			if (!standarsScopes.contains(type.getName()))
+				standarsScopes.add(type.getName());
 		}
 		
 		for (SystemType type: SystemType.values()) {
-			if (!STANDARD_SCOPES.contains(type.getName()))
-				STANDARD_SCOPES.add(type.getName());
+			if (!standarsScopes.contains(type.getName()))
+				standarsScopes.add(type.getName());
 		}
 		
 		for (FunctionType type: FunctionType.values()) {
-			if (!STANDARD_SCOPES.contains(type.getName()))
-				STANDARD_SCOPES.add(type.getName());
+			if (!standarsScopes.contains(type.getName()))
+				standarsScopes.add(type.getName());
 		}
 		
 		for (PowerSourceType type: PowerSourceType.values()) {
-			if (!STANDARD_SCOPES.contains(type.getName()))
-				STANDARD_SCOPES.add(type.getName());
+			if (!standarsScopes.contains(type.getName()))
+				standarsScopes.add(type.getName());
 		}
 		
 		for (HeatSourceType type: HeatSourceType.values()) {
-			if (!STANDARD_SCOPES.contains(type.getName()))
-				STANDARD_SCOPES.add(type.getName());
+			if (!standarsScopes.contains(type.getName()))
+				standarsScopes.add(type.getName());
 		}
 	}
 	
 	public void addScopes(Set<String> newScopes) {
-		STANDARD_SCOPES.addAll(newScopes);
+		standarsScopes.addAll(newScopes);
 	}
 	
 	public void addScopes(String newScope) {
-		STANDARD_SCOPES.add(newScope);
+		standarsScopes.add(newScope);
 	}
 	
 	/**
@@ -172,18 +166,7 @@ public final class PartConfig implements Serializable {
 						"PartConfig detected invalid type in parts.xml : " + type);
 
 			// Get storable
-			
-//			String storableString = partElement.getAttributeValue(STORABLE);
-//			boolean isStorable = Boolean.parseBoolean(storableString);
-			
-			Part p = null;
-			
-//			if (isStorable) {
-//				p = new StorableItem(name, nextID, description, goodType, mass, 1);
-//			}
-//			else {
-				p = new Part(name, nextID, description, goodType, mass, 1);
-//			}
+			Part p = new Part(name, nextID, description, goodType, mass, 1);
 
 			for (Part pp: newPartSet) {
 				if (pp.getName().equalsIgnoreCase(name))
@@ -198,7 +181,7 @@ public final class PartConfig implements Serializable {
 				for (Element entityElement : entityNodes) {
 					String entityName = entityElement.getAttributeValue(NAME);
 					boolean validName = false;
-					for (String s: STANDARD_SCOPES) {
+					for (String s: standarsScopes) {
 						if (s.equalsIgnoreCase(entityName) ) {
 							validName = true;
 							double probability = Double.parseDouble(entityElement.getAttributeValue(PROBABILITY));
@@ -210,7 +193,6 @@ public final class PartConfig implements Serializable {
 					}
 					
 					if (!validName) {
-//						logger.severe(entityName + " is not being clear defined in mars-sim.");
 						throw new IllegalArgumentException(entityName + " is not being clearly defined in mars-sim.");
 					}	
 				}
@@ -218,14 +200,11 @@ public final class PartConfig implements Serializable {
 			
 
 			// Add part to newPartSet.
-			newPartSet.add(p);
-//			partSet.add(p);
-			
+			newPartSet.add(p);			
 		}
 		
 		// Assign the partSet now built
-		partSet = Collections.unmodifiableSet(newPartSet);
-		
+		partSet = Collections.unmodifiableSet(newPartSet);	
 	}
 
 	/**
@@ -278,4 +257,14 @@ public final class PartConfig implements Serializable {
 	public Set<Part> getPartSet() {
 		return partSet;
 	}
+
+	/**
+	 * Find a part by name
+	 * @param name
+	 * @return
+	 */
+    public Part getPartByName(String name) {
+		return partSet.stream().filter(item -> item.getName().equalsIgnoreCase(name)).findFirst()
+		.orElse(null);
+    }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/resource/PartPackageConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/resource/PartPackageConfig.java
@@ -23,19 +23,16 @@ import org.jdom2.Element;
  * Provides configuration information about part packages. Uses a JDOM document
  * to get the information.
  */
-public class PartPackageConfig implements Serializable {
-
-	/** default serial id. */
-	private static final long serialVersionUID = 1L;
+public class PartPackageConfig  {
 
 	private static final Logger logger = Logger.getLogger(PartPackageConfig.class.getName());
 
 	// Element names
-	private final String PART_PACKAGE = "part-package";
-	private final String PART = "part";
-	private final String NAME = "name";
-	private final String TYPE = "type";
-	private final String NUMBER = "number";
+	private static final String PART_PACKAGE = "part-package";
+	private static final String PART = "part";
+	private static final String NAME = "name";
+	private static final String TYPE = "type";
+	private static final String NUMBER = "number";
 
 	// Data members
 	private Collection<PartPackage> partPackages;
@@ -46,8 +43,8 @@ public class PartPackageConfig implements Serializable {
 	 * @param partPackageDoc the part package XML document.
 	 * @throws Exception if error reading XML document
 	 */
-	public PartPackageConfig(Document partPackageDoc) {
-		loadPartPackages(partPackageDoc);
+	public PartPackageConfig(Document partPackageDoc, PartConfig partsConfig) {
+		loadPartPackages(partPackageDoc, partsConfig);
 	}
 
 	/**
@@ -56,7 +53,7 @@ public class PartPackageConfig implements Serializable {
 	 * @param partPackageDoc the part package XML document.
 	 * @throws Exception if error reading XML document.
 	 */
-	private synchronized void loadPartPackages(Document partPackageDoc) {
+	private synchronized void loadPartPackages(Document partPackageDoc, PartConfig partsConfig) {
 		if (partPackages != null) {
 			// just in case if another thread is being created
 			return;
@@ -74,7 +71,7 @@ public class PartPackageConfig implements Serializable {
 			List<Element> partNodes = partPackageElement.getChildren(PART);
 			for (Element partElement : partNodes) {
 				String partType = partElement.getAttributeValue(TYPE);
-				Part part = (Part) ItemResourceUtil.findItemResource(partType);
+				Part part = partsConfig.getPartByName(partType);
 				if (part == null)
 					logger.severe(partType + " shows up in part_packages.xml but doesn't exist in parts.xml.");
 				else {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/resource/ResourceUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/resource/ResourceUtil.java
@@ -7,7 +7,6 @@
 
 package com.mars_sim.core.resource;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -17,15 +16,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.food.Food;
 import com.mars_sim.core.food.FoodUtil;
 import com.mars_sim.core.logging.SimLogger;
 
-public class ResourceUtil implements Serializable {
-
-	/** default serial id. */
-	private static final long serialVersionUID = 1L;
+public class ResourceUtil {
 
 	/** default logger. */
 	private static SimLogger logger = SimLogger.getLogger(ResourceUtil.class.getName());
@@ -264,32 +259,22 @@ public class ResourceUtil implements Serializable {
 	public static AmountResource rockSamplesAR;
 	public static AmountResource sandAR;
 
-	//private static AmountResource[] ARs = new AmountResource[33];
-
-	/**
-	 * Creates the singleton instance.
-	 */
-	private static ResourceUtil INSTANCE = new ResourceUtil();
-
-	/**
-	 * Gets the singleton instance.
-	 *
-	 * @param instance the singleton instance.
-	 */
-	public static ResourceUtil getInstance() {
-		return INSTANCE;
-	}
-
 	/**
 	 * Default Constructor for ResoureUtil.
 	 */
 	private ResourceUtil() {
-		resources = SimulationConfig.instance().getResourceConfiguration().getAmountResources();
-		createItemResourceUtil();
+	}
+
+	/**
+	 * Register the known Amunt Resources in the helper
+	 * @param defined
+	 */
+	public static void registerResources(Set<AmountResource> defined) {
+		resources = defined;
+		mapInstances();
 		createLifeSupportResources();
 		createEssentialResources();
 	}
-
 
 	/**
 	 * Creates a set of life support resources.
@@ -360,35 +345,9 @@ public class ResourceUtil implements Serializable {
 	}
 	
 	/**
-	 * Starts ItemResourceUtil.
-	 */
-	public void createItemResourceUtil() {
-		new ItemResourceUtil();
-	}
-
-	/**
-	 * Sets the singleton instance.
-	 *
-	 * @param instance the singleton instance.
-	 */
-	public static void setInstance(ResourceUtil instance) {
-		ResourceUtil.INSTANCE = instance;
-	}
-
-	/**
-	 * Recreates the Amount Resource instances in all map.
-	 */
-	public void initializeInstances() {
-		// Create maps
-		createMaps();
-		// Map the static instances
-		mapInstances();
-	}
-
-	/**
 	 * Creates maps of amount resources.
 	 */
-	public static synchronized void createMaps() {
+	private static synchronized void createMaps() {
 		if (amountResourceMap == null) {
 			sortedResources = new ArrayList<>(resources);
 			Collections.sort(sortedResources);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementBuilder.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementBuilder.java
@@ -85,7 +85,7 @@ public final class SettlementBuilder {
 		this.settlementTemplateConfig = simConfig.getSettlementTemplateConfiguration();
 		this.robotConfig = simConfig.getRobotConfiguration();
 		this.raFactory = simConfig.getReportingAuthorityFactory();
-		this.namingSpecs = new NationSpecConfig();
+		this.namingSpecs = new NationSpecConfig(simConfig);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementTemplateConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/SettlementTemplateConfig.java
@@ -1,5 +1,6 @@
 package com.mars_sim.core.structure;
 
+import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.authority.Authority;
 import com.mars_sim.core.authority.AuthorityFactory;
 import com.mars_sim.core.building.BuildingPackageConfig;
@@ -80,21 +81,21 @@ public class SettlementTemplateConfig extends UserConfigurableConfig<SettlementT
      * Constructor.
      *
      * @param settlementDoc     DOM document with settlement configuration.
-     * @param partPackageConfig the part package configuration.
-     * @param settlementConfig
+     * @param resupplyConfig 
+     * @param buildingPackageConfig 
+     * @param partPackageConfig
+     * @param config          simulation configuration.
      */
-    public SettlementTemplateConfig(Document settlementDoc,
-                                    PartPackageConfig partPackageConfig,
-                                    BuildingPackageConfig buildingPackageConfig,
-                                    ResupplyConfig resupplyConfig, SettlementConfig settlementConfig,
-                                    AuthorityFactory authorityConfig) {
+    public SettlementTemplateConfig(Document settlementDoc, PartPackageConfig partPackageConfig,
+                                            BuildingPackageConfig buildingPackageConfig,
+                                            ResupplyConfig resupplyConfig, SimulationConfig config) {
         super("settlement");
         this.partPackageConfig = partPackageConfig;
         this.buildingPackageConfig = buildingPackageConfig;
         this.resupplyConfig = resupplyConfig;
-        this.settlementConfig = settlementConfig;
-        this.authorityConfig = authorityConfig;
-        setXSDName("settlement.xsd");
+        this.settlementConfig = config.getSettlementConfiguration();
+        this.authorityConfig = config.getReportingAuthorityFactory();
+        setXSDName("settlement.xsd", config);
 
         loadDefaults(loadSettlementTemplates(settlementDoc));
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.logging.Level;
 
 import com.mars_sim.core.LocalAreaUtil;
+import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitEventType;
 import com.mars_sim.core.UnitType;
@@ -193,7 +194,10 @@ public abstract class Vehicle extends AbstractMobileUnit
 
 	private LoadingController loadingController;
 	
-	static {
+	/**
+	 * Set up the internal flags for the vehicle.
+	 */
+	public static void initializeInstances(SimulationConfig simulationConfig) {
 		lifeSupportRangeErrorMargin = simulationConfig.getSettlementConfiguration()
 				.getRoverValues()[0];
 		fuelRangeErrorMargin = simulationConfig.getSettlementConfiguration().getRoverValues()[1];

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/VehicleSpec.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/VehicleSpec.java
@@ -17,7 +17,6 @@ import com.mars_sim.core.building.utility.power.PowerSourceType;
 import com.mars_sim.core.manufacture.ManufactureConfig;
 import com.mars_sim.core.manufacture.ManufactureProcessInfo;
 import com.mars_sim.core.map.location.LocalPosition;
-import com.mars_sim.core.person.Person;
 import com.mars_sim.core.process.ProcessItem;
 import com.mars_sim.core.resource.ItemType;
 import com.mars_sim.core.resource.Part;
@@ -343,7 +342,7 @@ public class VehicleSpec implements Serializable {
 		this.crewSize = crewSize;
 	
 		// Get estimated total crew weight
-		this.estimatedTotalCrewWeight = crewSize * Person.getAverageWeight();
+		this.estimatedTotalCrewWeight = crewSize * 68.5D;
 	}
 	
 	/**

--- a/mars-sim-core/src/test/java/com/mars_sim/core/AbstractMarsSimUnitTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/AbstractMarsSimUnitTest.java
@@ -59,8 +59,7 @@ public abstract class AbstractMarsSimUnitTest extends TestCase
 	@Before
 	public void setUp() {
 	    // Create new simulation instance.
-	    simConfig = SimulationConfig.instance();
-	    simConfig.loadConfig();
+	    simConfig = SimulationConfig.loadConfig();
 	    
 	    sim = Simulation.instance();
 	    sim.testRun();

--- a/mars-sim-core/src/test/java/com/mars_sim/core/MicroInventoryTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/MicroInventoryTest.java
@@ -27,7 +27,7 @@ extends TestCase {
 	
 	@Override
     public void setUp() throws Exception {
-        SimulationConfig.instance().loadConfig();
+        SimulationConfig.loadConfig();
         Simulation.instance().testRun();
         
         UnitManager unitManager = Simulation.instance().getUnitManager();
@@ -35,14 +35,13 @@ extends TestCase {
 		// Create test settlement.
 		settlement = new MockSettlement();	
 		unitManager.addUnit(settlement);
-
     }
 
 
 	/*
 	 * Test method loading Equipment
 	 */
-	public void testLoading() throws Exception {
+	public void testLoading() {
 		MicroInventory inv = new MicroInventory(settlement);
 		int resource = ResourceUtil.co2ID;
 		inv.setCapacity(resource, CAPACITY_AMOUNT);
@@ -62,7 +61,7 @@ extends TestCase {
 	/*
 	 * Test method loading Equipment
 	 */
-	public void testOverloading() throws Exception {
+	public void testOverloading() {
 		MicroInventory inv = new MicroInventory(settlement);
 		int resource = ResourceUtil.co2ID;
 		inv.setCapacity(resource, CAPACITY_AMOUNT);
@@ -77,7 +76,7 @@ extends TestCase {
 	/*
 	 * Test method loading Equipment
 	 */
-	public void testUnsupported() throws Exception {
+	public void testUnsupported() {
 		MicroInventory inv = new MicroInventory(settlement);
 		int resource = ResourceUtil.co2ID;
 		inv.setCapacity(resource, CAPACITY_AMOUNT);
@@ -96,7 +95,7 @@ extends TestCase {
 	/*
 	 * Test method loading Equipment
 	 */
-	public void testUnloading() throws Exception {
+	public void testUnloading()  {
 		MicroInventory inv = new MicroInventory(settlement);
 		int resource = ResourceUtil.co2ID;
 		inv.setCapacity(resource, CAPACITY_AMOUNT);
@@ -119,7 +118,7 @@ extends TestCase {
 	/*
 	 * Test method loading Equipment
 	 */
-	public void testMultiples() throws Exception {
+	public void testMultiples()  {
 		MicroInventory inv = new MicroInventory(settlement);
 		int resource = ResourceUtil.co2ID;
 		inv.setCapacity(resource, CAPACITY_AMOUNT);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/TestLocalAreaUtil.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/TestLocalAreaUtil.java
@@ -142,7 +142,7 @@ public class TestLocalAreaUtil extends TestCase {
 //     */
 //    public void testGetObjectRelativeLocation() {
 //        // Create new simulation instance.
-//        SimulationConfig.instance().loadConfig();
+//        SimulationConfig.loadConfig();
 //        Simulation.instance().testRun();
 //        
 //        // Clear out existing settlements in simulation.
@@ -212,8 +212,7 @@ public class TestLocalAreaUtil extends TestCase {
 	@Before
 	public void setUp() {
 	    // Create new simulation instance.
-        SimulationConfig simConfig = SimulationConfig.instance();
-        simConfig.loadConfig();
+        SimulationConfig simConfig = SimulationConfig.loadConfig();
         
         Simulation sim = Simulation.instance();
         sim.testRun();

--- a/mars-sim-core/src/test/java/com/mars_sim/core/TestSaving.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/TestSaving.java
@@ -31,8 +31,7 @@ public class TestSaving extends TestCase implements SimulationListener {
     @Override
     public void setUp() throws Exception {
 		// Create new simulation instance.
-        simConfig = SimulationConfig.instance();
-        simConfig.loadConfig();
+        simConfig = SimulationConfig.loadConfig();
     }
 
     public void testSaving() throws IOException {

--- a/mars-sim-core/src/test/java/com/mars_sim/core/TestSaving.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/TestSaving.java
@@ -42,7 +42,7 @@ public class TestSaving extends TestCase implements SimulationListener {
 
         // Build a realistic simulation with entities to save
         SettlementBuilder builder = new SettlementBuilder(sim, simConfig);
-        ScenarioConfig config = new ScenarioConfig();
+        ScenarioConfig config = new ScenarioConfig(simConfig);
         Scenario bootstrap = config.getItem("Single Settlement");
         builder.createInitialSettlements(bootstrap);
         

--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/BuildingConfigTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/BuildingConfigTest.java
@@ -70,8 +70,7 @@ public class BuildingConfigTest extends AbstractMarsSimUnitTest {
      * This tets is very tied to the building spec of LANDER_HAB
      */
     public void testInflatableGreenhouse() {
-	    var simConfig = SimulationConfig.instance();
-        simConfig.loadConfig();
+	    var simConfig = SimulationConfig.loadConfig();
         var bc = simConfig.getBuildingConfiguration();
 
         var found = bc.getBuildingSpec("Inflatable Greenhouse");

--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/BuildingConnectorManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/BuildingConnectorManagerTest.java
@@ -27,8 +27,7 @@ public class BuildingConnectorManagerTest extends TestCase {
 	@Before
 	public void setUp() {
 	    // Create new simulation instance.
-        SimulationConfig simConfig = SimulationConfig.instance();
-        simConfig.loadConfig();
+        SimulationConfig simConfig = SimulationConfig.loadConfig();
         
         Simulation sim = Simulation.instance();
         sim.testRun();

--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/construction/ConstructionManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/construction/ConstructionManagerTest.java
@@ -26,7 +26,7 @@ public class ConstructionManagerTest extends TestCase {
     protected void setUp() throws Exception {
         super.setUp();
         
-        SimulationConfig.instance().loadConfig();
+        SimulationConfig.loadConfig();
         Simulation.instance().testRun();
         
         Settlement settlement = new MockSettlement();

--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/construction/ConstructionStageTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/construction/ConstructionStageTest.java
@@ -36,7 +36,7 @@ public class ConstructionStageTest extends TestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        SimulationConfig.instance().loadConfig();
+        SimulationConfig.loadConfig();
         Simulation.instance().testRun();
 
         Part smallHammer = (Part) ItemResourceUtil.findItemResource(SMALL_HAMMER);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/equipment/GenericContainerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/equipment/GenericContainerTest.java
@@ -29,10 +29,9 @@ extends TestCase {
 	private Settlement settlement;
 	
 	@Override
-    public void setUp() throws Exception {
+    public void setUp() {
 		// Create new simulation instance.
-        SimulationConfig simConfig = SimulationConfig.instance();
-        simConfig.loadConfig();
+        SimulationConfig.loadConfig();
         
         Simulation sim = Simulation.instance();
         sim.testRun();
@@ -47,7 +46,7 @@ extends TestCase {
 	/*
 	 * Tests container associated settlement assignment.
 	 */
-	public void testAssociatedSettlement() throws Exception {
+	public void testAssociatedSettlement() {
 		GenericContainer c = new GenericContainer("Bag", EquipmentType.BAG, false, settlement);
 	
 		Settlement as = c.getAssociatedSettlement();
@@ -57,7 +56,7 @@ extends TestCase {
 	/*
 	 * Tests container with a single resource.
 	 */
-	public void testSingleResource() throws Exception {
+	public void testSingleResource() {
 		GenericContainer c = new GenericContainer("Bag", EquipmentType.BAG, false, settlement);
 		
 		int rockID = ResourceUtil.rockSamplesID;
@@ -82,7 +81,7 @@ extends TestCase {
 	/*
 	 * Tests container with 2 resources.
 	 */
-	public void testTwoResource() throws Exception {
+	public void testTwoResource() {
 		GenericContainer c = new GenericContainer("Bag", EquipmentType.BAG, false, settlement);
 		
 		int rockID = ResourceUtil.rockSamplesID;
@@ -104,7 +103,7 @@ extends TestCase {
 	/*
 	 * Tests container with 2 resources.
 	 */
-	public void testEmptying() throws Exception {
+	public void testEmptying() {
 		GenericContainer c = new GenericContainer("Bag", EquipmentType.BAG, false, settlement);
 		
 		int rockID = ResourceUtil.rockSamplesID;
@@ -132,7 +131,7 @@ extends TestCase {
 	/*
 	 * Tests container with 2 resources.
 	 */
-	public void testNoneReusable() throws Exception {
+	public void testNoneReusable() {
 		GenericContainer c = new GenericContainer("Bag", EquipmentType.BAG, false, settlement);
 		
 		int secondResource = ResourceUtil.iceID;
@@ -150,7 +149,7 @@ extends TestCase {
 	/*
 	 * Tests container with 2 resources.
 	 */
-	public void testReusable() throws Exception {
+	public void testReusable() {
 		GenericContainer c = new GenericContainer("Specimen", EquipmentType.SPECIMEN_BOX, true, settlement);
 		
 		int secondResource = ResourceUtil.iceID;
@@ -169,7 +168,7 @@ extends TestCase {
 	/*
 	 * Tests container with Liquids & Solids.
 	 */
-	public void testBarrelLiquid() throws Exception {
+	public void testBarrelLiquid() {
 		EquipmentType cType = EquipmentType.BARREL;
 		GenericContainer c = new GenericContainer(cType.getName(), cType, true, settlement);
 
@@ -195,22 +194,22 @@ extends TestCase {
 	/*
 	 * Test container with Gas.
 	 */
-	public void testCanisterGas() throws Exception {
+	public void testCanisterGas() {
 		assertPhaseSupported(EquipmentType.GAS_CANISTER, PhaseType.GAS);
 	}
 	
 	/*
 	 * Test container with Solids.
 	 */
-	public void testLargeBagSolid() throws Exception {
+	public void testLargeBagSolid() {
 		assertPhaseSupported(EquipmentType.LARGE_BAG, PhaseType.SOLID);
 	}
 	
-	public void testBoxSolid() throws Exception {
+	public void testBoxSolid() {
 		assertPhaseSupported(EquipmentType.SPECIMEN_BOX, PhaseType.SOLID);
 	}
 	
-	public void testBagSolid() throws Exception {
+	public void testBagSolid() {
 		assertPhaseSupported(EquipmentType.BAG, PhaseType.SOLID);
 	}
 	

--- a/mars-sim-core/src/test/java/com/mars_sim/core/food/FoodProductionConfigTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/food/FoodProductionConfigTest.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Maps;
@@ -24,17 +25,17 @@ class FoodProductionConfigTest {
     private static final String [] PACKAGE_ALTERNATIVES = {
                     "Carrot", "Leaves", "Swiss Chard", "Potato"
     };
+    private FoodProductionConfig foodConfig;
 
-
-    private FoodProductionConfig getFoodConfig() {
-        var config = SimulationConfig.instance();
-        config.reloadConfig();
-        return config.getFoodProductionConfiguration();
+    @BeforeEach
+    void setUp() {
+        var config = SimulationConfig.loadConfig();
+        foodConfig = config.getFoodProductionConfiguration();
     }
 
     @Test
     void testProcessesLoaded() {
-        var manuProcesses = getFoodConfig().getProcessList();
+        var manuProcesses = foodConfig.getProcessList();
         assertTrue("Food processes defined", !manuProcesses.isEmpty());
     }
 
@@ -42,7 +43,7 @@ class FoodProductionConfigTest {
     void testPackageFood() {
         // Build mapped key on process name
         var processByName =
-                    Maps.uniqueIndex(getFoodConfig().getProcessList(),
+                    Maps.uniqueIndex(foodConfig.getProcessList(),
                         FoodProductionProcessInfo::getName);
         var process = processByName.get(PACKAGE_FOOD);
         assertNotNull("Food processes defined", process);
@@ -66,7 +67,7 @@ class FoodProductionConfigTest {
     void testMakeSoybean() {
         // Build mapped key on process name
         var processByName =
-                    Maps.uniqueIndex(getFoodConfig().getProcessList(),
+                    Maps.uniqueIndex(foodConfig.getProcessList(),
                         FoodProductionProcessInfo::getName);
         var process = processByName.get("Process Soybean into Soy Flour");
         assertNotNull("Food processes defined", process);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/malfunction/TestMalfunctionManager.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/malfunction/TestMalfunctionManager.java
@@ -13,7 +13,7 @@
 //public class TestMalfunctionManager extends TestCase {
 //    @Override
 //    public void setUp() throws Exception {
-//        SimulationConfig.instance().loadConfig();
+//        SimulationConfig.loadConfig();
 //        Simulation.instance().testRun();
 //    }
 //

--- a/mars-sim-core/src/test/java/com/mars_sim/core/manufacture/ManufactureConfigTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/manufacture/ManufactureConfigTest.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Maps;
@@ -35,17 +36,18 @@ public class ManufactureConfigTest {
         "Nitrospira SPP","Rhizobia","iron powder","copper","hydrogen"
     };
     private static final int FERTILIZER_INPUTS = 10;
+    private ManufactureConfig manuConfig;
 
 
-    private ManufactureConfig getManufactureConfig() {
-        var config = SimulationConfig.instance();
-        config.loadConfig();
-        return config.getManufactureConfiguration();
+    @BeforeEach
+    void setup() {
+        var config = SimulationConfig.loadConfig();
+        manuConfig = config.getManufactureConfiguration();
     }
 
     @Test
     void testProcessesLoaded() {
-        var conf = getManufactureConfig();
+        var conf = manuConfig;
         var manuProcesses = conf.getManufactureProcessList();
         assertTrue("Manufacturing processes defined", !manuProcesses.isEmpty());
 
@@ -70,7 +72,7 @@ public class ManufactureConfigTest {
     void testPlasticBottle() {
         // Build mapped key on process name
         var processByName =
-                    Maps.uniqueIndex(getManufactureConfig().getManufactureProcessList(),
+                    Maps.uniqueIndex(manuConfig.getManufactureProcessList(),
                         ManufactureProcessInfo::getName);
         var fertilizerP = processByName.get(MAKE_FERTILIZERS);
         assertNotNull("Manufacturng processes defined", fertilizerP);
@@ -94,7 +96,7 @@ public class ManufactureConfigTest {
     void testMakeRadioAntenna() {
         // Build mapped key on process name
         var processByName =
-                    Maps.uniqueIndex(getManufactureConfig().getManufactureProcessList(),
+                    Maps.uniqueIndex(manuConfig.getManufactureProcessList(),
                         ManufactureProcessInfo::getName);
         var process = processByName.get(MAKE_RADIO_ANTENNA);
         assertNotNull("Manufacturng processes defined", process);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/manufacture/ManufactureConfigTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/manufacture/ManufactureConfigTest.java
@@ -39,7 +39,7 @@ public class ManufactureConfigTest {
 
     private ManufactureConfig getManufactureConfig() {
         var config = SimulationConfig.instance();
-        config.reloadConfig();
+        config.loadConfig();
         return config.getManufactureConfiguration();
     }
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/NationSpecConfigTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/NationSpecConfigTest.java
@@ -14,8 +14,7 @@ public class NationSpecConfigTest extends TestCase {
     
     @Override
     public void setUp() {
-        var simConfig = SimulationConfig.instance();
-        simConfig.loadConfig();
+        var simConfig = SimulationConfig.loadConfig();
         config = new NationSpecConfig(simConfig);
     }
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/NationSpecConfigTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/NationSpecConfigTest.java
@@ -3,6 +3,7 @@ package com.mars_sim.core.person;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.tool.RandomUtil;
 
 import junit.framework.TestCase;
@@ -13,7 +14,9 @@ public class NationSpecConfigTest extends TestCase {
     
     @Override
     public void setUp() {
-        config = new NationSpecConfig();
+        var simConfig = SimulationConfig.instance();
+        simConfig.loadConfig();
+        config = new NationSpecConfig(simConfig);
     }
 
     public void testGenerateName() {

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/PersonBuilderTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/PersonBuilderTest.java
@@ -29,7 +29,7 @@ public class PersonBuilderTest extends AbstractMarsSimUnitTest {
 
     public void testOptional() {
         var home = buildSettlement();
-        NationSpecConfig nsc = new NationSpecConfig();
+        NationSpecConfig nsc = new NationSpecConfig(getConfig());
         var country = nsc.getItem(TEST_COUNTRY);
 
         AuthorityFactory af = simConfig.getReportingAuthorityFactory();

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/PersonConfigTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/PersonConfigTest.java
@@ -18,8 +18,7 @@ public class PersonConfigTest extends TestCase {
     private PersonConfig pc;
 
     public void setUp() {
-        SimulationConfig config = SimulationConfig.instance();
-        config.loadConfig();
+        SimulationConfig config = SimulationConfig.loadConfig();
         pc = config.getPersonConfig();
     }
     

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/PersonNameSpecConfigTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/PersonNameSpecConfigTest.java
@@ -21,8 +21,7 @@ public class PersonNameSpecConfigTest extends TestCase {
     
     @Override
     public void setUp() {
-        var simConfig = SimulationConfig.instance();
-        simConfig.loadConfig();
+        var simConfig = SimulationConfig.loadConfig();
         config = new NationSpecConfig(simConfig);
     }
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/PersonNameSpecConfigTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/PersonNameSpecConfigTest.java
@@ -10,6 +10,7 @@ package com.mars_sim.core.person;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.tool.RandomUtil;
 
 import junit.framework.TestCase;
@@ -20,7 +21,9 @@ public class PersonNameSpecConfigTest extends TestCase {
     
     @Override
     public void setUp() {
-        config = new NationSpecConfig();
+        var simConfig = SimulationConfig.instance();
+        simConfig.loadConfig();
+        config = new NationSpecConfig(simConfig);
     }
 
     public void testGenerateName() {

--- a/mars-sim-core/src/test/java/com/mars_sim/core/preferences/ParameterCategoryTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/preferences/ParameterCategoryTest.java
@@ -12,7 +12,6 @@ import com.mars_sim.core.person.ai.mission.MissionType;
 import com.mars_sim.core.person.ai.task.meta.ScienceParameters;
 import com.mars_sim.core.person.ai.task.util.MetaTaskUtil;
 import com.mars_sim.core.person.ai.task.util.TaskParameters;
-import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.science.ScienceType;
 import com.mars_sim.core.structure.OverrideType;
 import com.mars_sim.core.structure.ProcessParameters;
@@ -25,7 +24,6 @@ public class ParameterCategoryTest extends TestCase {
     private static final String DISPLAY_PREFIX = "Display_";
     private static final String ID_PREFIX = "key_";
 
-    @SuppressWarnings("serial")
 	class TestCategory extends ParameterCategory {
 
         public TestCategory() {
@@ -77,7 +75,7 @@ public class ParameterCategoryTest extends TestCase {
         assertEquals("Science values", ScienceType.values().length,
                                     ScienceParameters.INSTANCE.getRange().size());
 
-        SimulationConfig.instance().loadConfig();
+        SimulationConfig.loadConfig();
         MetaTaskUtil.initializeMetaTasks();
         assertEquals("Science values", MetaTaskUtil.getAllMetaTasks().size(),
                                     TaskParameters.INSTANCE.getRange().size());

--- a/mars-sim-core/src/test/java/com/mars_sim/core/preferences/ParameterCategoryTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/preferences/ParameterCategoryTest.java
@@ -78,7 +78,6 @@ public class ParameterCategoryTest extends TestCase {
                                     ScienceParameters.INSTANCE.getRange().size());
 
         SimulationConfig.instance().loadConfig();
-        ResourceUtil.getInstance();
         MetaTaskUtil.initializeMetaTasks();
         assertEquals("Science values", MetaTaskUtil.getAllMetaTasks().size(),
                                     TaskParameters.INSTANCE.getRange().size());

--- a/mars-sim-core/src/test/java/com/mars_sim/core/resource/TestAmountResourcePhaseStorage.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/resource/TestAmountResourcePhaseStorage.java
@@ -11,24 +11,24 @@ public class TestAmountResourcePhaseStorage extends TestCase {
 	private static final String WATER = ResourceUtil.WATER;
 	
     @Override
-    public void setUp() throws Exception {
-        SimulationConfig.instance().loadConfig();
+    public void setUp() {
+        SimulationConfig.loadConfig();
     }
 	
-	public void testInventoryAmountResourcePhaseCapacityGood() throws Exception {
+	public void testInventoryAmountResourcePhaseCapacityGood() {
 		AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 		storage.addAmountResourcePhaseCapacity(PhaseType.GAS, 100D);
 		double amountGas = storage.getAmountResourcePhaseCapacity(PhaseType.GAS);
 		assertEquals("Amount resource phase capacity set correctly.", 100D, amountGas, 0D);
 	}
 	
-	public void testInventoryAmountResourcePhaseCapacityNotSet() throws Exception {
+	public void testInventoryAmountResourcePhaseCapacityNotSet() {
 		AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 		double amountGas = storage.getAmountResourcePhaseCapacity(PhaseType.GAS);
 		assertEquals("Amount resource phase capacity set correctly.", 0D, amountGas, 0D);
 	}
 	
-	public void testInventoryAmountResourcePhaseCapacityNegativeCapacity() throws Exception {
+	public void testInventoryAmountResourcePhaseCapacityNegativeCapacity() {
 		AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 		try {
 			storage.addAmountResourcePhaseCapacity(PhaseType.GAS, -100D);
@@ -37,7 +37,7 @@ public class TestAmountResourcePhaseStorage extends TestCase {
 		catch (Exception e) {}
 	}
 	
-	public void testInventoryAmountResourcePhaseStoreGood() throws Exception {
+	public void testInventoryAmountResourcePhaseStoreGood() {
 		AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 		storage.addAmountResourcePhaseCapacity(PhaseType.GAS, 100D);
 		AmountResource hydrogen = ResourceUtil.findAmountResource(HYDROGEN);
@@ -46,7 +46,7 @@ public class TestAmountResourcePhaseStorage extends TestCase {
 		assertEquals("Amount resource phase stored is correct.", 100D, amountPhaseStored, 0D);
 	}
 	
-	public void testInventoryAmountResourcePhaseStoreOverload() throws Exception {
+	public void testInventoryAmountResourcePhaseStoreOverload() {
 		AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 		storage.addAmountResourcePhaseCapacity(PhaseType.GAS, 100D);
 		AmountResource hydrogen = ResourceUtil.findAmountResource(HYDROGEN);
@@ -57,7 +57,7 @@ public class TestAmountResourcePhaseStorage extends TestCase {
 		catch (Exception e) {}
 	}
 	
-	public void testInventoryAmountResourcePhaseStoreNegativeAmount() throws Exception {
+	public void testInventoryAmountResourcePhaseStoreNegativeAmount() {
 		AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 		storage.addAmountResourcePhaseCapacity(PhaseType.GAS, 100D);
 		AmountResource hydrogen = ResourceUtil.findAmountResource(HYDROGEN);
@@ -68,7 +68,7 @@ public class TestAmountResourcePhaseStorage extends TestCase {
 		catch (Exception e) {}
 	}
 	
-	public void testInventoryAmountResourcePhaseStoreNoCapacity() throws Exception {
+	public void testInventoryAmountResourcePhaseStoreNoCapacity() {
 		AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 		AmountResource hydrogen = ResourceUtil.findAmountResource(HYDROGEN);
 		try {
@@ -78,7 +78,7 @@ public class TestAmountResourcePhaseStorage extends TestCase {
 		catch (Exception e) {}
 	}
 	
-	public void testInventoryAmountResourcePhaseTypeGood() throws Exception {
+	public void testInventoryAmountResourcePhaseTypeGood() {
 		AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 		storage.addAmountResourcePhaseCapacity(PhaseType.GAS, 100D);
 		AmountResource hydrogen = ResourceUtil.findAmountResource(HYDROGEN);
@@ -87,14 +87,14 @@ public class TestAmountResourcePhaseStorage extends TestCase {
 		assertEquals("Amount phase stored is of correct type.", hydrogen, resource);
 	}
 	
-	public void testInventoryAmountResourcePhaseTypeNoResource() throws Exception {
+	public void testInventoryAmountResourcePhaseTypeNoResource() {
 		AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 		storage.addAmountResourcePhaseCapacity(PhaseType.GAS, 100D);
 		AmountResource resource = storage.getAmountResourcePhaseType(PhaseType.GAS);
 		assertNull("Amount phase type stored is null.", resource);
 	}
 	
-	public void testInventoryAmountResourcePhaseRemainingCapacityGood() throws Exception {
+	public void testInventoryAmountResourcePhaseRemainingCapacityGood() {
 		AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 		storage.addAmountResourcePhaseCapacity(PhaseType.GAS, 100D);
 		AmountResource hydrogen = ResourceUtil.findAmountResource(HYDROGEN);
@@ -103,13 +103,13 @@ public class TestAmountResourcePhaseStorage extends TestCase {
 		assertEquals("Amount phase capacity remaining is correct amount.", 50D, remainingCapacity, 0D);
 	}
 	
-	public void testInventoryAmountResourcePhaseRemainingCapacityNoCapacity() throws Exception {
+	public void testInventoryAmountResourcePhaseRemainingCapacityNoCapacity() {
 		AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 		double remainingCapacity = storage.getAmountResourcePhaseRemainingCapacity(PhaseType.GAS);
 		assertEquals("Amount phase capacity remaining is correct amount.", 0D, remainingCapacity, 0D);
 	}
 	
-	public void testInventoryAmountResourcePhaseRetrieveGood() throws Exception {
+	public void testInventoryAmountResourcePhaseRetrieveGood() {
 		AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 		storage.addAmountResourcePhaseCapacity(PhaseType.GAS, 100D);
 		AmountResource hydrogen = ResourceUtil.findAmountResource(HYDROGEN);
@@ -119,7 +119,7 @@ public class TestAmountResourcePhaseStorage extends TestCase {
 		assertEquals("Amount phase capacity remaining is correct amount.", 50D, remainingCapacity, 0D);
 	}
 	
-	public void testInventoryAmountResourcePhaseRetrieveTooMuch() throws Exception {
+	public void testInventoryAmountResourcePhaseRetrieveTooMuch() {
 		try {
 			AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 			storage.addAmountResourcePhaseCapacity(PhaseType.GAS, 100D);
@@ -131,7 +131,7 @@ public class TestAmountResourcePhaseStorage extends TestCase {
 		catch (Exception e) {}
 	}
 	
-	public void testInventoryAmountResourcePhaseRetrieveNegative() throws Exception {
+	public void testInventoryAmountResourcePhaseRetrieveNegative() {
 		try {
 			AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 			storage.addAmountResourcePhaseCapacity(PhaseType.GAS, 100D);
@@ -143,7 +143,7 @@ public class TestAmountResourcePhaseStorage extends TestCase {
 		catch (Exception e) {}
 	}
 	
-	public void testInventoryAmountResourcePhaseRetrieveNoCapacity() throws Exception {
+	public void testInventoryAmountResourcePhaseRetrieveNoCapacity() {
 		try {
 			AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 			storage.retrieveAmountResourcePhase(PhaseType.GAS, 100D);
@@ -152,7 +152,7 @@ public class TestAmountResourcePhaseStorage extends TestCase {
 		catch (Exception e) {}
 	}
 	
-	public void testInventoryAmountResourcePhaseTotalAmount() throws Exception {
+	public void testInventoryAmountResourcePhaseTotalAmount() {
 		AmountResourcePhaseStorage storage = new AmountResourcePhaseStorage();
 		storage.addAmountResourcePhaseCapacity(PhaseType.GAS, 100D);
 		storage.addAmountResourcePhaseCapacity(PhaseType.LIQUID, 100D);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/resource/TestAmountResourceStorage.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/resource/TestAmountResourceStorage.java
@@ -20,7 +20,7 @@ public class TestAmountResourceStorage extends TestCase {
 	
     @Override
     public void setUp() throws Exception {
-        SimulationConfig.instance().loadConfig();
+        SimulationConfig.loadConfig();
         Simulation.instance().testRun();
         settlement = new MockSettlement();
     }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/resource/TestAmountResourceTypeStorage.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/resource/TestAmountResourceTypeStorage.java
@@ -12,11 +12,11 @@ public class TestAmountResourceTypeStorage extends TestCase {
     private static final String OXYGEN = ResourceUtil.OXYGEN;
 
     @Override
-    public void setUp() throws Exception {
-        SimulationConfig.instance().loadConfig();
+    public void setUp() {
+        SimulationConfig.loadConfig();
     }
 
-    public void testInventoryAmountResourceTypeCapacityGood() throws Exception {
+    public void testInventoryAmountResourceTypeCapacityGood() {
         AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
         AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
         storage.addAmountResourceTypeCapacity(carbonDioxide, 100D);
@@ -24,14 +24,14 @@ public class TestAmountResourceTypeStorage extends TestCase {
         assertEquals("Amount resource type capacity set correctly.", 100D, amountCO2, 0D);
     }
 
-    public void testInventoryAmountResourceTypeCapacityNotSet() throws Exception {
+    public void testInventoryAmountResourceTypeCapacityNotSet() {
         AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
         AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
         double amountCO2 = storage.getAmountResourceTypeCapacity(carbonDioxide);
         assertEquals("Amount resource type capacity set correctly.", 0D, amountCO2, 0D);
     }
 
-    public void testInventoryAmountResourceTypeCapacityNegativeCapacity() throws Exception {
+    public void testInventoryAmountResourceTypeCapacityNegativeCapacity() {
         AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
         AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
         try {
@@ -74,7 +74,7 @@ public class TestAmountResourceTypeStorage extends TestCase {
         assertEquals(0D, amountCarbonDioxide4);
     }
 
-    public void testInventoryAmountResourceTypeStoreGood() throws Exception {
+    public void testInventoryAmountResourceTypeStoreGood() {
         AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
         AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
         storage.addAmountResourceTypeCapacity(carbonDioxide, 100D);
@@ -83,7 +83,7 @@ public class TestAmountResourceTypeStorage extends TestCase {
         assertEquals("Amount resource type stored is correct.", 100D, amountTypeStored, 0D);
     }
 
-    public void testInventoryAmountResourceTypeStoreOverload() throws Exception {
+    public void testInventoryAmountResourceTypeStoreOverload() {
         AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
         AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
         storage.addAmountResourceTypeCapacity(carbonDioxide, 100D);
@@ -94,7 +94,7 @@ public class TestAmountResourceTypeStorage extends TestCase {
         catch (Exception e) {}
     }
 
-    public void testInventoryAmountResourceTypeStoreNegativeAmount() throws Exception {
+    public void testInventoryAmountResourceTypeStoreNegativeAmount() {
         AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
         AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
         storage.addAmountResourceTypeCapacity(carbonDioxide, 100D);
@@ -105,7 +105,7 @@ public class TestAmountResourceTypeStorage extends TestCase {
         catch (Exception e) {}
     }
 
-    public void testInventoryAmountResourceTypeStoreNoCapacity() throws Exception {
+    public void testInventoryAmountResourceTypeStoreNoCapacity() {
         AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
         AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
         try {
@@ -115,7 +115,7 @@ public class TestAmountResourceTypeStorage extends TestCase {
         catch (Exception e) {}
     }
 
-    public void testInventoryAmountResourceTypeRemainingCapacityGood() throws Exception {
+    public void testInventoryAmountResourceTypeRemainingCapacityGood() {
         AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
         AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
         storage.addAmountResourceTypeCapacity(carbonDioxide, 100D);
@@ -124,14 +124,14 @@ public class TestAmountResourceTypeStorage extends TestCase {
         assertEquals("Amount type capacity remaining is correct amount.", 50D, remainingCapacity, 0D);
     }
 
-    public void testInventoryAmountResourceTypeRemainingCapacityNoCapacity() throws Exception {
+    public void testInventoryAmountResourceTypeRemainingCapacityNoCapacity() {
         AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
         AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
         double remainingCapacity = storage.getAmountResourceTypeRemainingCapacity(carbonDioxide);
         assertEquals("Amount type capacity remaining is correct amount.", 0D, remainingCapacity, 0D);
     }
 
-    public void testInventoryAmountResourceTypeRetrieveGood() throws Exception {
+    public void testInventoryAmountResourceTypeRetrieveGood() {
         AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
         AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
         storage.addAmountResourceTypeCapacity(carbonDioxide, 100D);
@@ -141,7 +141,7 @@ public class TestAmountResourceTypeStorage extends TestCase {
         assertEquals("Amount type capacity remaining is correct amount.", 50D, remainingCapacity, 0D);
     }
 
-    public void testInventoryAmountResourceTypeRetrieveTooMuch() throws Exception {
+    public void testInventoryAmountResourceTypeRetrieveTooMuch() {
         try {
             AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
             AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
@@ -153,7 +153,7 @@ public class TestAmountResourceTypeStorage extends TestCase {
         catch (Exception e) {}
     }
 
-    public void testInventoryAmountResourceTypeRetrieveNegative() throws Exception {
+    public void testInventoryAmountResourceTypeRetrieveNegative() {
         try {
             AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
             AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
@@ -165,7 +165,7 @@ public class TestAmountResourceTypeStorage extends TestCase {
         catch (Exception e) {}
     }
 
-    public void testInventoryAmountResourceTypeRetrieveNoCapacity() throws Exception {
+    public void testInventoryAmountResourceTypeRetrieveNoCapacity() {
         try {
             AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
             AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
@@ -175,7 +175,7 @@ public class TestAmountResourceTypeStorage extends TestCase {
         catch (Exception e) {}
     }
 
-    public void testInventoryAmountResourceTypeTotalAmount() throws Exception {
+    public void testInventoryAmountResourceTypeTotalAmount() {
         AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
         AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
         AmountResource oxygen = ResourceUtil.findAmountResource(OXYGEN);
@@ -187,7 +187,7 @@ public class TestAmountResourceTypeStorage extends TestCase {
         assertEquals("Amount total stored is correct.", 30D, totalStored, 0D);
     }
 
-    public void testInventoryAmountResourceTypeAllStored() throws Exception {
+    public void testInventoryAmountResourceTypeAllStored() {
         AmountResourceTypeStorage storage = new AmountResourceTypeStorage();
         AmountResource carbonDioxide = ResourceUtil.findAmountResource(CARBON_DIOXIDE);
         AmountResource oxygen = ResourceUtil.findAmountResource(OXYGEN);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/resource/TestItemResource.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/resource/TestItemResource.java
@@ -22,8 +22,8 @@ public class TestItemResource extends TestCase {
     }
 
     @Override
-    public void setUp() throws Exception {
-        SimulationConfig.instance().loadConfig();
+    public void setUp() {
+        SimulationConfig.loadConfig();
 
         // initialize
         resources = ItemResourceUtil.getItemResources();

--- a/mars-sim-core/src/test/java/com/mars_sim/core/resource/TestItemResource.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/resource/TestItemResource.java
@@ -26,7 +26,6 @@ public class TestItemResource extends TestCase {
         SimulationConfig.instance().loadConfig();
 
         // initialize
-       	ResourceUtil.getInstance();
         resources = ItemResourceUtil.getItemResources();
         GoodType type = GoodType.TOOL;
         

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/goods/TestCreditManager.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/goods/TestCreditManager.java
@@ -15,7 +15,7 @@ public class TestCreditManager extends TestCase {
 
     @Override
     public void setUp() throws Exception {
-        SimulationConfig.instance().loadConfig();
+        SimulationConfig.loadConfig();
         Simulation.instance().testRun();
     }
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/goods/TestGoods.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/goods/TestGoods.java
@@ -27,7 +27,6 @@ public class TestGoods extends TestCase {
     protected void setUp() throws Exception {
         SimulationConfig config = SimulationConfig.instance();
         config.loadConfig();
-        ResourceUtil.getInstance();   
         
         // Don't need a full GoodsManager initialisation
         GoodsManager.initializeInstances(config, null, null);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/goods/TestGoods.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/goods/TestGoods.java
@@ -24,6 +24,7 @@ public class TestGoods extends TestCase {
 		super();
 	}
 
+	@Override
     protected void setUp() throws Exception {
         SimulationConfig config = SimulationConfig.instance();
         config.loadConfig();

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/goods/TestGoods.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/goods/TestGoods.java
@@ -26,9 +26,8 @@ public class TestGoods extends TestCase {
 
 	@Override
     protected void setUp() throws Exception {
-        SimulationConfig config = SimulationConfig.instance();
-        config.loadConfig();
-        
+        SimulationConfig config = SimulationConfig.loadConfig();
+  
         // Don't need a full GoodsManager initialisation
         GoodsManager.initializeInstances(config, null, null);
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadControllerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadControllerTest.java
@@ -55,8 +55,7 @@ extends TestCase {
 	@Override
     public void setUp() {
 
-        SimulationConfig config = SimulationConfig.instance();
-		config.loadConfig();
+        SimulationConfig config = SimulationConfig.loadConfig();
         Simulation.instance().testRun();
 
         unitManager = Simulation.instance().getUnitManager();

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/AuthorityGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/AuthorityGenerator.java
@@ -23,7 +23,7 @@ public class AuthorityGenerator extends TypeGenerator<Authority> {
 
     @Override
     protected List<Authority> getEntities() {
-        var factory = getParent().getConfig().getReportingAuthorityFactory();
+        var factory = getConfig().getReportingAuthorityFactory();
 
         return factory.getKnownItems().stream()
                     .filter(a -> a.isBundled())

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/BuildingGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/BuildingGenerator.java
@@ -34,7 +34,7 @@ public class BuildingGenerator extends TypeGenerator<BuildingSpec>{
      */
     @Override
     protected void addEntityProperties(BuildingSpec r, Map<String,Object> scope) {
-        var stage = getParent().getConfig().getConstructionConfiguration()
+        var stage = getConfig().getConstructionConfiguration()
                         .getConstructionStageInfoByName(r.getName());
         if (stage != null) {
             scope.put("construction", stage);
@@ -45,7 +45,7 @@ public class BuildingGenerator extends TypeGenerator<BuildingSpec>{
      * Gets a list of all the building specifications configured.
      */
     protected List<BuildingSpec> getEntities() {
-        return getParent().getConfig().getBuildingConfiguration().getBuildingTypes()
+        return getConfig().getBuildingConfiguration().getBuildingTypes()
                             .stream()
 		 					.sorted((o1, o2)->o1.getName().compareTo(o2.getName()))
 							.toList();

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/ComplaintGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/ComplaintGenerator.java
@@ -33,7 +33,7 @@ public class ComplaintGenerator extends TypeGenerator<Complaint> {
      */
     @Override
     protected List<Complaint> getEntities() {
-        return getParent().getConfig().getMedicalConfiguration().getComplaintList()
+        return getConfig().getMedicalConfiguration().getComplaintList()
                     .stream()
 		 			.sorted(Comparator.comparing(Complaint::getName))
 					.toList();

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/ConstructionGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/ConstructionGenerator.java
@@ -26,7 +26,7 @@ public class ConstructionGenerator extends TypeGenerator<ConstructionStageInfo> 
         // Groups according to stage
         setGrouper("Stage", r-> r.getType().name());
 
-        dependentsBySource = getParent().getConfig().getConstructionConfiguration().getAllConstructionStageInfoList()
+        dependentsBySource = getConfig().getConstructionConfiguration().getAllConstructionStageInfoList()
                 .stream()
                 .filter(v -> v.getPrerequisiteStage() != null)
                 .collect(Collectors.groupingBy(ConstructionStageInfo::getPrerequisiteStage));
@@ -68,7 +68,7 @@ public class ConstructionGenerator extends TypeGenerator<ConstructionStageInfo> 
 
     @Override
     protected List<ConstructionStageInfo> getEntities() {
-        return getParent().getConfig().getConstructionConfiguration().getAllConstructionStageInfoList();
+        return getConfig().getConstructionConfiguration().getAllConstructionStageInfoList();
     }
 
     @Override

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/CrewGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/CrewGenerator.java
@@ -25,7 +25,7 @@ public class CrewGenerator extends TypeGenerator<Crew> {
      * Get a list of all the predefined Crew configured.
      */
     protected List<Crew> getEntities() {
-        var config = new CrewConfig();
+        var config = new CrewConfig(getConfig());
         return config.getKnownItems()
                             .stream()
                             .filter(Crew::isBundled)

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/CropGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/CropGenerator.java
@@ -30,7 +30,7 @@ public class CropGenerator extends TypeGenerator<CropSpec> {
      * @return sorted list of crops
      */
     protected List<CropSpec> getEntities() {
-        return getParent().getConfig().getCropConfiguration().getCropTypes()
+        return getConfig().getCropConfiguration().getCropTypes()
                             .stream()
                             .sorted((o1, o2)->o1.getName().compareTo(o2.getName()))
                             .toList();

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/FoodGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/FoodGenerator.java
@@ -42,7 +42,7 @@ class FoodGenerator extends TypeGenerator<FoodProductionProcessInfo> {
      */
     @Override
     protected List<FoodProductionProcessInfo> getEntities() {
-		return getParent().getConfig().getFoodProductionConfiguration()
+		return getConfig().getFoodProductionConfiguration()
                         .getProcessList().stream()
 		 							.sorted((o1, o2)->o1.getName().compareTo(o2.getName()))
 									.toList();

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/HelpRunner.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/HelpRunner.java
@@ -40,8 +40,7 @@ public class HelpRunner {
      */
     public static void main(String[] args) {
         // Load config files
-        var config = SimulationConfig.instance();
-        config.loadConfig();
+        var config = SimulationConfig.loadConfig();
 
         // Setup commands
         Options options = new Options();

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/MalfunctionGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/MalfunctionGenerator.java
@@ -78,7 +78,7 @@ public class MalfunctionGenerator extends TypeGenerator<MalfunctionMeta> {
      */
     @Override
     protected List<MalfunctionMeta> getEntities() {
-        return getParent().getConfig().getMalfunctionConfiguration().getMalfunctionList()
+        return getConfig().getMalfunctionConfiguration().getMalfunctionList()
                     .stream()
                     .sorted((o1, o2)->o1.getName().compareTo(o2.getName()))
                     .toList();

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/ManifestGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/ManifestGenerator.java
@@ -26,7 +26,7 @@ public class ManifestGenerator extends TypeGenerator<ResupplyManifest> {
 
     @Override
     protected List<ResupplyManifest> getEntities() {
-        return getParent().getConfig().getSettlementTemplateConfiguration().getSupplyManifests();
+        return getConfig().getSettlementTemplateConfiguration().getSupplyManifests();
 
     }
 	/**

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/MealGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/MealGenerator.java
@@ -30,7 +30,7 @@ class MealGenerator extends TypeGenerator<HotMeal> {
      */
     @Override
     protected List<HotMeal> getEntities() {
-		return getParent().getConfig().getMealConfiguration().getDishList().stream()
+		return getConfig().getMealConfiguration().getDishList().stream()
 		 							.sorted((o1, o2)->o1.getMealName().compareTo(o2.getMealName()))
 									.toList();
 	

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/ProcessGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/ProcessGenerator.java
@@ -48,7 +48,7 @@ class ProcessGenerator extends TypeGenerator<ProcessInfo> {
      */
     @Override
     protected List<ProcessInfo> getEntities() {
-		var manuConfig = getParent().getConfig().getManufactureConfiguration();
+		var manuConfig = getConfig().getManufactureConfiguration();
         return Stream.concat(manuConfig.getManufactureProcessList().stream(),
                                 manuConfig.getSalvageInfoList().stream())
 		 					.sorted((o1, o2)->o1.getName().compareTo(o2.getName()))

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/ResourceGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/ResourceGenerator.java
@@ -41,7 +41,7 @@ public class ResourceGenerator extends TypeGenerator<AmountResource> {
 	private ResourceUse getFoodUsageByName(String name) {
 		if (foodProductionUse == null) {
 			foodProductionUse = new HashMap<>();
-			for (var m: getParent().getConfig().getFoodProductionConfiguration().getProcessList()) {
+			for (var m: getConfig().getFoodProductionConfiguration().getProcessList()) {
 				for (var r: m.getInputList()) {
 					foodProductionUse.computeIfAbsent(r.getName().toLowerCase(),
                                 k -> HelpContext.buildEmptyResourceUse()).asInput().add(m);
@@ -77,7 +77,7 @@ public class ResourceGenerator extends TypeGenerator<AmountResource> {
         scope.put("foodOutput", foodUse.asOutput());   
         
         if (r.getGoodType() == GoodType.CROP) {
-            var cropSpec = getParent().getConfig().getCropConfiguration().getCropTypeByName(r.getName());
+            var cropSpec = getConfig().getCropConfiguration().getCropTypeByName(r.getName());
             if (cropSpec != null) {
                 scope.put("cropspec", cropSpec.getName());
             }

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/ResourceProcessGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/ResourceProcessGenerator.java
@@ -60,7 +60,7 @@ class ResourceProcessGenerator extends TypeGenerator<ResourceProcessSpec> {
      */
     @Override
     protected List<ResourceProcessSpec> getEntities() {
-		var config = getParent().getConfig().getResourceProcessConfiguration();
+		var config = getConfig().getResourceProcessConfiguration();
         return config.getProcessSpecs().stream()
 		 					.sorted((o1, o2)->o1.getName().compareTo(o2.getName()))
 							.toList();

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/RobotGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/RobotGenerator.java
@@ -57,7 +57,7 @@ public class RobotGenerator extends TypeGenerator<RobotSpec> {
      */
     @Override
     protected List<RobotSpec> getEntities() {
-        return getParent().getConfig().getRobotConfiguration().getRobotSpecs()
+        return getConfig().getRobotConfiguration().getRobotSpecs()
                     .stream()
                     .sorted((o1, o2)->o1.getName().compareTo(o2.getName()))
                     .toList();

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/ScenarioGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/ScenarioGenerator.java
@@ -25,7 +25,7 @@ public class ScenarioGenerator extends TypeGenerator<Scenario> {
      * Get a list of all the predefined Crew configured.
      */
     protected List<Scenario> getEntities() {
-        var config = new ScenarioConfig();
+        var config = new ScenarioConfig(getConfig());
         return config.getKnownItems()
                             .stream()
                             .filter(Scenario::isBundled)

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/SettlementGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/SettlementGenerator.java
@@ -36,7 +36,7 @@ public class SettlementGenerator extends TypeGenerator<SettlementTemplate> {
      */
     protected List<SettlementTemplate> getEntities() {
 
-        return getParent().getConfig().getSettlementTemplateConfiguration().getKnownItems()
+        return getConfig().getSettlementTemplateConfiguration().getKnownItems()
                             .stream()
                             .filter(SettlementTemplate::isBundled)
 		 					.sorted(Comparator.comparing(SettlementTemplate::getName))

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/TreatmentGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/TreatmentGenerator.java
@@ -27,7 +27,7 @@ public class TreatmentGenerator extends TypeGenerator<Treatment> {
      */
     @Override
     protected List<Treatment> getEntities() {
-        return getParent().getConfig().getMedicalConfiguration().getTreatmentsByLevel(20)
+        return getConfig().getMedicalConfiguration().getTreatmentsByLevel(20)
                     .stream()
 		 			.sorted(Comparator.comparing(Treatment::getName))
 					.toList();

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/TypeGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/TypeGenerator.java
@@ -16,6 +16,7 @@ import java.util.function.Function;
 import java.util.logging.Logger;
 
 import com.github.mustachejava.Mustache;
+import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.process.ProcessItem;
 import com.mars_sim.core.resource.ItemType;
 import com.mars_sim.tools.helpgenerator.GenericsGrouper.NamedGroup;
@@ -116,6 +117,10 @@ public abstract class TypeGenerator<T> {
         return parent;
     }
 
+    protected SimulationConfig getConfig() {
+        return parent.getConfig();
+    }
+    
     /**
 	 * Creates an index page for a set of named entities.
 	 * 

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/VehicleGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/VehicleGenerator.java
@@ -29,7 +29,7 @@ public class VehicleGenerator extends TypeGenerator<VehicleSpec> {
      * Get a list of all the vehicle specifications configured.
      */
     protected List<VehicleSpec> getEntities() {
-        return getParent().getConfig().getVehicleConfiguration().getVehicleSpecs().stream()
+        return getConfig().getVehicleConfiguration().getVehicleSpecs().stream()
 		 							.sorted((o1, o2)->o1.getName().compareTo(o2.getName()))
 									 .toList();
     }

--- a/mars-sim-tools/src/test/java/com/mars_sim/tools/helpgenerator/HelpGeneratorTest.java
+++ b/mars-sim-tools/src/test/java/com/mars_sim/tools/helpgenerator/HelpGeneratorTest.java
@@ -25,8 +25,10 @@ import com.mars_sim.core.robot.RobotType;
 
 public class HelpGeneratorTest {
 
+    private SimulationConfig config;
+    
     private HelpContext createGenerator() {
-        var config = SimulationConfig.instance();
+        config = SimulationConfig.instance();
         config.loadConfig();
 
         return new HelpContext(config, HelpContext.HTML_STYLE);
@@ -217,7 +219,7 @@ public class HelpGeneratorTest {
         var context = createGenerator();
         
         // Has both inputs and outputs
-        var spec = (new ScenarioConfig()).getItem("Default");
+        var spec = (new ScenarioConfig(config)).getItem("Default");
 
         var vg = new ScenarioGenerator(context);
         var content = createDoc(vg, spec);

--- a/mars-sim-tools/src/test/java/com/mars_sim/tools/helpgenerator/HelpGeneratorTest.java
+++ b/mars-sim-tools/src/test/java/com/mars_sim/tools/helpgenerator/HelpGeneratorTest.java
@@ -25,13 +25,12 @@ import com.mars_sim.core.robot.RobotType;
 
 public class HelpGeneratorTest {
 
-    private SimulationConfig config;
+    private SimulationConfig simconfig;
     
     private HelpContext createGenerator() {
-        config = SimulationConfig.instance();
-        config.loadConfig();
+        simconfig = SimulationConfig.loadConfig();
 
-        return new HelpContext(config, HelpContext.HTML_STYLE);
+        return new HelpContext(simconfig, HelpContext.HTML_STYLE);
     }
 
     private <T> Document createDoc(TypeGenerator<T> gen, T entity) throws IOException {
@@ -219,7 +218,7 @@ public class HelpGeneratorTest {
         var context = createGenerator();
         
         // Has both inputs and outputs
-        var spec = (new ScenarioConfig(config)).getItem("Default");
+        var spec = (new ScenarioConfig(simconfig)).getItem("Default");
 
         var vg = new ScenarioGenerator(context);
         var content = createDoc(vg, spec);

--- a/mars-sim-tools/src/test/java/com/mars_sim/tools/helpgenerator/HelpLibraryTest.java
+++ b/mars-sim-tools/src/test/java/com/mars_sim/tools/helpgenerator/HelpLibraryTest.java
@@ -18,8 +18,7 @@ class HelpLibraryTest {
     @Test
     void testCreateLibrary() throws IOException {
 		// Load config files
-		var config = SimulationConfig.instance();
-		config.loadConfig();
+		var config = SimulationConfig.loadConfig();
 
         File output = Files.createTempDirectory("generator").toFile();
         try {
@@ -40,8 +39,7 @@ class HelpLibraryTest {
     @Test
     void testChangedVersion() throws IOException {
 		// Load config files
-		var config = SimulationConfig.instance();
-		config.loadConfig();
+		var config = SimulationConfig.loadConfig();
 
         File output = Files.createTempDirectory("generator").toFile();
         try {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/CrewEditor.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/CrewEditor.java
@@ -38,13 +38,13 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.WindowConstants;
 
+import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.authority.Authority;
 import com.mars_sim.core.authority.AuthorityFactory;
 import com.mars_sim.core.configuration.UserConfigurableConfig;
 import com.mars_sim.core.person.Crew;
 import com.mars_sim.core.person.GenderType;
 import com.mars_sim.core.person.Member;
-import com.mars_sim.core.person.PersonConfig;
 import com.mars_sim.core.person.NationSpecConfig;
 import com.mars_sim.core.person.ai.job.util.JobType;
 import com.mars_sim.core.tool.Conversion;
@@ -76,7 +76,7 @@ public class CrewEditor implements ActionListener {
 		 * 
 		 * @return
 		 */
-		MemberPanel(int i, CrewEditor parent) {
+		MemberPanel(int i) {
 			displayPanel = Box.createVerticalBox();
 
 			// Name 
@@ -190,8 +190,6 @@ public class CrewEditor implements ActionListener {
 								"Invalid Name Format",
 								JOptionPane.ERROR_MESSAGE);
 				
-				// Disable Start;
-				// event.consume();
 				nametf.requestFocus();
 				return false;
 			}
@@ -341,7 +339,7 @@ public class CrewEditor implements ActionListener {
 	private static final String FEMALE = "Female";
 		
 	private static final int PANEL_WIDTH = 180;
-	private static final int WIDTH = (int)(PANEL_WIDTH * 4);
+	private static final int WIDTH = (PANEL_WIDTH * 4);
 	private static final int HEIGHT = 512;
 
 	private static final String[] QUADRANT_A = {"<html><b>E</b>xtravert",
@@ -375,8 +373,7 @@ public class CrewEditor implements ActionListener {
 	 */
 	public CrewEditor(SimulationConfigEditor simulationConfigEditor,
 					  UserConfigurableConfig<Crew> config,
-					  AuthorityFactory raFactory,
-					  PersonConfig pc) {
+					  AuthorityFactory raFactory) {
 		
 		this.simulationConfigEditor = simulationConfigEditor;
 		this.raFactory = raFactory;
@@ -397,7 +394,7 @@ public class CrewEditor implements ActionListener {
 			mp = crewPanels.get(i);
 		}
 		else {
-			mp = new MemberPanel(i, this);
+			mp = new MemberPanel(i);
 			crewPanels.add(mp);
 			scrollPane.add(mp.displayPanel);
 		}
@@ -415,11 +412,12 @@ public class CrewEditor implements ActionListener {
 	 */
 	private void createGUI(UserConfigurableConfig<Crew> crewConfig) {
 	
-		f = new JDialog(simulationConfigEditor.getFrame(), TITLE + " - Alpha Crew On-board", true); //new JFrame(TITLE + " - Alpha Crew On-board");
+		f = new JDialog(simulationConfigEditor.getFrame(), TITLE + " - Alpha Crew On-board", true);
 		f.setIconImage(MainWindow.getIconImage());
 		f.setResizable(true);
 		f.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
 		f.addWindowListener(new WindowAdapter() {
+			@Override
 			public void windowClosing(WindowEvent ev) {
 				simulationConfigEditor.setCrewEditorOpen(false);
 				f.dispose();
@@ -481,11 +479,11 @@ public class CrewEditor implements ActionListener {
 	 */
 	public void actionPerformed(ActionEvent evt) {
 
-		String cmd = (String) evt.getActionCommand();
+		String cmd = evt.getActionCommand();
 		switch (cmd) {
 		
 		case ADD_MEMBER:
-			MemberPanel newPanel = new MemberPanel(crewPanels.size(), this);
+			MemberPanel newPanel = new MemberPanel(crewPanels.size());
 			crewPanels.add(newPanel);
 			scrollPane.add(newPanel.displayPanel);
 			break;
@@ -584,8 +582,9 @@ public class CrewEditor implements ActionListener {
 			return "J";
 		case 7:	
 			return "P";
+		default:
+			return null;
 		}
-		return null;
 	}
 
 	/**
@@ -609,7 +608,7 @@ public class CrewEditor implements ActionListener {
 	 */
 	private static DefaultComboBoxModel<String> setUpJobCBModel() {
 
-		DefaultComboBoxModel<String> m = new DefaultComboBoxModel<String>();
+		DefaultComboBoxModel<String> m = new DefaultComboBoxModel<>();
 		for (JobType jt : JobType.values()) {
 			if (jt != JobType.POLITICIAN) {
 				m.addElement(jt.getName());
@@ -656,7 +655,7 @@ public class CrewEditor implements ActionListener {
 
 		if ((sponsorCode == null) || SETTLEMENT_SPONSOR.equals(sponsorCode)) {
 			// Load all known countries
-			NationSpecConfig nameConfig = new NationSpecConfig();
+			NationSpecConfig nameConfig = new NationSpecConfig(SimulationConfig.instance());
 			model.addAll(nameConfig.getItemNames());			
 		}
 		else {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/main/MarsProject.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/main/MarsProject.java
@@ -325,7 +325,7 @@ public class MarsProject {
 
 		Scenario scenario = editor.getScenario();
 		if (scenario != null) {
-			builder.setScenario(scenario);
+			builder.setScenarioName(scenario.getName());
 		}
 	}
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/main/MarsProject.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/main/MarsProject.java
@@ -10,7 +10,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -77,8 +76,6 @@ public class MarsProject {
 
 	private Simulation sim;
 
-	private SimulationConfig simulationConfig = SimulationConfig.instance();
-
 	private String simFile;
 
 	/**
@@ -144,7 +141,7 @@ public class MarsProject {
 			}
 
 			// Preload the Config
-			simulationConfig.loadConfig();
+			SimulationConfig.loadConfig();
 			
 			if (useSiteEditor) {
 				logger.config("Start the Scenario Editor...");
@@ -183,9 +180,6 @@ public class MarsProject {
 						
 						builder.startSocietySim();
 
-						// Start the wait layer
-//						InteractiveTerm.startLayer();
-
 						// Start beryx console
 						startConsoleThread();
 						
@@ -200,9 +194,6 @@ public class MarsProject {
 
 			// Build and run the simulator
 			sim = builder.start();
-
-			// Start the wait layer
-//			InteractiveTerm.startLayer();
 
 			// Start beryx console
 			startConsoleThread();
@@ -252,15 +243,7 @@ public class MarsProject {
 		
 		DefaultParser commandline = new DefaultParser();
 		try {
-			Properties defaults = new Properties();
-			File defaultFile = new File(SimulationRuntime.getDataDir(), "default.props");
-			if (defaultFile.exists()) {
-				try (InputStream defaultInput = new FileInputStream(defaultFile)) {
-					defaults.load(defaultInput);
-				} catch (IOException e) {
-					logger.warning("Problem reading default.props " + e.getMessage());
-				}
-			}
+			Properties defaults = readDefaults();
 			CommandLine line = commandline.parse(options, args, defaults);
 
 			builder.parseCommandLine(line);
@@ -272,15 +255,10 @@ public class MarsProject {
 			if (line.hasOption(DISPLAY_HELP)) {
 				usage("See available options below", options);
 			}
-			if (line.hasOption(NOGUI)) {
-				useGUI = false;
-			}
-			if (line.hasOption(NEW)) {
-				useNew = true;
-			}
-			if (line.hasOption(CLEANUI)) {
-				useCleanUI = true;
-			}
+			useGUI = !line.hasOption(NOGUI);
+			useNew = line.hasOption(NEW);
+			useCleanUI = line.hasOption(CLEANUI);
+			
 			if (line.hasOption(LOAD_ARG)) {
 				simFile = line.getOptionValue(LOAD_ARG);
 				if (simFile == null) {
@@ -290,19 +268,30 @@ public class MarsProject {
 					simFile = Simulation.SAVE_FILE + Simulation.SAVE_FILE_EXTENSION;
 				}
 			}
-			if (line.hasOption(SITE_EDITOR)) {
-				useSiteEditor = true;
-			}
-			if (line.hasOption(PROFILE)) {
-				useProfile = true;
-			}
-			if (line.hasOption(SANDBOX)) {
-				isSandbox = true;
-			}
+			
+			useSiteEditor = line.hasOption(SITE_EDITOR);
+			useProfile = line.hasOption(PROFILE);
+			isSandbox = line.hasOption(SANDBOX);
 		}
 		catch (ParseException e) {
 			usage("Problem with arguments: " + e.getMessage(), options);
 		}
+	}
+
+	/**
+	 * Reads the default properties file.
+	 */
+	private Properties readDefaults() {
+		var props = new Properties();
+		File defaultFile = new File(SimulationRuntime.getDataDir(), "default.props");
+		if (defaultFile.exists()) {
+			try (InputStream defaultInput = new FileInputStream(defaultFile)) {
+				props.load(defaultInput);
+			} catch (IOException e) {
+				logger.warning("Problem reading default.props " + e.getMessage());
+			}
+		}
+		return props;
 	}
 
 	/**
@@ -440,7 +429,7 @@ public class MarsProject {
 	 *
 	 * @param args the command line arguments
 	 */
-	public static void main(String[] args) throws IOException, InterruptedException, URISyntaxException {
+	public static void main(String[] args) throws IOException {
 		// Note: Read the logging configuration from the classloader to make it webstart compatible
 		new File(System.getProperty("user.home"), ".mars-sim" + File.separator + "logs").mkdirs();
 

--- a/mars-sim-ui/src/test/java/com/mars_sim/ui/swing/tool/settlement/TestSVGMapUtil.java
+++ b/mars-sim-ui/src/test/java/com/mars_sim/ui/swing/tool/settlement/TestSVGMapUtil.java
@@ -23,9 +23,8 @@ public class TestSVGMapUtil extends TestCase {
     private SimulationConfig config;
 
     @Override
-    public void setUp() throws Exception {
-    	config = SimulationConfig.instance();
-        config.loadConfig();
+    public void setUp() {
+    	config = SimulationConfig.loadConfig();
     }
 
     /**


### PR DESCRIPTION
The objective of this change is to get the creation and load of the XML files under the control of the code. Currently, the config is created implicitly via the instance method via numerous static class initialisers. This pattern causes problem as the construction can not be parameterised by external influences.

The new approach is to create and load via the loadConfig method.

There are a number of sub-changes to support this:
- Change UserConfigurable to not use static
- Resource helpers are loaded by config explicitly instead of pulling from the config
- Config is not used in creating the global Vehicle settings

close #1555