### PR TITLE
Provide different executor options for UnitManager

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
@@ -1415,6 +1415,11 @@ public class Simulation implements ClockListener, Serializable {
 
 			surfaceFeatures.timePassing(pulse);
 
+			if (pulse.isNewSol()) {
+				// Compute reliability daily for each part
+				malfunctionFactory.computePartReliability(pulse.getMarsTime().getMissionSol());
+			}
+		
 			unitManager.timePassing(pulse);
 
 			marketManager.timePassing(pulse);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/SimulationConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/SimulationConfig.java
@@ -97,11 +97,12 @@ public class SimulationConfig {
 	private static final String AVERAGE_TRANSIT_TIME = "average-transit-time";
 	private static final String DEFAULT_TIME_PULSE = "default-time-pulse";
 	private static final String BASE_TIME_RATIO = "base-time-ratio";
-	private static final String DEFAULT_UNUSEDCORES = "unused-cores";
 
 	private static final String MISSION_CONFIGURATION = "mission-configuration";
 	private static final String EVA_LIGHT = "min-eva-light";
 	private static final String CONTENT_URL = "content-url";
+
+	protected static final String EXECUTOR_TYPE = "executor-type";
 
 	private static SimulationConfig instance = null;
 
@@ -117,7 +118,7 @@ public class SimulationConfig {
 	private int autosaveInterval = 0;
 	private int numberOfAutoSaves = 0;
 	private int averageTransitTime = 0;
-	private int unusedCores = 0;	
+	private String executorType = null;	
 	
 	/*
 	 * -----------------------------------------------------------------------------
@@ -217,7 +218,7 @@ public class SimulationConfig {
 		
 			defaultTimePulse = loadIntValue(timeConfig, DEFAULT_TIME_PULSE, 1, 2048);
 			baseTimeRatio = loadIntValue(timeConfig, BASE_TIME_RATIO, 1, (int)MasterClock.MAX_TIME_RATIO);
-			unusedCores = loadIntValue(timeConfig, DEFAULT_UNUSEDCORES, 1, 360);
+			executorType = loadValue(timeConfig, EXECUTOR_TYPE);
 			averageTransitTime = loadIntValue(timeConfig, AVERAGE_TRANSIT_TIME, 0, 430);
 			autosaveInterval = loadIntValue(timeConfig, AUTOSAVE_INTERVAL, 1, 360);
 			numberOfAutoSaves = loadIntValue(timeConfig, AUTOSAVE_NUMBER, 1, 100);
@@ -355,13 +356,12 @@ public class SimulationConfig {
 	}
 	
 	/**
-	 * The difference between number of cores in the machine and the simulation threads created, 
-	 * i.e. the unused cores. Must be positive.
+	 * The type of temporal executor to use for doing parallel pulse apply.
 	 * 
-	 * @return # of cores
+	 * @return Executor type defined in config
 	 */
-	public int getUnusedCores() {
-		return unusedCores;
+    public String getExecutorType() {
+        return executorType;
 	}
 	
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/UnitManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/UnitManager.java
@@ -34,6 +34,7 @@ import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.Temporal;
 import com.mars_sim.core.unit.TemporalExecutor;
 import com.mars_sim.core.unit.TemporalExecutorService;
+import com.mars_sim.core.unit.TemporalThreadExecutor;
 import com.mars_sim.core.vehicle.Vehicle;
 
 /**
@@ -56,6 +57,10 @@ public class UnitManager implements Serializable, Temporal {
 	private static final int TYPE_BITS = 4;
 	private static final int TYPE_MASK = (1 << (TYPE_BITS)) - 1;
 	private static final int MAX_BASE_ID = (1 << (32-TYPE_BITS)) - 1;
+
+	public static final String THREAD = "thread";
+	public static final String SHARED = "shared";
+	
 
 	// Data members
 	/** Counter of unit identifiers. */
@@ -326,7 +331,12 @@ public class UnitManager implements Serializable, Temporal {
 
 		logger.config("Activating the settlement task pulse for " + s + ".");
 		if (executor == null) {
-			executor = new TemporalExecutorService("Settlement-executor");
+			String execType = SimulationConfig.instance().getExecutorType();
+			executor = switch(execType) {
+				case THREAD -> new TemporalThreadExecutor();
+				case SHARED -> new TemporalExecutorService("Settlement-");
+				default -> throw new IllegalArgumentException("Unknown executor type called " + execType);
+			};
 		}
 		executor.addTarget(s);
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/TransportManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/TransportManager.java
@@ -23,6 +23,8 @@ import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.person.EventType;
 import com.mars_sim.core.structure.SettlementTemplateConfig;
 import com.mars_sim.core.time.ClockPulse;
+import com.mars_sim.core.time.MarsTime;
+import com.mars_sim.core.time.MasterClock;
 import com.mars_sim.core.time.Temporal;
 
 /**
@@ -42,13 +44,16 @@ public class TransportManager implements Serializable, Temporal {
 
 	private ScheduledEventManager futures;
 
+	private MasterClock clock;
+
 	/**
 	 * Constructor.
 	 */
 	public TransportManager(Simulation sim) {
 		this.eventManager = sim.getEventManager();
+		this.clock = sim.getMasterClock();
 
-		Transportable.initalizeInstances(sim.getMasterClock(), this);
+		Transportable.initalizeInstances(this);
 
 		// Initialize data
 		transportItems = new ArrayList<>();
@@ -78,7 +83,7 @@ public class TransportManager implements Serializable, Temporal {
 				throw new IllegalArgumentException("Arriving settlement has a incorrect RAcode " + a.getSponsorCode());
 			}
 			
-			a.scheduleLaunch(futures);
+			a.scheduleLaunch();
 			logger.config("Scheduling a new settlement called '" + a.getName() + "' to arrive at Sol "
 						+ a.getArrivalDate().getTruncatedDateTimeStamp());
 			transportItems.add(a);
@@ -137,7 +142,7 @@ public class TransportManager implements Serializable, Temporal {
 	 */
 	public void reinitalizeInstances(Simulation sim) {
 		this.eventManager = sim.getEventManager();
-		Transportable.initalizeInstances(sim.getMasterClock(), this);
+		Transportable.initalizeInstances(this);
 
 		UnitManager um = sim.getUnitManager();
 		for(Transportable t : transportItems) {
@@ -147,5 +152,13 @@ public class TransportManager implements Serializable, Temporal {
 
 	public ScheduledEventManager getFutureEvents() {
 		return futures;
+	}
+
+	/**
+	 * Get the current mars time
+	 * @return
+	 */
+	public MarsTime getMarsTime() {
+		return clock.getMarsTime();
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/Transportable.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/Transportable.java
@@ -16,7 +16,6 @@ import com.mars_sim.core.interplanetary.transport.resupply.ResupplyUtil;
 import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.person.EventType;
 import com.mars_sim.core.time.MarsTime;
-import com.mars_sim.core.time.MasterClock;
 
 /**
  * An class for an item that is transported between planets/moons/etc.
@@ -34,9 +33,8 @@ public abstract class Transportable
 	private String name;
 
 	protected static TransportManager tm;
-	protected static MasterClock master;
 
-	public Transportable(String name, Coordinates landingSite) {
+	protected Transportable(String name, Coordinates landingSite) {
 		this.name = name;
 		
 		this.landingSite = landingSite;
@@ -108,7 +106,7 @@ public abstract class Transportable
 		// Future: how do we handle a Mars date before sol 0 ?
 		
 		// Set resupply state based on launch and arrival time.
-		MarsTime now = master.getMarsTime();
+		MarsTime now = tm.getMarsTime();
 		MarsTime nextScheduledEvent = launchDate;
 		state = TransitState.PLANNED;
 		if (now.getMissionSol() < travelSols) {
@@ -192,16 +190,13 @@ public abstract class Transportable
 		return nextEvent;
 	}
 
+	/**
+	 * Compare firstly on arrival data and then secondly on name
+	 */
 	@Override
 	public int compareTo(Transportable o) {
-		int result = 0;
-
-		double arrivalTimeDiff = getArrivalDate().getTimeDiff(o.getArrivalDate());
-		if (arrivalTimeDiff < 0D) {
-			result = -1;
-		} else if (arrivalTimeDiff > 0D) {
-			result = 1;
-		} else {
+		int result  = getArrivalDate().compareTo(o.getArrivalDate());
+		if (result == 0) {
 			// If arrival time is the same, compare by name alphabetically.
 			result = getName().compareTo(o.getName());
 		}
@@ -215,8 +210,7 @@ public abstract class Transportable
 	 * @param mc
 	 * @param transportManager
 	 */
-	static void initalizeInstances(MasterClock mc, TransportManager transportManager) {
-		master = mc;
+	static void initalizeInstances(TransportManager transportManager) {
 		tm = transportManager;
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/settlement/ArrivingSettlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/settlement/ArrivingSettlement.java
@@ -13,7 +13,6 @@ import com.mars_sim.core.events.ScheduledEventManager;
 import com.mars_sim.core.interplanetary.transport.Transportable;
 import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.structure.InitialSettlement;
-import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.SettlementBuilder;
 import com.mars_sim.core.time.MarsTime;
 import com.mars_sim.core.tool.RandomUtil;
@@ -174,7 +173,7 @@ public class ArrivingSettlement extends Transportable {
 
 	@Override
 	public String toString() {
-		StringBuffer buff = new StringBuffer();
+		var buff = new StringBuilder();
 		buff.append(getName());
 		buff.append(": ");
 		buff.append(getArrivalDate().getDateTimeStamp());
@@ -187,18 +186,15 @@ public class ArrivingSettlement extends Transportable {
 		InitialSettlement spec = new InitialSettlement(getName(), sponsorCode,
 													   template, populationNum, numOfRobots,
 													   getLandingLocation(), null);
-		Settlement newSettlement = build.createFullSettlement(spec);
-		
-		// Sim is already running so add to the active queue
-		sim.getUnitManager().activateSettlement(newSettlement);
+		build.createFullSettlement(spec);
 	}
 
 	/**
 	 * Schedule the launch for a future date.
 	 */
-	public void scheduleLaunch(ScheduledEventManager futures) {
+	public void scheduleLaunch() {
 		// Determine the arrival date
-		MarsTime proposedArrival = master.getMarsTime().addTime(
+		MarsTime proposedArrival = tm.getMarsTime().addTime(
 					(arrivalSols - 1) * 1000D
 					+ 100 
 					+ RandomUtil.getRandomDouble(890));
@@ -208,6 +204,7 @@ public class ArrivingSettlement extends Transportable {
 	
 	@Override
 	public void reinit(UnitManager um) {
+		// This is not needed
 	}
 
     public void setLandingLocation(Coordinates landingLocation) {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/time/MasterClock.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/time/MasterClock.java
@@ -969,10 +969,8 @@ public class MasterClock implements Serializable {
 		if (listenerExecutor == null 
 				|| listenerExecutor.isShutdown()
 				|| listenerExecutor.isTerminated()) {
-			int num = Math.min(1, SimulationRuntime.NUM_CORES - SimulationConfig.instance().getUnusedCores());
-			if (num <= 0) num = 1;
-			logger.config(3_000, "Setting up " + num + " thread(s) for clock listener.");
-			listenerExecutor = Executors.newFixedThreadPool(num,
+			logger.config(3_000, "Setting up thread(s) for clock listener.");
+			listenerExecutor = Executors.newFixedThreadPool(1,
 					new ThreadFactoryBuilder().setNameFormat("clockListener-%d").build());
 		}
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/unit/TemporalExecutor.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/unit/TemporalExecutor.java
@@ -1,0 +1,34 @@
+/*
+ * Mars Simulation Project
+ * TemporalExecutor.java
+ * @date 2025-07-27
+ * @author Barry Evans
+ */
+package com.mars_sim.core.unit;
+
+import com.mars_sim.core.time.ClockPulse;
+import com.mars_sim.core.time.Temporal;
+
+/**
+ * The interface for an Exector that can apply a pluse to multiple
+ * Temporal instances in parallel
+ */
+public interface TemporalExecutor {
+
+    /**
+     * Aooly a pulse and block until all registered Temporals have applied the Pulse.
+     * @param pulse Pulse to apply
+     */
+    void applyPulse(ClockPulse pulse);
+
+    /**
+     * Stop the executor
+     */
+    void stop();
+
+    /**
+     * Register a new target to the existng collection.
+     * @param s Temporal to add
+     */
+    void addTarget(Temporal s);
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/unit/TemporalExecutorService.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/unit/TemporalExecutorService.java
@@ -1,0 +1,121 @@
+/*
+ * Mars Simulation Project
+ * TemporalExecutorService.java
+ * @date 2025-07-27
+ * @author Barry Evans
+ */
+package com.mars_sim.core.unit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.mars_sim.core.SimulationConfig;
+import com.mars_sim.core.SimulationRuntime;
+import com.mars_sim.core.logging.SimLogger;
+import com.mars_sim.core.time.ClockPulse;
+import com.mars_sim.core.time.Temporal;
+
+/**
+ * This is an implementation of a Temporal Excutor that uses a ExecutorService coupled with Callable 
+ * to apply a clock pulse in parallel.
+ */
+public class TemporalExecutorService implements TemporalExecutor {
+
+	/**
+	 * Prepares the Temporal task for setting up its own thread.
+	 */
+	private static class TemporalTask implements Callable<String> {
+		private Temporal target;
+		private ClockPulse currentPulse;
+
+		TemporalTask(Temporal target) {
+			this.target = target;
+		}
+
+		void setCurrentPulse(ClockPulse pulse) {
+			this.currentPulse = pulse;
+		}
+
+		@Override
+		public String call() throws Exception {
+			try {
+				target.timePassing(currentPulse);
+			}
+			catch (RuntimeException rte) {
+				String msg = "Problem with pulse on " + target
+        					  + ": " + rte.getMessage();
+	            logger.severe(msg, rte);
+	            return msg;
+			}
+			return target + " completed pulse #" + currentPulse.getId();
+		}
+	}
+
+    private static final SimLogger logger = SimLogger.getLogger(TemporalExecutorService.class.getName());
+
+    private ExecutorService executor;
+    private List<TemporalTask> tasks = new ArrayList<>();
+
+    /**
+     * Create a blank temporal executor
+     */
+    public TemporalExecutorService(String name) {
+        int maxThreads = SimulationRuntime.NUM_CORES - SimulationConfig.instance().getUnusedCores();
+
+
+        logger.config("Setting up a caching thread factory wuth a max " + maxThreads);
+
+        // This replaces the Executor.newCachedThreadPool method but enforces a max thread
+        executor = new ThreadPoolExecutor(0, maxThreads,
+                                      60L, TimeUnit.SECONDS,
+                                      new SynchronousQueue<>(),
+                                      new ThreadFactoryBuilder().setNameFormat(name + "-%d").build());
+    }
+
+    /**
+     * Apply a new pulse to all the registered temporals.
+     */
+    @Override
+    public void applyPulse(ClockPulse pulse) {
+
+		// May use parallelStream() after it's proven to be safe
+		tasks.stream().forEach(s -> s.setCurrentPulse(pulse));
+
+		// Execute all listener concurrently and wait for all to complete before advancing
+		// Ensure that Settlements stay synch'ed and some don't get ahead of others as tasks queue
+		try {
+			List<Future<String>> results = executor.invokeAll(tasks);
+			for (Future<String> future : results) {
+				future.get();
+			}
+		}
+		catch (ExecutionException ee) {
+			// Problem running the pulse
+			logger.severe("Problem running the settlement task pulses : ", ee);
+		}
+		catch (InterruptedException ie) {
+			// Program probably exiting
+			if (executor.isShutdown()) {
+				Thread.currentThread().interrupt();
+			}
+		}
+    }
+
+    @Override
+    public void stop() {
+        executor.shutdown();
+    }
+
+    @Override
+    public void addTarget(Temporal s) {
+        tasks.add(new TemporalTask(s));
+    }
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/unit/TemporalExecutorService.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/unit/TemporalExecutorService.java
@@ -11,14 +11,10 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.mars_sim.core.SimulationConfig;
-import com.mars_sim.core.SimulationRuntime;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.Temporal;
@@ -68,16 +64,10 @@ public class TemporalExecutorService implements TemporalExecutor {
      * Create a blank temporal executor
      */
     public TemporalExecutorService(String name) {
-        int maxThreads = SimulationRuntime.NUM_CORES - SimulationConfig.instance().getUnusedCores();
+        logger.config("Setting up a caching thread factory wuth a caching strategy");
 
-
-        logger.config("Setting up a caching thread factory wuth a max " + maxThreads);
-
-        // This replaces the Executor.newCachedThreadPool method but enforces a max thread
-        executor = new ThreadPoolExecutor(0, maxThreads,
-                                      60L, TimeUnit.SECONDS,
-                                      new SynchronousQueue<>(),
-                                      new ThreadFactoryBuilder().setNameFormat(name + "-%d").build());
+        // Use a standard cached thread pool
+        executor = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat(name + "-%d").build());
     }
 
     /**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/unit/TemporalThreadExecutor.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/unit/TemporalThreadExecutor.java
@@ -1,0 +1,121 @@
+/*
+ * Mars Simulation Project
+ * TemporalThreadExecutor.java
+ * @date 2025-07-27
+ * @author Barry Evans
+ */
+package com.mars_sim.core.unit;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
+
+import com.mars_sim.core.logging.SimLogger;
+import com.mars_sim.core.time.ClockPulse;
+import com.mars_sim.core.time.Temporal;
+
+/**
+ * This class implement a TemporalExecutor that uses a blocking worker Thread per Temporal
+ * managed.
+ */
+public class TemporalThreadExecutor implements TemporalExecutor {
+	/**
+	 * Prepares the Settlement task for setting up its own thread.
+	 */
+	private static class TemporalRunnable implements Runnable {
+		private Temporal target;
+		private ClockPulse currentPulse;
+		private Semaphore startLock = new Semaphore(0);  // Sets as zero so initially thread is blocked
+		private Semaphore doneLock = new Semaphore(0);  // Sets as zero so initially caller is blocked
+
+		private boolean keepRunning = true;
+
+		
+		private TemporalRunnable(Temporal target) {
+			this.target = target;
+		}
+
+		void applyPulse(ClockPulse pulse) {
+			this.currentPulse = pulse;
+			startLock.release();	// Release the worker element and processes in the background
+		}
+
+		/**
+		 * Wait for teh current pulse to be applied
+		 */
+		private void awaitPulse() {
+			try {
+				doneLock.acquire();
+			} catch (InterruptedException e) {
+				logger.severe(target + ": Problem waitng for pulse", e);
+			}
+		}
+
+		private void stop() {
+			keepRunning = false;
+            startLock.release();
+		}
+
+		@Override
+		public void run() {
+			// Keep running as will break once keepRunnign flag changes
+			while(true) {
+				try {
+					startLock.acquire();
+				} catch (InterruptedException e) {
+				    logger.severe(target + ": Problem waiting for startLock", e);
+				} // Wait for the pulse
+
+				// Graceful closedown
+				if (!keepRunning) {
+					break;
+				}
+
+				try {
+					target.timePassing(currentPulse);
+					doneLock.release();  // Notify parent pulse has been applied
+				}
+				catch (RuntimeException rte) {
+					logger.severe(target + ": Problem with Pulse", rte);
+				}	
+			}
+		}
+	}
+    
+    private static final SimLogger logger = SimLogger.getLogger(TemporalThreadExecutor.class.getName());
+    private Set<TemporalRunnable> tasks = new HashSet<>();
+
+    @Override
+    public void applyPulse(ClockPulse pulse) {
+
+		// Wakeup each thread by applying the latest Pulse
+		tasks.stream().forEach(s -> s.applyPulse(pulse));
+
+		// Wait for all to apply the new pulse as this is a blocking operation
+		// order of completion does not matter
+		// These must be seperate to applow the Thread to process
+		tasks.stream().forEach(s -> s.awaitPulse());
+    }
+
+    /**
+     * Stop all threads
+     */
+    @Override
+    public void stop() {
+        logger.info("Stopping executor");
+        tasks.stream().forEach(s -> s.stop());
+    }
+
+    /**
+     * Add a new Temporal to the executor. This will create a new Thread.
+     * @param s Temporal to add
+     */
+    @Override
+    public void addTarget(Temporal s) {
+        var task = new TemporalRunnable(s);
+        tasks.add(task);
+
+        var t = new Thread(task, s.toString() + " Pulse");
+        t.start();
+    }
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/OperateVehicle.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/OperateVehicle.java
@@ -737,7 +737,7 @@ public abstract class OperateVehicle extends Task {
 	 * @return true if destination is at a settlement location.
 	 */
 	private boolean isSettlementDestination() {
-        return unitManager.isSettlement(destination);
+        return unitManager.findSettlement(destination) != null;
     }
 	
 	/**

--- a/mars-sim-core/src/main/resources/xml/simulation.xml
+++ b/mars-sim-core/src/main/resources/xml/simulation.xml
@@ -3,7 +3,7 @@
 	<!ELEMENT simulation-configuration (time-configuration, mission-configuration)>
 	<!ELEMENT time-configuration (base-time-ratio, min-simulated-pulse, max-simulated-pulse, default-time-pulse,
 	accuracy-bias, earth-start-date-time, mars-start-date-time, autosave-interval, autosave-number, average-transit-time,
-	unused-cores)>
+	executor-type)>
 	<!ATTLIST simulation-configuration content-url CDATA #IMPLIED>
 	<!ELEMENT base-time-ratio EMPTY>
 	<!ATTLIST base-time-ratio value CDATA #REQUIRED>
@@ -25,8 +25,8 @@
 	<!ATTLIST autosave-number value CDATA #REQUIRED>
 	<!ELEMENT average-transit-time EMPTY>
 	<!ATTLIST average-transit-time value CDATA #REQUIRED>
-	<!ELEMENT unused-cores EMPTY>
-	<!ATTLIST unused-cores value CDATA #REQUIRED>
+	<!ELEMENT executor-type EMPTY>
+	<!ATTLIST executor-type value CDATA #REQUIRED>
 	<!ELEMENT mission-configuration (min-eva-light)>
 	<!ELEMENT min-eva-light EMPTY>
 	<!ATTLIST min-eva-light value CDATA #REQUIRED>
@@ -40,7 +40,7 @@
 		<!-- The base time ratio (TR) is the default simulation time ratio : the ratio of real time to sim time prior to modification
 			Note 1 : It denotes the initial speed of the simulation.
 			     2 : Value must be a positive integer between 16 and 2048 and cannot be zero.
-			     3 : The calculated TR is dependent upon the # of cpu threads available on user's machine.
+			     3 : The calculated TR is dependent upon the # of cpu threads available on users machine.
 			     4 : The base TR value below will be overridden by the calculated TR at the start of the sim.
 		-->
 		<!-- Default: 128. Min is 1. Max is 21870.  -->
@@ -129,11 +129,10 @@
 		<!-- Default: 66 -->
 		<average-transit-time value="66" />
 
-		<!-- unused-cores is the difference between the number of cores and the number of simulation threads -->
-		<!-- unused-cores are the numbers of cores that are free from being used by mars-sim -->
-		<!-- Min : 0 -->
-		<!-- Default: 2 -->
-		<unused-cores value="2" />
+		<!-- executor-type governs the type of temporal executor can be used in a Unitmanager -->
+		<!-- Default: shared : Shared thread model using a Callable -->
+		<!-- thread : Each Temporal runs on a permenant dedicated Thread -->
+		<executor-type value="shared" />
 	</time-configuration>
 
 	<!-- Lists configuration for missions -->

--- a/mars-sim-core/src/test/java/com/mars_sim/core/time/MarsTimeTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/time/MarsTimeTest.java
@@ -51,6 +51,16 @@ public class MarsTimeTest extends TestCase {
         assertEquals("Difference of different sol", 1050D, later.getTimeDiff(start));
     }
 
+    public void testCompare() {
+        MarsTime start = new MarsTime(1,1, 1, 100D, 1);
+
+        assertEquals("Compare same time", 0, start.compareTo(start));
+
+        MarsTime later = start.addTime(1000D);
+        assertEquals("Compare old to new", -1, start.compareTo(later));
+        assertEquals("Compare new to old", 1, later.compareTo(start));
+    }
+
     public void testMarsDate() {
         MarsTime start = new MarsTime(1,1, 1, 100D, 1);
         MarsTime later = new MarsTime(1,1, 1, 150D, 1);


### PR DESCRIPTION
This PR isolates the threading logic from UnitManager into a new set of classes that provide an option to change the executor behaviour. This is configured in a new property called 'executor-type' that can have 2 options:

1. 'shared' - This value uses a cached tread pool to executable the pulse in the Settlements. This is similar to the original approach but is allowed to grow and shrink the pool size as demand permits
2. 'thread' - This value uses a dedicated permanent Thread per Settlement. This removes the excessive logic of using Callables.

In addition, the dependencies on UnitManager and TransportManager have been reduced,
ref #1614