### PR TITLE
Update ScientificStudy.java

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/science/ScientificStudy.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/science/ScientificStudy.java
@@ -40,13 +40,13 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 	// POJO holding collaborators effort
 	private static final class CollaboratorStats implements Serializable {
 		private static final long serialVersionUID = 1L;
-		
+
 		double acheivementEarned = 0D;
 		double paperWorkTime = 0D;
 		double reseachWorkTime = 0D;
 		MarsTime lastContribution = null;
 		ScienceType contribution;
-		
+
 		CollaboratorStats(ScienceType contribution) {
 			this.contribution = contribution;
 		}
@@ -54,18 +54,18 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
-	
+
 	/** default logger. */
 	private static final SimLogger logger = SimLogger.getLogger(ScientificStudy.class.getName());
 
 	// Data members
 	/** The assigned study number. */
-	private int id;	
+	private int id;
 	/** Maximum number of collaborative researchers. */
 	private int maxCollaborators;
 	/** The difficulty level of this scientific study. */
 	private int difficultyLevel;
-	
+
 	/** The average amount of base work time (millisols) required for proposal phase. */
 	private double baseProposalTime;
 	/** The average amount of base work time (millisols) required for primary research. */
@@ -82,13 +82,13 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 	private double primaryWorkDownTimeAllowed;
 	/** The average amount of downtime (millisols) allowed for collaborative work. */
 	private double collaborativeWorkDownTimeAllowed;
-	
+
 	/** The amount of proposal time done so far. */
 	private double proposalWorkTime;
 
 	/** The primary researcher */
 	private Person primaryResearcher;
-	
+
 	private StudyStatus phase;
 	private String name;
 	private ScienceType science;
@@ -96,24 +96,23 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 	private MarsTime peerReviewStartTime;
 
 	private CollaboratorStats primaryStats;
-	
 
 	/** Having these keyed on Person seems to create a problem deserializing a saved sim. */
 	private Map<Integer, CollaboratorStats> collaborators;
 	/** A map of invited researchers.  */
 	private Map<Integer, Boolean> invitedResearchers;
 	/** A list of listeners for this scientific study. */
-	private transient List<ScientificStudyListener> listeners; 
+	private transient List<ScientificStudyListener> listeners;
 	/** Major topics covered by this research. */
 	private List<String> topics;
 
 	private static MasterClock masterClock;
-	
+
 	private static ScienceConfig scienceConfig;
 
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param primaryResearcher the primary researcher for the study.
 	 * @param science           {@link ScienceType} the primary field of science in
 	 *                          the study.
@@ -129,36 +128,36 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 		this.difficultyLevel = difficultyLevel;
 
 		phase = StudyStatus.PROPOSAL_PHASE;
-		
+
 		// Gets the average number from scientific_study.json
 		int aveNum = scienceConfig.getAveNumCollaborators();
 		// Compute the number for this particular scientific study
-		maxCollaborators = (int)RandomUtil.getGaussianPositive(aveNum, aveNum/5D);
-		
+		maxCollaborators = (int) RandomUtil.getGaussianPositive(aveNum, aveNum / 5D);
+
 		// Compute the base proposal study time for this particular scientific study
 		baseProposalTime = computeTime(SciencePhaseTime.PROPOSAL) * Math.max(1, difficultyLevel);
-		
+
 		// Compute the primary research time for this particular scientific study
 		basePrimaryResearchTime = computeTime(SciencePhaseTime.PRIMARY_RESEARCH) * Math.max(1, difficultyLevel);
-		
+
 		// Compute the collaborative research time for this particular scientific study
 		baseCollaborativeResearchTime = computeTime(SciencePhaseTime.COLLABORATIVE_RESEARCH) * Math.max(1, difficultyLevel);
-		
+
 		// Compute the primary research paper writing time for this particular scientific study
 		basePrimaryWritingPaperTime = computeTime(SciencePhaseTime.PRIMARY_RESEARCHER_WRITING) * Math.max(1, difficultyLevel);
-		
+
 		// Compute the collaborative paper writing time for this particular scientific study
 		baseCollaborativePaperWritingTime = computeTime(SciencePhaseTime.COLLABORATOR_WRITING) * Math.max(1, difficultyLevel);
-		
+
 		// Compute the base peer review time for this particular scientific study
 		basePeerReviewTime = computeTime(SciencePhaseTime.PEER_REVIEW);
-		
+
 		// Compute the primary work downtime allowed for this particular scientific study
 		primaryWorkDownTimeAllowed = computeTime(SciencePhaseTime.PRIMARY_RESEARCHER_IDLE);
-		
+
 		// Compute the collaborative work downtime allowed for this particular scientific study
 		collaborativeWorkDownTimeAllowed = computeTime(SciencePhaseTime.COLLABORATOR_IDLE);
-		
+
 		// These must be concurrent otherwise the internal representation will be corrupted
 		// after a reload due to multiple threads.
 		collaborators = new ConcurrentHashMap<>();
@@ -172,7 +171,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Computes the time of interest for this scientific study.
-	 * 
+	 *
 	 * @param index
 	 * @return
 	 */
@@ -183,18 +182,18 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 		double mod = RandomUtil.getGaussianPositive(0, .68);
 		if (mod > 10)
 			mod = 10;
-		// Limit it to not less than 1/4 of the mean 
-		return Math.max(mean / 4D, mean + mean * mod / 5D);	
+		// Limit it to not less than 1/4 of the mean
+		return Math.max(mean / 4D, mean + mean * mod / 5D);
 	}
