### PR TITLE
Make the Navigator Window resizable

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/map/IntegerMapData.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/map/IntegerMapData.java
@@ -369,10 +369,11 @@ import com.mars_sim.core.map.location.Coordinates;
  		
  		// Create an array of int RGB color values to create the map image from.
  		int[] mapArray = new int[mapBoxWidth * mapBoxHeight];
-		var rendered = hardwareAccel;
+		var rendered = false;
 		if (hardwareAccel) {
 			try {
 				gpu(centerPhi, centerTheta, mapBoxWidth, mapBoxHeight, newRho, mapArray);
+				rendered = true;
 			} catch(Exception e) {
 				hardwareAccel = false;
 				rendered = false; // Fallback to CPU
@@ -384,7 +385,7 @@ import com.mars_sim.core.map.location.Coordinates;
 		}
 
 	 	// Gets the color pixels ready for the new projected map image in Mars Navigator.
-	 	setRGB(bImage, 0, 0, mapBoxWidth, mapBoxHeight, mapArray, 0, mapBoxHeight);
+	 	setRGB(bImage, 0, 0, mapBoxWidth, mapBoxHeight, mapArray, 0, mapBoxWidth);
 	
 	 	bImageCache = bImage;
 	 	

--- a/mars-sim-core/src/main/java/com/mars_sim/core/map/IntegerMapData.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/map/IntegerMapData.java
@@ -65,22 +65,16 @@ import com.mars_sim.core.map.location.Coordinates;
 	private int pixelHeight;
 	/* The resolution of the map image. */
 	private int resolution;
-	/* The cache for the last rho. */
-	private double rhoCache;
 	/* The default value of rho. */
 	private double rhoDefault;
 	
 	/* The base map color pixels double array. */
  	private int[][] colorPixels = new int[0][0];
  	
-	/* The cache for the last center. */
-	private Coordinates centerCache;
  	/* The meta data of the map. */
 	private MapMetaData meta;
  	/* The OpenCL kernel instance. */
 	private CLKernel kernel;
-	
-	private BufferedImage bImageCache;
 
 	private MapState loaded = MapState.PENDING;
  	
@@ -349,15 +343,8 @@ import com.mars_sim.core.map.location.Coordinates;
  	@Override
  	public Image createMapImage(Coordinates center, int mapBoxWidth, int mapBoxHeight, double newRho) {
 		 
- 		if (bImageCache != null && newRho == rhoCache
-				&& centerCache.equals(center))
- 			return bImageCache;
 		double centerPhi = center.getPhi();
 		double centerTheta = center.getTheta();
- 
- 		// Update cache identifiers
-		centerCache = center;
-		rhoCache = newRho;
 
  		// Create a new buffered image to draw the map on.
  		BufferedImage bImage 
@@ -386,8 +373,6 @@ import com.mars_sim.core.map.location.Coordinates;
 
 	 	// Gets the color pixels ready for the new projected map image in Mars Navigator.
 	 	setRGB(bImage, 0, 0, mapBoxWidth, mapBoxHeight, mapArray, 0, mapBoxWidth);
-	
-	 	bImageCache = bImage;
 	 	
  		return bImage;
  	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/map/location/Coordinates.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/map/location/Coordinates.java
@@ -429,11 +429,12 @@ public final class Coordinates implements Serializable {
 	 *
 	 * @param newCoords    the offset location
 	 * @param rho      diameter of planet (in km)
-	 * @param halfMap half the map's width (in pixels)
-	 * @param lowEdge lower edge of map (in pixels)
+	 * @param xHalfMap half the map's width (in pixels)
+	 * @param xLowEdge lower edge of map (in pixels)
 	 * @return pixel offset value for map
 	 */
-	public IntPoint findRectPosition(Coordinates newCoords, double rho, int halfMap, int lowEdge) {
+	public IntPoint findRectPosition(Coordinates newCoords, double rho, int xHalfMap, int xLowEdge,
+							int yHalfMap, int yLowEdge) {
 
 		double sinPhi = Math.sin(this.phi);
 		double cosPhi = Math.cos(this.phi);
@@ -444,10 +445,10 @@ public final class Coordinates implements Serializable {
 		double col = newTheta + (-PI_HALF - theta);
 		double x = rho * Math.sin(newPhi);
 		
-		int buffX = ((int) Math.round(x * Math.cos(col)) + halfMap) - lowEdge;
+		int buffX = ((int) Math.round(x * Math.cos(col)) + xHalfMap) - xLowEdge;
 		int buffY = ((int) Math.round(((x * (0D - cosPhi)) * Math.sin(col)) 
 				+ (rho * Math.cos(newPhi) * (0D - sinPhi)))
-				+ halfMap) - lowEdge;
+				+ yHalfMap) - yLowEdge;
 		return new IntPoint(buffX, buffY);
 	}
  	

--- a/mars-sim-core/src/main/java/com/mars_sim/core/map/location/IntPoint.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/map/location/IntPoint.java
@@ -5,24 +5,24 @@
  * @author Greg Whelan
  */
 package com.mars_sim.core.map.location;
-
-import java.awt.Point;
+import java.io.Serializable;
 
 /**
- * The IntPoint class is an extension of
+ * The IntPoint class is a replacement of
  * java.awt.Point that returns int typed
  * X and Y coordinates.
  */
-
-public final class IntPoint
-extends Point {
+public final class IntPoint implements Serializable {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
+	private int x;
+	private int y;
 
 	/** Constructor. */
 	public IntPoint(int x, int y) {
-		super(x, y);
+		this.x = x;
+		this.y = y;
 	}
 
 	/**
@@ -30,8 +30,12 @@ extends Point {
 	 * 
 	 * @return the X coordinate of the point as int
 	 */
-	public int getiX() {
+	public int getX() {
 		return x;
+	}
+
+	public int getiX() {
+		return getX();
 	}
 
 	/**
@@ -39,7 +43,21 @@ extends Point {
 	 * 
 	 * @return the Y coordinate of the point as int
 	 */
-	public int getiY() {
+	public int getY() {
 		return y;
+	}
+
+	public int getiY() {
+		return getY();
+	}
+
+	/**
+	 * Get the distance between 2 points.
+	 * @param position
+	 * @return
+	 */
+	public int getDistance(IntPoint position) {
+		return (int) Math.round(Math.sqrt(Math.pow(getX() - position.getX(), 2D) +
+			        Math.pow(getY() - position.getY(), 2D)));
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/CannedMarsMap.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/CannedMarsMap.java
@@ -21,16 +21,20 @@ import com.mars_sim.core.map.location.Coordinates;
  * order to generate a map image.
  */
 @SuppressWarnings("serial")
-public class CannedMarsMap extends JComponent implements MapDisplay {
+public class CannedMarsMap implements MapDisplay {
 
 	// Data members
 	private boolean mapImageDone = false;
 
-	private transient Image mapImage = null;
+	private Image mapImage = null;
 	
-	private transient MapData mapData;
+	private MapData mapData;
 
-	private double rho;
+	private double lastRHO;
+
+	private Coordinates lastCenter;
+
+	private Dimension lastSize;
 
 	/**
 	 * Constructor.
@@ -60,7 +64,9 @@ public class CannedMarsMap extends JComponent implements MapDisplay {
 	public void drawMap(Coordinates newCenter, double rho, Dimension d) {	
 		mapImage = mapData.createMapImage(newCenter,
 								(int)d.getWidth(), (int)d.getHeight(), rho);
-		this.rho = rho;
+		this.lastRHO = rho;
+		this.lastCenter = newCenter;
+		this.lastSize = d;
 		mapImageDone = true;
 	}
 	
@@ -80,7 +86,11 @@ public class CannedMarsMap extends JComponent implements MapDisplay {
 	 * @return constructed map image
 	 */
 	@Override
-	public Image getMapImage() {
+	public Image getMapImage(Coordinates center, double rho, Dimension size) {
+		if (!lastCenter.equals(center) || (lastRHO != rho) || !lastSize.equals(size)) {
+			// Redraw map
+			drawMap(center, rho, size);
+		}
 		return mapImage;
 	}
 
@@ -90,7 +100,7 @@ public class CannedMarsMap extends JComponent implements MapDisplay {
      * @return
      */
     public double getScale() {
-		return rho/mapData.getRhoDefault();
+		return lastRHO/mapData.getRhoDefault();
 	}
 	   
 	/**
@@ -100,7 +110,7 @@ public class CannedMarsMap extends JComponent implements MapDisplay {
 	 */
 	@Override
 	public double getRho() {
-		return rho;
+		return lastRHO;
 	}
 	
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/CannedMarsMap.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/CannedMarsMap.java
@@ -6,6 +6,7 @@
  */
 package com.mars_sim.ui.swing.tool.map;
 
+import java.awt.Dimension;
 import java.awt.Image;
 
 import javax.swing.JComponent;
@@ -55,9 +56,10 @@ public class CannedMarsMap extends JComponent implements MapDisplay {
 	 * 
 	 * @param newCenter the new center location
 	 */
-	public void drawMap(Coordinates newCenter, double rho) {	
+	@Override
+	public void drawMap(Coordinates newCenter, double rho, Dimension d) {	
 		mapImage = mapData.createMapImage(newCenter,
-								MapPanel.MAP_BOX_WIDTH, MapPanel.MAP_BOX_HEIGHT, rho);
+								(int)d.getWidth(), (int)d.getHeight(), rho);
 		this.rho = rho;
 		mapImageDone = true;
 	}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/EllipseLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/EllipseLayer.java
@@ -7,6 +7,7 @@
 package com.mars_sim.ui.swing.tool.map;
 
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
@@ -67,7 +68,7 @@ public class EllipseLayer implements MapLayer {
 	 * @param g2d         graphics context of the map display.
 	 */
 	@Override
-	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g2d) {
+	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g2d, Dimension d) {
 		// Display ellipse if flag is true.
 		if (displayEllipse) {
 			g2d.setColor(drawColor);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapDisplay.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapDisplay.java
@@ -7,6 +7,7 @@
 
 package com.mars_sim.ui.swing.tool.map;
 
+import java.awt.Dimension;
 import java.awt.Image;
 
 import com.mars_sim.core.data.Range;
@@ -18,11 +19,6 @@ import com.mars_sim.core.map.location.Coordinates;
  */
 public interface MapDisplay {
 
-	/** The display box map dimensions (for scrolling) */
-	public static final int MAP_BOX_HEIGHT = 512;
-	public static final int MAP_BOX_WIDTH = MAP_BOX_HEIGHT;
-	public static final int HALF_MAP_BOX = (int) (0.5 * MAP_BOX_HEIGHT);
-
 	public static final double HALF_MAP_ANGLE = 0.48587;
 	public static final double QUARTER_HALF_MAP_ANGLE = HALF_MAP_ANGLE / 4;
 
@@ -33,9 +29,9 @@ public interface MapDisplay {
 	 * 
 	 * @param newCenter 	The new center location
 	 * @param rho 		The new map rho
-	 * @throws Exception if error in drawing map.
+	 * @param d			Size of the map to draw
 	 */
-	public void drawMap(Coordinates newCenter, double rho);
+	public void drawMap(Coordinates newCenter, double rho, Dimension d);
 
 	/**
 	 * Checks if a requested map is complete.

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapDisplay.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapDisplay.java
@@ -41,11 +41,13 @@ public interface MapDisplay {
 	public boolean isImageDone();
 
 	/**
-	 * Gets the constructed map image.
+	 * Gte an image for this details.
 	 * 
-	 * @return constructed map image
+	 * @param newCenter 	The new center location
+	 * @param rho 		The new map rho
+	 * @param d			Size of the map to draw
 	 */
-	public Image getMapImage();
+	public Image getMapImage(Coordinates newCenter, double rho, Dimension d);
 
 	/**
 	 * Gets the rho of the Mars surface map (height pixels divided by pi).

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapLayer.java
@@ -7,6 +7,7 @@
 
 package com.mars_sim.ui.swing.tool.map;
 
+import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.util.List;
 
@@ -23,6 +24,7 @@ public interface MapLayer {
 	 * @param mapCenter the location of the center of the map.
 	 * @param baseMap   the base map controlling coordinate frame
 	 * @param g         graphics context of the map display.
+	 * @param d			Size of region being drawn
 	 */
-	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g);
+	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g, Dimension d);
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapPanel.java
@@ -52,8 +52,6 @@ import com.mars_sim.core.map.location.IntPoint;
 import com.mars_sim.core.tool.Msg;
 import com.mars_sim.ui.swing.MainDesktopPane;
 import com.mars_sim.ui.swing.StyleManager;
-import com.mars_sim.ui.swing.tool.mission.MissionWindow;
-import com.mars_sim.ui.swing.tool.navigator.NavigatorWindow;
 
 @SuppressWarnings("serial")
 public class MapPanel extends JPanel implements MouseWheelListener {
@@ -81,7 +79,6 @@ public class MapPanel extends JPanel implements MouseWheelListener {
 	
 	private Coordinates centerCoords;
 
-	private Image mapImage;
 	private MapDisplay marsMap;
 	private MainDesktopPane desktop;
 	
@@ -495,15 +492,8 @@ public class MapPanel extends JPanel implements MouseWheelListener {
 	 * @param rho
 	 */
 	private void updateDisplay(double rho) {
-		if ((desktop.isToolWindowOpen(NavigatorWindow.NAME) 
-			|| desktop.isToolWindowOpen(MissionWindow.NAME))
-			&& (!executor.isTerminated() || !executor.isShutdown())) {
-				if (marsMap == null) {
-					logger.warning("No mars map loaded for updateDisplay");
-				}
-				else {
-					executor.execute(new MapTask(rho));
-				}
+		if (!executor.isTerminated() || !executor.isShutdown() && (marsMap != null)) {
+			executor.execute(new MapTask(rho));
 		}
 	}
 
@@ -597,7 +587,7 @@ public class MapPanel extends JPanel implements MouseWheelListener {
         		
 	                if (centerCoords != null) {
 	                	if (marsMap != null && marsMap.isImageDone()) {
-	                		mapImage = marsMap.getMapImage();
+	                		var mapImage = marsMap.getMapImage(centerCoords, calculateRHO(), size);
 	                		if (mapImage != null) {
 	                			g2d.drawImage(mapImage, 0, 0, this);  
 	                		}         		
@@ -738,6 +728,5 @@ public class MapPanel extends JPanel implements MouseWheelListener {
 		}
 		executor = null;
 		marsMap = null;
-		mapImage = null;
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapUtils.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapUtils.java
@@ -7,6 +7,8 @@
 
 package com.mars_sim.ui.swing.tool.map;
 
+import java.awt.Dimension;
+
 import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.map.location.IntPoint;
 
@@ -23,16 +25,21 @@ public class MapUtils {
 	}
 
 	/**
-	 * Gets a coordinate x, y position on the map image.
+	 * Gets a coordinate x, y position on the ma(p image.
 	 * 
-	 * @param coords location of unit
+	 * @param coords location of position to convert
+	 * @param mapCenter Center of the map in the displau
 	 * @param baseMap the type of map.
+	 * @param displaySize Size of the target display
 	 * @return display point on map
 	 */
-	public static IntPoint getRectPosition(Coordinates coords, Coordinates mapCenter, MapDisplay baseMap) {
-		int halfMap = baseMap.getPixelHeight()/2;
+	public static IntPoint getRectPosition(Coordinates coords, Coordinates mapCenter, MapDisplay baseMap,
+					Dimension displaySize) {
+		var xHalf = baseMap.getPixelWidth()/2;
+		var yHalf = baseMap.getPixelHeight()/2;
 		return mapCenter.findRectPosition(coords, baseMap.getRho(),
-											halfMap, halfMap - (MapPanel.MAP_BOX_HEIGHT/2));
+						xHalf, (int)(xHalf - (displaySize.getWidth()/2)),
+						yHalf, (int)(yHalf - (displaySize.getHeight()/2)));
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/NavpointEditLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/NavpointEditLayer.java
@@ -9,6 +9,7 @@ package com.mars_sim.ui.swing.tool.map;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
@@ -159,7 +160,7 @@ public class NavpointEditLayer implements MapLayer {
 	 * @param g2d         graphics context of the map display.
 	 */
 	@Override
-	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g2d) {
+	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g2d, Dimension d) {
 
 		g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 		g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/NavpointMapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/NavpointMapLayer.java
@@ -7,6 +7,7 @@
 package com.mars_sim.ui.swing.tool.map;
 
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.util.ArrayList;
@@ -113,18 +114,18 @@ public class NavpointMapLayer implements MapLayer {
 	 * @param g         graphics context of the map display.
 	 */
 	@Override
-	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g) {
+	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g, Dimension d) {
 		List<MapHotspot> results;
 		if (singleMission != null) {
 			if (singleMission instanceof VehicleMission vm)
-				results = displayMission(vm, mapCenter, baseMap, g);
+				results = displayMission(vm, mapCenter, baseMap, g, d);
 			else
 				results = Collections.emptyList();
 		} else {
 			results = new ArrayList<>();
 			for (Mission mission : missionManager.getMissions()) {
 				if (mission instanceof VehicleMission vm)
-					results.addAll(displayMission(vm, mapCenter, baseMap, g));
+					results.addAll(displayMission(vm, mapCenter, baseMap, g, d));
 			}
 		}
 
@@ -139,10 +140,11 @@ public class NavpointMapLayer implements MapLayer {
 	 * @param baseMap   the type of map.
 	 * @param g         graphics context of the map display.
 	 */
-	private List<MapHotspot> displayMission(VehicleMission mission, Coordinates mapCenter, MapDisplay baseMap, Graphics g) {
+	private List<MapHotspot> displayMission(VehicleMission mission, Coordinates mapCenter, MapDisplay baseMap, Graphics g,
+			Dimension d) {
 		List<MapHotspot> results = new ArrayList<>();
 		for (NavPoint np : mission.getNavpoints()) {
-			var hotspot = displayNavpoint(mission, np, mapCenter, baseMap, g);
+			var hotspot = displayNavpoint(mission, np, mapCenter, baseMap, g, d);
 			if (hotspot != null) {
 				results.add(hotspot);
 			}
@@ -161,7 +163,8 @@ public class NavpointMapLayer implements MapLayer {
 	 * @param g         graphics context of the map display.
 	 * @return 
 	 */
-	private NavpointHotspot displayNavpoint(Mission mission, NavPoint navpoint, Coordinates mapCenter, MapDisplay baseMap, Graphics g) {
+	private NavpointHotspot displayNavpoint(Mission mission, NavPoint navpoint, Coordinates mapCenter, MapDisplay baseMap,
+					Graphics g, Dimension displaySize) {
 
 		if (mapCenter.getAngle(navpoint.getLocation()) < baseMap.getHalfAngle()) {
 			MapMetaData mapType = baseMap.getMapMetaData();
@@ -176,7 +179,7 @@ public class NavpointMapLayer implements MapLayer {
 				navIcon = navpointIconColor;
 
 			// Determine the draw location for the icon.
-			IntPoint location = MapUtils.getRectPosition(navpoint.getLocation(), mapCenter, baseMap);
+			IntPoint location = MapUtils.getRectPosition(navpoint.getLocation(), mapCenter, baseMap, displaySize);
 			IntPoint drawLocation = new IntPoint(location.getiX() + MAP_X_OFFSET, 
 					(location.getiY() + MAP_Y_OFFSET - navIcon.getIconHeight()));
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/ShadingMapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/ShadingMapLayer.java
@@ -8,6 +8,7 @@
 package com.mars_sim.ui.swing.tool.map;
 
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.util.Collections;
 import java.util.List;
@@ -42,7 +43,7 @@ public class ShadingMapLayer implements MapLayer {
 	 * @param g2d         graphics context of the map display.
 	 */
 	@Override
-	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g2d) {
+	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g2d, Dimension d) {
 
 		// Need to determine which side of Mars is facing the sun
 		
@@ -53,7 +54,7 @@ public class ShadingMapLayer implements MapLayer {
         if (sunlight < 0.85) {	        
         	int opacity = LIGHT_THRESHOLD - sunlightInt;
             g2d.setColor(new Color(5, 0, 0, opacity));
-            g2d.fillRect(0, 0, MapDisplay.MAP_BOX_WIDTH, MapDisplay.MAP_BOX_HEIGHT);
+            g2d.fillRect(0, 0, (int)d.getWidth(), (int)d.getHeight());
 		}
 
 		return Collections.emptyList();

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/SurfaceFeatureLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/SurfaceFeatureLayer.java
@@ -6,6 +6,7 @@
  */
 package com.mars_sim.ui.swing.tool.map;
 
+import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +45,7 @@ public abstract class SurfaceFeatureLayer<T extends SurfacePOI> implements MapLa
      * @return Any hotspots this layer creates.
 	 */
 	@Override
-	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g2d) {
+	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g2d, Dimension d) {
         List<MapHotspot> hotspots = new ArrayList<>();
 
         timer.startTimer();
@@ -56,7 +57,7 @@ public abstract class SurfaceFeatureLayer<T extends SurfacePOI> implements MapLa
         boolean isColourful = baseMap.getMapMetaData().isColourful();
 		for (var f : features) {
             // Determine display location of feature on the map.
-            IntPoint pointOnMap = MapUtils.getRectPosition(f.getCoordinates(), mapCenter, baseMap);
+            IntPoint pointOnMap = MapUtils.getRectPosition(f.getCoordinates(), mapCenter, baseMap, d);
             if ((pointOnMap.getiX() >= 0) && (pointOnMap.getiY() >= 0)) {
                 var h = displayFeature(f, pointOnMap, g2d, isColourful);
                 if (h != null) {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/UnitMapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/UnitMapLayer.java
@@ -6,6 +6,7 @@
  */
 package com.mars_sim.ui.swing.tool.map;
 
+import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -92,7 +93,7 @@ public class UnitMapLayer implements FilteredMapLayer {
 	 * @param g2d         graphics context of the map display.
 	 */
 	@Override
-	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g2d) {	
+	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g2d, Dimension d) {	
 		List<MapHotspot> hotspots = new ArrayList<>();
 		
 		Collection<Settlement> settlements = unitsToDisplay;
@@ -104,12 +105,12 @@ public class UnitMapLayer implements FilteredMapLayer {
 		}
 
 		// Display Settlements first
-		settlements.forEach(s -> renderUnit(s, s.getCoordinates(), mapCenter, baseMap, g2d, hotspots));
+		settlements.forEach(s -> renderUnit(s, s.getCoordinates(), mapCenter, baseMap, g2d, d, hotspots));
 
 		if (vehicles != null) {
 			for(var v : vehicles) {
 				if (v.isOutsideOnMarsMission()) {
-					renderUnit(v, v.getCoordinates(), mapCenter, baseMap, g2d, hotspots);
+					renderUnit(v, v.getCoordinates(), mapCenter, baseMap, g2d, d, hotspots);
 				}
 			}
 		}
@@ -133,13 +134,13 @@ public class UnitMapLayer implements FilteredMapLayer {
 	 * @param hotspots 
 	 */
 	private void renderUnit(Unit unit, Coordinates unitPosn, Coordinates mapCenter, MapDisplay baseMap, Graphics2D g,
-				List<MapHotspot> hotspots) {
+							Dimension displaySize, List<MapHotspot> hotspots) {
 		
 		UnitDisplayInfo i = UnitDisplayInfoFactory.getUnitDisplayInfo(unit);
 		if (i != null && i.isMapDisplayed(unit)
 			&& mapCenter != null && mapCenter.getAngle(unitPosn) < baseMap.getHalfAngle()) {
 				
-				IntPoint locn = MapUtils.getRectPosition(unitPosn, mapCenter, baseMap);
+				IntPoint locn = MapUtils.getRectPosition(unitPosn, mapCenter, baseMap, displaySize);
 				var hs = displayUnit(unit, i, locn, baseMap, g);
 				hotspots.add(hs);
 		}
@@ -154,7 +155,7 @@ public class UnitMapLayer implements FilteredMapLayer {
 	 * @param baseMap   the type of map.
 	 * @param g         the graphics context.
 	 */
-	protected MapHotspot displayUnit(Unit unit, UnitDisplayInfo displayInfo, IntPoint location,
+	private MapHotspot displayUnit(Unit unit, UnitDisplayInfo displayInfo, IntPoint location,
 							MapDisplay baseMap, Graphics2D g) {
 
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/VehicleTrailMapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/VehicleTrailMapLayer.java
@@ -8,6 +8,7 @@
 package com.mars_sim.ui.swing.tool.map;
 
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.util.ArrayList;
@@ -52,17 +53,17 @@ public class VehicleTrailMapLayer implements MapLayer {
 	 * @param g         graphics context of the map display.
 	 */
 	@Override
-	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g) {
+	public List<MapHotspot> displayLayer(Coordinates mapCenter, MapDisplay baseMap, Graphics2D g, Dimension d) {
 
 		// Set trail color
 		g.setColor((baseMap.getMapMetaData().isColourful() ? Color.BLACK : new Color(0, 96, 0)));
 
 		// Draw trail
 		if (singleVehicle != null)
-			displayTrail(singleVehicle, mapCenter, baseMap, g);
+			displayTrail(singleVehicle, mapCenter, baseMap, g, d);
 		else {
 			for(var v : unitManager.getVehicles()) {
-				displayTrail(v, mapCenter, baseMap, g);
+				displayTrail(v, mapCenter, baseMap, g, d);
 			}
 		}
 
@@ -77,7 +78,7 @@ public class VehicleTrailMapLayer implements MapLayer {
 	 * @param baseMap   the type of map.
 	 * @param g         the graphics context.
 	 */
-	private void displayTrail(Vehicle vehicle, Coordinates mapCenter, MapDisplay baseMap, Graphics g) {
+	private void displayTrail(Vehicle vehicle, Coordinates mapCenter, MapDisplay baseMap, Graphics g, Dimension displaySize) {
 
 		// Get map angle.
 		double angle = baseMap.getHalfAngle();
@@ -89,7 +90,7 @@ public class VehicleTrailMapLayer implements MapLayer {
 			Coordinates c = j.next();
 			if (c != null
 				&& mapCenter.getAngle(c) < angle) {
-					IntPoint pt = MapUtils.getRectPosition(c, mapCenter, baseMap);
+					IntPoint pt = MapUtils.getRectPosition(c, mapCenter, baseMap, displaySize);
 					if (oldpt == null)
 						g.drawRect(pt.getiX(), pt.getiY(), 1, 1);
 					else if (!pt.equals(oldpt))

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/MissionWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/MissionWindow.java
@@ -42,7 +42,6 @@ import com.mars_sim.ui.swing.MainDesktopPane;
 import com.mars_sim.ui.swing.StyleManager;
 import com.mars_sim.ui.swing.tool.mission.create.CreateMissionWizard;
 import com.mars_sim.ui.swing.tool.mission.edit.ModifyMissionDialog;
-import com.mars_sim.ui.swing.tool.navigator.NavigatorWindow;
 import com.mars_sim.ui.swing.tool_window.ToolWindow;
 
 /**
@@ -59,9 +58,11 @@ public class MissionWindow extends ToolWindow implements ConfigurableWindow {
 	
 	private static final int PADDING = 20;
 	static final int LEFT_PANEL_WIDTH = 220;
-	static final int WIDTH = LEFT_PANEL_WIDTH + NavigatorWindow.MAP_BOX_WIDTH + PADDING * 2;
+	private static final int MAP_WIDTH = 512;
+	private static final int MAP_HEIGHT = 512;
+	static final int WIDTH = LEFT_PANEL_WIDTH + MAP_WIDTH + PADDING * 2;
 	
-	static final int MAP_BOX_HEIGHT = NavigatorWindow.MAP_BOX_HEIGHT;
+	private static final int MAP_BOX_HEIGHT = MAP_HEIGHT;
 	static final int TABLE_HEIGHT = 160;
 	static final int HEIGHT = MAP_BOX_HEIGHT + TABLE_HEIGHT;
 	
@@ -133,8 +134,7 @@ public class MissionWindow extends ToolWindow implements ConfigurableWindow {
 		            .getPath().getLastPathComponent();
 			Object selection = node.getUserObject();
 
-			if (selection instanceof Mission) {
-				Mission m = (Mission) selection;
+			if (selection instanceof Mission m) {
 				selectMission(m);
 			}
 			else {
@@ -231,12 +231,11 @@ public class MissionWindow extends ToolWindow implements ConfigurableWindow {
 
 	private DefaultMutableTreeNode addMissionNode(Mission m) {
 		Settlement s = m.getAssociatedSettlement();
-		DefaultMutableTreeNode sNode = settlementNodes.get(s);
-		if (sNode == null) {
-			sNode = new DefaultMutableTreeNode(s.getName(), true);
-			treeModel.insertNodeInto(sNode, missionRoot, missionRoot.getChildCount());
-			settlementNodes.put(s, sNode);
-		}
+		DefaultMutableTreeNode sNode = settlementNodes.computeIfAbsent(s, k -> {
+			var n = new DefaultMutableTreeNode(k.getName(), true);
+			treeModel.insertNodeInto(n, missionRoot, missionRoot.getChildCount());
+			return n;
+		});
 
 		DefaultMutableTreeNode mNode = new DefaultMutableTreeNode(m, false);
 		treeModel.insertNodeInto(mNode, sNode, sNode.getChildCount());

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/NavpointPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/NavpointPanel.java
@@ -57,8 +57,8 @@ public class NavpointPanel
 extends JPanel
 implements MissionListener {
 
-	private static final int WIDTH = MapPanel.MAP_BOX_WIDTH;
-	private static final int HEIGHT = MapPanel.MAP_BOX_HEIGHT;
+	private static final int WIDTH = 512;
+	private static final int HEIGHT = 512;
 	private static final double TWO_PI = Math.PI * 2D;
 	
 	// Private members.
@@ -121,7 +121,7 @@ implements MissionListener {
 		mapPanel.setBackground(new Color(0, 0, 0, 128));
 		mapPanel.setOpaque(false);
 		// Set up mouse control
-		mapPanel.setMouseDragger(false);
+		mapPanel.setMouseDragger();
 
 		var mouseListener = new MapMouseListener(mapPanel);
 		mapPanel.addMouseListener(mouseListener);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/NavpointPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/NavpointPanel.java
@@ -118,6 +118,8 @@ implements MissionListener {
 		
 		// Create the map panel.
 		mapPanel = new MapPanel(missionWindow.getDesktop());
+		mapPane.setPreferredSize(new Dimension(400, 512));
+
 		mapPanel.setBackground(new Color(0, 0, 0, 128));
 		mapPanel.setOpaque(false);
 		// Set up mouse control

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/ExplorationSitesPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/ExplorationSitesPanel.java
@@ -38,7 +38,6 @@ import com.mars_sim.core.vehicle.Rover;
 import com.mars_sim.ui.swing.MainDesktopPane;
 import com.mars_sim.ui.swing.MarsPanelBorder;
 import com.mars_sim.ui.swing.tool.map.EllipseLayer;
-import com.mars_sim.ui.swing.tool.map.MapDisplay;
 import com.mars_sim.ui.swing.tool.map.MapPanel;
 import com.mars_sim.ui.swing.tool.map.MapUtils;
 import com.mars_sim.ui.swing.tool.map.MineralMapLayer;
@@ -114,7 +113,7 @@ class ExplorationSitesPanel extends WizardPanel {
 		centerPane.add(mapMainPane, BorderLayout.WEST);
 
 		// Create the map panel.
-		mapPane = new MapPanel(desktop, 200L);
+		mapPane = new MapPanel(desktop);
 		mineralLayer = new MineralMapLayer(mapPane);
 		ellipseLayer = new EllipseLayer(Color.GREEN);
 		navLayer = new NavpointEditLayer(mapPane, true);
@@ -171,7 +170,7 @@ class ExplorationSitesPanel extends WizardPanel {
 				SitePanel p = new SitePanel(siteListPane.getComponentCount(), getNewSiteLocation());
 				siteListPane.add(p);
 				navLayer.addNavpointPosition(
-						MapUtils.getRectPosition(p.getSite(), getCenterCoords(), mapPane.getMap()));
+						MapUtils.getRectPosition(p.getSite(), getCenterCoords(), mapPane.getMap(), mapPane.getSize()));
 				mapPane.repaint();
 				addButton.setEnabled(canAddMoreSites());
 				validate();
@@ -254,7 +253,8 @@ class ExplorationSitesPanel extends WizardPanel {
 			SitePanel startingSitePane = new SitePanel(0, startingSite);
 			siteListPane.add(startingSitePane);
 			navLayer.addNavpointPosition(
-					MapUtils.getRectPosition(startingSitePane.getSite(), getCenterCoords(), mapPane.getMap()));
+					MapUtils.getRectPosition(startingSitePane.getSite(), getCenterCoords(), mapPane.getMap(),
+								mapPane.getSize()));
 			mapPane.showMap(startingSite);
 			addButton.setEnabled(canAddMoreSites());
 		} catch (Exception e) {
@@ -406,7 +406,7 @@ class ExplorationSitesPanel extends WizardPanel {
 			SitePanel sitePane = (SitePanel) siteListPane.getComponent(x);
 			sitePane.setSiteNum(x);
 			navLayer.addNavpointPosition(
-					MapUtils.getRectPosition(sitePane.getSite(), getCenterCoords(), mapPane.getMap()));
+					MapUtils.getRectPosition(sitePane.getSite(), getCenterCoords(), mapPane.getMap(), mapPane.getSize()));
 		}
 		mapPane.repaint();
 	}
@@ -558,10 +558,13 @@ class ExplorationSitesPanel extends WizardPanel {
 				navLayer.selectNavpoint(navSelected);
 				navOffset = determineOffset(event.getX(), event.getY());
 
-				IntPoint prevNavpoint = MapUtils.getRectPosition(getPreviousNavpoint(), getCenterCoords(),
-						mapPane.getMap());
-				IntPoint nextNavpoint = MapUtils.getRectPosition(getNextNavpoint(), getCenterCoords(),
-						mapPane.getMap());
+				var displaySize = mapPane.getSize();
+				var map = mapPane.getMap();
+				var center = getCenterCoords();
+				IntPoint prevNavpoint = MapUtils.getRectPosition(getPreviousNavpoint(), center,
+										map, displaySize);
+				IntPoint nextNavpoint = MapUtils.getRectPosition(getNextNavpoint(), center,
+										map, displaySize);
 				int radiusPixels = convertDistanceToMapPixels(getRadius());
 
 				ellipseLayer.setEllipseDetails(prevNavpoint, nextNavpoint, radiusPixels);
@@ -641,9 +644,7 @@ class ExplorationSitesPanel extends WizardPanel {
 				int displayY = event.getPoint().y + navOffset.getiY();
 				IntPoint displayPos = new IntPoint(displayX, displayY);
 				Coordinates center = getWizard().getMissionData().getStartingSettlement().getCoordinates();
-				Coordinates navpoint = center.convertRectIntToSpherical(displayPos.getiX() - MapDisplay.HALF_MAP_BOX, 
-						displayPos.getiY() - MapDisplay.HALF_MAP_BOX,
-						mapPane.getMap().getRho());
+				Coordinates navpoint = mapPane.getCoordsOfPoint(center, displayPos);
 
 				// Only drag navpoint flag if within ellipse range bounds.
 				if (withinBounds(displayPos, navpoint)) {
@@ -763,12 +764,11 @@ class ExplorationSitesPanel extends WizardPanel {
 		public Object getValueAt(int row, int column) {
 			if (row < getRowCount()) {
 				String mineralName = mineralNames.get(row);
-				if (column == 0) {
-					return mineralName;
-				} else if (column == 1) {
-					return mineralColors.get(mineralName);
-				} else
-					return null;
+				return switch (column) {
+					case 0 -> mineralName;
+					case 1 -> mineralColors.get(mineralName);
+					default -> null;
+					};
 			} else
 				return null;
 		}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/ExplorationSitesPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/ExplorationSitesPanel.java
@@ -114,6 +114,7 @@ class ExplorationSitesPanel extends WizardPanel {
 
 		// Create the map panel.
 		mapPane = new MapPanel(desktop);
+		mapPane.setPreferredSize(new Dimension(400, 512));
 		mineralLayer = new MineralMapLayer(mapPane);
 		ellipseLayer = new EllipseLayer(Color.GREEN);
 		navLayer = new NavpointEditLayer(mapPane, true);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/FieldSitePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/FieldSitePanel.java
@@ -65,7 +65,8 @@ public class FieldSitePanel extends WizardPanel {
         
         // Create the map panel.
         mapPane = new MapPanel(wizard.getDesktop());
-        
+        mapPane.setPreferredSize(new Dimension(400, 512));
+
         mapPane.addMapLayer(new UnitMapLayer(mapPane), 0);
         mapPane.addMapLayer(ellipseLayer = new EllipseLayer(Color.GREEN), 1);
         mapPane.addMapLayer(navLayer = new NavpointEditLayer(mapPane, false), 2);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/MiningSitePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/MiningSitePanel.java
@@ -35,14 +35,12 @@ import javax.swing.table.TableCellRenderer;
 import com.mars_sim.core.environment.ExploredLocation;
 import com.mars_sim.core.environment.SurfaceFeatures;
 import com.mars_sim.core.map.location.Coordinates;
-import com.mars_sim.core.map.location.IntPoint;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.ui.swing.MarsPanelBorder;
 import com.mars_sim.ui.swing.NumberCellRenderer;
 import com.mars_sim.ui.swing.StyleManager;
 import com.mars_sim.ui.swing.tool.map.EllipseLayer;
 import com.mars_sim.ui.swing.tool.map.ExploredSiteMapLayer;
-import com.mars_sim.ui.swing.tool.map.MapDisplay;
 import com.mars_sim.ui.swing.tool.map.MapPanel;
 import com.mars_sim.ui.swing.tool.map.MapUtils;
 import com.mars_sim.ui.swing.tool.map.MineralMapLayer;
@@ -112,7 +110,7 @@ public class MiningSitePanel extends WizardPanel {
 		centerPane.add(mapPanel, BorderLayout.WEST);
 
 		// Create the map panel.
-		mapPane = new MapPanel(wizard.getDesktop(), 200L);
+		mapPane = new MapPanel(wizard.getDesktop());
 		mineralLayer = new MineralMapLayer(mapPane);
 		
 		mapPane.addMapLayer(mineralLayer, 0);
@@ -276,8 +274,8 @@ public class MiningSitePanel extends WizardPanel {
 			Collection<Settlement> unitsToDisplay = new ArrayList<>(1);
 			unitsToDisplay.add(getWizard().getMissionData().getStartingSettlement());
 			unitLayer.setUnitsToDisplay(unitsToDisplay);
-			ellipseLayer.setEllipseDetails(new IntPoint(MapDisplay.HALF_MAP_BOX, MapDisplay.HALF_MAP_BOX), new IntPoint(MapDisplay.HALF_MAP_BOX, MapDisplay.HALF_MAP_BOX),
-					(convertRadiusToMapPixels(getRoverRange()) * 2));
+			var mapCenter = mapPane.getCenterPoint();
+			ellipseLayer.setEllipseDetails(mapCenter, mapCenter, (convertRadiusToMapPixels(getRoverRange()) * 2));
 			ellipseLayer.setDisplayEllipse(true);
 			selectMiningSite(null);
 			mapPane.showMap(getCenterCoords());
@@ -367,8 +365,9 @@ public class MiningSitePanel extends WizardPanel {
 
 		Coordinates center = getCenterCoords();
 		if (center != null) {
-			int xValue = xLoc - (MapDisplay.MAP_BOX_WIDTH / 2) - 1 + (exploredSiteLayer.getIconWidth() / 2);
-			int yValue = yLoc - (MapDisplay.MAP_BOX_HEIGHT / 2) - 1 + (exploredSiteLayer.getIconHeight() / 2);
+			var d = mapPane.getSize();
+			int xValue = (int) (xLoc - (d.getWidth() / 2) - 1 + (exploredSiteLayer.getIconWidth() / 2));
+			int yValue = (int) (yLoc - (d.getHeight() / 2) - 1 + (exploredSiteLayer.getIconHeight() / 2));
 			Coordinates clickedPosition = center.convertRectIntToSpherical(xValue, yValue,
 								mapPane.getMap().getRho());
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/MiningSitePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/MiningSitePanel.java
@@ -111,6 +111,8 @@ public class MiningSitePanel extends WizardPanel {
 
 		// Create the map panel.
 		mapPane = new MapPanel(wizard.getDesktop());
+		mapPane.setPreferredSize(new Dimension(400, 512));
+
 		mineralLayer = new MineralMapLayer(mapPane);
 		
 		mapPane.addMapLayer(mineralLayer, 0);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/ProspectingSitePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/ProspectingSitePanel.java
@@ -25,7 +25,6 @@ import com.mars_sim.core.map.location.IntPoint;
 import com.mars_sim.core.person.ai.mission.MissionType;
 import com.mars_sim.ui.swing.MarsPanelBorder;
 import com.mars_sim.ui.swing.tool.map.EllipseLayer;
-import com.mars_sim.ui.swing.tool.map.MapDisplay;
 import com.mars_sim.ui.swing.tool.map.MapPanel;
 import com.mars_sim.ui.swing.tool.map.MapUtils;
 import com.mars_sim.ui.swing.tool.map.NavpointEditLayer;
@@ -84,7 +83,7 @@ class ProspectingSitePanel extends WizardPanel {
 		add(Box.createVerticalStrut(10));
 		
 		// Create the map panel.
-		mapPane = new MapPanel(wizard.getDesktop(), 200L);
+		mapPane = new MapPanel(wizard.getDesktop());
 		
 		mapPane.addMapLayer(new UnitMapLayer(mapPane), 0);
 		mapPane.addMapLayer(ellipseLayer = new EllipseLayer(Color.GREEN), 1);
@@ -134,8 +133,7 @@ class ProspectingSitePanel extends WizardPanel {
 	@Override
 	boolean commitChanges(boolean isTesting) {
 		IntPoint navpointPixel = navLayer.getNavpointPosition(0);
-		Coordinates navpoint = getCenterCoords().convertRectIntToSpherical(navpointPixel.getiX() - MapDisplay.HALF_MAP_BOX, 
-				 navpointPixel.getiY() - MapDisplay.HALF_MAP_BOX, mapPane.getMap().getRho());
+		Coordinates navpoint = mapPane.getCoordsOfPoint(getCenterCoords(), navpointPixel);
 		MissionType type = getWizard().getMissionData().getMissionType();
 		if (MissionType.COLLECT_ICE == type) 
 			getWizard().getMissionData().setIceCollectionSite(navpoint);
@@ -160,8 +158,9 @@ class ProspectingSitePanel extends WizardPanel {
 			
 			pixelRange = convertRadiusToMapPixels(getRoverRange());
 			
-			ellipseLayer.setEllipseDetails(new IntPoint(MapDisplay.HALF_MAP_BOX, MapDisplay.HALF_MAP_BOX), new IntPoint(MapDisplay.HALF_MAP_BOX, MapDisplay.HALF_MAP_BOX), (pixelRange * 2));
-			IntPoint initialNavpointPos = new IntPoint(MapDisplay.HALF_MAP_BOX, MapDisplay.HALF_MAP_BOX - (pixelRange / 2));
+			var paneCenter = mapPane.getCenterPoint();
+			ellipseLayer.setEllipseDetails(paneCenter, paneCenter, (pixelRange * 2));
+			IntPoint initialNavpointPos = new IntPoint(paneCenter.getiX(), paneCenter.getiY() - (pixelRange / 2));
 			navLayer.addNavpointPosition(initialNavpointPos);
 			Coordinates initialNavpoint = getCenterCoords().convertRectToSpherical(0.0, pixelRange / 2D, 
 										mapPane.getMap().getRho());
@@ -268,8 +267,7 @@ class ProspectingSitePanel extends WizardPanel {
 				if (withinBounds(displayPos)) {
 					navLayer.setNavpointPosition(0, displayPos);
 					Coordinates center = getWizard().getMissionData().getStartingSettlement().getCoordinates();
-					Coordinates navpoint = center.convertRectIntToSpherical(displayPos.getiX() - MapDisplay.HALF_MAP_BOX, 
-							displayPos.getiY() - MapDisplay.HALF_MAP_BOX, mapPane.getMap().getRho());
+					Coordinates navpoint = mapPane.getCoordsOfPoint(center, displayPos);
 					locationLabel.setText("Location: " + navpoint.getFormattedString());
 				
 					mapPane.repaint();
@@ -289,10 +287,7 @@ class ProspectingSitePanel extends WizardPanel {
 				return false;
 			
 			pixelRange = convertRadiusToMapPixels(getRoverRange());
-			
-            int radius = (int) Math.round(Math.sqrt(Math.pow(MapDisplay.HALF_MAP_BOX - position.getX(), 2D) +
-			        Math.pow(MapDisplay.HALF_MAP_BOX - position.getY(), 2D)));
-            
+            int radius = mapPane.getCenterPoint().getDistance(position);
 			if (radius > pixelRange) 
 				return false;
 			else

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/ProspectingSitePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/mission/create/ProspectingSitePanel.java
@@ -9,6 +9,7 @@ package com.mars_sim.ui.swing.tool.mission.create;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -84,7 +85,8 @@ class ProspectingSitePanel extends WizardPanel {
 		
 		// Create the map panel.
 		mapPane = new MapPanel(wizard.getDesktop());
-		
+		mapPane.setPreferredSize(new Dimension(400, 512));
+
 		mapPane.addMapLayer(new UnitMapLayer(mapPane), 0);
 		mapPane.addMapLayer(ellipseLayer = new EllipseLayer(Color.GREEN), 1);
 		mapPane.addMapLayer(navLayer = new NavpointEditLayer(mapPane, false), 2);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/navigator/NavigatorWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/navigator/NavigatorWindow.java
@@ -160,6 +160,8 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 	private static final int MAP_BOX_HEIGHT = 512;
 	private static final int HEIGHT_STATUS_BAR = 18;
 	private static final int CONTROL_PANE_WIDTH = 250;
+	private static final int MIN_WIDTH = 400 + CONTROL_PANE_WIDTH;
+	private static final int MIN_HEIGHT = 450;
 
 
 	private static final String MAP_SEPERATOR = "~";
@@ -245,11 +247,9 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 								BorderFactory.createEmptyBorder(1, 1, 1, 1)));
 		contentPane.add(wholePane, BorderLayout.CENTER);
 
-		JPanel mapPane = new JPanel();
-		wholePane.add(mapPane, BorderLayout.CENTER);
-
 		mapPanel = new MapPanel(desktop);
 		mapPanel.setPreferredSize(new Dimension(MAP_BOX_WIDTH, MAP_BOX_HEIGHT));
+		wholePane.add(mapPanel, BorderLayout.CENTER);
 		
 		mapPanel.setMouseDragger();
 
@@ -276,8 +276,6 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 
 		mapPanel.showMap(new Coordinates((Math.PI / 2D), 0D));
 		
-		mapPane.add(mapPanel);
-
 		wholePane.add(createControlPanel(), BorderLayout.EAST);
 
 		// Create the status bar
@@ -287,20 +285,19 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 		checkSettings();
 		
 		setClosable(true);
-		setResizable(false);
-		setMaximizable(false);
 
 		setVisible(true);
 		// Pack window
 		pack();
+		setMinimumSize(new Dimension(MIN_WIDTH, MIN_HEIGHT));
+
 	}
 
 	private JPanel createControlPanel() {
 		JPanel controlPane = new JPanel(new BorderLayout(0, 0));
 
 		controlPane.setPreferredSize(new Dimension(CONTROL_PANE_WIDTH, MAP_BOX_HEIGHT));
-		controlPane.setMinimumSize(new Dimension(CONTROL_PANE_WIDTH, MAP_BOX_HEIGHT));
-		controlPane.setMaximumSize(new Dimension(CONTROL_PANE_WIDTH, MAP_BOX_HEIGHT));
+		controlPane.setMinimumSize(new Dimension(CONTROL_PANE_WIDTH, 200));
 		
 		JPanel searchPane = new JPanel();
 		searchPane.setLayout(new BoxLayout(searchPane, BoxLayout.Y_AXIS));
@@ -412,7 +409,7 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 			IntegerMapData.setHardwareAccel(isSelected);
 			gpuButton.setText(Msg.getString("NavigatorWindow.button.gpu") + gpuStateStr1);
 			
-			mapPanel.setRho(mapPanel.getRho());
+			mapPanel.repaint();
 		}
 		else {
 			gpuButton.setEnabled(false);
@@ -432,11 +429,7 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 			
 			String resolutionString = userSettings.getProperty(RESOLUTION_PROP, RESOLUTION);
 			
-			int resolution = mapPanel.getMapResolution();
-			
-			if (resolutionString != null) {
-				resolution = Integer.parseInt(resolutionString);
-			}
+			int resolution = Integer.parseInt(resolutionString);
 			
 			// Set the map type
 			changeMap(userSettings.getProperty(MAPTYPE_PROP, MapDataFactory.DEFAULT_MAP_TYPE), resolution);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/navigator/NavigatorWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/navigator/NavigatorWindow.java
@@ -60,7 +60,6 @@ import com.mars_sim.ui.swing.tool.map.ExploredSiteMapLayer;
 import com.mars_sim.ui.swing.tool.map.FilteredMapLayer;
 import com.mars_sim.ui.swing.tool.map.FilteredMapLayer.MapFilter;
 import com.mars_sim.ui.swing.tool.map.LandmarkMapLayer;
-import com.mars_sim.ui.swing.tool.map.MapDisplay;
 import com.mars_sim.ui.swing.tool.map.MapLayer;
 import com.mars_sim.ui.swing.tool.map.MapMouseListener;
 import com.mars_sim.ui.swing.tool.map.MapPanel;
@@ -157,8 +156,8 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 
 	private static final Logger logger = Logger.getLogger(NavigatorWindow.class.getName());
 
-	public static final int MAP_BOX_WIDTH = MapDisplay.MAP_BOX_WIDTH; // Refers to Map's MAP_BOX_WIDTH in mars-sim-mapdata maven submodule
-	public static final int MAP_BOX_HEIGHT = MapDisplay.MAP_BOX_HEIGHT;
+	private static final int MAP_BOX_WIDTH = 512;
+	private static final int MAP_BOX_HEIGHT = 512;
 	private static final int HEIGHT_STATUS_BAR = 18;
 	private static final int CONTROL_PANE_WIDTH = 250;
 
@@ -250,9 +249,9 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 		wholePane.add(mapPane, BorderLayout.CENTER);
 
 		mapPanel = new MapPanel(desktop);
-		mapPanel.setPreferredSize(new Dimension(MAP_BOX_WIDTH, MAP_BOX_WIDTH));
+		mapPanel.setPreferredSize(new Dimension(MAP_BOX_WIDTH, MAP_BOX_HEIGHT));
 		
-		mapPanel.setMouseDragger(true);
+		mapPanel.setMouseDragger();
 
 		// Create a mouse listener to show hotspots and update status bar
 		var mapListner = new MapMouseListener(mapPanel) {


### PR DESCRIPTION
The goal of this PR is to allow the Navigator Window to be resized by the user.
The first step was to remove the hard coded sizes of 512x512 in the MapPanel and all other classes. The solution is to drive the logic by the size of the MapPanel instead of the constants.
Second step was to allow the Navigator window to be resizable. The caching of the images is moved from the MapData classes into the MapDisplay classes. This because the MapData is shared by multiple MapPanels and hence provides no benefit. 