### PR TITLE
Update TabPanelHealth.java

### DIFF
--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelHealth.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelHealth.java
@@ -61,6 +61,9 @@ extends TabPanel {
 
 	private static final String HEALTH_ICON = "health"; //$NON-NLS-1$
 	
+	/** Max rows to render in the Health Risks list. */
+	private static final int RISK_ROWS = 10;
+
 	private static final String THIRTY_DAY = "30-Day";
 	private static final String ANNUAL = "Annual";
 	private static final String CAREER = "Career";
@@ -195,7 +198,7 @@ extends TabPanel {
 						
 		hungerCache = (int)condition.getHunger();
 		hungerLabel = conditionPanel.addTextField(Msg.getString("TabPanelHealth.hunger"), //$NON-NLS-1$
-										DECIMAL_MSOLS.format(thirstCache), null);
+										DECIMAL_MSOLS.format(hungerCache), null);
 		
 		maxDailyEnergy = (int)(condition.getPersonalMaxEnergy());
 		maxDailyEnergyLabel = conditionPanel.addRow(Msg.getString("TabPanelHealth.maxDailyEnergy"), //$NON-NLS-1$
@@ -225,7 +228,7 @@ extends TabPanel {
 		muscleTorLabel = conditionPanel.addRow(Msg.getString("TabPanelHealth.muscle.tolerance"), //$NON-NLS-1$
 				DECIMAL_PLACES1.format(muscleTor));	
 		
-		bodyMassDev = Math.round(condition.getPersonalMaxEnergy()*10.0)/10.0;
+		bodyMassDev = Math.round(condition.getBodyMassDeviation()*10.0)/10.0;
 		bodyMassDevLabel = conditionPanel.addRow(Msg.getString("TabPanelHealth.bodyMassDev"), //$NON-NLS-1$
 				DECIMAL_PLACES1.format(bodyMassDev));
 		
@@ -460,12 +463,15 @@ extends TabPanel {
 		Map<HealthRiskType, Double> riskMap = condition.getHealthRisks();
 		
 		List<HealthRiskType> riskList = new ArrayList<>(riskMap.keySet());
-		
-		Collections.sort(riskList);
-		
-		for (int i = 0; i < 10; i++) {
+		// Sort by descending risk value and cap the number of displayed rows.
+		riskList.sort((a, b) -> Double.compare(
+				riskMap.getOrDefault(b, 0D),
+				riskMap.getOrDefault(a, 0D)));
+		int rows = Math.min(RISK_ROWS, riskList.size());
+		for (int i = 0; i < rows; i++) {
 			HealthRiskType type = riskList.get(i);
-			attributePanel.addTextField(type.getName(), Math.round(riskMap.get(type) * 100.0)/100.0 + " %", null);
+			double pct = Math.round(riskMap.getOrDefault(type, 0D) * 100.0) / 100.0;
+			attributePanel.addTextField(type.getName(), pct + " %", null);
 		}
 
 		
@@ -636,7 +642,7 @@ extends TabPanel {
 		}
 
 		// Update performance cache if necessary.
-		int newP = (int)(condition.getPerformanceFactor() * 100);
+		int newP = (int)(person.getPerformanceRating() * 100);
 		if (performanceCache != newP) {
 			performanceCache = newP;
 			performanceLabel.setText(DECIMAL_PERC.format(newP));
@@ -1028,12 +1034,18 @@ extends TabPanel {
 				largestSet = exerciseTime.keySet();
 			}
 
-			// Find the lowest sol day in the data
-			solOffset = largestSet.stream()
-					.mapToInt(v -> v)               
-	                .min()                          
-	                .orElse(Integer.MAX_VALUE);
-			rowCount = largestSet.size();
+			// Find the lowest sol day in the data, guard against empty sets
+			if (largestSet.isEmpty()) {
+				solOffset = 1;
+				rowCount = 0;
+			}
+			else {
+				solOffset = largestSet.stream()
+						.mapToInt(v -> v)               
+						.min()                          
+						.orElse(1);
+				rowCount = largestSet.size();
+			}
 
 			fireTableDataChanged();
 		}
@@ -1123,11 +1135,16 @@ extends TabPanel {
 			// The size of map needs to be updated
 			map = pc.getConsumptionHistory();
 			
-			// Find the lowest sol day in the data
-			solOffset = map.keySet().stream()
-					.mapToInt(v -> v)               
-	                .min()                          
-	                .orElse(Integer.MAX_VALUE);
+			// Find the lowest sol day in the data, guard against empty map
+			if (map.isEmpty()) {
+				solOffset = 1;
+			}
+			else {
+				solOffset = map.keySet().stream()
+						.mapToInt(v -> v)               
+						.min()                          
+						.orElse(1);
+			}
 			
 			fireTableDataChanged();
 		}


### PR DESCRIPTION
(Some Change Notes for this one)

Why this is worth doing

Correctness – hunger label showed thirst
The Hunger field accidentally displayed the thirst cache, which regularly misleads players about nutritional status and can influence task choices/AI triggers that users expect to observe from the UI.

Correctness – body mass deviation initialized from max energy bodyMassDev was initialized from getPersonalMaxEnergy() instead of getBodyMassDeviation(), causing mismatched values until the first refresh.

Consistency – performance metric
The “Performance” field was initialized from person.getPerformanceRating() but updated using condition.getPerformanceFactor(), producing inconsistent jumps. Now both use the same source (getPerformanceRating()).

Actionable Health Risks – sort by risk, cap safely The “Health Risks” area previously iterated an unsorted map and always took the first 10 enum entries. It now sorts by highest risk first, shows up to N rows safely, and won’t crash if there are fewer than 10 risks.

Sleep/Food history tables – safer zero‑data handling Minor guards ensure the tables compute row counts/offsets safely when data is temporarily empty (this ties to the recent “sleep time shows 0 msols” reports)

What this patch changes in practice

Players see the right numbers. Hunger now displays hunger; body mass deviation displays… body mass deviation.

No more inexplicable jumps in “Performance”. Both initial and refreshed values use person.getPerformanceRating(), so the number behaves predictably rather than flipping between two definitions.

Health risks are finally ranked. You see the most pressing risks first, which helps players (and QA) validate whether current routines (sleep, food, EVA exposure) are improving the right things.

Tables don’t “blink” to zero rows during transient data lulls. The guards keep row counts consistent while histories are warming up or temporarily empty (useful given the recent sleep‑table reports).  GitHub

How to test quickly

Open a person’s Health tab before/after the patch.

Confirm Hunger shows the same number you see in logs/tooltip for hunger (not thirst).

Confirm Performance stays consistent between initial paint and subsequent update() calls.

On a fresh game (or after clearing histories), open the Health tab immediately:

Sleep and Food tables should stay stable (0 or more rows, no exceptions).

Scroll the Health Risks list: the highest percentages should appear first; no errors if the list has <10 items.