### PR TITLE
Create SpaceWeatherSeverity.java

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/spaceweather/SolarStormEvent.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/spaceweather/SolarStormEvent.java
@@ -1,0 +1,42 @@
+/*
+ * Mars Simulation Project - Space Weather
+ * GPL-3.0-or-later
+ */
+package org.mars_sim.msp.core.spaceweather;
+
+/** Immutable snapshot of an active solar storm. */
+public final class SolarStormEvent {
+    private final SpaceWeatherSeverity severity;
+    private final double totalDurationMsol;
+    private double remainingMsol;
+
+    public SolarStormEvent(SpaceWeatherSeverity severity, double durationMsol) {
+        this.severity = severity;
+        this.totalDurationMsol = durationMsol;
+        this.remainingMsol = durationMsol;
+    }
+
+    public SpaceWeatherSeverity getSeverity() { return severity; }
+    public double getTotalDurationMsol() { return totalDurationMsol; }
+    public double getRemainingMsol() { return remainingMsol; }
+    public boolean isFinished() { return remainingMsol <= 0.0; }
+
+    /** Advance time (millisols). */
+    public void advance(double deltaMsol) {
+        remainingMsol -= deltaMsol;
+    }
+
+    /** Multiplier to apply to solar array output. */
+    public double solarPowerMultiplier() { return severity.solarPowerMultiplier; }
+
+    /** True if comms blackout is in effect. */
+    public boolean commsBlackout() { return severity.commsBlackout; }
+
+    /** Scale factor to apply to ambient radiation dose rate calculations (optional hook). */
+    public double radiationDoseScale() { return severity.radiationDoseScale; }
+
+    @Override
+    public String toString() {
+        return "SolarStormEvent[" + severity + ", remainingMsol=" + Math.max(0.0, remainingMsol) + "]";
+    }
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/spaceweather/SpaceWeatherService.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/spaceweather/SpaceWeatherService.java
@@ -9,38 +9,75 @@ import java.util.Random;
 
 /**
  * Models heliophysical "space weather" events that periodically strike the colony.
- * It is intentionally small and deterministic (seeded RNG) so it can be saved/loaded easily.
+ * <p>
+ * This service is deterministic when constructed with a fixed RNG seed, which makes
+ * save/load straightforward. Call {@link #advance(double)} exactly once per
+ * simulation pulse (with the elapsed millisols) and query its public getters for
+ * effects such as the current solar power multiplier and comms blackout status.
+ * </p>
  *
- * Wire it from Simulation.clockPulse(...) once per pulse:
- *     spaceWeather.advance(deltaMsol);
+ * <pre>
+ * // Wire from Simulation.clockPulse(...):
+ * double deltaMsol = ...;    // elapsed millisols this pulse
+ * spaceWeather.advance(deltaMsol);
+ * </pre>
  */
 public final class SpaceWeatherService {
 
-    /** One sol == 1000 msol in Mars-sim notation. */
+    /** One sol equals 1000 msol in mars-sim notation. */
     public static final double MSOL_PER_SOL = 1000.0;
+
+    // --- Tuning constants (kept as named constants to satisfy style checks) ---
+
+    /** Default per-sol chance that a storm begins. */
+    private static final double DEFAULT_DAILY_STORM_PROBABILITY = 0.08;
+
+    /** Default severity weighting for new storms. */
+    private static final double DEFAULT_WEIGHT_MILD = 0.60;
+    private static final double DEFAULT_WEIGHT_MODERATE = 0.30;
+    private static final double DEFAULT_WEIGHT_SEVERE = 0.10;
+
+    /** Randomized base duration range, in sols: base in [BASE_DURATION_MIN, BASE_DURATION_MIN + BASE_DURATION_RANGE]. */
+    private static final double BASE_DURATION_MIN = 0.6;     // sols
+    private static final double BASE_DURATION_RANGE = 0.6;   // sols, so 0.6-1.2 total
+
+    /** Per-severity scaling of duration. */
+    private static final double MILD_DURATION_SCALE = 0.7;
+    private static final double MODERATE_DURATION_SCALE = 1.0;
+    private static final double SEVERE_DURATION_SCALE = 1.3;
 
     private final Random rng;
     private SolarStormEvent active;
     private double solarMultiplier = 1.0;
     private boolean commsBlackout = false;
 
-    /** Accumulator for detecting sol boundaries (optional future use). */
+    /** Accumulator for detecting sol boundaries (rolls for storm starts). */
     private double sinceLastCheckMsol = 0.0;
 
     /** Baseline per-sol chance for a storm to begin (tuned for gameplay). */
-    private double baseDailyStormProbability = 0.08; // 8% per sol by default
-    /** Weighting of mild/moderate/severe events. */
-    private double pMild = 0.60;
-    private double pModerate = 0.30;
-    private double pSevere = 0.10;
+    private double baseDailyStormProbability = DEFAULT_DAILY_STORM_PROBABILITY;
 
-    /** Construct with a seed for deterministic runs (serialize the seed for saves). */
+    /** Severity weights (mild, moderate, severe); normalized in {@link #setSeverityWeights(double, double, double)}. */
+    private double pMild = DEFAULT_WEIGHT_MILD;
+    private double pModerate = DEFAULT_WEIGHT_MODERATE;
+    private double pSevere = DEFAULT_WEIGHT_SEVERE;
+
+    /**
+     * Constructs the service with a deterministic RNG.
+     *
+     * @param seed random seed used to generate events deterministically
+     */
     public SpaceWeatherService(long seed) {
         this.rng = new Random(seed);
         recomputeMultipliers();
     }
 
-    /** Advance the model by delta msol. Call exactly once per clock pulse. */
+    /**
+     * Advances the space weather model by the given elapsed time in millisols.
+     * <p>Call once per simulation pulse.</p>
+     *
+     * @param deltaMsol elapsed millisols for this pulse (1000 msol == 1 sol)
+     */
     public void advance(double deltaMsol) {
         sinceLastCheckMsol += deltaMsol;
 
@@ -51,42 +88,64 @@ public final class SpaceWeatherService {
                 recomputeMultipliers();
             }
             else {
-                // Keep current multipliers.
+                // Keep current multipliers and return early if storm still active.
                 return;
             }
         }
 
-        // No active event: roll the dice once per sol in aggregate (cheap and predictable)
+        // No active event: roll the dice once per sol in aggregate (cheap and predictable).
         if (sinceLastCheckMsol >= MSOL_PER_SOL) {
             sinceLastCheckMsol -= MSOL_PER_SOL;
             maybeStartNewStorm();
         }
     }
 
-    /** Exposes the current solar power multiplier for arrays. */
+    /**
+     * Gets the current solar power multiplier to apply to solar array output.
+     *
+     * @return multiplier in [0, 1], where 1 means no curtailment
+     */
     public double getSolarPowerMultiplier() {
         return solarMultiplier;
     }
 
-    /** True if long-range communications are blacked out. */
+    /**
+     * Indicates whether a long-range communications blackout is in effect.
+     *
+     * @return {@code true} if comms are blacked out, otherwise {@code false}
+     */
     public boolean isCommsBlackout() {
         return commsBlackout;
     }
 
-    /** Returns the active event, or null if clear skies. */
+    /**
+     * Returns the currently active storm event, if any.
+     *
+     * @return the active {@link SolarStormEvent} or {@code null} if clear skies
+     */
     public SolarStormEvent getActiveEvent() {
         return active;
     }
 
-    /** Optional: tweak baseline storm probability at runtime (0..1). */
+    /**
+     * Sets the baseline per-sol probability that a new storm begins.
+     *
+     * @param p probability in [0, 1]
+     */
     public void setBaseDailyStormProbability(double p) {
-        this.baseDailyStormProbability = Math.max(0, Math.min(1, p));
+        this.baseDailyStormProbability = Math.max(0.0, Math.min(1.0, p));
     }
 
-    /** Optional: tweak severity distribution. Values are normalized automatically. */
+    /**
+     * Sets the relative weights for sampling storm severity. Values are normalized.
+     *
+     * @param mild     weight for {@link SpaceWeatherSeverity#MILD}
+     * @param moderate weight for {@link SpaceWeatherSeverity#MODERATE}
+     * @param severe   weight for {@link SpaceWeatherSeverity#SEVERE}
+     */
     public void setSeverityWeights(double mild, double moderate, double severe) {
         double sum = mild + moderate + severe;
-        if (sum <= 0) {
+        if (sum <= 0.0) {
             return;
         }
         this.pMild = mild / sum;
@@ -97,18 +156,18 @@ public final class SpaceWeatherService {
     private void maybeStartNewStorm() {
         if (rng.nextDouble() < baseDailyStormProbability) {
             SpaceWeatherSeverity s = sampleSeverity();
-            // Duration 0.4–1.6 sols, severity-weighted
-            double base = 0.6 + rng.nextDouble() * 0.6; // 0.6-1.2 sols
+            // Duration 0.6-1.2 sols, severity-weighted scaling.
+            double base = BASE_DURATION_MIN + rng.nextDouble() * BASE_DURATION_RANGE;
             double durationSol;
             switch (s) {
                 case MILD:
-                    durationSol = base * 0.7;
+                    durationSol = base * MILD_DURATION_SCALE;
                     break;
                 case MODERATE:
-                    durationSol = base * 1.0;
+                    durationSol = base * MODERATE_DURATION_SCALE;
                     break;
                 case SEVERE:
-                    durationSol = base * 1.3;
+                    durationSol = base * SEVERE_DURATION_SCALE;
                     break;
                 default:
                     durationSol = base;
@@ -141,12 +200,19 @@ public final class SpaceWeatherService {
         }
     }
 
-    // --- Save/load helpers (optional) ---
-    /** Minimal serialization DTO; implement with the project’s existing save system. */
+    // ---------------------------------------------------------------------
+    // Save/load helpers (optional)
+    // ---------------------------------------------------------------------
+
+    /**
+     * Creates a snapshot DTO of the current service state.
+     *
+     * @return immutable state snapshot suitable for serialization
+     */
     public SpaceWeatherState snapshot() {
         return new SpaceWeatherState(
             active == null ? null : active.getSeverity().name(),
-            active == null ? 0 : active.getRemainingMsol(),
+            active == null ? 0.0 : active.getRemainingMsol(),
             baseDailyStormProbability,
             pMild,
             pModerate,
@@ -154,31 +220,51 @@ public final class SpaceWeatherService {
         );
     }
 
+    /**
+     * Restores the service state from a snapshot DTO.
+     *
+     * @param state previously captured state; must not be null
+     * @throws NullPointerException if {@code state} is null
+     */
     public void restore(SpaceWeatherState state) {
         Objects.requireNonNull(state, "state");
-        if (state.activeSeverity != null) {
-            SpaceWeatherSeverity s = SpaceWeatherSeverity.valueOf(state.activeSeverity);
-            active = new SolarStormEvent(s, state.remainingMsol);
+        if (state.getActiveSeverity() != null) {
+            SpaceWeatherSeverity s = SpaceWeatherSeverity.valueOf(state.getActiveSeverity());
+            active = new SolarStormEvent(s, state.getRemainingMsol());
         }
         else {
             active = null;
         }
-        baseDailyStormProbability = state.baseDailyStormProbability;
-        pMild = state.pMild;
-        pModerate = state.pModerate;
-        pSevere = state.pSevere;
+        baseDailyStormProbability = state.getBaseDailyStormProbability();
+        pMild = state.getPMild();
+        pModerate = state.getPModerate();
+        pSevere = state.getPSevere();
         recomputeMultipliers();
     }
 
-    /** Tiny DTO. Replace with project’s serialization mechanism as needed. */
+    /**
+     * Immutable DTO for persisting {@link SpaceWeatherService} state.
+     * <p>Replace with the project's serialization mechanism as needed.</p>
+     */
     public static final class SpaceWeatherState {
-        public final String activeSeverity;
-        public final double remainingMsol;
-        public final double baseDailyStormProbability;
-        public final double pMild;
-        public final double pModerate;
-        public final double pSevere;
 
+        private final String activeSeverity;
+        private final double remainingMsol;
+        private final double baseDailyStormProbability;
+        private final double pMild;
+        private final double pModerate;
+        private final double pSevere;
+
+        /**
+         * Creates a new state snapshot.
+         *
+         * @param activeSeverity             {@code null} if no active storm, otherwise enum name
+         * @param remainingMsol              remaining duration of the active storm in millisols
+         * @param baseDailyStormProbability  per-sol probability that a storm begins
+         * @param pMild                      normalized weight for mild storms
+         * @param pModerate                  normalized weight for moderate storms
+         * @param pSevere                    normalized weight for severe storms
+         */
         public SpaceWeatherState(
                 String activeSeverity,
                 double remainingMsol,
@@ -192,6 +278,36 @@ public final class SpaceWeatherService {
             this.pMild = pMild;
             this.pModerate = pModerate;
             this.pSevere = pSevere;
+        }
+
+        /** @return enum name of the active severity or {@code null} if none */
+        public String getActiveSeverity() {
+            return activeSeverity;
+        }
+
+        /** @return remaining duration in millisols for the active storm */
+        public double getRemainingMsol() {
+            return remainingMsol;
+        }
+
+        /** @return per-sol probability that a storm begins */
+        public double getBaseDailyStormProbability() {
+            return baseDailyStormProbability;
+        }
+
+        /** @return normalized weight for mild storms */
+        public double getPMild() {
+            return pMild;
+        }
+
+        /** @return normalized weight for moderate storms */
+        public double getPModerate() {
+            return pModerate;
+        }
+
+        /** @return normalized weight for severe storms */
+        public double getPSevere() {
+            return pSevere;
         }
     }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/spaceweather/SpaceWeatherService.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/spaceweather/SpaceWeatherService.java
@@ -29,8 +29,10 @@ public final class SpaceWeatherService {
 
     /** Baseline per-sol chance for a storm to begin (tuned for gameplay). */
     private double baseDailyStormProbability = 0.08; // 8% per sol by default
-    /** Weighting of moderate vs severe vs mild events. */
-    private double pMild = 0.60, pModerate = 0.30, pSevere = 0.10;
+    /** Weighting of mild/moderate/severe events. */
+    private double pMild = 0.60;
+    private double pModerate = 0.30;
+    private double pSevere = 0.10;
 
     /** Construct with a seed for deterministic runs (serialize the seed for saves). */
     public SpaceWeatherService(long seed) {
@@ -47,7 +49,8 @@ public final class SpaceWeatherService {
             if (active.isFinished()) {
                 active = null;
                 recomputeMultipliers();
-            } else {
+            }
+            else {
                 // Keep current multipliers.
                 return;
             }
@@ -61,13 +64,19 @@ public final class SpaceWeatherService {
     }
 
     /** Exposes the current solar power multiplier for arrays. */
-    public double getSolarPowerMultiplier() { return solarMultiplier; }
+    public double getSolarPowerMultiplier() {
+        return solarMultiplier;
+    }
 
     /** True if long-range communications are blacked out. */
-    public boolean isCommsBlackout() { return commsBlackout; }
+    public boolean isCommsBlackout() {
+        return commsBlackout;
+    }
 
     /** Returns the active event, or null if clear skies. */
-    public SolarStormEvent getActiveEvent() { return active; }
+    public SolarStormEvent getActiveEvent() {
+        return active;
+    }
 
     /** Optional: tweak baseline storm probability at runtime (0..1). */
     public void setBaseDailyStormProbability(double p) {
@@ -90,11 +99,21 @@ public final class SpaceWeatherService {
             SpaceWeatherSeverity s = sampleSeverity();
             // Duration 0.4–1.6 sols, severity-weighted
             double base = 0.6 + rng.nextDouble() * 0.6; // 0.6-1.2 sols
-            double durationSol = switch (s) {
-                case MILD -> base * 0.7;
-                case MODERATE -> base * 1.0;
-                case SEVERE -> base * 1.3;
-            };
+            double durationSol;
+            switch (s) {
+                case MILD:
+                    durationSol = base * 0.7;
+                    break;
+                case MODERATE:
+                    durationSol = base * 1.0;
+                    break;
+                case SEVERE:
+                    durationSol = base * 1.3;
+                    break;
+                default:
+                    durationSol = base;
+                    break;
+            }
             active = new SolarStormEvent(s, durationSol * MSOL_PER_SOL);
             recomputeMultipliers();
         }
@@ -102,8 +121,12 @@ public final class SpaceWeatherService {
 
     private SpaceWeatherSeverity sampleSeverity() {
         double u = rng.nextDouble();
-        if (u < pSevere) return SpaceWeatherSeverity.SEVERE;
-        if (u < pSevere + pModerate) return SpaceWeatherSeverity.MODERATE;
+        if (u < pSevere) {
+            return SpaceWeatherSeverity.SEVERE;
+        }
+        if (u < pSevere + pModerate) {
+            return SpaceWeatherSeverity.MODERATE;
+        }
         return SpaceWeatherSeverity.MILD;
     }
 
@@ -111,7 +134,8 @@ public final class SpaceWeatherService {
         if (active == null) {
             solarMultiplier = 1.0;
             commsBlackout = false;
-        } else {
+        }
+        else {
             solarMultiplier = active.solarPowerMultiplier();
             commsBlackout = active.commsBlackout();
         }
@@ -135,7 +159,8 @@ public final class SpaceWeatherService {
         if (state.activeSeverity != null) {
             SpaceWeatherSeverity s = SpaceWeatherSeverity.valueOf(state.activeSeverity);
             active = new SolarStormEvent(s, state.remainingMsol);
-        } else {
+        }
+        else {
             active = null;
         }
         baseDailyStormProbability = state.baseDailyStormProbability;
@@ -149,7 +174,10 @@ public final class SpaceWeatherService {
     public static final class SpaceWeatherState {
         public final String activeSeverity;
         public final double remainingMsol;
-        public final double baseDailyStormProbability, pMild, pModerate, pSevere;
+        public final double baseDailyStormProbability;
+        public final double pMild;
+        public final double pModerate;
+        public final double pSevere;
 
         public SpaceWeatherState(
                 String activeSeverity,

--- a/mars-sim-core/src/main/java/com/mars_sim/core/spaceweather/SpaceWeatherService.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/spaceweather/SpaceWeatherService.java
@@ -1,0 +1,152 @@
+/*
+ * Mars Simulation Project - Space Weather
+ * GPL-3.0-or-later
+ */
+package org.mars_sim.msp.core.spaceweather;
+
+import java.util.Objects;
+import java.util.Random;
+
+/**
+ * Models heliophysical "space weather" events that periodically strike the colony.
+ * It is intentionally small and deterministic (seeded RNG) so it can be saved/loaded easily.
+ *
+ * Wire it from Simulation.clockPulse(...) once per pulse:
+ *     spaceWeather.advance(deltaMsol);
+ */
+public final class SpaceWeatherService {
+
+    /** One sol == 1000 msol in Mars-sim notation. */
+    public static final double MSOL_PER_SOL = 1000.0;
+
+    private final Random rng;
+    private SolarStormEvent active;
+    private double solarMultiplier = 1.0;
+    private boolean commsBlackout = false;
+
+    /** Accumulator for detecting sol boundaries (optional future use). */
+    private double sinceLastCheckMsol = 0.0;
+
+    /** Baseline per-sol chance for a storm to begin (tuned for gameplay). */
+    private double baseDailyStormProbability = 0.08; // 8% per sol by default
+    /** Weighting of moderate vs severe vs mild events. */
+    private double pMild = 0.60, pModerate = 0.30, pSevere = 0.10;
+
+    /** Construct with a seed for deterministic runs (serialize the seed for saves). */
+    public SpaceWeatherService(long seed) {
+        this.rng = new Random(seed);
+        recomputeMultipliers();
+    }
+
+    /** Advance the model by delta msol. Call exactly once per clock pulse. */
+    public void advance(double deltaMsol) {
+        sinceLastCheckMsol += deltaMsol;
+
+        if (active != null && !active.isFinished()) {
+            active.advance(deltaMsol);
+            if (active.isFinished()) {
+                active = null;
+                recomputeMultipliers();
+            } else {
+                // Keep current multipliers.
+                return;
+            }
+        }
+
+        // No active event: roll the dice once per sol in aggregate (cheap and predictable)
+        if (sinceLastCheckMsol >= MSOL_PER_SOL) {
+            sinceLastCheckMsol -= MSOL_PER_SOL;
+            maybeStartNewStorm();
+        }
+    }
+
+    /** Exposes the current solar power multiplier for arrays. */
+    public double getSolarPowerMultiplier() { return solarMultiplier; }
+
+    /** True if long-range communications are blacked out. */
+    public boolean isCommsBlackout() { return commsBlackout; }
+
+    /** Returns the active event, or null if clear skies. */
+    public SolarStormEvent getActiveEvent() { return active; }
+
+    /** Optional: tweak baseline storm probability at runtime (0..1). */
+    public void setBaseDailyStormProbability(double p) {
+        this.baseDailyStormProbability = Math.max(0, Math.min(1, p));
+    }
+
+    /** Optional: tweak severity distribution. Values are normalized automatically. */
+    public void setSeverityWeights(double mild, double moderate, double severe) {
+        double sum = mild + moderate + severe;
+        if (sum <= 0) return;
+        this.pMild = mild / sum;
+        this.pModerate = moderate / sum;
+        this.pSevere = severe / sum;
+    }
+
+    private void maybeStartNewStorm() {
+        if (rng.nextDouble() < baseDailyStormProbability) {
+            SpaceWeatherSeverity s = sampleSeverity();
+            // Duration 0.4–1.6 sols, severity-weighted
+            double base = 0.6 + rng.nextDouble() * 0.6; // 0.6-1.2 sols
+            double durationSol = switch (s) {
+                case MILD -> base * 0.7;
+                case MODERATE -> base * 1.0;
+                case SEVERE -> base * 1.3;
+            };
+            active = new SolarStormEvent(s, durationSol * MSOL_PER_SOL);
+            recomputeMultipliers();
+        }
+    }
+
+    private SpaceWeatherSeverity sampleSeverity() {
+        double u = rng.nextDouble();
+        if (u < pSevere) return SpaceWeatherSeverity.SEVERE;
+        if (u < pSevere + pModerate) return SpaceWeatherSeverity.MODERATE;
+        return SpaceWeatherSeverity.MILD;
+    }
+
+    private void recomputeMultipliers() {
+        if (active == null) {
+            solarMultiplier = 1.0;
+            commsBlackout = false;
+        } else {
+            solarMultiplier = active.solarPowerMultiplier();
+            commsBlackout = active.commsBlackout();
+        }
+    }
+
+    // --- Save/load helpers (optional) ---
+    /** Minimal serialization DTO; implement with the project’s existing save system. */
+    public SpaceWeatherState snapshot() {
+        return new SpaceWeatherState(active == null ? null : active.getSeverity().name(),
+                                     active == null ? 0 : active.getRemainingMsol(),
+                                     baseDailyStormProbability, pMild, pModerate, pSevere);
+    }
+
+    public void restore(SpaceWeatherState state) {
+        Objects.requireNonNull(state, "state");
+        if (state.activeSeverity != null) {
+            SpaceWeatherSeverity s = SpaceWeatherSeverity.valueOf(state.activeSeverity);
+            active = new SolarStormEvent(s, state.remainingMsol);
+        } else {
+            active = null;
+        }
+        baseDailyStormProbability = state.baseDailyStormProbability;
+        pMild = state.pMild; pModerate = state.pModerate; pSevere = state.pSevere;
+        recomputeMultipliers();
+    }
+
+    /** Tiny DTO. Replace with project’s serialization mechanism as needed. */
+    public static final class SpaceWeatherState {
+        public final String activeSeverity;
+        public final double remainingMsol;
+        public final double baseDailyStormProbability, pMild, pModerate, pSevere;
+        public SpaceWeatherState(String activeSeverity, double remainingMsol,
+                                 double baseDailyStormProbability, double pMild, double pModerate, double pSevere) {
+            this.activeSeverity = activeSeverity;
+            this.remainingMsol = remainingMsol;
+            this.baseDailyStormProbability = baseDailyStormProbability;
+            this.pMild = pMild; this.pModerate = pModerate; this.pSevere = pSevere;
+        }
+    }
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/spaceweather/SpaceWeatherService.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/spaceweather/SpaceWeatherService.java
@@ -77,7 +77,9 @@ public final class SpaceWeatherService {
     /** Optional: tweak severity distribution. Values are normalized automatically. */
     public void setSeverityWeights(double mild, double moderate, double severe) {
         double sum = mild + moderate + severe;
-        if (sum <= 0) return;
+        if (sum <= 0) {
+            return;
+        }
         this.pMild = mild / sum;
         this.pModerate = moderate / sum;
         this.pSevere = severe / sum;
@@ -118,9 +120,14 @@ public final class SpaceWeatherService {
     // --- Save/load helpers (optional) ---
     /** Minimal serialization DTO; implement with the project’s existing save system. */
     public SpaceWeatherState snapshot() {
-        return new SpaceWeatherState(active == null ? null : active.getSeverity().name(),
-                                     active == null ? 0 : active.getRemainingMsol(),
-                                     baseDailyStormProbability, pMild, pModerate, pSevere);
+        return new SpaceWeatherState(
+            active == null ? null : active.getSeverity().name(),
+            active == null ? 0 : active.getRemainingMsol(),
+            baseDailyStormProbability,
+            pMild,
+            pModerate,
+            pSevere
+        );
     }
 
     public void restore(SpaceWeatherState state) {
@@ -132,7 +139,9 @@ public final class SpaceWeatherService {
             active = null;
         }
         baseDailyStormProbability = state.baseDailyStormProbability;
-        pMild = state.pMild; pModerate = state.pModerate; pSevere = state.pSevere;
+        pMild = state.pMild;
+        pModerate = state.pModerate;
+        pSevere = state.pSevere;
         recomputeMultipliers();
     }
 
@@ -141,12 +150,20 @@ public final class SpaceWeatherService {
         public final String activeSeverity;
         public final double remainingMsol;
         public final double baseDailyStormProbability, pMild, pModerate, pSevere;
-        public SpaceWeatherState(String activeSeverity, double remainingMsol,
-                                 double baseDailyStormProbability, double pMild, double pModerate, double pSevere) {
+
+        public SpaceWeatherState(
+                String activeSeverity,
+                double remainingMsol,
+                double baseDailyStormProbability,
+                double pMild,
+                double pModerate,
+                double pSevere) {
             this.activeSeverity = activeSeverity;
             this.remainingMsol = remainingMsol;
             this.baseDailyStormProbability = baseDailyStormProbability;
-            this.pMild = pMild; this.pModerate = pModerate; this.pSevere = pSevere;
+            this.pMild = pMild;
+            this.pModerate = pModerate;
+            this.pSevere = pSevere;
         }
     }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/spaceweather/SpaceWeatherSeverity.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/spaceweather/SpaceWeatherSeverity.java
@@ -1,0 +1,25 @@
+/*
+ * Mars Simulation Project - Space Weather
+ * GPL-3.0-or-later
+ */
+package org.mars_sim.msp.core.spaceweather;
+
+/** Severity tiers for solar storms. */
+public enum SpaceWeatherSeverity {
+    MILD(0.80, 1.5, false),
+    MODERATE(0.50, 2.5, true),
+    SEVERE(0.20, 4.0, true);
+
+    /** Multiplier applied to solar power output during the event. */
+    public final double solarPowerMultiplier;
+    /** Scale factor applied to environmental radiation dose rate (conceptual). */
+    public final double radiationDoseScale;
+    /** Whether long-range comms are blacked out. */
+    public final boolean commsBlackout;
+
+    SpaceWeatherSeverity(double solarPowerMultiplier, double radiationDoseScale, boolean commsBlackout) {
+        this.solarPowerMultiplier = solarPowerMultiplier;
+        this.radiationDoseScale = radiationDoseScale;
+        this.commsBlackout = commsBlackout;
+    }
+}


### PR DESCRIPTION
Space‑Weather & Comms Blackouts (implemented below) Model solar energetic particle (SEP) events and periodic comms blackouts. Effects: EVA risk spikes, solar power curtailed, long‑range comms down (no inter‑settlement trading missions while it lasts). Hooks cleanly into the clock pulse and Weather/Radiation subsystems.

Implementation: Space‑Weather & Comms Blackouts
Overview

What players feel: Every few sols a solar storm can hit. Solar arrays produce less, comms can go dark for moderate/severe storms, and EVA scheduling UI shows “shelter in place” advisories. When the storm passes, systems recover.

How it fits: A tiny service registered from Simulation on each clock pulse. It exposes:

getSolarPowerMultiplier() — e.g., 0.8/0.5/0.2 based on severity

isCommsBlackout() — true for moderate/severe storms

getActiveEvent() — for UI and logs

Low coupling: One call from Simulation.clockPulse(...), an optional single‑line multiplier in solar output, and a mission gate that refuses to spawn new trading missions during blackout.