### PR TITLE
Redesign shortest path algorithm

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/BuildingTemplate.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/BuildingTemplate.java
@@ -216,23 +216,16 @@ public class BuildingTemplate implements Serializable, Comparable<BuildingTempla
 			return hatchFace;
 		}
 		
-		public void setPosition(double x, double y) {
-			location = new LocalPosition(x, y);
-		}
-		
-		
 		@Override
 		public boolean equals(Object otherObject) {
 			boolean result = false;
 
-			if (otherObject instanceof BuildingConnectionTemplate) {
-				BuildingConnectionTemplate template = (BuildingConnectionTemplate) otherObject;
-				if ((id == template.id) 
-						&& location.equals(template.location)
-						&& hatchFace.equals(template.hatchFace)) {
-					result = true;
-				}
+			if (otherObject instanceof BuildingConnectionTemplate template && (id == template.id) 
+					&& location.equals(template.location)
+					&& hatchFace.equals(template.hatchFace)) {
+				result = true;
 			}
+			
 			return result;
 		}
 		

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/BuildingConnector.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/BuildingConnector.java
@@ -81,6 +81,22 @@ public class BuildingConnector implements Serializable, InsidePathLocation {
     }
 
     /**
+     * Get the otehr end of the connection
+     * @return
+     */
+    public Building getOtherBuilding(Building building) {
+        if (building.equals(building1)) {
+            return building2;
+        }
+        else if (building.equals(building2)) {
+            return building1;
+        }
+        else {
+            throw new IllegalArgumentException("Building not part of this connector.");
+        }
+    }
+
+    /**
      * Gets the hatch connecting the first building.
      * 
      * @return hatch.
@@ -116,26 +132,23 @@ public class BuildingConnector implements Serializable, InsidePathLocation {
     @Override
     public boolean equals(Object other) {
 
-        boolean result = false;
-
         // Note: building 1 and building 2 can be reversed in equal connectors.
-        if (other instanceof BuildingConnector) {
-            BuildingConnector otherConnector = (BuildingConnector) other;
+        if (other instanceof BuildingConnector otherConnector) {
             if (building1.equals(otherConnector.getBuilding1()) &&
                     hatch1.equals(otherConnector.getHatch1()) &&
                     building2.equals(otherConnector.getBuilding2()) &&
                     hatch2.equals(otherConnector.getHatch2())) {
-                result = true;
+                return true;
             }
-            else if (building1.equals(otherConnector.getBuilding2()) &&
+            else {
+                return (building1.equals(otherConnector.getBuilding2()) &&
                     hatch1.equals(otherConnector.getHatch2()) &&
                     building2.equals(otherConnector.getBuilding1()) &&
-                    hatch2.equals(otherConnector.getHatch1())) {
-                result = true;
+                    hatch2.equals(otherConnector.getHatch1()));
             }
         }
 
-        return result;
+        return false;
     }
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/InsideBuildingPath.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/InsideBuildingPath.java
@@ -29,20 +29,7 @@ public class InsideBuildingPath implements Serializable {
         pathLocations = new CopyOnWriteArrayList<>();
         nextLocationIndex = 0;
     }
-    
-    /**
-     * Copy Constructor.
-     */
-    public InsideBuildingPath(InsideBuildingPath insideBuildingPath) {
-    	this();
-    	
-        Iterator<InsidePathLocation> i = insideBuildingPath.getPathLocations().iterator();
-        while (i.hasNext()) {
-        	addPathLocation(i.next());
-        }
-        
-        nextLocationIndex = insideBuildingPath.getNextLocationIndex();
-    }
+
     
     /**
      * Adds a new location object to the path.
@@ -89,7 +76,6 @@ public class InsideBuildingPath implements Serializable {
      */
     public List<InsidePathLocation> getRemainingPathLocations() {
         
-//        int size = pathLocations.size() - nextLocationIndex;
         List<InsidePathLocation> result = new CopyOnWriteArrayList<>();
         for (int x = nextLocationIndex; x < pathLocations.size(); x++) {
             result.add(pathLocations.get(x));

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/PathFinder.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/PathFinder.java
@@ -1,0 +1,174 @@
+/*
+ * Mars Simulation Project
+ * PathFinder.java
+ * @date 2025-07-19
+ * @author Barry Evans
+ */
+package com.mars_sim.core.building.connection;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.mars_sim.core.building.Building;
+
+/**
+ * This is reponsible for finding a path between two positions in a settlement.
+ * It uses a 2 phase approach
+ * 1. It finds the best route between two buildings in a settlement.
+ * 2. It converts the route into a specific path with connectors and hatches.
+ */
+public class PathFinder {
+
+    private List<Building> bestRoute = null;
+    private Set<Building> visitedBuildings = new HashSet<>();
+    private BuildingLocation end;
+    private BuildingConnectorManager connectMgr;
+    private BuildingLocation start;
+    
+    public PathFinder(BuildingConnectorManager buildingConnectorManager, BuildingLocation startPosition,
+            BuildingLocation endPosition) {
+        this.connectMgr = buildingConnectorManager;
+        this.end = endPosition;
+        this.start = startPosition;
+
+        // If different building find a path otherwise route is simple
+        if (endPosition.getBuilding().equals(startPosition.getBuilding())) {
+            // If the start and end are the same building, just return the start position
+            bestRoute = new ArrayList<>();
+            bestRoute.add(startPosition.getBuilding());
+            bestRoute.add(endPosition.getBuilding());
+        }
+        else {
+            var route = new ArrayList<Building>();
+            visitBuilding(startPosition.getBuilding(), route);
+        }
+    }
+
+    /**
+     * Visit a building on the route search. Steps are:
+     * 1. Check if the building has been visited.
+     * 2. If it has, check see if the current route is a shortcut for the best route found so far.
+     * 3. If it hasn't, add it to the visited list and current route.      
+     * 4. If the building is the end building, check if the current route is shorter than the best route found so far.
+     * 5. If it is, update the best route.     
+     * 7. For each connection out of the current building, visit the other building connected.
+     * 8. Remove the current building from the current route.
+     * @param current
+     * @param currentRoute
+     */
+    private void visitBuilding(Building current, List<Building> currentRoute) {
+        if (visitedBuildings.contains(current)) {
+            // Already visited this building
+            checkShortCut(current, currentRoute);
+            return; 
+        }
+        else if (bestRoute != null && currentRoute.size() >= bestRoute.size()) {
+            // Current route is longer than the best route found so far, so skip it
+            return;  
+        }
+
+        visitedBuildings.add(current);
+        currentRoute.add(current);
+
+        if (current.equals(end.getBuilding())) {
+            // Found a valid route
+            if (bestRoute == null || (currentRoute.size() < bestRoute.size())) {
+                bestRoute = new ArrayList<>(currentRoute);
+            }
+        }
+        else {
+            // Potentially optimise the order of connected Buildings according to points on compass
+            // between start and end. Would only save time buit seem fast currently
+            for (var bc : connectMgr.getConnectionsToBuilding(current)) {
+                var b = bc.getOtherBuilding(current);
+                visitBuilding(b, currentRoute);
+            }
+        }
+        currentRoute.removeLast();
+    }
+
+    /**
+     * Check if the current route is a shortcut for the best route found so far.
+     * Presence is best route is A,B,C,D,E,F but current partial Route is A,E
+     * So this will change the Best route to be A,E,F
+     * @param current
+     * @param currentRoute
+     */
+    private void checkShortCut(Building current, List<Building> currentRoute) {
+        if (bestRoute != null) {
+            int currentInBest = bestRoute.indexOf(current);
+            if (currentInBest >= 0 && currentRoute.size() < currentInBest) {
+                // Current route is shorter than the best route found so far, so update the best route
+                // add the best tail to the current route
+                var newBest = new ArrayList<>(currentRoute);
+                for(int i = currentInBest; i < bestRoute.size(); i++) {
+                    newBest.add(bestRoute.get(i));
+                }
+                bestRoute = newBest;
+            }
+        }
+    }
+
+    /**
+     * Has a valid route between teh  Buildoings been found
+     * @return
+     */
+    public boolean isValidRoute() {
+        return bestRoute != null;
+    }
+
+    /**
+     * This converts an already found Buildoing Route into a specific walking path.
+     * @return
+     */
+    public InsideBuildingPath toPath() {
+        if (!isValidRoute()) {
+            throw new IllegalStateException("No valid route found.");
+        }
+
+        InsideBuildingPath newPath = new InsideBuildingPath();
+        newPath.addPathLocation(start);
+
+        // Remove start building off the best route
+        var finalRoute = new ArrayList<>(bestRoute);
+        var current = finalRoute.remove(0); // Remove the start building
+
+        // Visit each building in the best route to find the connectors and hatches.
+        for(var b : finalRoute) {
+            if (!b.equals(current)) {
+                // Find valid connector between current and next
+                final var fixedSeed = current;
+                BuildingConnector connector = connectMgr.getConnectionsToBuilding(fixedSeed).stream()
+                    .filter(c -> c.getOtherBuilding(fixedSeed).equals(b))
+                    .findFirst().orElseThrow(() -> 
+                        new IllegalStateException("No connector found between " + fixedSeed.getName() + " -> " + b.getName()));
+
+                // Add building connector to new path with hatches if needed
+                if (connector.isSplitConnection()) {
+                    boolean isCurrentBuilding1 = connector.getBuilding1().equals(current);
+                    newPath.addPathLocation(isCurrentBuilding1 ? connector.getHatch1() : connector.getHatch2());
+                    newPath.addPathLocation(connector);
+                    newPath.addPathLocation(!isCurrentBuilding1 ? connector.getHatch1() : connector.getHatch2());
+                } else {
+                    newPath.addPathLocation(connector);
+                }
+            }
+
+            // Last building needs the end position
+            if (!b.equals(end.getBuilding())) {
+                newPath.addPathLocation(b);
+            }
+
+            current = b; // Update current building
+        }
+
+        // Add the explict end position
+        newPath.addPathLocation(end);
+    
+        newPath.iteratePathLocation(); // This feels wrong but all the calling code is based on this
+        return newPath;
+    }
+
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/WalkSettlementInterior.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/WalkSettlementInterior.java
@@ -51,15 +51,11 @@ public class WalkSettlementInterior extends Task {
 	private static final TaskPhase WALKING = new TaskPhase(Msg.getString("Task.phase.walking")); //$NON-NLS-1$
 
 	// Static members
-	public static final int NUM_ITERATION = 3;
 	private static final double VERY_SMALL_DISTANCE = .01D;
 	private static final double STRESS_MODIFIER = -.2D;
-//	private static final double MIN_PULSE_TIME = Walk.MIN_PULSE_TIME;
 	/** The minimum pulse time for completing a task phase in this class.  */
-	private static double minPulseTime = 0; //Math.min(standardPulseTime, MIN_PULSE_TIME);
-	
-	// Data members
-//	private double destZLoc;
+	private static double minPulseTime = 0;
+
 
 	private LocalPosition destPosition;
 	private Settlement settlement;
@@ -125,13 +121,9 @@ public class WalkSettlementInterior extends Task {
 			// while Dijkstra uses a priority queue to prioritize nodes with the smallest distance.
 			
 			// Determine the walking path to the destination.
-			if (settlement != null) {
-				
-				int iteration = RandomUtil.getRandomInt(2, NUM_ITERATION + 2);
-			
+			if (settlement != null) {			
 				walkingPath = settlement.getBuildingConnectorManager().determineShortestPath(
-						iteration, startBuilding,
-						person.getPosition(), destinationBuilding, destPosition);
+						startBuilding, person.getPosition(), destinationBuilding, destPosition);
 			}
 			
 			// If no valid walking path is found, end task.
@@ -196,12 +188,9 @@ public class WalkSettlementInterior extends Task {
 		
 		try {
 			// Determine the walking path to the destination.
-			if (settlement != null) {
-				
-				int iteration = RandomUtil.getRandomInt(2, NUM_ITERATION + 2);
-				
+			if (settlement != null) {				
 				walkingPath = settlement.getBuildingConnectorManager().determineShortestPath(
-						iteration, startBuilding,
+						startBuilding,
 						robot.getPosition(), destinationBuilding, destPosition);
 			}
 				

--- a/mars-sim-core/src/test/java/com/mars_sim/core/AbstractMarsSimUnitTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/AbstractMarsSimUnitTest.java
@@ -114,12 +114,12 @@ public abstract class AbstractMarsSimUnitTest extends TestCase
 		return buildBuilding(buildingManager, "Mock", BuildingCategory.COMMAND, pos, facing, true);
 	}
 
-	private MockBuilding buildBuilding(BuildingManager buildingManager, String type, BuildingCategory cat,
+	protected MockBuilding buildBuilding(BuildingManager buildingManager, String type, BuildingCategory cat,
 								LocalPosition pos, double facing, boolean lifeSupport) {
 
 		int id = buildingManager.getNumBuildings();
 		String name = "B" + id;
-		var building0 = new MockBuilding(buildingManager.getSettlement(), name, id,
+		var building0 = new MockBuilding(buildingManager.getSettlement(), name, Integer.toString(id),
 										new BoundedObject(pos, BUILDING_WIDTH, BUILDING_LENGTH, facing),
 										type, cat, lifeSupport);
 	    buildingManager.addMockBuilding(building0);	

--- a/mars-sim-core/src/test/java/com/mars_sim/core/TestLocalAreaUtil.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/TestLocalAreaUtil.java
@@ -2,8 +2,6 @@ package com.mars_sim.core;
 
 import java.util.Iterator;
 
-import org.junit.Before;
-
 import com.mars_sim.core.building.BuildingCategory;
 import com.mars_sim.core.building.MockBuilding;
 import com.mars_sim.core.building.function.Function;
@@ -20,196 +18,9 @@ import junit.framework.TestCase;
 public class TestLocalAreaUtil extends TestCase {
     
     // Comparison to indicate a small but non-zero amount.
-//    private static final double SMALL_AMOUNT_COMPARISON = .0000001D;
 	private UnitManager unitManager;
     
-//    /**
-//     * Test the checkLinePathCollisionAtSettlement method.
-//     */
-//    public void testCheckLinePathCollisionAtSettlement() {
-//        
-//        // Create new simulation instance.
-//        SimulationConfig.loadConfig();
-//        Simulation.testRun();
-//        
-//        // Clear out existing settlements in simulation.
-//        UnitManager unitManager = Simulation.instance().getUnitManager();
-//        Iterator<Settlement> i = unitManager.getSettlements().iterator();
-//        while (i.hasNext()) {
-//            unitManager.removeUnit(i.next());
-//        }
-//        
-//        // Create test settlement.
-//        Settlement settlement = new MockSettlement();
-//        
-//        BuildingManager buildingManager = settlement.getBuildingManager();
-//        
-//		// Removes all mock buildings and building functions in the settlement.
-//		buildingManager.removeAllMockBuildings();
-//
-//		unitManager.addUnit(settlement);
-//        Coordinates loc = settlement.getCoordinates();   
-//        
-//        // Create test building.
-//        MockBuilding building = new MockBuilding(buildingManager);
-//        building.setWidth(10D);
-//        building.setLength(10D);
-//        building.setXLocation(0D);
-//        building.setYLocation(0D);
-//        building.setFacing(0D);
-////        settlement.getBuildingManager().addBuilding(building, true);
-////        buildingManager.addMockBuilding(building);
-////		settlement.getBuildingConnectorManager().createBuildingConnections(building);
-//
-//		// Clear obstacle cache.
-//		LocalAreaUtil.clearObstacleCache();
-//	
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 0D, 10D, 0D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(10D, 0D, 0D, 0D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 5D, 10D, 5D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, -5D, 10D, -5D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, -5D, 10D, 5D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 5D, 10D, -5D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(5D, 0D, 5D, 10D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(-5D, 10D, -5D, 0D), loc, true));
-////        assertTrue(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(-6D, 10D, -6D, 0D), loc, true));
-////        assertTrue(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(6D, 10D, 6D, 0D), loc, true));
-////        assertTrue(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 6D, 10D, 6D), loc, true));
-////        assertTrue(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, -6D, 10D, -6D), loc, true));
-//        
-//        building.setFacing(45D);
-//        
-//        // Clear obstacle cache.
-//        LocalAreaUtil.clearObstacleCache();
-//        
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 0D, 10D, 0D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(10D, 0D, 0D, 0D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 5D, 10D, 5D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, -5D, 10D, -5D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, -5D, 10D, 5D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 5D, 10D, -5D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(5D, 0D, 5D, 10D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(-5D, 10D, -5D, 0D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(-6D, 10D, -6D, 0D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(6D, 10D, 6D, 0D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 6D, 10D, 6D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, -6D, 10D, -6D), loc, true));
-//        
-//        building.setFacing(0D);
-//        building.setXLocation(10D);
-//        
-//        // Clear obstacle cache.
-//        LocalAreaUtil.clearObstacleCache();
-//        
-////        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(10D, 0D, 20D, 0D), loc, true));
-////        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(20D, 0D, 10D, 0D), loc, true));
-////        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(10D, 5D, 20D, 5D), loc, true));
-////        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(10D, -5D, 20D, -5D), loc, true));
-////        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(10D, -5D, 20D, 5D), loc, true));
-////        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(10D, 5D, 20D, -5D), loc, true));
-////        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(15D, 0D, 15D, 10D), loc, true));
-////        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(5D, 10D, 5D, 0D), loc, true));
-////        assertTrue(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(4D, 10D, 4D, 0D), loc, true));
-////        assertTrue(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(16D, 10D, 16D, 0D), loc, true));
-////        assertTrue(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(10D, 6D, 20D, 6D), loc, true));
-////        assertTrue(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(10D, -6D, 20D, -6D), loc, true));
-//        
-//        building.setXLocation(0D);
-//        building.setYLocation(10D);
-//        
-//        // Clear obstacle cache.
-//        LocalAreaUtil.clearObstacleCache();
-//        
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 10D, 20D, 0D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(10D, 10D, 0D, 10D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 15D, 10D, 15D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 5D, 10D, 5D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 5D, 10D, 15D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 15D, 10D, 5D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(5D, 10D, 5D, 20D), loc, true));
-//        assertFalse(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(-5D, 20D, -5D, 10D), loc, true));
-//        assertTrue(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(-6D, 20D, -6D, 10D), loc, true));
-//        assertTrue(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(6D, 20D, 6D, 10D), loc, true));
-//        assertTrue(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 16D, 10D, 16D), loc, true));
-//        assertTrue(LocalAreaUtil.checkLinePathCollision(new Line2D.Double(0D, 4D, 10D, 4D), loc, true));
-//        
-//        // Clear obstacle cache.
-//        LocalAreaUtil.clearObstacleCache();
-//    }
-    
-//    /**
-//     * Test the getObjectRelativeLocation.
-//     */
-//    public void testGetObjectRelativeLocation() {
-//        // Create new simulation instance.
-//        SimulationConfig.loadConfig();
-//        Simulation.instance().testRun();
-//        
-//        // Clear out existing settlements in simulation.
-//        UnitManager unitManager = Simulation.instance().getUnitManager();
-//        Iterator<Settlement> i = unitManager.getSettlements().iterator();
-//        while (i.hasNext()) {
-//            unitManager.removeUnit(i.next());
-//        }
-//        
-//        
-//        Settlement settlement = new MockSettlement();
-//        BuildingManager buildingManager = settlement.getBuildingManager();
-//        
-//        MockBuilding building = new MockBuilding(buildingManager);
-//        building.setWidth(10D);
-//        building.setLength(10D);
-//        building.setXLocation(0D);
-//        building.setYLocation(0D);
-//        building.setFacing(0D);
-//        
-//        Point2D point0 = new Point2D.Double(12D, -7D);
-//        
-//        Point2D point1 = LocalAreaUtil.getLocalRelativeLocation(point0.getX(), point0.getY(), building);
-//        
-//        Point2D point2 = LocalAreaUtil.getObjectRelativeLocation(point1.getX(), point1.getY(), building);
-//        
-//        assertTrue(Math.abs(point0.getX() - point2.getX()) < SMALL_AMOUNT_COMPARISON);
-//        assertTrue(Math.abs(point0.getY() - point2.getY()) < SMALL_AMOUNT_COMPARISON);
-//        
-//        building.setXLocation(15D);
-//        building.setYLocation(-8D);
-//        
-//        Point2D point3 = new Point2D.Double(5D, 12D);
-//        
-//        Point2D point4 = LocalAreaUtil.getLocalRelativeLocation(point3.getX(), point3.getY(), building);
-//        
-//        Point2D point5 = LocalAreaUtil.getObjectRelativeLocation(point4.getX(), point4.getY(), building);
-//        
-//        assertTrue(Math.abs(point3.getX() - point5.getX()) < SMALL_AMOUNT_COMPARISON);
-//        assertTrue(Math.abs(point3.getY() - point5.getY()) < SMALL_AMOUNT_COMPARISON);
-//        
-//        building.setFacing(135D);
-//        
-//        Point2D point6 = new Point2D.Double(-3D, -7D);
-//        
-//        Point2D point7 = LocalAreaUtil.getLocalRelativeLocation(point6.getX(), point6.getY(), building);
-//        
-//        Point2D point8 = LocalAreaUtil.getObjectRelativeLocation(point7.getX(), point7.getY(), building);
-//        
-//        assertTrue(Math.abs(point6.getX() - point8.getX()) < SMALL_AMOUNT_COMPARISON);
-//        assertTrue(Math.abs(point6.getY() - point8.getY()) < SMALL_AMOUNT_COMPARISON);
-//        
-//        building.setXLocation(-32D);
-//        building.setYLocation(12.7D);
-//        building.setFacing(290.2D);
-//        
-//        Point2D point9 = new Point2D.Double(-11.2D, 33.56D);
-//        
-//        Point2D point10 = LocalAreaUtil.getLocalRelativeLocation(point9.getX(), point9.getY(), building);
-//        
-//        Point2D point11 = LocalAreaUtil.getObjectRelativeLocation(point10.getX(), point10.getY(), building);
-//        
-//        assertTrue(Math.abs(point9.getX() - point11.getX()) < SMALL_AMOUNT_COMPARISON);
-//        assertTrue(Math.abs(point9.getY() - point11.getY()) < SMALL_AMOUNT_COMPARISON);
-//    }
-    
-	@Before
+	@Override
 	public void setUp() {
 	    // Create new simulation instance.
         SimulationConfig simConfig = SimulationConfig.loadConfig();
@@ -237,7 +48,7 @@ public class TestLocalAreaUtil extends TestCase {
         Settlement settlement = new MockSettlement();
  
         var bounds = new BoundedObject(0D, 0D, 10, 10, 0);
-        MockBuilding mb0 = new MockBuilding(settlement, "Mock B0", 1, bounds, "Mock", BuildingCategory.COMMAND, false);
+        MockBuilding mb0 = new MockBuilding(settlement, "Mock B0", "1", bounds, "Mock", BuildingCategory.COMMAND, false);
         
         assertTrue(LocalAreaUtil.isPositionWithinLocalBoundedObject(new LocalPosition(0D, 0D), mb0));
         assertTrue(LocalAreaUtil.isPositionWithinLocalBoundedObject(new LocalPosition(4.99D, 4.99D), mb0));
@@ -257,10 +68,15 @@ public class TestLocalAreaUtil extends TestCase {
         assertFalse(LocalAreaUtil.isPositionWithinLocalBoundedObject(new LocalPosition(-5.01D, 0D), mb0));
         assertFalse(LocalAreaUtil.isPositionWithinLocalBoundedObject(new LocalPosition(0D, 5.01D), mb0));
         assertFalse(LocalAreaUtil.isPositionWithinLocalBoundedObject(new LocalPosition(0D, -5.01D), mb0));
-        
+    }
+
+    public void testRotate45Degrees() {
+            
+        Settlement settlement = new MockSettlement();
+ 
         // Rotate building 45 degrees.
-        bounds = new BoundedObject(0D, 0D, 10, 10, 45D);
-        mb0 = new MockBuilding(settlement, "Mock B0", 1, bounds, "Mock", BuildingCategory.COMMAND, false);
+        var bounds = new BoundedObject(0D, 0D, 10, 10, 45D);
+        var mb0 = new MockBuilding(settlement, "Mock B0", "1", bounds, "Mock", BuildingCategory.COMMAND, false);
                 
         assertTrue(LocalAreaUtil.isPositionWithinLocalBoundedObject(new LocalPosition(0D, 0D), mb0));
         assertFalse(LocalAreaUtil.isPositionWithinLocalBoundedObject(new LocalPosition(4.99D, 4.99D), mb0));

--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/MockBuilding.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/MockBuilding.java
@@ -24,10 +24,10 @@ public class MockBuilding extends Building {
 	}
 
     
-    public MockBuilding(Settlement owner, String name, int id, BoundedObject bounds,
+    public MockBuilding(Settlement owner, String name, String id, BoundedObject bounds,
 						String buildingType, BuildingCategory cat,
 						boolean needsLifeSupport)  {
-		super(owner, Integer.toString(id), 1, "Mock Building " + id, bounds, buildingType, cat);
+		super(owner, id, 1, name, bounds, buildingType, cat);
 
 		malfunctionManager = new MalfunctionManager(this, 0D, 1D);
 		if (needsLifeSupport) {
@@ -35,8 +35,8 @@ public class MockBuilding extends Building {
 		}
 	}
 
-	public MockBuilding(Settlement owner, int id, BoundedObject bounds) {
-		super(owner, Integer.toString(id), 1, "Mock Building " + id, bounds, "Mock", BuildingCategory.LIVING);
+	public MockBuilding(Settlement owner, String id, BoundedObject bounds) {
+		super(owner, id, 1, "Mock Building " + id, bounds, "Mock", BuildingCategory.LIVING);
 	}
 }
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/BuildingConnectorManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/BuildingConnectorManagerTest.java
@@ -116,16 +116,10 @@ public class BuildingConnectorManagerTest extends TestCase {
         assertNotNull(connections7);
         assertEquals(2, connections7.size());
 
-        BuildingConnector[] origConnections = new BuildingConnector[2];
-        connections.toArray(origConnections);
+        manager.removeAllConnectionsToBuilding(buildings.get(1));
+        assertTrue("Nothing to building 1", manager.getConnectionsToBuilding(buildings.get(1)).isEmpty());
+        assertEquals("Building 2 reduced", 1, manager.getConnectionsToBuilding(buildings.get(2)).size());
 
-        manager.removeBuildingConnection(origConnections[0]);
-
-        assertEquals(1, manager.getAllBuildingConnections().size());
-
-        manager.removeBuildingConnection(origConnections[1]);
-
-        assertEquals(0, manager.getAllBuildingConnections().size());
     }
 
     public void testShortestPathAdjacent() {

--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/BuildingConnectorManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/BuildingConnectorManagerTest.java
@@ -5,17 +5,15 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Before;
-
 import com.mars_sim.core.Simulation;
 import com.mars_sim.core.SimulationConfig;
+import com.mars_sim.core.building.Building;
 import com.mars_sim.core.building.BuildingManager;
 import com.mars_sim.core.building.BuildingTemplate;
 import com.mars_sim.core.building.MockBuilding;
 import com.mars_sim.core.building.function.Function;
 import com.mars_sim.core.map.location.BoundedObject;
 import com.mars_sim.core.map.location.LocalPosition;
-import com.mars_sim.core.person.ai.task.WalkSettlementInterior;
 import com.mars_sim.core.structure.MockSettlement;
 import com.mars_sim.core.structure.Settlement;
 
@@ -24,11 +22,12 @@ import junit.framework.TestCase;
 public class BuildingConnectorManagerTest extends TestCase {
 
     private static final double SMALL_DELTA = .0000001D;
+    private SimulationConfig simConfig;
     
-	@Before
+	@Override
 	public void setUp() {
 	    // Create new simulation instance.
-        SimulationConfig simConfig = SimulationConfig.loadConfig();
+        simConfig = SimulationConfig.loadConfig();
         
         Simulation sim = Simulation.instance();
         sim.testRun();
@@ -54,28 +53,26 @@ public class BuildingConnectorManagerTest extends TestCase {
     public void testConstructorWithBuildingTemplates() {
 
         Settlement settlement = new MockSettlement();
-        BuildingManager buildingManager = settlement.getBuildingManager();
 
-        MockBuilding building0 = new MockBuilding(settlement, 0, new BoundedObject(0D, 0D, 9D, 9D, 0D));
         BuildingTemplate buildingTemplate0 = new BuildingTemplate("0", 0, "building 0", "building 0", new BoundedObject(0D, 0D, 9D, 9D, 0D));
         buildingTemplate0.addBuildingConnection("2", new LocalPosition(-4.5D, 0D));
-        buildingManager.addBuilding(building0, false);
 
-        MockBuilding building1 = new MockBuilding(settlement, 1, new BoundedObject(-12D, 0D, 6D, 9D, 270D));
         BuildingTemplate buildingTemplate1 = new BuildingTemplate("1", 0, "building 1","building 1", new BoundedObject(-12D, 0D, 6D, 9D, 270D));
         buildingTemplate1.addBuildingConnection("2", new LocalPosition(0D, 4.5D));
-        buildingManager.addBuilding(building1, false);
 
-        MockBuilding building2 = new MockBuilding(settlement, 2, new BoundedObject(-6D, 0D, 2D, 3D, 270D));
         BuildingTemplate buildingTemplate2 = new BuildingTemplate("2", 0, "building 2","building 2", new BoundedObject(-6D, 0D, 6D, 9D, 270D));
         buildingTemplate2.addBuildingConnection("0", new LocalPosition(0D, 1.5D));
         buildingTemplate2.addBuildingConnection("1", new LocalPosition(0D, -1.5D));
-        buildingManager.addBuilding(building2, false);
 
         List<BuildingTemplate> buildingTemplates = new ArrayList<BuildingTemplate>();
         buildingTemplates.add(buildingTemplate0);
         buildingTemplates.add(buildingTemplate1);
         buildingTemplates.add(buildingTemplate2);
+
+        List<Building> buildings = new ArrayList<>();
+        for(var bt : buildingTemplates) {
+            buildings.add(addBuildingFromTemplate(settlement, bt));
+        }
 
         BuildingConnectorManager manager = new BuildingConnectorManager(settlement, buildingTemplates);
         assertNotNull(manager);
@@ -91,31 +88,31 @@ public class BuildingConnectorManagerTest extends TestCase {
             assertTrue(manager.containsBuildingConnector(connector));
         }
 
-        Set<BuildingConnector> connections1 = manager.getBuildingConnections(building0, building2);
+        Set<BuildingConnector> connections1 = manager.getBuildingConnections(buildings.get(0), buildings.get(2));
         assertNotNull(connections1);
         assertEquals(1, connections1.size());
 
-        Set<BuildingConnector> connections2 = manager.getBuildingConnections(building2, building0);
+        Set<BuildingConnector> connections2 = manager.getBuildingConnections(buildings.get(2), buildings.get(0));
         assertNotNull(connections2);
         assertEquals(1, connections2.size());
 
-        Set<BuildingConnector> connections3 = manager.getBuildingConnections(building1, building2);
+        Set<BuildingConnector> connections3 = manager.getBuildingConnections(buildings.get(1), buildings.get(2));
         assertNotNull(connections3);
         assertEquals(1, connections3.size());
 
-        Set<BuildingConnector> connections4 = manager.getBuildingConnections(building2, building1);
+        Set<BuildingConnector> connections4 = manager.getBuildingConnections(buildings.get(2), buildings.get(1));
         assertNotNull(connections4);
         assertEquals(1, connections4.size());
 
-        Set<BuildingConnector> connections5 = manager.getConnectionsToBuilding(building0);
+        Set<BuildingConnector> connections5 = manager.getConnectionsToBuilding(buildings.get(0));
         assertNotNull(connections5);
         assertEquals(1, connections5.size());
 
-        Set<BuildingConnector> connections6 = manager.getConnectionsToBuilding(building1);
+        Set<BuildingConnector> connections6 = manager.getConnectionsToBuilding(buildings.get(1));
         assertNotNull(connections6);
         assertEquals(1, connections6.size());
 
-        Set<BuildingConnector> connections7 = manager.getConnectionsToBuilding(building2);
+        Set<BuildingConnector> connections7 = manager.getConnectionsToBuilding(buildings.get(2));
         assertNotNull(connections7);
         assertEquals(2, connections7.size());
 
@@ -131,82 +128,120 @@ public class BuildingConnectorManagerTest extends TestCase {
         assertEquals(0, manager.getAllBuildingConnections().size());
     }
 
-    public void testDetermineShortestPath() {
+    public void testShortestPathAdjacent() {
         
         Settlement settlement = new MockSettlement();
-        BuildingManager buildingManager = settlement.getBuildingManager();
 
-        MockBuilding building0 = new MockBuilding(settlement, 0, new BoundedObject(0D, 0D, 9D, 9D, 0D));
         BuildingTemplate buildingTemplate0 = new BuildingTemplate("0", 0, "building 0", "building 0", new BoundedObject(0D, 0D, 9D, 9D, 0D));
-        buildingTemplate0.addBuildingConnection("2", new LocalPosition(-4.5D, 0D));
-        buildingManager.addBuilding(building0, false);
+        var connectorB0B2 = new LocalPosition(-4.5D, 0D);
+        buildingTemplate0.addBuildingConnection("2", connectorB0B2);
 
-        MockBuilding building1 = new MockBuilding(settlement, 1, new BoundedObject(-12D, 0D, 6D, 9D, 270D));
         BuildingTemplate buildingTemplate1 = new BuildingTemplate("1", 0, "building 1", "building 1", new BoundedObject(-12D, 0D, 6D, 9D, 270D));
         buildingTemplate1.addBuildingConnection("2", new LocalPosition(0D, 4.5D));
-        buildingManager.addBuilding(building1, false);
 
-        MockBuilding building2 = new MockBuilding(settlement, 2, new BoundedObject(-6D, 0D, 2D, 3D, 270D));
         BuildingTemplate buildingTemplate2 = new BuildingTemplate("2", 0, "building 2", "building 2", new BoundedObject(-6D, 0D, 6D, 9D, 270D));
         buildingTemplate2.addBuildingConnection("0", new LocalPosition(0D, 1.5D));
         buildingTemplate2.addBuildingConnection("1", new LocalPosition(0D, -1.5D));
-        buildingManager.addBuilding(building2, false);
 
         List<BuildingTemplate> buildingTemplates = new ArrayList<BuildingTemplate>();
         buildingTemplates.add(buildingTemplate0);
         buildingTemplates.add(buildingTemplate1);
         buildingTemplates.add(buildingTemplate2);
 
+        List<Building> buildings = new ArrayList<>();
+        for(var bt : buildingTemplates) {
+            buildings.add(addBuildingFromTemplate(settlement, bt));
+        }
+
         BuildingConnectorManager manager = new BuildingConnectorManager(settlement, buildingTemplates);
 
-        InsideBuildingPath path1 = manager.determineShortestPath(100, //WalkSettlementInterior.NUM_ITERATION, 
-        		building0, new LocalPosition(0D, 0D), building0, new LocalPosition(4.5D, 0D));
-        assertNotNull(path1);
-        assertEquals(4.5D, path1.getPathLength(), SMALL_DELTA);
-        assertEquals(1, path1.getRemainingPathLocations().size());
-        InsidePathLocation nextPath = path1.getNextPathLocation();
-        assertNotNull(nextPath);
-        assertEquals(4.5D, nextPath.getPosition().getX(), SMALL_DELTA);
-        assertEquals(0D, nextPath.getPosition().getY(), SMALL_DELTA);
-        assertTrue(path1.isEndOfPath());
+        var b0 = buildings.get(0);
+        var b2 = buildings.get(2);
 
-        InsideBuildingPath path2 = manager.determineShortestPath(100, //WalkSettlementInterior.NUM_ITERATION, 
-        		building0, new LocalPosition(2D, -1D), building2, new LocalPosition(-5D, 1D));
+        var startPosn = new LocalPosition(2D, -1D);
+        var endPosn = new LocalPosition(-5D, 1D);
+        InsideBuildingPath path2 = manager.determineShortestPath( b0, startPosn, b2, endPosn);
 
-        // 2016-12-09 To pass maven test, change the code in getBuilding(int id) in BuildingManager to the non-java stream version
         assertNotNull(path2);
+        assertPathValidity(path2, b0, b2);
+        assertEquals(3, path2.getPathLocations().size());
+
         assertEquals(7.694507207732848D, path2.getPathLength(), SMALL_DELTA);
         assertEquals(2, path2.getRemainingPathLocations().size());
-        nextPath = path2.getNextPathLocation();
+        var nextPath = path2.getNextPathLocation();
         assertNotNull(nextPath);
-        assertEquals(-4.5D, nextPath.getPosition().getX(), SMALL_DELTA);
-        assertEquals(0D, nextPath.getPosition().getY(), SMALL_DELTA);
+        assertEquals(connectorB0B2.getX(), nextPath.getPosition().getX(), SMALL_DELTA);
+        assertEquals(connectorB0B2.getY(), nextPath.getPosition().getY(), SMALL_DELTA);
         assertFalse(path2.isEndOfPath());
+
         path2.iteratePathLocation();
         assertEquals(1, path2.getRemainingPathLocations().size());
         nextPath = path2.getNextPathLocation();
         assertNotNull(nextPath);
-        assertEquals(-5D, nextPath.getPosition().getX(), SMALL_DELTA);
-        assertEquals(1D, nextPath.getPosition().getY(), SMALL_DELTA);
+        assertEquals(endPosn.getX(), nextPath.getPosition().getX(), SMALL_DELTA);
+        assertEquals(endPosn.getY(), nextPath.getPosition().getY(), SMALL_DELTA);
         assertTrue(path2.isEndOfPath());
 
-        InsideBuildingPath path3 = manager.determineShortestPath(100, //WalkSettlementInterior.NUM_ITERATION, 
-        		building0, new LocalPosition(2D, -1D), building1, new LocalPosition(-10D, 1D));
+    }
+
+     public void testShortestPathMiddleBuilding() {
+        
+        Settlement settlement = new MockSettlement();
+
+        BuildingTemplate buildingTemplate0 = new BuildingTemplate("0", 0, "building 0", "building 0", new BoundedObject(0D, 0D, 9D, 9D, 0D));
+        var connectorB0B2 = new LocalPosition(-4.5D, 0D);
+        buildingTemplate0.addBuildingConnection("2", connectorB0B2);
+
+        BuildingTemplate buildingTemplate1 = new BuildingTemplate("1", 0, "building 1", "building 1", new BoundedObject(-12D, 0D, 6D, 9D, 270D));
+        var connectorB1B2 = new LocalPosition(0D, 4.5D);
+        buildingTemplate1.addBuildingConnection("2", connectorB1B2);
+
+        BuildingTemplate buildingTemplate2 = new BuildingTemplate("2", 0, "building 2", "building 2", new BoundedObject(-6D, 0D, 6D, 9D, 270D));
+        var connectorB2B0 = new LocalPosition(0D, 1.5D);
+        var connectorB2B1 = new LocalPosition(0D, -1.5D);
+        buildingTemplate2.addBuildingConnection("0", connectorB2B0);
+        buildingTemplate2.addBuildingConnection("1", connectorB2B1);
+
+        List<BuildingTemplate> buildingTemplates = new ArrayList<>();
+        buildingTemplates.add(buildingTemplate0);
+        buildingTemplates.add(buildingTemplate1);
+        buildingTemplates.add(buildingTemplate2);
+
+        List<Building> buildings = new ArrayList<>();
+        for(var bt : buildingTemplates) {
+            buildings.add(addBuildingFromTemplate(settlement, bt));
+        }
+
+        BuildingConnectorManager manager = new BuildingConnectorManager(settlement, buildingTemplates);
+
+        var b0 = buildings.get(0);
+        var b1 = buildings.get(1);
+        var b2 = buildings.get(2);
+
+        var startPosn = new LocalPosition(2D, -1D);
+        var endPosn = new LocalPosition(-10D, 1D);  
+        InsideBuildingPath path3 = manager.determineShortestPath(b0, startPosn, b1, endPosn);
         assertNotNull(path3);
+        assertPathValidity(path3, b0, b1);
+        assertEquals(5, path3.getPathLocations().size());
+
         assertEquals(12.269055622550205D, path3.getPathLength(), SMALL_DELTA);
         assertEquals(4, path3.getRemainingPathLocations().size());
-        nextPath = path3.getNextPathLocation();
+        
+        var nextPath = path3.getNextPathLocation();
         assertNotNull(nextPath);
-        assertEquals(-4.5D, nextPath.getPosition().getX(), SMALL_DELTA);
-        assertEquals(0D, nextPath.getPosition().getY(), SMALL_DELTA);
+        assertEquals(connectorB0B2.getX(), nextPath.getPosition().getX(), SMALL_DELTA);
+        assertEquals(connectorB0B2.getY(), nextPath.getPosition().getY(), SMALL_DELTA);
         assertFalse(path3.isEndOfPath());
+
         path3.iteratePathLocation();
         assertEquals(3, path3.getRemainingPathLocations().size());
         nextPath = path3.getNextPathLocation();
         assertNotNull(nextPath);
-        assertEquals(-6D, nextPath.getPosition().getX(), SMALL_DELTA);
-        assertEquals(0D, nextPath.getPosition().getY(), SMALL_DELTA);
+        assertEquals(b2.getPosition().getX(), nextPath.getPosition().getX(), SMALL_DELTA);
+        assertEquals(b2.getPosition().getY(), nextPath.getPosition().getY(), SMALL_DELTA);
         assertFalse(path3.isEndOfPath());
+
         path3.iteratePathLocation();
         assertEquals(2, path3.getRemainingPathLocations().size());
         nextPath = path3.getNextPathLocation();
@@ -214,12 +249,113 @@ public class BuildingConnectorManagerTest extends TestCase {
         assertEquals(-7.5D, nextPath.getPosition().getX(), SMALL_DELTA);
         assertEquals(0D, nextPath.getPosition().getY(), .0001D);
         assertFalse(path3.isEndOfPath());
+
         path3.iteratePathLocation();
         assertEquals(1, path3.getRemainingPathLocations().size());
         nextPath = path3.getNextPathLocation();
         assertNotNull(nextPath);
-        assertEquals(-10D, nextPath.getPosition().getX(), SMALL_DELTA);
-        assertEquals(1D, nextPath.getPosition().getY(), SMALL_DELTA);
+        assertEquals(endPosn.getX(), nextPath.getPosition().getX(), SMALL_DELTA);
+        assertEquals(endPosn.getY(), nextPath.getPosition().getY(), SMALL_DELTA);
         assertTrue(path3.isEndOfPath());
+    }
+
+    public void testShortestPathSameBuilding() {
+        
+        Settlement settlement = new MockSettlement();
+
+        BuildingTemplate buildingTemplate0 = new BuildingTemplate("0", 0, "building 0", "building 0", new BoundedObject(0D, 0D, 9D, 9D, 0D));
+
+        List<BuildingTemplate> buildingTemplates = new ArrayList<BuildingTemplate>();
+        buildingTemplates.add(buildingTemplate0);
+
+        var b0 = addBuildingFromTemplate(settlement, buildingTemplate0);
+
+        BuildingConnectorManager manager = new BuildingConnectorManager(settlement, buildingTemplates);
+
+        var startPosn = new LocalPosition(0D, 0D);
+        var endPosn = new LocalPosition(4.5D, 0D);
+        InsideBuildingPath path1 = manager.determineShortestPath(b0, startPosn, b0, endPosn);
+        assertNotNull(path1);
+        assertEquals("Path1 length", 2, path1.getPathLocations().size());
+        assertPathValidity(path1, b0, b0);
+
+        assertEquals(4.5D, path1.getPathLength(), SMALL_DELTA);
+        assertEquals(1, path1.getRemainingPathLocations().size());
+        InsidePathLocation nextPath = path1.getNextPathLocation();
+        assertNotNull(nextPath);
+        assertEquals(endPosn.getX(), nextPath.getPosition().getX(), SMALL_DELTA);
+        assertEquals(endPosn.getY(), nextPath.getPosition().getY(), SMALL_DELTA);
+        assertTrue(path1.isEndOfPath());
+    }
+
+    private Building addBuildingFromTemplate(Settlement settlement, BuildingTemplate template) {
+        BuildingManager buildingManager = settlement.getBuildingManager();
+
+        MockBuilding newBuilding = new MockBuilding(settlement, template.getID(), template.getBounds());
+        buildingManager.addBuilding(newBuilding, false);
+
+        return newBuilding;
+    }
+
+    public void testLargeRoute() {
+        var largeTemplate = "Sector Base 1-MS";
+        List<BuildingTemplate> buildingTemplates = simConfig.getSettlementTemplateConfiguration().getItem(largeTemplate).getSupplies().getBuildings();
+        Settlement settlement = new MockSettlement();
+
+        for(var bt : buildingTemplates) {
+            addBuildingFromTemplate(settlement, bt);
+        }
+        BuildingConnectorManager manager = new BuildingConnectorManager(settlement, buildingTemplates);
+
+        var bMgr = settlement.getBuildingManager();
+        var lHab = bMgr.getBuildingByTemplateID("000"); // Lander Hab
+        var lab = bMgr.getBuildingByTemplateID("605"); // Laboratory
+        var path = manager.determineShortestPath(lHab, lHab.getPosition(), lab, lab.getPosition());
+        assertNotNull("Found route", path);
+        assertPathValidity(path, lHab, lab);
+
+        var core = bMgr.getBuildingByTemplateID("906n7"); 
+        path = manager.determineShortestPath(lHab, lHab.getPosition(), core, core.getPosition());
+        assertNotNull("Found route", path);
+        assertPathValidity(path, lHab, core);
+    }
+
+    /**
+     * Assert the path is valid.
+     * 1. Path only changes Building at a Connector
+     * 2. First item is start building
+     * 3. Last item is end building
+     * @param path
+     * @param lHab
+     * @param lab
+     */
+    public static void assertPathValidity(InsideBuildingPath path, Building start, Building end) {
+        var steps = path.getPathLocations();
+
+        assertEquals("First step is start building", start, ((BuildingLocation)steps.get(0)).getBuilding());
+        assertEquals("Last step is end building", end, ((BuildingLocation)steps.get(steps.size()-1)).getBuilding());
+
+        int i = 0;
+        var currentBuilding = start;
+        for(var step : steps) {
+            switch(step) {
+                case BuildingLocation bl -> assertEquals("Step " + i + " is in buildingLocation ", currentBuilding, bl.getBuilding());
+                case Building b -> assertEquals("Step " + i + " is Building ", currentBuilding, b);
+                case Hatch h -> assertEquals("Step " + i + " is Hatch ", currentBuilding, h.getBuilding());
+                case BuildingConnector bc -> {
+                    if (bc.getBuilding1().equals(currentBuilding)) {
+                        currentBuilding = bc.getBuilding2();
+                    }
+                    else if (bc.getBuilding2().equals(currentBuilding)) {
+                        currentBuilding = bc.getBuilding1();
+                    }
+                    else {
+                        fail("Step " + i + " is a BuildingConnector but does not match current building: " + currentBuilding);
+                    }
+                }
+                default -> fail("Step " + i + " is unknown type " + step.getClass().getSimpleName());
+            }
+            i++;
+        }
     }
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/BuildingConnectorTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/BuildingConnectorTest.java
@@ -1,23 +1,22 @@
 package com.mars_sim.core.building.connection;
 
+import com.mars_sim.core.AbstractMarsSimUnitTest;
 import com.mars_sim.core.building.MockBuilding;
 import com.mars_sim.core.map.location.BoundedObject;
 import com.mars_sim.core.map.location.LocalPosition;
 import com.mars_sim.core.structure.MockSettlement;
 
-import junit.framework.TestCase;
-
-public class BuildingConnectorTest extends TestCase {
+public class BuildingConnectorTest extends AbstractMarsSimUnitTest{
     
     private static final LocalPosition BUILDING3_POSITION = new LocalPosition(0D, 7D);
-	private static final LocalPosition BUILDING2_POSITION = new LocalPosition(0D, 5D);
-	private static final LocalPosition BUILDING_POSITION = BUILDING2_POSITION;
+    private static final LocalPosition BUILDING2_POSITION = new LocalPosition(0D, 5D);
+    private static final LocalPosition BUILDING_POSITION = BUILDING2_POSITION;
 
-	public void testNonSplitBuildingConnector() {
+    public void testNonSplitBuildingConnector() {
         
         MockSettlement settlement = new MockSettlement();
-        MockBuilding building1 = new MockBuilding(settlement, 1, new BoundedObject(0D, 0D, 10D, 10D, 0D));
-        MockBuilding building2 = new MockBuilding(settlement, 2, new BoundedObject(0D, 0D, 10D, 10D, 0D));
+        MockBuilding building1 = new MockBuilding(settlement, "1", new BoundedObject(0D, 0D, 10D, 10D, 0D));
+        MockBuilding building2 = new MockBuilding(settlement, "2", new BoundedObject(0D, 0D, 10D, 10D, 0D));
 
         
         BuildingConnector connector = new BuildingConnector(building1, 
@@ -54,8 +53,8 @@ public class BuildingConnectorTest extends TestCase {
     public void testSplitBuildingConnector() {
         
         MockSettlement settlement = new MockSettlement();
-        MockBuilding building1 = new MockBuilding(settlement, 1, new BoundedObject(0D, 0D, 10D, 10D, 0D));
-        MockBuilding building2 = new MockBuilding(settlement, 2, new BoundedObject(0D, 12D, 10D, 10D, 0D));
+        MockBuilding building1 = new MockBuilding(settlement, "1", new BoundedObject(0D, 0D, 10D, 10D, 0D));
+        MockBuilding building2 = new MockBuilding(settlement, "2", new BoundedObject(0D, 12D, 10D, 10D, 0D));
 
         BuildingConnector connector = new BuildingConnector(building1, 
                 BUILDING2_POSITION, 0D, building2, BUILDING3_POSITION, 180D);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/HatchTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/HatchTest.java
@@ -1,13 +1,12 @@
 package com.mars_sim.core.building.connection;
 
+import com.mars_sim.core.AbstractMarsSimUnitTest;
 import com.mars_sim.core.building.MockBuilding;
 import com.mars_sim.core.map.location.BoundedObject;
 import com.mars_sim.core.map.location.LocalPosition;
 import com.mars_sim.core.structure.MockSettlement;
 
-import junit.framework.TestCase;
-
-public class HatchTest extends TestCase {
+public class HatchTest extends AbstractMarsSimUnitTest {
 
 	
     private static final LocalPosition BUILDING_POSITION = new LocalPosition(0D, 0D);
@@ -18,8 +17,8 @@ public class HatchTest extends TestCase {
 	public void testConstructor() {
         
         MockSettlement settlement = new MockSettlement();
-        MockBuilding building1 = new MockBuilding(settlement, 1, BUILDING_POSN);
-        MockBuilding building2 = new MockBuilding(settlement, 2, BUILDING_POSN);
+        MockBuilding building1 = new MockBuilding(settlement, "1", BUILDING_POSN);
+        MockBuilding building2 = new MockBuilding(settlement, "2", BUILDING_POSN);
         BuildingConnector connector = new BuildingConnector(building1, 
                 BUILDING_POSITION, 0D, building2, BUILDING_POSITION, 0D);
         
@@ -36,8 +35,8 @@ public class HatchTest extends TestCase {
     
     public void testSetLocation() {
         MockSettlement settlement = new MockSettlement();
-        MockBuilding building1 = new MockBuilding(settlement, 1, BUILDING_POSN);
-        MockBuilding building2 = new MockBuilding(settlement, 2, BUILDING_POSN);
+        MockBuilding building1 = new MockBuilding(settlement, "1", BUILDING_POSN);
+        MockBuilding building2 = new MockBuilding(settlement, "2", BUILDING_POSN);
         BuildingConnector connector = new BuildingConnector(building1, 
         		BUILDING_POSITION, 0D, building2, BUILDING_POSITION, 0D);
         
@@ -50,8 +49,8 @@ public class HatchTest extends TestCase {
     public void testEquals() {
         
         MockSettlement settlement = new MockSettlement();
-        MockBuilding building1 = new MockBuilding(settlement, 1, BUILDING_POSN);
-        MockBuilding building2 = new MockBuilding(settlement, 2, BUILDING_POSN);
+        MockBuilding building1 = new MockBuilding(settlement, "1", BUILDING_POSN);
+        MockBuilding building2 = new MockBuilding(settlement, "2", BUILDING_POSN);
         BuildingConnector connector = new BuildingConnector(building1, 
         		BUILDING_POSITION, 0D, building2, BUILDING_POSITION, 0D);
         

--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/InsideBuildingPathTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/InsideBuildingPathTest.java
@@ -2,14 +2,13 @@ package com.mars_sim.core.building.connection;
 
 import java.util.List;
 
+import com.mars_sim.core.AbstractMarsSimUnitTest;
 import com.mars_sim.core.building.MockBuilding;
 import com.mars_sim.core.map.location.BoundedObject;
 import com.mars_sim.core.map.location.LocalPosition;
 import com.mars_sim.core.structure.MockSettlement;
 
-import junit.framework.TestCase;
-
-public class InsideBuildingPathTest extends TestCase {
+public class InsideBuildingPathTest extends AbstractMarsSimUnitTest {
 
     private static final LocalPosition POSITION_5X5 = new LocalPosition(5D, 5D);
 	private static final LocalPosition POSITION_10X5 = new LocalPosition(10D, 5D);
@@ -38,7 +37,7 @@ public class InsideBuildingPathTest extends TestCase {
         assertEquals(0, remainingLocations1.size());
         
         MockSettlement settlement = new MockSettlement();
-        MockBuilding building = new MockBuilding(settlement, 1, BUILDING_POSN);
+        MockBuilding building = new MockBuilding(settlement, "1", BUILDING_POSN);
         InsidePathLocation location = new BuildingLocation(building, POSITION_5X5);
         
         assertFalse(path.containsPathLocation(location));
@@ -61,7 +60,7 @@ public class InsideBuildingPathTest extends TestCase {
         InsideBuildingPath path = new InsideBuildingPath();
         
         MockSettlement settlement = new MockSettlement();
-        MockBuilding building = new MockBuilding(settlement, 1, BUILDING_POSN);
+        MockBuilding building = new MockBuilding(settlement, "1", BUILDING_POSN);
         InsidePathLocation location1 = new BuildingLocation(building, POSITION_5X5);
         path.addPathLocation(location1);
         
@@ -80,7 +79,7 @@ public class InsideBuildingPathTest extends TestCase {
         InsideBuildingPath path = new InsideBuildingPath();
         
         MockSettlement settlement = new MockSettlement();
-        MockBuilding building = new MockBuilding(settlement, 1, BUILDING_POSN);
+        MockBuilding building = new MockBuilding(settlement, "1", BUILDING_POSN);
         
         InsidePathLocation location1 = new BuildingLocation(building, POSITION_5X5);
         path.addPathLocation(location1);
@@ -116,7 +115,7 @@ public class InsideBuildingPathTest extends TestCase {
         InsideBuildingPath path = new InsideBuildingPath();
 
         MockSettlement settlement = new MockSettlement();
-        MockBuilding building = new MockBuilding(settlement, 1, BUILDING_POSN);
+        MockBuilding building = new MockBuilding(settlement, "1", BUILDING_POSN);
         
         InsidePathLocation location1 = new BuildingLocation(building, POSITION_5X5);
         path.addPathLocation(location1);
@@ -147,7 +146,7 @@ public class InsideBuildingPathTest extends TestCase {
         InsideBuildingPath path = new InsideBuildingPath();
         
         MockSettlement settlement = new MockSettlement();
-        MockBuilding building = new MockBuilding(settlement, 1, BUILDING_POSN);
+        MockBuilding building = new MockBuilding(settlement, "1", BUILDING_POSN);
         
         InsidePathLocation location1 = new BuildingLocation(building, POSITION_5X5);
         path.addPathLocation(location1);
@@ -168,45 +167,5 @@ public class InsideBuildingPathTest extends TestCase {
         path.addPathLocation(location4);
         
         assertEquals(10D + Math.sqrt(50D), path.getPathLength());
-    }
-    
-    public void testClone() {
-        
-        InsideBuildingPath path1 = new InsideBuildingPath();
-        
-        MockSettlement settlement = new MockSettlement();
-        MockBuilding building = new MockBuilding(settlement, 1, BUILDING_POSN);        
-        InsidePathLocation location1 = new BuildingLocation(building, POSITION_5X5);
-        path1.addPathLocation(location1);
-        
-        InsidePathLocation location2 = new BuildingLocation(building, POSITION_10X5);
-        path1.addPathLocation(location2);
-        
-        InsidePathLocation location3 = new BuildingLocation(building, POSITION_10X10);
-        path1.addPathLocation(location3);
-        
-        InsideBuildingPath path2 = new InsideBuildingPath(path1);
-        assertNotNull(path2);
-        
-        assertEquals(location1, path2.getNextPathLocation());
-        assertEquals(10D, path2.getPathLength());
-        
-        List<InsidePathLocation> remainingLocations2 = path2.getRemainingPathLocations();
-        assertNotNull(remainingLocations2);
-        assertEquals(3, remainingLocations2.size());
-        assertEquals(location1, remainingLocations2.get(0));
-        
-        path2.iteratePathLocation();
-        
-        InsideBuildingPath path3 = new InsideBuildingPath(path2);
-        assertNotNull(path3);
-        
-        assertEquals(location2, path3.getNextPathLocation());
-        assertEquals(10D, path3.getPathLength());
-        
-        List<InsidePathLocation> remainingLocations3 = path3.getRemainingPathLocations();
-        assertNotNull(remainingLocations3);
-        assertEquals(2, remainingLocations3.size());
-        assertEquals(location2, remainingLocations3.get(0));
     }
 }


### PR DESCRIPTION
This PR redevelops the path finding for inside a settlement. It now uses a new dedicated ```PathFinder``` class that is more optimised than the previous implementation.
Essentially the finder uses 2 phases to create a path:

1. Find the high level route based on Buildings
2. Convert the route into a detailed path

To accompany this the Unit Test is significantly changed.
close #1611 