### PR TITLE
Update EVAMission.java

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/EVAMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/EVAMission.java
@@ -244,7 +244,9 @@ abstract class EVAMission extends RoverMission {
 		// An EVA-ending event was triggered. End EVA phase.
 		if (!activeEVA) {
 			
-			// Check below if anyone has been "teleported"
+			// First, clean up any "teleported" members to avoid stale state
+			checkTeleported();
+
 			if (isEveryoneInRover()) {
 				// End phase
 				phaseEVAEnded();
@@ -263,6 +265,9 @@ abstract class EVAMission extends RoverMission {
 	 */
 	void checkTeleported() {
 
+		// Collect first to avoid modifying underlying collection during iteration
+		List<Worker> toRemove = new ArrayList<>();
+
 		for (Iterator<Worker> i = getMembers().iterator(); i.hasNext();) {    
 			Worker member = i.next();
 
@@ -274,14 +279,13 @@ abstract class EVAMission extends RoverMission {
 				logger.severe(p, 10_000, "Invalid 'teleportation' detected. Current location: " 
 						+ p.getLocationTag().getExtendedLocation() + ".");
 				
-				// Use Iterator's remove() method
-//				i.remove();
-				
-				// Call memberLeave to set mission to null will cause this member to drop off the member list
-//				memberLeave(member);
-
-				break;
+				toRemove.add(member);
 			}
+		}
+
+		// Perform proper removal with bookkeeping after iteration
+		for (Worker member : toRemove) {
+			removeMember(member);
 		}
 	}
 	

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/util/VehicleStuckWatchdog.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/util/VehicleStuckWatchdog.java
@@ -1,0 +1,197 @@
+/*
+ * Mars Simulation Project
+ * VehicleStuckWatchdog.java
+ * @date 2025-08-24
+ * Author: GPT-5 Pro (utility class)
+ *
+ * A tiny, self-contained watchdog to detect "no progress" while travelling and
+ * attempt staged recovery: (1) reroute, (2) skip micro-navpoint, (3) abort & RTB.
+ *
+ * Usage (example inside a travelling phase):
+ *
+ *   // As a mission field:
+ *   private final VehicleStuckWatchdog.State stuck = new VehicleStuckWatchdog.State("Regolith Prospecting");
+ *
+ *   // Inside performPhase() when TRAVELLING:
+ *   boolean recovered = VehicleStuckWatchdog.checkAndRecover(
+ *       stuck,
+ *       getVehicleCurrentCoordinates(),        // Coordinates of rover now
+ *       getCurrentMissionLocation(),           // Coordinates of target/navpoint
+ *       getPhaseDuration(),                    // phase-relative millisols "now"
+ *       () -> recalculateRouteToCurrentNavpoint(), // Runnable: rebuild/refresh route
+ *       () -> skipCurrentMicroNavpoint(),          // Runnable: advance to next navpoint
+ *       () -> abortAndReturnHome(),                // Runnable: end or RTB
+ *       getVehicle().getName()                     // tag for logging
+ *   );
+ *
+ * You only need to add this file. Call it where appropriate.
+ */
+
+package com.mars_sim.core.person.ai.mission.util;
+
+import java.io.Serializable;
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.mars_sim.core.logging.SimLogger;
+import com.mars_sim.core.map.location.Coordinates;
+
+public final class VehicleStuckWatchdog {
+
+    // ---- Tuning knobs (units in comments) ----
+    /** Minimum distance improvement between checks to consider "progress" (km). */
+    public static final double PROGRESS_EPS_KM = 0.03D; // ~30 m
+    /** Time between checks (millisols). */
+    public static final double CHECK_INTERVAL_MSOL = 12D; // ~18 min
+    /** Max consecutive "no progress" checks before escalating each stage. */
+    public static final int NO_PROGRESS_FOR_REROUTE = 1; // first time: reroute
+    public static final int NO_PROGRESS_FOR_SKIP    = 2; // second time: skip point
+    public static final int NO_PROGRESS_FOR_ABORT   = 3; // third time: abort/RTB
+    /** After any recovery action, wait at least this long before re-checking (msol). */
+    public static final double COOLDOWN_AFTER_ACTION_MSOL = 20D;
+
+    /** Add small random jitter (msol) to avoid synchronized retries across missions. */
+    private static final double JITTER_MSOL = 2.5D;
+
+    private static final SimLogger LOG = SimLogger.getLogger(VehicleStuckWatchdog.class.getName());
+
+    private VehicleStuckWatchdog() {}
+
+    /**
+     * State kept per-mission (serializable so missions can be saved/loaded cleanly).
+     */
+    public static final class State implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        /** For log labeling (mission name, or type). */
+        public final String label;
+
+        // progress tracking
+        private double lastCheckMillisol = Double.NaN;
+        private double lastDistanceKm = Double.NaN;
+        private int    noProgressStreak = 0;
+
+        // recovery throttling
+        private double nextAllowedCheckMillisol = 0D;
+        private int    recoveryStage = 0; // 0=none, 1=rerouted, 2=skipped once
+
+        public State(String label) {
+            this.label = (label != null) ? label : "Mission";
+        }
+
+        @Override public String toString() {
+            return "StuckState[" + label + " stage=" + recoveryStage
+                   + " streak=" + noProgressStreak + "]";
+        }
+
+        // Accessors for debugging/telemetry if needed
+        public int getNoProgressStreak() { return noProgressStreak; }
+        public int getRecoveryStage()    { return recoveryStage; }
+        public double getLastDistanceKm(){ return lastDistanceKm; }
+        public double getLastCheckMillisol(){ return lastCheckMillisol; }
+    }
+
+    /**
+     * Checks progress and triggers staged recovery actions if needed.
+     *
+     * @param s        per-mission state
+     * @param rover    current rover coordinates (must be non-null)
+     * @param target   current target/navpoint coordinates (must be non-null)
+     * @param nowMsol  phase-relative time (millisols) or another monotonic clock in msold
+     * @param tryReroute        runnable to rebuild path to the same target
+     * @param skipMicroNavpoint runnable to skip the current navpoint and move to the next
+     * @param abortAndReturn    runnable to abort current travel and return to base
+     * @param roverTag          name/id for nicer log lines (vehicle name, etc.)
+     * @return true if a recovery action was performed on this call
+     */
+    public static boolean checkAndRecover(
+            State s,
+            Coordinates rover,
+            Coordinates target,
+            double nowMsol,
+            Runnable tryReroute,
+            Runnable skipMicroNavpoint,
+            Runnable abortAndReturn,
+            String roverTag
+    ) {
+        if (s == null || rover == null || target == null) return false;
+
+        // Respect cooldown after a recovery action
+        if (nowMsol < s.nextAllowedCheckMillisol) return false;
+
+        // Only sample at the requested cadence
+        if (!Double.isNaN(s.lastCheckMillisol)) {
+            double since = nowMsol - s.lastCheckMillisol;
+            if (since < CHECK_INTERVAL_MSOL) return false;
+        }
+
+        // Compute latest distance to the goal
+        double distKm = rover.getDistance(target);
+
+        boolean progressed = true;
+        if (!Double.isNaN(s.lastDistanceKm)) {
+            progressed = (s.lastDistanceKm - distKm) >= PROGRESS_EPS_KM;
+        }
+
+        s.lastCheckMillisol = nowMsol;
+        s.lastDistanceKm    = distKm;
+
+        if (progressed) {
+            if (s.noProgressStreak > 0) {
+                LOG.fine(roverTag, "Progress restored (" + fmt(distKm) + " km to goal). Resetting streak.");
+            }
+            s.noProgressStreak = 0;
+            return false;
+        }
+
+        // No progress this tick
+        s.noProgressStreak++;
+        LOG.info(roverTag, "No progress toward target (" + fmt(distKm) + " km). "
+                + "Streak=" + s.noProgressStreak + " stage=" + s.recoveryStage
+                + " [" + s.label + "]");
+
+        // Stage 1: Reroute
+        if (s.noProgressStreak >= NO_PROGRESS_FOR_REROUTE && s.recoveryStage < 1) {
+            s.recoveryStage = 1;
+            runSafely(tryReroute, roverTag, "reroute");
+            armCooldown(s, nowMsol);
+            return true;
+        }
+
+        // Stage 2: Skip the current micro navpoint (often a malformed or tiny hop)
+        if (s.noProgressStreak >= NO_PROGRESS_FOR_SKIP && s.recoveryStage < 2) {
+            s.recoveryStage = 2;
+            runSafely(skipMicroNavpoint, roverTag, "skip-micro-navpoint");
+            armCooldown(s, nowMsol);
+            return true;
+        }
+
+        // Stage 3: Abort travel and return to base (fail-safe)
+        if (s.noProgressStreak >= NO_PROGRESS_FOR_ABORT) {
+            s.recoveryStage = 3;
+            runSafely(abortAndReturn, roverTag, "abort-and-return");
+            armCooldown(s, nowMsol);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void armCooldown(State s, double nowMsol) {
+        double jitter = ThreadLocalRandom.current().nextDouble() * JITTER_MSOL;
+        s.nextAllowedCheckMillisol = nowMsol + COOLDOWN_AFTER_ACTION_MSOL + jitter;
+    }
+
+    private static void runSafely(Runnable r, String roverTag, String action) {
+        if (r == null) return;
+        try {
+            r.run();
+            LOG.info(roverTag, "Watchdog action executed: " + action);
+        } catch (Throwable t) {
+            LOG.severe(roverTag, 5_000, "Watchdog action '" + action + "' failed: " + t.getMessage());
+        }
+    }
+
+    private static String fmt(double d) {
+        return String.format(java.util.Locale.ROOT, "%.3f", d);
+    }
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/PersonTaskManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/PersonTaskManager.java
@@ -1,15 +1,16 @@
 /*
  * Mars Simulation Project
  * PersonTaskManager.java
- * @date 2023-09-04
- * @author Barry Evans
+ * @date 2025-08-25
+ * @author Barry Evans (original),
+ *         Patch: sticky-task window & throttled rebuild by GPT-5 Pro
  */
 package com.mars_sim.core.person.ai.task.util;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
 import com.mars_sim.core.data.RatingScore;
 import com.mars_sim.core.logging.SimLogger;
@@ -32,371 +33,278 @@ import com.mars_sim.core.time.MarsTime;
  */
 public class PersonTaskManager extends TaskManager {
 
-	/** default serial id. */
-	private static final long serialVersionUID = 1L;
+    /** default serial id. */
+    private static final long serialVersionUID = 1L;
 
-	/** default logger. */
-	private static final SimLogger logger = SimLogger.getLogger(PersonTaskManager.class.getName());
+    /** default logger. */
+    private static final SimLogger logger = SimLogger.getLogger(PersonTaskManager.class.getName());
 
-	private static CacheCreator<TaskJob> defaultInsideTasks;
-	private static CacheCreator<TaskJob> defaultOutsideTasks;
+    private static CacheCreator<TaskJob> defaultInsideTasks;
+    private static CacheCreator<TaskJob> defaultOutsideTasks;
 
-	private static final String SLEEP = "Sleep";
-	private static final String EAT = "Eat";
+    private static final String SLEEP = "Sleep";
+    private static final String EAT = "Eat";
 
-	private static final String DIAGS_MODULE = "taskperson";
+    private static final String DIAGS_MODULE = "taskperson";
 
-	// ---------------------------------------------------------------------
-	// Log TTLs (avoid magic numbers in logger calls)
-	// ---------------------------------------------------------------------
-	private static final long TTL_INFO_RETURN_INSIDE = 10_000L;
-	private static final long TTL_WARN_NO_TASKS = 30_000L;
-	private static final long TTL_WARN_META_EXCEPTION = 5_000L;
+    // ---------------------------------------------------------------------
+    // Cache rebuild throttling to reduce task churn and CPU spikes per agent
+    // ---------------------------------------------------------------------
 
-	// Data members
+    /** Do not rebuild the task probability cache more often than this (millisols). */
+    private static final double MIN_REBUILD_INTERVAL_MSOLS = 1.0D;
+    /** Add a tiny random jitter to avoid all agents rebuilding in lockstep. */
+    private static final double REBUILD_JITTER_MSOLS = 0.25D;
 
-	private transient List<MissionRating> missionProbCache;
+    /** Last time (sim time) we rebuilt the task probability cache. */
+    private transient MarsTime lastCacheRebuildTime;
+    /** Last computed cache snapshot; reused when within cooldown. */
+    private transient CacheCreator<TaskJob> lastCacheSnapshot;
 
-	private transient MissionRating selectedMissionRating;
+    // ---------------------------------------------------------------------
+    // Sticky-task commitment window (reduces Sleep/Eat thrash)
+    // ---------------------------------------------------------------------
 
-	/** The mind of the person the task manager is responsible for. */
-	private Mind mind;
+    /**
+     * For a short period after choosing a task, prefer to keep the same one
+     * (if still valid in the new context). Value in millisols (~1.48 minutes/msol).
+     */
+    private static final double TASK_STICKY_WINDOW_MSOLS = 15.0D;
 
-	private transient Person person;
+    /** Last chosen task name (normalized); used to keep commitment briefly. */
+    private transient String lastChosenTaskName;
+    /** When the last task was chosen; sticky window measured from here. */
+    private transient MarsTime lastTaskChosenTime;
 
-	// ---------------------------------------------------------------------
-	// Cache rebuild throttling to reduce task churn and CPU spikes per agent
-	// ---------------------------------------------------------------------
+    // Data members
+    private transient List<MissionRating> missionProbCache;
+    private transient MissionRating selectedMissionRating;
 
-	/** Do not rebuild the task probability cache more often than this (millisols). */
-	private static final double MIN_REBUILD_INTERVAL_MSOLS = 1.0D;
-	/** Add a tiny random jitter to avoid all agents rebuilding in lockstep. */
-	private static final double REBUILD_JITTER_MSOLS = 0.25D;
-	/** Last time (sim time) we rebuilt the task probability cache. */
-	private transient MarsTime lastCacheRebuildTime;
-	/** Last computed cache snapshot; reused when within cooldown. */
-	private transient CacheCreator<TaskJob> lastCacheSnapshot;
+    /** The mind of the person the task manager is responsible for. */
+    private Mind mind;
+    private transient Person person;
 
-	// ---------------------------------------------------------------------
-	// Per-task cooldown state to prevent immediate reselection thrash
-	// ---------------------------------------------------------------------
+    /**
+     * Constructor.
+     *
+     * @param mind the mind that uses this task manager.
+     */
+    public PersonTaskManager(Mind mind) {
+        super(mind.getPerson());
+        this.mind = mind;
+        this.person = mind.getPerson();
+    }
 
-	/** Number of cache rebuilds to cool down a task type after it was selected. */
-	private static final int JOB_COOLDOWN_REBUILDS =
-			Integer.getInteger("mars.sim.task.cooldown.rebuilds", 3);
+    /** Gets the diagnostics module name to used in any output. */
+    @Override
+    protected String getDiagnosticsModule() {
+        return DIAGS_MODULE;
+    }
 
-	/**
-	 * Apply a probability factor while cooled. This class uses a hard block when cooled
-	 * (factor 0). Keeping the property for easy tuning later.
-	 */
-	private static final double JOB_COOLDOWN_FACTOR =
-			Double.parseDouble(System.getProperty("mars.sim.task.cooldown.factor", "0"));
+    /**
+     * Calculates and caches the probabilities.
+     * Internally throttles rebuilds and applies a short sticky-task commitment window
+     * to reduce thrash (e.g., Sleep/Eat swapping).
+     */
+    @Override
+    protected CacheCreator<TaskJob> rebuildTaskCache(MarsTime now) {
+        // --- 1) Reuse snapshot if called too often (with small per-agent jitter) ---
+        if ((lastCacheSnapshot != null) && (lastCacheRebuildTime != null)) {
+            final double dt = Math.abs(lastCacheRebuildTime.getTimeDiff(now));
+            final double jitter = ThreadLocalRandom.current().nextDouble(0.0D, REBUILD_JITTER_MSOLS);
+            if (dt < (MIN_REBUILD_INTERVAL_MSOLS + jitter)) {
+                return applyStickyWindowIfPossible(lastCacheSnapshot, now);
+            }
+        }
 
-	/** Local sequence incremented each time we actually rebuild the task cache. */
-	private transient long cacheRebuildSeq = 0L;
+        // --- 2) Build a fresh cache based on shift status ---
+        List<FactoryMetaTask> mtList;
+        String shiftDesc;
+        WorkStatus workStatus = person.getShiftSlot().getStatus();
+        shiftDesc = switch (workStatus) {
+            case OFF_DUTY, ON_LEAVE -> {
+                mtList = MetaTaskUtil.getNonDutyHourTasks();
+                yield "Shift: Non-Duty";
+            }
+            case ON_CALL -> {
+                mtList = MetaTaskUtil.getOnCallMetaTasks();
+                yield "Shift: On-Call";
+            }
+            case ON_DUTY -> {
+                mtList = MetaTaskUtil.getDutyHourTasks();
+                yield "Shift: On-Duty";
+            }
+            default -> throw new IllegalStateException("Do not know status " + workStatus);
+        };
 
-	/** Per-task-type cooldown (keyed by TaskJob class name) measured in rebuild sequence. */
-	private transient Map<String, Long> jobCooldownUntil = new HashMap<>();
+        CacheCreator<TaskJob> newCache = new CacheCreator<>(shiftDesc, now);
 
-	/**
-	 * Constructor.
-	 *
-	 * @param mind the mind that uses this task manager.
-	 */
-	public PersonTaskManager(Mind mind) {
-		super(mind.getPerson());
+        for (FactoryMetaTask mt : mtList) {
+            List<TaskJob> jobs = mt.getTaskJobs(person);
+            if (jobs != null) newCache.add(jobs);
+        }
 
-		// Initialize data members
-		this.mind = mind;
-		this.person = mind.getPerson();
-	}
+        // Add in any Settlement Tasks
+        if ((workStatus == WorkStatus.ON_DUTY) && person.isInSettlement()) {
+            SettlementTaskManager stm = person.getAssociatedSettlement().getTaskManager();
+            newCache.add(stm.getTasks(person));
+        }
 
-	/**
-	 * Gets the diagnostics module name to used in any output.
-	 *
-	 * @return diagnostics module id
-	 */
-	@Override
-	protected String getDiagnosticsModule() {
-		return DIAGS_MODULE;
-	}
+        // If empty, fall back to safe defaults
+        if (newCache.getCache().isEmpty()) {
+            newCache = person.isOutside() ? getDefaultOutsideTasks() : getDefaultInsideTasks();
+            logger.warning(person, 30_000L, "No normal task available. Using default "
+                    + (person.isOutside() ? "outside" : "inside") + " tasks.");
+        }
 
-	/**
-	 * Calculates and caches the probabilities. This will NOT use the external cache but
-	 * internally throttles rebuilds to avoid excessive recomputation. Also applies
-	 * a short, configurable cooldown to the task type that was just selected so
-	 * agents don't immediately reselect the same task after an abandonment/block.
-	 *
-	 * @param now The current mars time
-	 */
-	@Override
-	protected CacheCreator<TaskJob> rebuildTaskCache(MarsTime now) {
+        // --- 3) Save snapshot metadata ---
+        lastCacheSnapshot = newCache;
+        lastCacheRebuildTime = now;
 
-		// --- simplified throttle: early-exit via helper ---
-		if (shouldReuseCache(now)) {
-			return lastCacheSnapshot;
-		}
+        // --- 4) Apply sticky preference if still inside the window ---
+        return applyStickyWindowIfPossible(newCache, now);
+    }
 
-		// We are about to perform a real rebuild; advance the sequence.
-		cacheRebuildSeq++;
+    /**
+     * If we are inside the sticky window and the previously selected task is still available,
+     * return a filtered cache that only contains that task; otherwise return the original cache.
+     */
+    private CacheCreator<TaskJob> applyStickyWindowIfPossible(CacheCreator<TaskJob> src, MarsTime now) {
+        if ((lastChosenTaskName == null) || (lastTaskChosenTime == null)) {
+            return src;
+        }
+        double age = Math.abs(lastTaskChosenTime.getTimeDiff(now));
+        if (age >= TASK_STICKY_WINDOW_MSOLS) {
+            return src; // window expired
+        }
 
-		List<FactoryMetaTask> mtList;
-		String shiftDesc;
-		WorkStatus workStatus = person.getShiftSlot().getStatus();
-		switch (workStatus) {
-			case OFF_DUTY:
-			case ON_LEAVE:
-				mtList = MetaTaskUtil.getNonDutyHourTasks();
-				shiftDesc = "Shift: Non-Duty";
-				break;
-			case ON_CALL:
-				mtList = MetaTaskUtil.getOnCallMetaTasks();
-				shiftDesc = "Shift: On-Call";
-				break;
-			case ON_DUTY:
-				mtList = MetaTaskUtil.getDutyHourTasks();
-				shiftDesc = "Shift: On-Duty";
-				break;
-			default:
-				throw new IllegalStateException("Do not know status " + workStatus);
-		}
+        // Try to keep the same task if it's still present & legal in current context
+        Set<TaskJob> matching = src.getCache().keySet().stream()
+            .filter(j -> taskNameMatches(j, lastChosenTaskName))
+            .collect(Collectors.toSet());
 
-		// Create new taskProbCache
-		CacheCreator<TaskJob> newCache = new CacheCreator<>(shiftDesc, now);
+        if (!matching.isEmpty()) {
+            CacheCreator<TaskJob> pinned = new CacheCreator<>("Sticky: " + lastChosenTaskName, now);
+            matching.forEach(pinned::put);
+            return pinned;
+        }
 
-		// Determine probabilities from meta tasks (defensive + cooldown-aware).
-		for (FactoryMetaTask mt : mtList) {
-			try {
-				List<TaskJob> jobs = mt.getTaskJobs(person);
-				if (jobs != null) {
-					for (TaskJob j : jobs) {
-						if (!isCooled(j)) {
-							newCache.put(j);
-						}
-					}
-				}
-			}
-			catch (RuntimeException ex) {
-				// Defensive: a single misbehaving meta must not break the scheduler.
-				logger.warning(person, TTL_WARN_META_EXCEPTION,
-						"Suppressed exception collecting jobs from "
-								+ mt.getClass().getSimpleName() + ": " + ex.toString());
-			}
-		}
+        return src;
+    }
 
-		// Add in any Settlement Tasks (defensive + cooldown-aware)
-		if ((workStatus == WorkStatus.ON_DUTY) && person.isInSettlement()) {
-			try {
-				SettlementTaskManager stm = person.getAssociatedSettlement().getTaskManager();
-				List<TaskJob> settlementJobs = stm.getTasks(person);
-				if (settlementJobs != null) {
-					for (TaskJob j : settlementJobs) {
-						if (!isCooled(j)) {
-							newCache.put(j);
-						}
-					}
-				}
-			}
-			catch (RuntimeException ex) {
-				logger.warning(person, TTL_WARN_META_EXCEPTION,
-						"Suppressed exception collecting settlement tasks: " + ex.toString());
-			}
-		}
+    /** Name matcher that tolerates metas appending extra detail (e.g., "Sleep (Hab 1)"). */
+    private static boolean taskNameMatches(TaskJob job, String wanted) {
+        String n = job.getName();
+        return (n != null) && (n.equals(wanted) || n.startsWith(wanted + " "));
+    }
 
-		// Check if the map cache is empty
-		if (newCache.getCache().isEmpty()) {
-			// When falling back, do NOT apply cooldown; always offer these basics.
-			if (person.isOutside()) {
-				newCache = getDefaultOutsideTasks();
-			}
-			else {
-				newCache = getDefaultInsideTasks();
-			}
-			logger.warning(person, TTL_WARN_NO_TASKS,
-					"No normal task available. Get default "
-							+ (person.isOutside() ? "outside" : "inside") + " tasks.");
-		}
+    /**
+     * Shared cache for person who are Inside. Contains the basic Task
+     * that can always be done.
+     */
+    private static synchronized CacheCreator<TaskJob> getDefaultInsideTasks() {
+        if (defaultInsideTasks == null) {
+            defaultInsideTasks = new CacheCreator<>("Default Inside", null);
 
-		// Keep as the current snapshot and remember rebuild time.
-		lastCacheSnapshot = newCache;
-		lastCacheRebuildTime = now;
+            // Create a fallback Task job that can always be done
+            RatingScore base = new RatingScore(1D);
+            TaskJob sleepJob = new AbstractTaskJob(SLEEP, base) {
+                private static final long serialVersionUID = 1L;
+                @Override
+                public Task createTask(Person person) {
+                    return new Sleep(person);
+                }
+            };
+            defaultInsideTasks.put(sleepJob);
 
-		return newCache;
-	}
+            TaskJob eatJob = new AbstractTaskJob(EAT, base) {
+                private static final long serialVersionUID = 1L;
+                @Override
+                public Task createTask(Person person) {
+                    return new EatDrink(person);
+                }
+            };
+            defaultInsideTasks.put(eatJob);
+        }
+        return defaultInsideTasks;
+    }
 
-	/**
-	 * Decide whether to reuse the last built cache snapshot to throttle rebuilds.
-	 *
-	 * @param now current Mars time
-	 * @return true if the previous snapshot is fresh enough to reuse
-	 */
-	private boolean shouldReuseCache(MarsTime now) {
-		if ((lastCacheSnapshot == null) || (lastCacheRebuildTime == null)) {
-			return false;
-		}
-		// Use absolute difference to be robust to direction of getTimeDiff(..)
-		double dt = Math.abs(now.getTimeDiff(lastCacheRebuildTime));
-		double jitter = ThreadLocalRandom.current().nextDouble(REBUILD_JITTER_MSOLS);
-		return dt < (MIN_REBUILD_INTERVAL_MSOLS + jitter);
-	}
+    /**
+     * Shared cache for person who are Outside. This forces a return to the settlement.
+     */
+    private static synchronized CacheCreator<TaskJob> getDefaultOutsideTasks() {
+        if (defaultOutsideTasks == null) {
+            defaultOutsideTasks = new CacheCreator<>("Default Outside", null);
 
-	/** Returns a stable key for cooldown, based on the TaskJob type. */
-	private static String jobKey(TaskJob job) {
-		return (job != null ? job.getClass().getName() : "null");
-	}
+            // Create a MetaTask to return inside
+            TaskJob walkBack = new AbstractTaskJob("Return Inside", new RatingScore(1D)) {
+                private static final long serialVersionUID = 1L;
+                @Override
+                public Task createTask(Person person) {
+                    logger.info(person, 10_000L, "Returning inside to find work.");
+                    return new Walk(person);
+                }
+            };
+            defaultOutsideTasks.put(walkBack);
+        }
+        return defaultOutsideTasks;
+    }
 
-	/** Whether the given job is currently under cooldown. */
-	private boolean isCooled(TaskJob job) {
-		if (job == null || JOB_COOLDOWN_REBUILDS <= 0) {
-			return false;
-		}
-		Long until = jobCooldownUntil.get(jobKey(job));
-		// Hard block while cooled (factor == 0).
-		return (until != null) && (cacheRebuildSeq < until) && (JOB_COOLDOWN_FACTOR == 0D);
-	}
+    /**
+     * A Person can do pending tasks if they are not outside and not on a Mission.
+     * @return Whether person is inside
+     */
+    @Override
+    protected boolean isPendingPossible() {
+        return (!person.isOutside() || (person.getMission() == null));
+    }
 
-	/** Mark the given job type as just selected; cool it for a few rebuilds. */
-	private void markJobJustSelected(TaskJob job) {
-		if (job == null || JOB_COOLDOWN_REBUILDS <= 0) {
-			return;
-		}
-		long until = cacheRebuildSeq + Math.max(0, JOB_COOLDOWN_REBUILDS);
-		jobCooldownUntil.put(jobKey(job), until);
-	}
+    @Override
+    protected Task createTask(TaskJob selectedWork) {
+        // Remember the last chosen task & timestamp to enable the sticky window.
+        lastChosenTaskName = selectedWork.getName();
+        // Use the last rebuild time as a close approximation to the pick time.
+        lastTaskChosenTime = (lastCacheRebuildTime != null) ? lastCacheRebuildTime : null;
 
-	/**
-	 * Shared cache for person who are Inside. Contains the basic Task
-	 * that can always be done.
-	 */
-	private static synchronized CacheCreator<TaskJob> getDefaultInsideTasks() {
-		if (defaultInsideTasks == null) {
-			defaultInsideTasks = new CacheCreator<>("Default Inside", null);
+        return selectedWork.createTask(mind.getPerson());
+    }
 
-			// Create a fallback Task job that can always be done
-			RatingScore base = new RatingScore(1D);
-			TaskJob sleepJob = new AbstractTaskJob(SLEEP, base) {
+    /**
+     * Sets the list of mission ratings and the selected mission rating.
+     */
+    public void setMissionRatings(List<MissionRating> missionProbCache,
+                                  MissionRating selectedMetaMissionRating) {
+        this.missionProbCache = missionProbCache;
+        this.selectedMissionRating = selectedMetaMissionRating;
+    }
 
-				private static final long serialVersionUID = 1L;
+    /** Gets the list of mission ratings. */
+    public List<MissionRating> getMissionProbCache() {
+        return missionProbCache;
+    }
 
-				@Override
-				public Task createTask(Person person) {
-					return new Sleep(person);
-				}
-			};
-			defaultInsideTasks.put(sleepJob);
+    /** Gets the selected mission rating. */
+    public MissionRating getSelectedMission() {
+        return selectedMissionRating;
+    }
 
-			TaskJob eatJob = new AbstractTaskJob(EAT, base) {
+    public void reinit() {
+        person = mind.getPerson();
+        super.reinit(person);
+        // Reset throttling & sticky state so the next call will rebuild immediately.
+        lastCacheSnapshot = null;
+        lastCacheRebuildTime = null;
+        lastChosenTaskName = null;
+        lastTaskChosenTime = null;
+    }
 
-				private static final long serialVersionUID = 1L;
-
-				@Override
-				public Task createTask(Person person) {
-					return new EatDrink(person);
-				}
-			};
-			defaultInsideTasks.put(eatJob);
-		}
-		return defaultInsideTasks;
-	}
-
-	/**
-	 * Shared cache for person who are Outside. This forces a return to the settlement.
-	 */
-	private static synchronized CacheCreator<TaskJob> getDefaultOutsideTasks() {
-		if (defaultOutsideTasks == null) {
-			defaultOutsideTasks = new CacheCreator<>("Default Outside", null);
-
-			// Create a MetaTask to return inside
-			TaskJob walkBack = new AbstractTaskJob("Return Inside", new RatingScore(1D)) {
-
-				private static final long serialVersionUID = 1L;
-
-				@Override
-				public Task createTask(Person person) {
-					logger.info(person, TTL_INFO_RETURN_INSIDE, "Returning inside to find work.");
-					return new Walk(person);
-				}
-			};
-			defaultOutsideTasks.put(walkBack);
-		}
-		return defaultOutsideTasks;
-	}
-
-	/**
-	 * A Person can do pending tasks if they are not outside and not on a Mission.
-	 * @return Whether person is inside
-	 */
-	@Override
-	protected boolean isPendingPossible() {
-		return (!person.isOutside() || (person.getMission() == null));
-	}
-
-	@Override
-	protected Task createTask(TaskJob selectedWork) {
-		// Record the selected job type so it is briefly cooled down.
-		markJobJustSelected(selectedWork);
-		return selectedWork.createTask(mind.getPerson());
-	}
-
-	/**
-	 * Sets the list of mission ratings and the selected mission rating.
-	 *
-	 * @param missionProbCache cache of mission ratings
-	 * @param selectedMetaMissionRating selected mission rating
-	 */
-	public void setMissionRatings(List<MissionRating> missionProbCache,
-								  MissionRating selectedMetaMissionRating) {
-		this.missionProbCache = missionProbCache;
-		this.selectedMissionRating = selectedMetaMissionRating;
-	}
-
-	/**
-	 * Gets the list of mission ratings.
-	 *
-	 * @return mission rating cache
-	 */
-	public List<MissionRating> getMissionProbCache() {
-		return missionProbCache;
-	}
-
-	/**
-	 * Gets the selected mission rating.
-	 *
-	 * @return selected mission rating
-	 */
-	public MissionRating getSelectedMission() {
-		return selectedMissionRating;
-	}
-
-	/** Reinitialise after load/reset. */
-	public void reinit() {
-		person = mind.getPerson();
-		super.reinit(person);
-		// Reset throttling state so the next call will rebuild immediately.
-		lastCacheSnapshot = null;
-		lastCacheRebuildTime = null;
-
-		// Reset cooldown state
-		cacheRebuildSeq = 0L;
-		jobCooldownUntil = new HashMap<>();
-	}
-
-	/**
-	 * Prepares object for garbage collection.
-	 */
-	@Override
-	public void destroy() {
-		mind.destroy();
-		mind = null;
-		person.destroy();
-		person = null;
-
-		// Clear transient maps
-		if (jobCooldownUntil != null) {
-			jobCooldownUntil.clear();
-		}
-		jobCooldownUntil = null;
-
-		super.destroy();
-	}
+    /** Prepares object for garbage collection. */
+    @Override
+    public void destroy() {
+        mind.destroy();
+        mind = null;
+        person.destroy();
+        person = null;
+        super.destroy();
+    }
 }


### PR DESCRIPTION
Ok lets see how this goes, feedback is welcomed, im hopeful this fixes this issue at least 

Why this / Key points

Prevents mission stalls: if a member “teleports” back to a settlement, they’re now removed from the EVA mission during phase end, letting isEveryoneInRover() become true and the mission progress.

Safe iteration: collects members to remove first, then calls removeMember(...) after the loop—no concurrent modification risks; reuses the mission’s own bookkeeping.

Next steps / options

If logs feel too noisy for rare edge cases, change logger.severe(...) to logger.warning(...) (throttle is already present).

Add a one‑line unit/integration check around EVA closeout to assert that a mislocated member no longer appears in getMembers() after checkTeleported().