### PR TITLE
Update ResearchProject.java

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/moon/LunarActivity.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/moon/LunarActivity.java
@@ -45,7 +45,7 @@ public class LunarActivity implements Temporal, Serializable {
 	/**
 	 * Returns the colony.
 	 * 
-	 * @return
+	 * @return the colony
 	 */
 	public Colony getColony() {
 		return colony;
@@ -54,7 +54,7 @@ public class LunarActivity implements Temporal, Serializable {
 	/**
 	 * Returns the LunarActivityType.
 	 * 
-	 * @return
+	 * @return the activity type
 	 */
 	public LunarActivityType getLunarActivityType() {
 		return type;
@@ -63,47 +63,45 @@ public class LunarActivity implements Temporal, Serializable {
 	/**
 	 * Returns the demand.
 	 * 
-	 * @return
+	 * @return demand value
 	 */
 	public double getDemand() {
 		return demand;
 	}
 	
 	/**
-	 * Gets one researcher project that this researcher may join in.
+	 * Gets one research project that this researcher may join.
+	 * Selects a project where the researcher is not the lead,
+	 * is not already a participant, and the project has capacity.
 	 * 
-	 * @param researcher
-	 * @return
+	 * @param researcher the researcher seeking a project
+	 * @return a joinable ResearchProject, or {@code null} if none available
 	 */
 	public ResearchProject getOneResearchProject(ColonyResearcher researcher) {
-		for (ResearchProject p: researchProjects) {
-			if (!p.getLead().equals(researcher)) {
-				Set<Colonist> participants = p.getParticipants();
-				for (Colonist c: participants) {
-					if (!c.equals(researcher)) {
-						return p;
-					}
-				}
+		for (ResearchProject p : researchProjects) {
+			if (!p.getLead().equals(researcher)
+					&& !p.getParticipants().contains(researcher)
+					&& p.canAddParticipants()) {
+				return p;
 			}
 		}
 		return null;
 	}
 	
 	/**
-	 * Gets one engineering project that this engineer may join in.
+	 * Gets one engineering project that this engineer may join.
+	 * Selects a project where the engineer is not the lead,
+	 * is not already a participant, and the project has capacity.
 	 * 
-	 * @param Engineer
-	 * @return
+	 * @param engineer the engineer seeking a project
+	 * @return a joinable DevelopmentProject, or {@code null} if none available
 	 */
 	public DevelopmentProject getOneEngineeringProject(ColonySpecialist engineer) {
-		for (DevelopmentProject p: engineeringProjects) {
-			if (!p.getLead().equals(engineer)) {
-				Set<Colonist> participants = p.getParticipants();
-				for (Colonist c: participants) {
-					if (!c.equals(engineer)) {
-						return p;
-					}
-				}
+		for (DevelopmentProject p : engineeringProjects) {
+			if (!p.getLead().equals(engineer)
+					&& !p.getParticipants().contains(engineer)
+					&& p.canAddParticipants()) {
+				return p;
 			}
 		}
 		return null;
@@ -112,7 +110,7 @@ public class LunarActivity implements Temporal, Serializable {
 	/**
 	 * Adds a research project.
 	 * 
-	 * @param rp
+	 * @param rp the research project
 	 */
 	public void addResearchProject(ResearchProject rp) {
 		researchProjects.add(rp);
@@ -121,7 +119,7 @@ public class LunarActivity implements Temporal, Serializable {
 	/**
 	 * Adds an engineering project.
 	 * 
-	 * @param ep
+	 * @param ep the engineering project
 	 */
 	public void addEngineeringProject(DevelopmentProject ep) {
 		engineeringProjects.add(ep);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/moon/project/ResearchProject.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/moon/project/ResearchProject.java
@@ -7,6 +7,8 @@
 package com.mars_sim.core.moon.project;
 
 import java.io.Serializable;
+import java.util.Objects;
+import java.util.logging.Level;
 
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.moon.Colonist;
@@ -17,33 +19,66 @@ public class ResearchProject extends LunarProject implements Serializable {
 	private static final long serialVersionUID = 1L;
 
 	public static final SimLogger logger = SimLogger.getLogger(ResearchProject.class.getName());
-	
+
+	/** Weight applied to the project lead in activeness averaging. */
+	private static final double LEAD_WEIGHT = 2.0;
+
 	/**
 	 * Constructor.
-	 * 
-	 * @param lead
-	 * @param name
-	 * @param science
+	 *
+	 * @param lead    the project lead (must not be null)
+	 * @param name    the project name (must not be null)
+	 * @param science the science type (must not be null)
 	 */
 	ResearchProject(Colonist lead, String name, ScienceType science) {
-		super(lead, name, science);
+		super(
+			Objects.requireNonNull(lead, "lead"),
+			Objects.requireNonNull(name, "name"),
+			Objects.requireNonNull(science, "science")
+		);
 	}
-	
+
 	public void addResearchValue(double value) {
 		addValue(value);
 	}
-	
+
 	public double getResearchValue() {
 		return getValue();
 	}
-	
+
+	/**
+	 * Computes the weighted average research activeness for this project.
+	 * <p>
+	 * The lead counts twice (see {@link #LEAD_WEIGHT}); non-researcher
+	 * participants (if any) are ignored rather than causing a class cast.
+	 * If no valid contributors are present, returns {@code 0.0}.
+	 *
+	 * @return weighted average activeness in the range determined by contributor values
+	 */
 	public double getAverageResearchActiveness() {
-		int num = 1;
-		double sum = ((ColonyResearcher)getLead()).getActiveness() * 2;
-		for (Colonist c: getParticipants()) {
-			num++;
-			sum += ((ColonyResearcher)c).getActiveness();
+		double sum = 0.0;
+		double denom = 0.0;
+
+		// Lead (weighted)
+		if (getLead() instanceof ColonyResearcher) {
+			ColonyResearcher lead = (ColonyResearcher) getLead();
+			sum += lead.getActiveness() * LEAD_WEIGHT;
+			denom += LEAD_WEIGHT;
+		} else if (logger.isLoggable(Level.WARNING)) {
+			logger.warning("Lead is not a ColonyResearcher; average excludes lead.");
 		}
-		return sum / num;
+
+		// Participants (defensively handle any non-researchers)
+		for (Object p : getParticipants()) {
+			if (p instanceof ColonyResearcher) {
+				ColonyResearcher cr = (ColonyResearcher) p;
+				sum += cr.getActiveness();
+				denom += 1.0;
+			} else if (logger.isLoggable(Level.FINE)) {
+				logger.fine("Ignoring non-researcher participant " + p);
+			}
+		}
+
+		return (denom == 0.0) ? 0.0 : (sum / denom);
 	}
 }


### PR DESCRIPTION
1) Low‑risk, high‑value improvements inside ResearchProject.java A. Correct the weighted‑average math (and make it defensive)

getAverageResearchActiveness() intends to weight the lead twice, but it divides by 1 + participants, which over-weights the lead (should divide by 2 + participants). It also blindly casts all participants to ColonyResearcher. Fix both by computing a true weighted average and ignoring any non‑researcher participants.

Why:

Fixes the math and prevents ClassCastException if a non‑researcher slips into the set.

Adds lightweight, gated logging using your SimLogger API (no noisy logs unless enabled).  GitHub

B. Guard against null inputs on construction

The constructor just forwards parameters to super today. Wrapping them with Objects.requireNonNull yields immediate, readable failures if a caller ever passes nulls, without changing behavior otherwise (arguments are still forwarded to LunarProject)