### PR TITLE
Add caching to the inside path routing

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/BuildingCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/BuildingCommand.java
@@ -9,14 +9,12 @@ package com.mars_sim.console.chat.simcommand.settlement;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 
 import com.mars_sim.console.chat.ChatCommand;
 import com.mars_sim.console.chat.Conversation;
 import com.mars_sim.console.chat.simcommand.CommandHelper;
 import com.mars_sim.console.chat.simcommand.StructuredResponse;
 import com.mars_sim.core.building.Building;
-import com.mars_sim.core.building.BuildingManager;
 import com.mars_sim.core.malfunction.MalfunctionManager;
 import com.mars_sim.core.structure.Settlement;
 
@@ -34,10 +32,13 @@ public class BuildingCommand extends AbstractSettlementCommand {
 	protected boolean execute(Conversation context, String input, Settlement settlement) {
 		StructuredResponse response = new StructuredResponse();
 		
-		BuildingManager bm = settlement.getBuildingManager();
-		List<Building> i = new ArrayList<>(bm.getBuildingSet());
+		var cm = settlement.getBuildingConnectorManager();
+		response.appendLabeledString("Path Cache", cm.getPathCacheStatus());
+
+		var bm = settlement.getBuildingManager();
+		var i = new ArrayList<>(bm.getBuildingSet());
 		Collections.sort(i);
-		
+	
 		response.appendTableHeading("Building", CommandHelper.BUILIDNG_WIDTH, 
 									"Category", 12, 
 									"Power Mode", 10,

--- a/mars-sim-core/src/main/java/com/mars_sim/core/SimulationBuilder.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/SimulationBuilder.java
@@ -10,7 +10,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -384,10 +383,7 @@ public class SimulationBuilder {
 		}
 		
 		// Pick a random name
-		List<String> settlementNames = authority.getSettlementNames();
-		// Use shuffle to alter the order of these settlement names
-		Collections.shuffle(settlementNames);
-		
+		List<String> settlementNames = authority.getSettlementNames();		
 		String settlementName = RandomUtil.getRandomElement(settlementNames);
 		
 		logger.info("Starting a single settlement sim using template '" + template

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/BuildingConnectorManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/BuildingConnectorManager.java
@@ -8,11 +8,15 @@ package com.mars_sim.core.building.connection;
 
 import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -39,6 +43,9 @@ public class BuildingConnectorManager implements Serializable {
 	/** Comparison to indicate a small but non-zero amount. */
 	private static final double SMALL_AMOUNT_COMPARISON = .0000001D;
 
+	private static record PathKey(Building start, Building end) {};
+	private transient Map<PathKey,List<InsidePathLocation>> learntPaths = buildCache();
+	
 	/**
 	 * Inner class for representing a partial building connector.
 	 */
@@ -310,15 +317,6 @@ public class BuildingConnectorManager implements Serializable {
 	}
 
 	/**
-	 * Gets the settlement.
-	 * 
-	 * @return settlement.
-	 */
-	public Settlement getSettlement() {
-		return settlement;
-	}
-
-	/**
 	 * Adds a new building connector.
 	 * 
 	 * @param buildingConnector new building connector.
@@ -419,19 +417,24 @@ public class BuildingConnectorManager implements Serializable {
 	/**
 	 * Checks if there is a valid interior walking path between two buildings.
 	 * 
-	 * @param building1 the first building.
-	 * @param building2 the second building.
+	 * @param startBuilding the first building.
+	 * @param endBuilding the second building.
 	 * @return true if valid interior walking path.
 	 */
-	public boolean hasValidPath(Building building1, Building building2) {
+	public boolean hasValidPath(Building startBuilding, Building endBuilding) {
+		// Check agsint the already learnt paths
+		PathKey key = new PathKey(startBuilding, endBuilding);
+		if (learntPaths.containsKey(key)) {
+			return true;
+		}
 
-		BuildingLocation start = new BuildingLocation(building1, building1.getPosition());
-		BuildingLocation end = new BuildingLocation(building2, building2.getPosition());
+		BuildingLocation start = new BuildingLocation(startBuilding, startBuilding.getPosition());
+		BuildingLocation end = new BuildingLocation(endBuilding, endBuilding.getPosition());
 		var finder = new PathFinder(this, start, end);
 
 		var result = finder.isValidRoute();
 		if (!result && logger.isLoggable(Level.FINEST)) {
-			logger.fine(building1, "Unable to find valid interior walking path to " + building2);
+			logger.fine(startBuilding, "Unable to find valid interior walking path to " + endBuilding);
 		}
 
 		return result;
@@ -448,13 +451,24 @@ public class BuildingConnectorManager implements Serializable {
 	 */
 	public InsideBuildingPath determineShortestPath(Building startBuilding, LocalPosition startPosition,
 			Building endBuilding, LocalPosition endPosition) {
+		// Check agsint the already learnt paths
+		PathKey key = new PathKey(startBuilding, endBuilding);
+		var foundPath = learntPaths.get(key);
+		if (foundPath != null) {
+			// Reuse the found path but alter the start and end posns
+			return new InsideBuildingPath(foundPath, startPosition, endPosition);
+		}
 
 		BuildingLocation start = new BuildingLocation(startBuilding, startPosition);
 		BuildingLocation end = new BuildingLocation(endBuilding, endPosition);
 
 		var finder = new PathFinder(this, start, end);
 		if (finder.isValidRoute()) {
-			return finder.toPath();
+			// Actual path is immutable so it can be shared savely
+			var sharedPath = Collections.unmodifiableList(finder.toPath());
+			learntPaths.put(key, sharedPath);
+
+			return new InsideBuildingPath(sharedPath);
 		}
 		return null;
 	}
@@ -780,12 +794,23 @@ public class BuildingConnectorManager implements Serializable {
 	 * Prepares object for garbage collection.
 	 */
 	public void destroy() {
-		settlement = null;
-		Iterator<BuildingConnector> i = buildingConnections.iterator();
-		while (i.hasNext()) {
-			i.next().destroy();
-		}
+		buildingConnections.forEach(c -> c.destroy());
 		buildingConnections = null;
 	}
 
+	/**
+	 * Initiase the 
+	 * @param in
+	 * @throws IOException
+	 * @throws ClassNotFoundException
+	 */
+	private void readObject(java.io.ObjectInputStream in)
+    throws IOException, ClassNotFoundException {
+		in.defaultReadObject();
+		learntPaths = buildCache();
+	}
+
+	private static Map<PathKey, List<InsidePathLocation>> buildCache() {
+		return new HashMap<>();
+	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/BuildingConnectorManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/BuildingConnectorManager.java
@@ -12,15 +12,15 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.mars_sim.core.LocalAreaUtil;
 import com.mars_sim.core.building.Building;
 import com.mars_sim.core.building.BuildingManager;
@@ -43,9 +43,47 @@ public class BuildingConnectorManager implements Serializable {
 	/** Comparison to indicate a small but non-zero amount. */
 	private static final double SMALL_AMOUNT_COMPARISON = .0000001D;
 
-	private static record PathKey(Building start, Building end) {};
-	private transient Map<PathKey,List<InsidePathLocation>> learntPaths = buildCache();
+	/**
+	 * This be a bidirectional equality. Ends are stored according to the identfier value.
+	 * A,B == B,A as well as A,B == A,B
+	 */
+	private static class PathKey {
+		private Building lower;
+		private Building upper;
+
+		PathKey(Building start, Building end) {
+			if (start.getIdentifier() < end.getIdentifier()) {
+				this.lower = start;
+				this.upper = end;
+			}
+			else {
+				this.upper = start;
+				this.lower = end;
+			}
+		}
+
+		@Override
+		public int hashCode() {
+			return lower.hashCode();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			PathKey other = (PathKey) obj;
+			if (!lower.equals(other.lower))
+				return false;
+			return upper.equals(other.upper);
+		}
+	}
 	
+	private transient Cache<PathKey,List<InsidePathLocation>> learntPaths = buildCache();
+
 	/**
 	 * Inner class for representing a partial building connector.
 	 */
@@ -424,7 +462,7 @@ public class BuildingConnectorManager implements Serializable {
 	public boolean hasValidPath(Building startBuilding, Building endBuilding) {
 		// Check agsint the already learnt paths
 		PathKey key = new PathKey(startBuilding, endBuilding);
-		if (learntPaths.containsKey(key)) {
+		if (learntPaths.getIfPresent(key) != null) {
 			return true;
 		}
 
@@ -451,16 +489,17 @@ public class BuildingConnectorManager implements Serializable {
 	 */
 	public InsideBuildingPath determineShortestPath(Building startBuilding, LocalPosition startPosition,
 			Building endBuilding, LocalPosition endPosition) {
-		// Check agsint the already learnt paths
-		PathKey key = new PathKey(startBuilding, endBuilding);
-		var foundPath = learntPaths.get(key);
-		if (foundPath != null) {
-			// Reuse the found path but alter the start and end posns
-			return new InsideBuildingPath(foundPath, startPosition, endPosition);
-		}
-
+		
 		BuildingLocation start = new BuildingLocation(startBuilding, startPosition);
 		BuildingLocation end = new BuildingLocation(endBuilding, endPosition);
+
+		// Check agsint the already learnt paths
+		PathKey key = new PathKey(startBuilding, endBuilding);
+		var foundPath = learntPaths.getIfPresent(key);
+		if (foundPath != null) {
+			// Reuse the found path but alter the start and end posns
+			return new InsideBuildingPath(foundPath, start, end);
+		}
 
 		var finder = new PathFinder(this, start, end);
 		if (finder.isValidRoute()) {
@@ -805,12 +844,31 @@ public class BuildingConnectorManager implements Serializable {
 	 * @throws ClassNotFoundException
 	 */
 	private void readObject(java.io.ObjectInputStream in)
-    throws IOException, ClassNotFoundException {
+    	throws IOException, ClassNotFoundException {
 		in.defaultReadObject();
 		learntPaths = buildCache();
 	}
 
-	private static Map<PathKey, List<InsidePathLocation>> buildCache() {
-		return new HashMap<>();
+	/**
+	 * Get a status of the learnt path cache
+	 * @return
+	 */
+	public String getPathCacheStatus() {
+		var stats = learntPaths.stats();
+		return "Size=" + learntPaths.size() + ", Hit rate=" + Math.round(stats.hitRate() * 1000D)/10D
+			+ "%, requests=" + stats.requestCount() + ", evicted=" + stats.evictionCount();
+	}
+
+	/**
+	 * Use a cache that will purge the older paths
+	 * @return
+	 */
+	private static Cache<PathKey, List<InsidePathLocation>> buildCache() {
+		// Set a maximum number of routes to be cached
+		// Use a concurrency of 1 because it's a private Cache for this settlement
+		return CacheBuilder.newBuilder()
+						.recordStats()
+						.concurrencyLevel(1)
+						.maximumSize(100).build();
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/BuildingLocation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/BuildingLocation.java
@@ -43,4 +43,26 @@ public class BuildingLocation implements Serializable, InsidePathLocation {
     public LocalPosition getPosition() {
     	return pos;
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((building == null) ? 0 : building.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        BuildingLocation other = (BuildingLocation) obj;
+       if (!building.equals(other.building))
+            return false;
+        return pos.equals(other.pos);
+    }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/InsideBuildingPath.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/InsideBuildingPath.java
@@ -7,9 +7,11 @@
 package com.mars_sim.core.building.connection;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+
+import com.mars_sim.core.map.location.LocalPosition;
 
 /**
  * A path of location navigation objects at a settlement.
@@ -25,26 +27,35 @@ public class InsideBuildingPath implements Serializable {
     /**
      * Constructor.
      */
-    public InsideBuildingPath() {
-        pathLocations = new CopyOnWriteArrayList<>();
-        nextLocationIndex = 0;
+    public InsideBuildingPath(List<InsidePathLocation> path) {
+        pathLocations = path;
+        nextLocationIndex = 1;
     }
 
-    
     /**
-     * Adds a new location object to the path.
-     * 
-     * @param newLocation new location object.
+     * Create an instance by taking the base path and replacing the start and end position
+     * @param basePath
+     * @param startPosition
+     * @param endPosition
      */
-    public void addPathLocation(InsidePathLocation newLocation){
-        if (!pathLocations.contains(newLocation)) {
-            pathLocations.add(newLocation);
+    public InsideBuildingPath(List<InsidePathLocation> basePath, LocalPosition startPosition,
+            LocalPosition endPosition) {
+        pathLocations = new ArrayList<>();
+        var origStart = (BuildingLocation)basePath.get(0);
+        pathLocations.add(new BuildingLocation(origStart.getBuilding(), startPosition));
+
+        int endIndex = basePath.size()-1;
+
+        // Copy over the middle section
+        for(int idx = 1; idx < endIndex; idx++) {
+            pathLocations.add(basePath.get(idx));
         }
-        else {
-            throw new IllegalArgumentException("Path already includes new location object");
-        }
+        var origEnd = (BuildingLocation)basePath.get(endIndex);
+        pathLocations.add(new BuildingLocation(origEnd.getBuilding(), endPosition));
+        nextLocationIndex = 1;
     }
-    
+
+
     /**
      * Checks if the building path contains a given location object.
      * 
@@ -76,7 +87,7 @@ public class InsideBuildingPath implements Serializable {
      */
     public List<InsidePathLocation> getRemainingPathLocations() {
         
-        List<InsidePathLocation> result = new CopyOnWriteArrayList<>();
+        List<InsidePathLocation> result = new ArrayList<>();
         for (int x = nextLocationIndex; x < pathLocations.size(); x++) {
             result.add(pathLocations.get(x));
         }
@@ -127,17 +138,5 @@ public class InsideBuildingPath implements Serializable {
     
     public List<InsidePathLocation> getPathLocations() {
     	return pathLocations;
-    }
-    
-    public int getNextLocationIndex() {
-    	return nextLocationIndex;
-    }
-    
-    /**
-     * Destroys object.
-     */
-    public void destroy() {
-        pathLocations.clear();
-        pathLocations = null;
     }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/InsideBuildingPath.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/InsideBuildingPath.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import com.mars_sim.core.map.location.LocalPosition;
 
 /**
  * A path of location navigation objects at a settlement.
@@ -33,25 +32,37 @@ public class InsideBuildingPath implements Serializable {
     }
 
     /**
-     * Create an instance by taking the base path and replacing the start and end position
+     * Create an instance by taking the base path and replacing the start and end position.
+     * The base path may be in a reverse order.
      * @param basePath
      * @param startPosition
      * @param endPosition
      */
-    public InsideBuildingPath(List<InsidePathLocation> basePath, LocalPosition startPosition,
-            LocalPosition endPosition) {
+    public InsideBuildingPath(List<InsidePathLocation> basePath, BuildingLocation startPosition,
+            BuildingLocation endPosition) {
+         
         pathLocations = new ArrayList<>();
-        var origStart = (BuildingLocation)basePath.get(0);
-        pathLocations.add(new BuildingLocation(origStart.getBuilding(), startPosition));
+        pathLocations.add(startPosition);
 
-        int endIndex = basePath.size()-1;
-
-        // Copy over the middle section
-        for(int idx = 1; idx < endIndex; idx++) {
-            pathLocations.add(basePath.get(idx));
+        // Is the new end at the start of the base path
+        if (((BuildingLocation)basePath.get(0)).getBuilding().equals(endPosition.getBuilding())) {
+            // base path is in reverse order
+            for(int idx = basePath.size()-2; idx > 0 ; idx--) {
+                pathLocations.add(basePath.get(idx));
+            }
         }
-        var origEnd = (BuildingLocation)basePath.get(endIndex);
-        pathLocations.add(new BuildingLocation(origEnd.getBuilding(), endPosition));
+        else if (!((BuildingLocation)basePath.get(0)).getBuilding().equals(startPosition.getBuilding())) {
+            throw new IllegalArgumentException("Base path for not match either end");
+        }
+        else {
+            // In correct order
+            for(int idx = 1; idx < basePath.size()-1; idx++) {
+                pathLocations.add(basePath.get(idx));
+            }
+        }
+
+        // Add new end
+        pathLocations.add(endPosition);
         nextLocationIndex = 1;
     }
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/PathFinder.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/connection/PathFinder.java
@@ -125,13 +125,14 @@ public class PathFinder {
      * 
      * @return
      */
-    public InsideBuildingPath toPath() {
+    public List<InsidePathLocation> toPath() {
         if (!isValidRoute()) {
             throw new IllegalStateException("No valid route found.");
         }
 
-        InsideBuildingPath newPath = new InsideBuildingPath();
-        newPath.addPathLocation(start);
+        List<InsidePathLocation> path = new ArrayList<>();
+
+        path.add(start);
 
         // Remove start building off the best route
         var finalRoute = new ArrayList<>(bestRoute);
@@ -150,27 +151,25 @@ public class PathFinder {
                 // Add building connector to new path with hatches if needed
                 if (connector.isSplitConnection()) {
                     boolean isCurrentBuilding1 = connector.getBuilding1().equals(current);
-                    newPath.addPathLocation(isCurrentBuilding1 ? connector.getHatch1() : connector.getHatch2());
-                    newPath.addPathLocation(connector);
-                    newPath.addPathLocation(!isCurrentBuilding1 ? connector.getHatch1() : connector.getHatch2());
+                    path.add(isCurrentBuilding1 ? connector.getHatch1() : connector.getHatch2());
+                    path.add(connector);
+                    path.add(!isCurrentBuilding1 ? connector.getHatch1() : connector.getHatch2());
                 } else {
-                    newPath.addPathLocation(connector);
+                    path.add(connector);
                 }
             }
 
             // Last building needs the end position
             if (!b.equals(end.getBuilding())) {
-                newPath.addPathLocation(b);
+                path.add(b);
             }
 
             current = b; // Update current building
         }
 
         // Add the explicit end position
-        newPath.addPathLocation(end);
+        path.add(end);
     
-        newPath.iteratePathLocation(); // This feels wrong but all the calling code is based on this
-        return newPath;
+        return path;
     }
-
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/tool/RandomUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/tool/RandomUtil.java
@@ -11,8 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
-
 
 /**
  * The RandomUtil class is a library of various random-related methods.
@@ -37,12 +35,14 @@ public final class RandomUtil {
 	// See Mersenne Twister in JAVA 
 	// at http://www.math.sci.hiroshima-u.ac.jp/m-mat/MT/VERSIONS/JAVA/java.html
 	
-	private static final Random random = ThreadLocalRandom.current();
+	// Initiaise the Ramdom with a seed based oon current time
+	private static ThreadLocal<Random> random = ThreadLocal.withInitial(() -> new Random(System.currentTimeMillis()));
+
 
 	private RandomUtil() {}
 
 	public static Random getRandom() {
-		return random;
+		return random.get();
 	}
 
 
@@ -85,7 +85,7 @@ public final class RandomUtil {
 	 * @return true if random percent is less than percentage limit
 	 */
 	public static boolean lessThanRandPercent(int randomLimit) {
-		int rand = random.nextInt(100) + 1;
+		int rand = getRandom().nextInt(100) + 1;
 		return rand < randomLimit;
 	}
 
@@ -96,7 +96,7 @@ public final class RandomUtil {
 	 * @return true if random percent is less than percentage limit
 	 */
 	public static boolean lessThanRandPercent(double randomLimit) {
-		double rand = random.nextDouble() * 100;
+		double rand = getRandom().nextDouble() * 100;
 		return rand < randomLimit;
 	}
 
@@ -109,7 +109,7 @@ public final class RandomUtil {
 	public static int getRandomInt(int ceiling) {
 		if (ceiling < 0)
 			throw new IllegalArgumentException(Msg.getString("RandomUtil.log.ceilingMustBePositive") + ceiling); //$NON-NLS-1$
-		return random.nextInt(ceiling + 1);
+		return getRandom().nextInt(ceiling + 1);
 	}
 
 	/**
@@ -123,7 +123,7 @@ public final class RandomUtil {
 	public static int getRandomInt(int base, int ceiling) {
 		if (ceiling < base)
 			throw new IllegalArgumentException(Msg.getString("RandomUtil.log.ceilingMustGreaterBase")); //$NON-NLS-1$
-		return random.nextInt(ceiling - base + 1) + base;
+		return getRandom().nextInt(ceiling - base + 1) + base;
 	}
 
 	/**
@@ -133,7 +133,7 @@ public final class RandomUtil {
 	 * @return the random number
 	 */
 	public static double getRandomDouble(double ceiling) {
-		return random.nextDouble() * ceiling;
+		return getRandom().nextDouble() * ceiling;
 	}
 
 	/**
@@ -146,7 +146,7 @@ public final class RandomUtil {
 		if (ceiling < base)
 			throw new IllegalArgumentException(Msg.getString("RandomUtil.log.ceilingMustGreaterBase")); //$NON-NLS-1$
 		// Note: switch from using ThreadLocalRandom.current().nextDouble(base, ceiling)
-		return (random.nextDouble() * (ceiling - base)) + base;
+		return (getRandom().nextDouble() * (ceiling - base)) + base;
 	}
 
 	/**
@@ -157,7 +157,7 @@ public final class RandomUtil {
 	 * @return the random number
 	 */
 	public static double getGaussianDouble() {
-		return random.nextGaussian();
+		return getRandom().nextGaussian();
 	}
 
 	/**

--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/BuildingConnectorManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/BuildingConnectorManagerTest.java
@@ -347,11 +347,17 @@ public class BuildingConnectorManagerTest extends TestCase {
 
         // Check the repeat path finding half the original time to show cachign has worked
         assertTrue("Reduced time on repeat path", secondDuration < (firstDuration/2));
-
-        // Compare paths
         assertNotEquals("Cached path different", path, path2);
         assertPathValidity(path2, lHab, lHab.getPosition(), lab, lab.getPosition());
 
+        // Try reverse path
+        startTime = System.nanoTime();
+        var reversePath = manager.determineShortestPath(lab, lab.getPosition(), lHab, lHab.getPosition());
+        long reverseDuration = System.nanoTime() - startTime;
+        assertTrue("Reduced time on repeat path", reverseDuration < (firstDuration/2));
+        assertPathValidity(reversePath, lab, lab.getPosition(), lHab, lHab.getPosition());
+
+        // Change start position
         var newStart = lHab.getPosition().getPosition(0.01, 0);
 
         startTime = System.currentTimeMillis();

--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/InsideBuildingPathTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/connection/InsideBuildingPathTest.java
@@ -1,5 +1,7 @@
 package com.mars_sim.core.building.connection;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.mars_sim.core.AbstractMarsSimUnitTest;
@@ -15,9 +17,9 @@ public class InsideBuildingPathTest extends AbstractMarsSimUnitTest {
 	private static final LocalPosition POSITION_10X10 = new LocalPosition(10D, 10D);
     private static final BoundedObject BUILDING_POSN = new BoundedObject(0, 0, 20, 20, 0);
 
-	public void testConstructor() {
+	public void testEmptyPath() {
         
-        InsideBuildingPath path = new InsideBuildingPath();
+        InsideBuildingPath path = new InsideBuildingPath(Collections.emptyList());
         assertEquals(0D, path.getPathLength());
         assertNull(path.getNextPathLocation());
         
@@ -27,113 +29,100 @@ public class InsideBuildingPathTest extends AbstractMarsSimUnitTest {
     }
     
     public void testAddPathLocation() {
-        
-        InsideBuildingPath path = new InsideBuildingPath();
-        assertEquals(0D, path.getPathLength());
-        assertNull(path.getNextPathLocation());
-        
-        List<InsidePathLocation> remainingLocations1 = path.getRemainingPathLocations();
-        assertNotNull(remainingLocations1);
-        assertEquals(0, remainingLocations1.size());
+
         
         MockSettlement settlement = new MockSettlement();
         MockBuilding building = new MockBuilding(settlement, "1", BUILDING_POSN);
         InsidePathLocation location = new BuildingLocation(building, POSITION_5X5);
-        
-        assertFalse(path.containsPathLocation(location));
-        
-        path.addPathLocation(location);
-        
+                
+        List<InsidePathLocation> steps = new ArrayList<>();
+
+        steps.add(location);
+        InsideBuildingPath path = new InsideBuildingPath(steps);
+
         assertTrue(path.containsPathLocation(location));
         
         assertEquals(0D, path.getPathLength());
-        assertEquals(location, path.getNextPathLocation());
+        assertNull(path.getNextPathLocation());
         
         List<InsidePathLocation> remainingLocations2 = path.getRemainingPathLocations();
         assertNotNull(remainingLocations2);
-        assertEquals(1, remainingLocations2.size());
-        assertEquals(location, remainingLocations2.get(0));
+        assertTrue(remainingLocations2.isEmpty());
     }
     
     public void testIteratePathLocation() {
         
-        InsideBuildingPath path = new InsideBuildingPath();
         
         MockSettlement settlement = new MockSettlement();
         MockBuilding building = new MockBuilding(settlement, "1", BUILDING_POSN);
         InsidePathLocation location1 = new BuildingLocation(building, POSITION_5X5);
-        path.addPathLocation(location1);
+
+        List<InsidePathLocation> steps = new ArrayList<>();
+        steps.add(location1);
         
         InsidePathLocation location2 = new BuildingLocation(building, POSITION_10X5);
-        path.addPathLocation(location2);
-        
-        assertEquals(location1, path.getNextPathLocation());
-        
-        path.iteratePathLocation();
+        steps.add(location2);
+        InsideBuildingPath path = new InsideBuildingPath(steps);
         
         assertEquals(location2, path.getNextPathLocation());
     }
     
     public void testGetRemainingLocations() {
         
-        InsideBuildingPath path = new InsideBuildingPath();
         
         MockSettlement settlement = new MockSettlement();
         MockBuilding building = new MockBuilding(settlement, "1", BUILDING_POSN);
         
+        List<InsidePathLocation> steps = new ArrayList<>();
+
         InsidePathLocation location1 = new BuildingLocation(building, POSITION_5X5);
-        path.addPathLocation(location1);
+        steps.add(location1);
         
         InsidePathLocation location2 = new BuildingLocation(building, POSITION_10X5);
-        path.addPathLocation(location2);
+        steps.add(location2);
         
         InsidePathLocation location3 = new BuildingLocation(building, POSITION_10X10);
-        path.addPathLocation(location3);
+        steps.add(location3);
         
+        InsideBuildingPath path = new InsideBuildingPath(steps);
+        assertEquals(3, path.getPathLocations().size());
+
         List<InsidePathLocation> remainingLocations1 = path.getRemainingPathLocations();
         assertNotNull(remainingLocations1);
-        assertEquals(3, remainingLocations1.size());
-        assertEquals(location1, remainingLocations1.get(0));
+        assertEquals(2, remainingLocations1.size());
+        assertEquals(location2, remainingLocations1.get(0));
         
         path.iteratePathLocation();
         
         List<InsidePathLocation> remainingLocations2 = path.getRemainingPathLocations();
         assertNotNull(remainingLocations2);
-        assertEquals(2, remainingLocations2.size());
-        assertEquals(location2, remainingLocations2.get(0));
+        assertEquals(1, remainingLocations2.size());
+        assertEquals(location3, remainingLocations2.get(0));
         
         path.iteratePathLocation();
         
         List<InsidePathLocation> remainingLocations3 = path.getRemainingPathLocations();
         assertNotNull(remainingLocations3);
-        assertEquals(1, remainingLocations3.size());
-        assertEquals(location3, remainingLocations3.get(0));
     }
     
     public void testIsEndOfPath() {
         
-        InsideBuildingPath path = new InsideBuildingPath();
-
         MockSettlement settlement = new MockSettlement();
         MockBuilding building = new MockBuilding(settlement, "1", BUILDING_POSN);
         
+        List<InsidePathLocation> steps = new ArrayList<>();
+
         InsidePathLocation location1 = new BuildingLocation(building, POSITION_5X5);
-        path.addPathLocation(location1);
-        
-        assertTrue(path.isEndOfPath());
+        steps.add(location1);
         
         InsidePathLocation location2 = new BuildingLocation(building, POSITION_10X5);
-        path.addPathLocation(location2);
-        
-        assertFalse(path.isEndOfPath());
-        
+        steps.add(location2);
+                
         InsidePathLocation location3 = new BuildingLocation(building, POSITION_10X10);
-        path.addPathLocation(location3);
+        steps.add(location3);
         
-        assertFalse(path.isEndOfPath());
-        
-        path.iteratePathLocation();
-        
+        InsideBuildingPath path = new InsideBuildingPath(steps);
+
         assertFalse(path.isEndOfPath());
         
         path.iteratePathLocation();
@@ -143,29 +132,26 @@ public class InsideBuildingPathTest extends AbstractMarsSimUnitTest {
     
     public void testGetPathLength() {
         
-        InsideBuildingPath path = new InsideBuildingPath();
         
         MockSettlement settlement = new MockSettlement();
         MockBuilding building = new MockBuilding(settlement, "1", BUILDING_POSN);
-        
+        List<InsidePathLocation> steps = new ArrayList<>();
+
+
         InsidePathLocation location1 = new BuildingLocation(building, POSITION_5X5);
-        path.addPathLocation(location1);
-        
-        assertEquals(0D, path.getPathLength());
-        
+        steps.add(location1);
+                
         InsidePathLocation location2 = new BuildingLocation(building, POSITION_10X5);
-        path.addPathLocation(location2);
-        
-        assertEquals(5D, path.getPathLength());
-        
+        steps.add(location2);
+                
         InsidePathLocation location3 = new BuildingLocation(building, POSITION_10X10);
-        path.addPathLocation(location3);
-        
-        assertEquals(10D, path.getPathLength());
-        
+        steps.add(location3);
+                
         InsidePathLocation location4 = new BuildingLocation(building, POSITION_5X5);
-        path.addPathLocation(location4);
+        steps.add(location4);
         
+        InsideBuildingPath path = new InsideBuildingPath(steps);
+
         assertEquals(10D + Math.sqrt(50D), path.getPathLength());
     }
 }


### PR DESCRIPTION
This PR adds caching to the path finding in the connections manager. It uses a Cache with a max size where paths will be evicted based on the oldest accessed.

The caching support bi-directional so a path going from Building A->B will pick up an cached entry going from B -> A. If a hit is not found then the PathFinder will be executed and the result cached.
The building command shows the status of the cache hit rates.

In addition it adjusts the log blocking algorithm