### PR TITLE
Move common logic into ProcessInfo & ProcessItem

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/manufacture/ManufactureProcess.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/manufacture/ManufactureProcess.java
@@ -7,18 +7,13 @@
 
 package com.mars_sim.core.manufacture;
 
-import java.util.logging.Level;
-
 import com.mars_sim.core.building.function.Manufacture;
-import com.mars_sim.core.logging.SimLogger;
 
 /**
  * A manufacturing process.
  */
 public class ManufactureProcess extends WorkshopProcess {
 	
-	private static final SimLogger logger = SimLogger.getLogger(ManufactureProcess.class.getName());
-
 	/**
 	 * Constructor.
 	 * 
@@ -40,21 +35,7 @@ public class ManufactureProcess extends WorkshopProcess {
 		}
 		var settlement = getBuilding().getSettlement();
 
-		// Consume inputs.
-		for (var item : getInfo().getInputList()) {
-			switch(item.getType()) {
-				case AMOUNT_RESOURCE:
-					settlement.retrieveAmountResource(item.getId(), item.getAmount());
-					break;
-				case PART:
-					settlement.retrieveItemResource(item.getId(), (int) item.getAmount());
-					break;
-				default:
-					logger.log(getBuilding(), Level.SEVERE, 20_000,
-							"Manufacture process input: " + item.getType() + " not a valid type.");
-					return false;
-			}
-		}
+		getInfo().retrieveInputs(settlement);
 
 		return true;
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/manufacture/WorkshopProcess.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/manufacture/WorkshopProcess.java
@@ -8,29 +8,15 @@ package com.mars_sim.core.manufacture;
 
 import java.io.Serializable;
 
-import com.mars_sim.core.Simulation;
 import com.mars_sim.core.building.Building;
 import com.mars_sim.core.building.function.Manufacture;
-import com.mars_sim.core.equipment.BinFactory;
-import com.mars_sim.core.equipment.EquipmentFactory;
-import com.mars_sim.core.equipment.EquipmentType;
-import com.mars_sim.core.goods.Good;
-import com.mars_sim.core.goods.GoodsUtil;
-import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.process.ProcessInfo;
-import com.mars_sim.core.process.ProcessItem;
-import com.mars_sim.core.resource.ItemResourceUtil;
-import com.mars_sim.core.resource.Part;
 import com.mars_sim.core.structure.Settlement;
-import com.mars_sim.core.vehicle.Vehicle;
-import com.mars_sim.core.vehicle.VehicleFactory;
-import com.mars_sim.core.vehicle.VehicleType;
 
 /**
  * A process that is executed in a Workshop.
  */
 public abstract class WorkshopProcess implements Serializable {
-	private static final SimLogger logger = SimLogger.getLogger(WorkshopProcess.class.getName());
 
 	private String name;
 	private double workTimeRemaining;
@@ -184,10 +170,7 @@ public abstract class WorkshopProcess implements Serializable {
 		var host = getWorkshop().getBuilding();
 		Settlement settlement = host.getAssociatedSettlement();
 
-		// Produce outputs.
-		for (var item : info.getOutputList()) {
-			depositItem(item, settlement, host, true);
-		}
+		info.depositOutputs(settlement, true);
 	}
 
 	/**
@@ -199,92 +182,9 @@ public abstract class WorkshopProcess implements Serializable {
 		var host = getWorkshop().getBuilding();
 		Settlement settlement = host.getAssociatedSettlement();
 
-		// Produce outputs.
-		for (var item : info.getInputList()) {
-			depositItem(item, settlement, host, false);
-		}
+		info.returnInputs(settlement);
 	}
 
-	private void depositItem(ProcessItem item, Settlement settlement, Building host, boolean updateGoods) {
-		int outputId = -1;
-		double outputAmount = item.getAmount();
-		switch(item.getType()) {
-			case AMOUNT_RESOURCE: {
-
-				// Produce amount resources.
-				outputId = item.getId();
-				double capacity = settlement.getAmountResourceRemainingCapacity(outputId);
-				if (outputAmount> capacity) {
-					double overAmount = item.getAmount() - capacity;
-					logger.severe(host, "Not enough storage capacity to store " 
-						+ Math.round(overAmount * 10.0)/10.0 + " kg " + item.getName()
-							+ " from '" + name + "'.");
-					outputAmount = capacity;
-				}
-				settlement.storeAmountResource(outputId, outputAmount);
-			} break;
-
-			case PART: {
-				// Produce parts.
-				outputId = item.getId();
-				Part part = ItemResourceUtil.findItemResource(outputId);
-				int num = (int)outputAmount;
-				double mass = num * part.getMassPerItem();
-				double capacity = settlement.getCargoCapacity();
-				if (mass <= capacity) {
-					settlement.storeItemResource(outputId, num);
-				}
-				else {
-					outputId = -1;
-				}
-			} break;
-
-			case EQUIPMENT: {
-				// Produce equipment.
-				var equipmentType = EquipmentType.convertName2Enum(item.getName());
-				outputId = EquipmentType.getResourceID(equipmentType);
-				int number = (int) outputAmount;
-				for (int x = 0; x < number; x++) {
-					EquipmentFactory.createEquipment(equipmentType, settlement);
-				}
-			} break;
-
-			case BIN: {
-				// Produce bins.
-				outputAmount = item.getAmount();
-				int number = (int) outputAmount;
-				for (int x = 0; x < number; x++) {
-					BinFactory.createBins(item.getName(), settlement);
-				}
-			} break;
-		
-			case VEHICLE: {
-				// Produce vehicles.
-				int number = (int) outputAmount;
-				var unitMgr = Simulation.instance().getUnitManager();// Don't like this
-				for (int x = 0; x < number; x++) {
-					Vehicle v = VehicleFactory.createVehicle(unitMgr, settlement, item.getName());
-
-					outputId = VehicleType.getVehicleID(v.getVehicleType());
-				}
-			} break;
-		}
-
-		// Record goods benefit
-		if (updateGoods) {
-			if (outputId >= 0) {
-				settlement.addOutput(outputId, outputAmount, info.getWorkTimeRequired());
-			}
-
-			Good good = GoodsUtil.getGood(item.getName());
-			if (good == null) {
-				logger.severe(item.getName() + " is not a good.");
-			}
-			else
-				// Recalculate settlement good value for the output item.
-				settlement.getGoodsManager().determineGoodValue(good);
-		}
-	}
 
 	/**
 	 * Start the process running

--- a/mars-sim-core/src/main/java/com/mars_sim/core/process/ProcessInfo.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/process/ProcessInfo.java
@@ -185,6 +185,48 @@ public abstract class ProcessInfo implements Serializable , Comparable<ProcessIn
 		return true;
 	}
 
+	/**
+	 * Deposit the outputs of this process into the given settlement.
+	 * @param settlement
+	 * @param updateGoods Update the value of teh goods
+	 */
+    public void depositOutputs(Settlement settlement, boolean updateGoods) {
+		for (var item : outputList) {
+			item.deposit(settlement, this, true);
+		}
+    }
+
+	/**
+	 * Retrieve the required inputs from the given settlement.
+	 * @param settlement
+	 */
+	public void retrieveInputs(Settlement settlement) {
+		// Consume inputs.
+		for (var item : inputList) {
+			switch(item.getType()) {
+				case AMOUNT_RESOURCE:
+					settlement.retrieveAmountResource(item.getId(), item.getAmount());
+					break;
+				case PART:
+					settlement.retrieveItemResource(item.getId(), (int) item.getAmount());
+					break;
+				default:
+					throw new IllegalArgumentException("Process input: " + item.getType() + " not a valid type.");
+			}
+		}
+	}
+	
+	/**
+	 * Returns the used inputs to the given settlement.
+	 * @param settlement
+	 */
+	public void returnInputs(Settlement settlement) {
+			// Produce outputs.
+		for (var item : inputList) {
+			item.deposit(settlement, this, false);
+		}
+	}
+
 	@Override
 	public String toString() {
 		return name;


### PR DESCRIPTION
Changes:
- ProcessInfo responsible for the depositOutputs, retieveInpouts & returnInputs as logic moved out of WorkshopProcess
- ProcessItem handles depositing items into a Settlement
- ManufactureProcess & WorkshopProcess uses the delegated logic
- FoodProduction uses the new shared logic from ProcessInfo

Close #871