### PR TITLE
Fix problem with Mining missions

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/task/CollectMinedMinerals.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/task/CollectMinedMinerals.java
@@ -46,9 +46,6 @@ public class CollectMinedMinerals extends EVAOperation {
 
 	public static final double COLLECTION_RATE = 0.3D;
 	
-	// Data members
-	protected int resourceType;
-	
 	/** The container type to use to collect resource. */
 	private EquipmentType containerType = EquipmentType.LARGE_BAG;
 	
@@ -98,7 +95,7 @@ public class CollectMinedMinerals extends EVAOperation {
 		else if (num > 1) {
 			// Return extra containers
 			for (int i=0; i<num-1; i++) {
-				Container container = person.findContainer(containerType, false, resourceType); 
+				Container container = person.findContainer(containerType, false, mineralType); 
 				if (container != null) {
 					boolean done = container.transfer(rover);
 					if (done)
@@ -126,7 +123,7 @@ public class CollectMinedMinerals extends EVAOperation {
 	 */
 	private boolean takeContainer(Rover rover) {
 		
-		Container container = ContainerUtil.findLeastFullContainer(rover, containerType, resourceType);
+		Container container = ContainerUtil.findLeastFullContainer(rover, containerType, mineralType);
 
 		if (container != null) {
 			boolean success = container.transfer(person);
@@ -193,7 +190,7 @@ public class CollectMinedMinerals extends EVAOperation {
 			worker.storeAmountResource(mineralType, mineralsCollected);
 			
 			if ((maxAmount <= 0D) || (mineralsCollected >= remainingPersonCapacity)) {
-				checkLocation("Excavated minerals collected exceeded capacity.");
+				endEVA("Excavated minerals collected exceeded capacity.");
 			}
 	
 			// Check for an accident during the EVA operation.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/task/MineSite.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/task/MineSite.java
@@ -81,13 +81,8 @@ public class MineSite extends EVAOperation {
 		this.luv = objective.getLUV();
 		operatingLUV = false;
 
-		if (shouldEndEVAOperation()) {
-			checkLocation("EVA ended.");
-        	return;
-        }
-
 		if (person.isSuperUnfit()) {
-			checkLocation("Super Unfit.");
+			endEVA("Super Unfit.");
         	return;
 		}
 
@@ -152,7 +147,8 @@ public class MineSite extends EVAOperation {
 				operatingLUV = false;
 
 			}
-			checkLocation("Time on site expired.");
+			endEVA("Time on site expired.");
+			return 0;
 		}
 	
 		// Note: need to call addTimeOnSite() ahead of checkReadiness() since

--- a/mars-sim-core/src/main/resources/xml/settlements.xml
+++ b/mars-sim-core/src/main/resources/xml/settlements.xml
@@ -108,7 +108,7 @@
 			bring -->
 		<!-- default value : 1.5 Valid from 1.0 to 3.0 -->
 		<rover-life-support-range-error-margin
-			value="1.2" />
+			value="1.8" />
 
 		<!-- This vehicle range error margin imposed on the fuel of the vehicle. -->
 		<!-- This value will multiply with the amount of fuel needed for the mission -->


### PR DESCRIPTION
Changes:
- CollectMinedMinerals drops the second useless resourceID; mineralType controls what is collected
- MineSite does check pre-eva conditions during the EVA; drop use of shouldEndEva
- In Mining remove the check of all members being EVA able; this premeturally stop EVA
- Increased the buffer margin for mission resources via settlements.xml
- TabPanelCrew only shows Mission members if the Vehicle the primary Vehicle is the mission. Solves the problem with LUV showing everyone

Close #1144