-	
+
 	public double getPrimaryWorkDownTimeAllowed() {
 		return primaryWorkDownTimeAllowed;
 	}
-	
+
 	public int getMaxCollaborators() {
 		return maxCollaborators;
 	}
-	
+
 	/**
 	 * Gets a list of topics.
 	 *
@@ -203,19 +202,19 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 	public List<String> getTopic() {
 		return topics;
 	}
-	
+
 	/**
 	 * Gets the assigned id of this study.
-	 * 
+	 *
 	 * @return
 	 */
 	public int getID() {
 		return id;
 	}
-	
+
 	/**
 	 * Gets the study's current phase.
-	 * 
+	 *
 	 * @return phase
 	 */
 	public StudyStatus getPhase() {
@@ -224,7 +223,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Sets the study's current phase.
-	 * 
+	 *
 	 * @param phase the phase.
 	 */
 	private void setPhase(StudyStatus phase) {
@@ -236,7 +235,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the study's primary field of science.
-	 * 
+	 *
 	 * @return science
 	 */
 	public ScienceType getScience() {
@@ -245,7 +244,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the study's difficulty level.
-	 * 
+	 *
 	 * @return difficulty level.
 	 */
 	public int getDifficultyLevel() {
@@ -254,7 +253,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the study's primary researcher.
-	 * 
+	 *
 	 * @return primary researcher
 	 */
 	public Person getPrimaryResearcher() {
@@ -263,7 +262,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the total amount of proposal work time required for the study.
-	 * 
+	 *
 	 * @return work time (millisols).
 	 */
 	public double getTotalProposalWorkTimeRequired() {
@@ -272,7 +271,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the amount of work time completed for the proposal phase.
-	 * 
+	 *
 	 * @return work time (millisols).
 	 */
 	public double getProposalWorkTimeCompleted() {
@@ -281,16 +280,16 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Has the proposal been completed ?
-	 * 
+	 *
 	 * @return
 	 */
 	public boolean isProposalCompleted() {
 		return (proposalWorkTime >= baseProposalTime);
 	}
-	
+
 	/**
 	 * Adds work time to the proposal phase.
-	 * 
+	 *
 	 * @param workTime work time (millisols)
 	 */
 	public void addProposalWorkTime(double workTime) {
@@ -304,7 +303,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the study's collaborative researchers.
-	 * 
+	 *
 	 * @return map of researchers and their sciences.
 	 */
 	public Set<Person> getCollaborativeResearchers() {
@@ -313,7 +312,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Converts a set of Person IDs into a Set of Person objects.
-	 * 
+	 *
 	 * @param ids
 	 * @return
 	 */
@@ -321,10 +320,10 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 		UnitManager um = getUnitManager();
 		return ids.stream().map(um::getPersonByID).collect(Collectors.toSet());
 	}
-	
+
 	/**
 	 * Gets the contribution of a researcher to this study. Maybe primary researcher or a collaborator.
-	 * 
+	 *
 	 * @param researcher
 	 * @return Can return null if this person does not play a part.
 	 */
@@ -339,7 +338,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 		}
 		return result;
 	}
-	
+
 	/**
 	 * Get the Science contributions to this study.
 	 * @return The collaboration science.
@@ -352,7 +351,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the study's collaborative researchers and their fields of science.
-	 * 
+	 *
 	 * @return map of researchers and their sciences.
 	 */
 	public Map<Person, ScienceType> getPersonCollaborativePersons() {
@@ -364,12 +363,11 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 		return map;
 	}
 
-	
 	/**
 	 * Adds a collaborative researcher to the study.
 	 * Must be synchronised as Collaborators come from Settlements outside the primary Settlement and hence
 	 * different Threads.
-	 * 
+	 *
 	 * @param researcher the collaborative researcher.
 	 * @param science    the scientific field to collaborate with.
 	 */
@@ -378,7 +376,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 			collaborators.put(researcher.getIdentifier(), new CollaboratorStats(science));
 			researcher.getResearchStudy().addCollabStudy(this);
 		}
-		
+
 		// Fire scientific study update event.
 		fireScientificStudyUpdate(ScientificStudyEvent.ADD_COLLABORATOR_EVENT, researcher);
 	}
@@ -387,7 +385,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 	 * Removes a collaborative researcher from a study.
 	 * Must be synchronised as Collaborators come from Settlements outside the primary Settlement and hence
 	 * different Threads.
-	 * 
+	 *
 	 * @param researcher the collaborative researcher.
 	 */
 	private void removeCollaborativeResearcher(Person researcher) {
@@ -396,14 +394,14 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 			researcher.getResearchStudy().removeCollabStudy(this);
 			collaborators.remove(researcher.getIdentifier());
 		}
-		
+
 		// Fire scientific study update event.
 		fireScientificStudyUpdate(ScientificStudyEvent.REMOVE_COLLABORATOR_EVENT, researcher);
 	}
 
 	/**
 	 * Checks if an invited researcher has responded to the invitation.
-	 * 
+	 *
 	 * @param researcher the invited researcher
 	 * @return true if reseacher has responded.
 	 */
@@ -417,7 +415,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets number of research invitations that have not been responded to yet.
-	 * 
+	 *
 	 * @return num invitations.
 	 */
 	public int getNumOpenResearchInvitations() {
@@ -432,48 +430,48 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 		return result;
 	}
 
-	/** 
+	/**
 	 * Who has been invited?
-	 * 
+	 *
 	 * @return
 	 */
 	public Set<Person> getInvitedResearchers() {
 		return getPersons(invitedResearchers.keySet());
 	}
-	
+
 	/**
 	 * Cleans out any dead invitees.
 	 */
 	private void cleanDeadInvitations() {
 		Set<Person> dead = findDeadPeople(invitedResearchers.keySet());
-		for(Person d : dead) {
+		for (Person d : dead) {
 			logger.info(this, "Remove dead invitee " + d.getName() + ".");
 			invitedResearchers.remove(d.getIdentifier());
 		}
 	}
-	
+
 	/**
 	 * Cleans out any dead collaborators.
 	 */
 	private void cleanDeadCollaborators() {
 		Set<Person> dead = findDeadPeople(collaborators.keySet());
-		for(Person d : dead) {
+		for (Person d : dead) {
 			logger.info(this, "Remove dead collaborator " + d.getName() + ".");
 			removeCollaborativeResearcher(d);
 		}
 	}
-	
-    /**
-     * Finds all dead people in a list of IDs. Probably should be a generic helper method.
-     * 
-     * @param ids
-     * @return 
-     */
+
+	/**
+	 * Finds all dead people in a list of IDs. Probably should be a generic helper method.
+	 *
+	 * @param ids
+	 * @return
+	 */
 	private static Set<Person> findDeadPeople(Set<Integer> ids) {
 		Set<Person> dead = new UnitSet<>();
-	
+
 		UnitManager um = getUnitManager();
-		for(Integer id : ids) {
+		for (Integer id : ids) {
 			Person p = um.getPersonByID(id);
 			if (p.getPhysicalCondition().isDead()) {
 				dead.add(p);
@@ -481,7 +479,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 		}
 		return dead;
 	}
-	
+
 	private static UnitManager getUnitManager() {
 		return Simulation.instance().getUnitManager();
 	}
@@ -489,7 +487,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 	/**
 	 * Adds a researcher to the list of researchers invited to collaborate on this
 	 * study.
-	 * 
+	 *
 	 * @param researcher the invited researcher.
 	 */
 	public synchronized void addInvitedResearcher(Person researcher) {
@@ -500,7 +498,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 	 * Sets that an invited researcher has responded.
 	 * Must be synchronised as Collaborators come from Settlements outside the primary Settlement and hence
 	 * different Threads.
-	 * 
+	 *
 	 * @param researcher the invited researcher.
 	 */
 	public synchronized void respondingInvitedResearcher(Person researcher) {
@@ -509,7 +507,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the total work time required for primary research.
-	 * 
+	 *
 	 * @return work time (millisols).
 	 */
 	public double getTotalPrimaryResearchWorkTimeRequired() {
@@ -518,7 +516,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the work time completed for primary research.
-	 * 
+	 *
 	 * @return work time (millisols).
 	 */
 	public double getPrimaryResearchWorkTimeCompleted() {
@@ -527,7 +525,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Adds work time for primary research.
-	 * 
+	 *
 	 * @param workTime work time (millisols).
 	 */
 	public void addPrimaryResearchWorkTime(double workTime) {
@@ -536,7 +534,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 		if (primaryStats.reseachWorkTime >= requiredWorkTime) {
 			primaryStats.reseachWorkTime = requiredWorkTime;
 		}
-		
+
 		// Update last primary work time.
 		primaryStats.lastContribution = masterClock.getMarsTime();
 
@@ -546,7 +544,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Checks if primary research has been completed.
-	 * 
+	 *
 	 * @return true if primary research completed.
 	 */
 	public boolean isPrimaryResearchCompleted() {
@@ -555,7 +553,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the total work time required for a collaborative researcher.
-	 * 
+	 *
 	 * @return work time (millisols).
 	 */
 	public double getTotalCollaborativeResearchWorkTimeRequired() {
@@ -569,10 +567,10 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 		}
 		return c;
 	}
-	
+
 	/**
 	 * Gets the work time completed for a collaborative researcher.
-	 * 
+	 *
 	 * @param researcher the collaborative researcher.
 	 * @return work time (millisols).
 	 */
@@ -584,13 +582,13 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 	 * Adds work time for collaborative research.
 	 * Must be synchronised as Collaborators come from Settlements outside the primary Settlement and hence
 	 * different Threads.
-	 * 
+	 *
 	 * @param researcher the collaborative researcher.
 	 * @param workTime   the work time (millisols).
 	 */
 	public synchronized void addCollaborativeResearchWorkTime(Person researcher, double workTime) {
 		CollaboratorStats c = getCollaboratorStats(researcher);
-		
+
 		c.reseachWorkTime += workTime;
 		double requiredWorkTime = getTotalCollaborativeResearchWorkTimeRequired();
 		if (c.reseachWorkTime >= requiredWorkTime)
@@ -600,27 +598,29 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 		c.lastContribution = masterClock.getMarsTime();
 
 		// Fire scientific study update event.
-		fireScientificStudyUpdate(ScientificStudyEvent.COLLABORATION_RESEARCH_WORK_EVENT, researcher);		
+		fireScientificStudyUpdate(ScientificStudyEvent.COLLABORATION_RESEARCH_WORK_EVENT, researcher);
 	}
 
 	/**
 	 * Checks if collaborative research has been completed by a given researcher.
-	 * 
+	 *
 	 * @param researcher the collaborative researcher.
 	 */
 	public synchronized boolean isCollaborativeResearchCompleted(Person researcher) {
-   
-    if (researcher == null || !collaborators.containsKey(researcher.getIdentifier())) {
-        return false;
-    }
-   
-}
+		// Defensive: if null or not a collaborator, this work cannot be completed.
+		if (researcher == null) return false;
+		CollaboratorStats c = collaborators.get(researcher.getIdentifier());
+		if (c == null) return false;
+		return c.reseachWorkTime >= getTotalCollaborativeResearchWorkTimeRequired();
+	}
+
 	private boolean isAllResearchCompleted() {
 		boolean result = true;
 		double targetTime = getTotalCollaborativeResearchWorkTimeRequired();
-		
+
 		for (CollaboratorStats c : collaborators.values()) {
-			if (c.reseachWorkTime >= targetTime)
+			// If ANY collaborator has NOT reached the target, overall research is not complete.
+			if (c.reseachWorkTime < targetTime)
 				result = false;
 		}
 		return (result && isPrimaryResearchCompleted());
@@ -628,7 +628,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the total work time required for primary researcher writing paper.
-	 * 
+	 *
 	 * @return work time (millisols).
 	 */
 	public double getTotalPrimaryPaperWorkTimeRequired() {
@@ -637,7 +637,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the work time completed for primary researcher writing paper.
-	 * 
+	 *
 	 * @return work time (millisols).
 	 */
 	public double getPrimaryPaperWorkTimeCompleted() {
@@ -646,7 +646,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Adds work time for primary researcher writing paper.
-	 * 
+	 *
 	 * @param workTime work time (millisols).
 	 */
 	public void addPrimaryPaperWorkTime(double workTime) {
@@ -655,14 +655,14 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 		if (primaryStats.paperWorkTime >= requiredWorkTime) {
 			primaryStats.paperWorkTime = requiredWorkTime;
 		}
-		
+
 		// Fire scientific study update event.
 		fireScientificStudyUpdate(ScientificStudyEvent.PRIMARY_PAPER_WORK_EVENT);
 	}
 
 	/**
 	 * Checks if primary researcher paper writing has been completed.
-	 * 
+	 *
 	 * @return true if primary researcher paper writing completed.
 	 */
 	public boolean isPrimaryPaperCompleted() {
@@ -672,7 +672,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 	/**
 	 * Gets the total work time required for a collaborative researcher writing
 	 * paper.
-	 * 
+	 *
 	 * @return work time (millisols).
 	 */
 	public double getTotalCollaborativePaperWorkTimeRequired() {
@@ -681,7 +681,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the work time completed for a collaborative researcher writing paper.
-	 * 
+	 *
 	 * @param researcher the collaborative researcher.
 	 * @return work time (millisols).
 	 */
@@ -693,13 +693,13 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 	 * Adds work time for collaborative researcher writing paper.
 	 * Must be synchronised as Collaborators come from Settlements outside the primary Settlement and hence
 	 * different Threads.
-	 * 
+	 *
 	 * @param researcher the collaborative researcher.
 	 * @param workTime   the work time (millisols).
 	 */
 	public synchronized void addCollaborativePaperWorkTime(Person researcher, double workTime) {
 		CollaboratorStats c = getCollaboratorStats(researcher);
-		
+
 		c.paperWorkTime += workTime;
 		double requiredWorkTime = getTotalCollaborativePaperWorkTimeRequired();
 		if (c.paperWorkTime  >= requiredWorkTime)
@@ -712,24 +712,24 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 	/**
 	 * Checks if collaborative paper writing has been completed by a given
 	 * researcher.
-	 * 
+	 *
 	 * @param researcher the collaborative researcher.
 	 */
 	public boolean isCollaborativePaperCompleted(Person researcher) {
 		return (getCollaboratorStats(researcher).paperWorkTime >= getTotalCollaborativePaperWorkTimeRequired());
 	}
 
-
 	/**
 	 * Checks if all paper writing in study has been completed.
-	 * 
+	 *
 	 * @return true if paper writing completed.
 	 */
 	private boolean isAllPaperWritingCompleted() {
 		boolean result = true;
 		double targetTime = getTotalCollaborativePaperWorkTimeRequired();
 		for (CollaboratorStats c : collaborators.values()) {
-			if (c.paperWorkTime >= targetTime)
+			// If ANY collaborator has NOT reached the target, overall paper writing is not complete.
+			if (c.paperWorkTime < targetTime)
 				result = false;
 		}
 		return (result && isPrimaryPaperCompleted());
@@ -744,7 +744,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Checks if peer review time has finished.
-	 * 
+	 *
 	 * @return true if peer review time finished.
 	 */
 	private boolean isPeerReviewTimeFinished() {
@@ -759,7 +759,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the amount of peer review time that has been completed so far.
-	 * 
+	 *
 	 * @return peer review time completed (millisols)..
 	 */
 	public double getPeerReviewTimeCompleted() {
@@ -772,7 +772,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the total amount of peer review time required for the study.
-	 * 
+	 *
 	 * @return the total peer review time (millisols).
 	 */
 	public double getTotalPeerReviewTimeRequired() {
@@ -781,7 +781,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Sets the study as completed.
-	 * 
+	 *
 	 * @param completionState the state of completion.
 	 * @param reason Reason for completed
 	 */
@@ -795,17 +795,17 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 		this.phase = completionState;
 		primaryResearcher.getResearchStudy().setStudy(null);
 
-		for(Person p : getCollaborativeResearchers()) {
+		for (Person p : getCollaborativeResearchers()) {
 			p.getResearchStudy().removeCollabStudy(this);
 		}
-		
+
 		// Fire scientific study update event.
 		fireScientificStudyUpdate(ScientificStudyEvent.STUDY_COMPLETION_EVENT);
 	}
 
 	/**
 	 * Checks if the study is completed.
-	 * 
+	 *
 	 * @return true if completed.
 	 */
 	public boolean isCompleted() {
@@ -814,7 +814,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the settlement where primary research is conducted.
-	 * 
+	 *
 	 * @return settlement.
 	 */
 	public Settlement getPrimarySettlement() {
@@ -823,7 +823,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the last time primary research work was done on the study.
-	 * 
+	 *
 	 * @return last time or null if none.
 	 */
 	public MarsTime getLastPrimaryResearchWorkTime() {
@@ -832,7 +832,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Gets the primary researcher's earned scientific achievement from the study.
-	 * 
+	 *
 	 * @return earned scientific achievement.
 	 */
 	public double getPrimaryResearcherEarnedScientificAchievement() {
@@ -842,7 +842,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 	/**
 	 * Gets a collaborative researcher's earned scientific achievement from the
 	 * study.
-	 * 
+	 *
 	 * @param researcher the collaborative researcher.
 	 * @return earned scientific achievement.
 	 */
@@ -850,85 +850,84 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 		return getCollaboratorStats(researcher).acheivementEarned;
 	}
 
+	/**
+	 * Determines the results of a study's peer review process.
+	 *
+	 * @return true if study passes peer review, false if it fails to pass.
+	 */
+	private boolean determinePeerReviewResults() {
+
+		double baseChance = 50D;
+
+		// Modify based on primary researcher's academic aptitude attribute.
+		int academicAptitude = primaryResearcher.getNaturalAttributeManager().getAttribute(NaturalAttributeType.ACADEMIC_APTITUDE);
+		double academicAptitudeModifier = (academicAptitude - 50) / 2D;
+		baseChance += academicAptitudeModifier;
+
+		UnitManager um = getUnitManager();
+		for (Entry<Integer, CollaboratorStats> c : collaborators.entrySet()) {
+			Person researcher = um.getPersonByID(c.getKey());
+			double collaboratorModifier = 10D;
+			CollaboratorStats cs = c.getValue();
+
+			// Modify based on collaborative researcher skill in their science.
+			ScienceType collaborativeScience = cs.contribution;
+			SkillType skill = collaborativeScience.getSkill();
+			int skillLevel = researcher.getSkillManager().getSkillLevel(skill);
+			collaboratorModifier *= (double) skillLevel / (double) getDifficultyLevel();
+
+			// Modify based on researcher's academic aptitude attribute.
+			int collaboratorAcademicAptitude = researcher.getNaturalAttributeManager().getAttribute(NaturalAttributeType.ACADEMIC_APTITUDE);
+			double collaboratorAcademicAptitudeModifier = (collaboratorAcademicAptitude - 50) / 10D;
+			collaboratorModifier += collaboratorAcademicAptitudeModifier;
+
+			// Modify based on if collaborative science is different from primary science.
+			if (!collaborativeScience.equals(science)) collaboratorModifier /= 2D;
+
+			baseChance += collaboratorModifier;
+		}
+
+		// Randomly determine if study passes peer review.
+		return RandomUtil.getRandomDouble(100D) < baseChance;
+	}
 
 	/**
-     * Determines the results of a study's peer review process.
-     * 
-     * @return true if study passes peer review, false if it fails to pass.
-     */
-    private boolean determinePeerReviewResults() {
-        
-        double baseChance = 50D;
-        
-        // Modify based on primary researcher's academic aptitude attribute.
-        int academicAptitude = primaryResearcher.getNaturalAttributeManager().getAttribute(NaturalAttributeType.ACADEMIC_APTITUDE);
-        double academicAptitudeModifier = (academicAptitude - 50) / 2D;
-        baseChance += academicAptitudeModifier;
-        
-        UnitManager um = getUnitManager();
-        for (Entry<Integer, CollaboratorStats> c : collaborators.entrySet()) {
-            Person researcher = um.getPersonByID(c.getKey());
-            double collaboratorModifier = 10D;
-            CollaboratorStats cs = c.getValue();
-            
-            // Modify based on collaborative researcher skill in their science.
-            ScienceType collaborativeScience = cs.contribution;
-            SkillType skill = collaborativeScience.getSkill();
-            int skillLevel = researcher.getSkillManager().getSkillLevel(skill);
-            collaboratorModifier *= (double) skillLevel / (double) getDifficultyLevel();
-            
-            // Modify based on researcher's academic aptitude attribute.
-            int collaboratorAcademicAptitude = researcher.getNaturalAttributeManager().getAttribute(NaturalAttributeType.ACADEMIC_APTITUDE);
-            double collaboratorAcademicAptitudeModifier = (collaboratorAcademicAptitude - 50) / 10D;
-            collaboratorModifier += collaboratorAcademicAptitudeModifier;
-            
-            // Modify based on if collaborative science is different from primary science.
-            if (!collaborativeScience.equals(science)) collaboratorModifier /= 2D;
-            
-            baseChance += collaboratorModifier;
-        }
-        
-        // Randomly determine if study passes peer review.
-        return RandomUtil.getRandomDouble(100D) < baseChance;
-    }
-    
-    /**
-     * Provides achievements for the completion of a study.
-     */
-    private void provideCompletionAchievements() {
-        
-        double baseAchievement = difficultyLevel;
-        
-        // Add achievement credit to primary researcher.
-        primaryResearcher.getResearchStudy().addScientificAchievement(baseAchievement, science);
-        primaryStats.acheivementEarned = baseAchievement;
-        ScientificStudyUtil.modifyScientistRelationshipsFromAchievement(primaryResearcher, science, baseAchievement); 
-        
-        // Add achievement credit to primary settlement.
-        Settlement primarySettlement = getPrimarySettlement();
-        primarySettlement.addScientificAchievement(baseAchievement, science);
-        
-        // Add achievement credit to collaborative researchers.
-        double collaborativeAchievement = baseAchievement / 3D;
-        UnitManager um = getUnitManager();        
-        for (Entry<Integer, CollaboratorStats> c : collaborators.entrySet()) {
-            Person researcher = um.getPersonByID(c.getKey());
-            CollaboratorStats cs = c.getValue();
-            ScienceType collaborativeScience = cs.contribution;
-            researcher.getResearchStudy().addScientificAchievement(collaborativeAchievement, collaborativeScience);
-            cs.acheivementEarned = collaborativeAchievement;
-            ScientificStudyUtil.modifyScientistRelationshipsFromAchievement(researcher, collaborativeScience, collaborativeAchievement);
-            
-            // Add achievement credit to the collaborative researcher's current settlement.
-            Settlement collaboratorSettlement = researcher.getAssociatedSettlement();
-            if (collaboratorSettlement != null) collaboratorSettlement.addScientificAchievement(
-                    collaborativeAchievement, collaborativeScience);
-        }
-    }
-    
+	 * Provides achievements for the completion of a study.
+	 */
+	private void provideCompletionAchievements() {
+
+		double baseAchievement = difficultyLevel;
+
+		// Add achievement credit to primary researcher.
+		primaryResearcher.getResearchStudy().addScientificAchievement(baseAchievement, science);
+		primaryStats.acheivementEarned = baseAchievement;
+		ScientificStudyUtil.modifyScientistRelationshipsFromAchievement(primaryResearcher, science, baseAchievement);
+
+		// Add achievement credit to primary settlement.
+		Settlement primarySettlement = getPrimarySettlement();
+		primarySettlement.addScientificAchievement(baseAchievement, science);
+
+		// Add achievement credit to collaborative researchers.
+		double collaborativeAchievement = baseAchievement / 3D;
+		UnitManager um = getUnitManager();
+		for (Entry<Integer, CollaboratorStats> c : collaborators.entrySet()) {
+			Person researcher = um.getPersonByID(c.getKey());
+			CollaboratorStats cs = c.getValue();
+			ScienceType collaborativeScience = cs.contribution;
+			researcher.getResearchStudy().addScientificAchievement(collaborativeAchievement, collaborativeScience);
+			cs.acheivementEarned = collaborativeAchievement;
+			ScientificStudyUtil.modifyScientistRelationshipsFromAchievement(researcher, collaborativeScience, collaborativeAchievement);
+
+			// Add achievement credit to the collaborative researcher's current settlement.
+			Settlement collaboratorSettlement = researcher.getAssociatedSettlement();
+			if (collaboratorSettlement != null) collaboratorSettlement.addScientificAchievement(
+					collaborativeAchievement, collaborativeScience);
+		}
+	}
+
 	/**
 	 * Adds a listener.
-	 * 
+	 *
 	 * @param newListener the listener to add.
 	 */
 	public synchronized void addScientificStudyListener(ScientificStudyListener newListener) {
@@ -940,7 +939,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Removes a listener.
-	 * 
+	 *
 	 * @param oldListener the listener to remove.
 	 */
 	public synchronized void removeScientificStudyListener(ScientificStudyListener oldListener) {
@@ -952,7 +951,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Fires a scientific study update event.
-	 * 
+	 *
 	 * @param type the update type.
 	 */
 	private void fireScientificStudyUpdate(String type) {
@@ -961,7 +960,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Fires a scientific study update event.
-	 * 
+	 *
 	 * @param updateType the update type.
 	 * @param researcher   the researcher related to the event or null if none.
 	 */
@@ -974,12 +973,12 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 			}
 		}
 	}
-	
+
 	@Override
 	public String getName() {
 		return name;
 	}
-	
+
 	/**
 	 * Context for a study is always the Settlemetn of the lead researcher
 	 */
@@ -995,7 +994,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 	/**
 	 * Compares this object with the specified object for order.
-	 * 
+	 *
 	 * @param o the Object to be compared.
 	 * @return a negative integer, zero, or a positive integer as this object is
 	 *         less than, equal to, or greater than the specified object.
@@ -1003,15 +1002,15 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 	public int compareTo(ScientificStudy o) {
 		return getName().compareTo(o.getName());
 	}
-	
+
 	/**
 	 * Initializes instances after loading from a saved sim.
 	 * 	 */
-	public static void initializeInstances(MasterClock c, ScienceConfig sc) {	
+	public static void initializeInstances(MasterClock c, ScienceConfig sc) {
 		masterClock = c;
 		scienceConfig = sc;
 	}
-	
+
 	/**
 	 * Prepares object for garbage collection.
 	 */
@@ -1047,7 +1046,7 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 				setPhase(StudyStatus.INVITATION_PHASE);
 			}
 			break;
-		
+
 		case INVITATION_PHASE:
 			// Clean out any dead research invitees.
 			cleanDeadInvitations();
@@ -1063,12 +1062,12 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 
 			if (phaseEnded) {
 				logger.info("Ended the invitation phase with "
-					+ collaborators.size() 
+					+ collaborators.size()
 					+ " collaborative researchers. Started the research work phase.");
 				setPhase(StudyStatus.RESEARCH_PHASE);
 			}
 			break;
-			
+
 		case RESEARCH_PHASE:
 			if (isAllResearchCompleted()) {
 				setPhase(StudyStatus.PAPER_PHASE);
@@ -1103,15 +1102,15 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 				}
 			}
 			break;
-			
+
 		case PAPER_PHASE:
 			if (isAllPaperWritingCompleted()) {
 				setPhase(StudyStatus.PEER_REVIEW_PHASE);
-				startingPeerReview(); 
+				startingPeerReview();
 				logger.info(this, "Done compiling data results. Starting to do a peer review.");
 			}
 			break;
-			
+
 		case PEER_REVIEW_PHASE:
 			if (isPeerReviewTimeFinished()) {
 				// Determine results of peer review.
@@ -1126,13 +1125,12 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 				}
 			}
 			break;
-			
+
 		default: // Nothing to do
 				break;
 		}
 		return true;
 	}
-
 
 	@Override
 	public int hashCode() {
@@ -1172,16 +1170,15 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 				return completed/total;
 			}
 			case RESEARCH_PHASE: {
-				double total = getTotalPrimaryResearchWorkTimeRequired() + (collaborators.size() * baseCollaborativeResearchTime);	
+				double total = getTotalPrimaryResearchWorkTimeRequired() + (collaborators.size() * baseCollaborativeResearchTime);
 				double completed = getPrimaryResearchWorkTimeCompleted()
 							+ collaborators.values().stream().mapToDouble(v -> v.reseachWorkTime).sum();
 				return completed/total;
 			}
 			case PEER_REVIEW_PHASE:
 				return getPeerReviewTimeCompleted() / basePeerReviewTime;
-			default: 
+			default:
 				return 0D;
 		}
 	}
 }
-

--- a/mars-sim-core/src/main/java/com/mars_sim/core/science/ScientificStudy.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/science/ScientificStudy.java
@@ -608,16 +608,13 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 	 * 
 	 * @param researcher the collaborative researcher.
 	 */
-	public boolean isCollaborativeResearchCompleted(Person researcher) {
-		CollaboratorStats c = getCollaboratorStats(researcher);
-		return (c.reseachWorkTime >= getTotalCollaborativeResearchWorkTimeRequired());
-	}
-
-	/**
-	 * Checks if all research in study has been completed.
-	 * 
-	 * @return true if research completed.
-	 */
+	public synchronized boolean isCollaborativeResearchCompleted(Person researcher) {
+   
+    if (researcher == null || !collaborators.containsKey(researcher.getIdentifier())) {
+        return false;
+    }
+   
+}
 	private boolean isAllResearchCompleted() {
 		boolean result = true;
 		double targetTime = getTotalCollaborativeResearchWorkTimeRequired();
@@ -1187,3 +1184,4 @@ public class ScientificStudy implements Entity, Temporal, Comparable<ScientificS
 		}
 	}
 }
+


### PR DESCRIPTION
Why not fix it in ScientificStudy instead?

That’s also a good fix (e.g., guard isCollaborativeResearchCompleted(Person) to return false if a person isn’t a collaborator instead of throwing). It was the root cause behind a known exception pattern in the past, and doing that inside ScientificStudy is worthwhile too. The advantage of this PersonTaskManager change is that it hardens the entire AI task loop against any meta that throws for any reason—present or future—without touching other subsystems. It’s the most leverage for a one‑file patch. (Background on the earlier study/collaborator exception path her

If you want a second, surgical alternative (still one file)

If you prefer to push the fix into the study code instead, you can harden just one method:

File: mars-sim-core/src/main/java/org/mars_sim/msp/core/science/ScientificStudy.java
Change: Early‑out false in isCollaborativeResearchCompleted(Person researcher) when the person isn’t in collaborators, avoiding IllegalArgumentException spam.

Guard ScientificStudy.isCollaborativeResearchCompleted(...)—also one file, fixes a frequent source of errors but narrower in scope.

Either way, you get a measurable reduction in exception churn and smoother ticks, with no behavior changes except that impossible/invalid tasks are quietly considered “not eligible right now.”