### PR TITLE
Create AreoBodyConstants.java

### DIFF
--- a/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/AreoBodyConstants.java
+++ b/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/AreoBodyConstants.java
@@ -15,7 +15,7 @@
  *     fundamental constants below; comments include their nominal values.
  */
 
-package com.mars_sim.core.orbit;
+package org.mars_sim.msp.core.orbit;
 
 import java.time.Instant;
 import java.util.Locale;

--- a/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/AreoBodyConstants.java
+++ b/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/AreoBodyConstants.java
@@ -1,0 +1,161 @@
+/*
+ * This file is part of the Mars Simulation Project (mars-sim).
+ * License: GPL-3.0 (see the project root LICENSE file).
+ *
+ * Purpose:
+ *   Canonical areocentric (Mars) physical constants and a few derived
+ *   areostationary (areosynchronous) orbit parameters for use by the
+ *   orbital / comms layer.
+ *
+ * Notes:
+ *   - All units are SI unless otherwise indicated.
+ *   - Values follow common references (e.g., IAU/JPL) and are suitable
+ *     for two-body propagation and first-order geometry/coverage math.
+ *   - Areostationary quantities are derived at class load from the
+ *     fundamental constants below; comments include their nominal values.
+ */
+
+package com.mars_sim.core.orbit;
+
+import java.time.Instant;
+import java.util.Locale;
+
+public final class AreoBodyConstants {
+
+    private AreoBodyConstants() {
+        throw new AssertionError("No instances");
+    }
+
+    // ---------------------------------------------------------------------
+    // Universal / numeric helpers
+    // ---------------------------------------------------------------------
+
+    /** Speed of light in vacuum [m/s]. */
+    public static final double SPEED_OF_LIGHT_M_S = 299_792_458.0;
+
+    /** 2π convenience constant. */
+    public static final double TWO_PI = 2.0 * Math.PI;
+
+    /** Degrees↔radians conversion factors. */
+    public static final double DEG2RAD = Math.PI / 180.0;
+    public static final double RAD2DEG = 180.0 / Math.PI;
+
+    /** Generic numeric tolerance for orbital math comparisons. */
+    public static final double EPS = 1e-12;
+
+    // ---------------------------------------------------------------------
+    // Mars (areocentric) geodetic & gravity constants
+    // ---------------------------------------------------------------------
+
+    /** Mars standard gravitational parameter μ = GM [m^3/s^2]. */
+    public static final double MARS_GM_M3_S2 = 42_828_370_000_000.0; // 4.282837e13
+
+    /** Mars equatorial radius (IAU) [m]. */
+    public static final double MARS_EQUATORIAL_RADIUS_M = 3_396_190.0; // 3396.19 km
+
+    /** Mars polar radius (IAU) [m]. */
+    public static final double MARS_POLAR_RADIUS_M = 3_376_200.0; // 3376.20 km
+
+    /** Mars mean (spherical) radius [m]. */
+    public static final double MARS_MEAN_RADIUS_M = 3_389_500.0; // 3389.5 km
+
+    /** Mars dynamic form factor J2 [-] (for future perturbations, optional). */
+    public static final double MARS_J2 = 1.96045e-3;
+
+    /** Geometric flattening f = (a - b) / a [-]. */
+    public static final double MARS_FLATTENING =
+            (MARS_EQUATORIAL_RADIUS_M - MARS_POLAR_RADIUS_M) / MARS_EQUATORIAL_RADIUS_M;
+
+    // ---------------------------------------------------------------------
+    // Mars rotation / timekeeping
+    // ---------------------------------------------------------------------
+
+    /** Mars sidereal rotation period (relative to stars) [s]. */
+    public static final double MARS_SIDEREAL_DAY_S = 88_642.663; // 24h 37m 22.663s
+
+    /** Mars solar day ("sol", noon-to-noon) [s]. */
+    public static final double MARS_SOLAR_DAY_S = 88_775.244; // 24h 39m 35.244s
+
+    /** Mars rotation rate ω (areocentric inertial → areo-fixed) [rad/s]. */
+    public static final double MARS_ROTATION_RATE_RAD_S = TWO_PI / MARS_SIDEREAL_DAY_S; // ≈ 7.088218e-05
+
+    /** Default epoch for orbital elements/configs (can be overridden by XML). */
+    public static final Instant DEFAULT_EPOCH = Instant.parse("2025-01-01T00:00:00Z");
+
+    // ---------------------------------------------------------------------
+    // Areostationary (areosynchronous) derived parameters
+    //   Defined by T_sidereal = orbital period; assumes circular equatorial orbit.
+    // ---------------------------------------------------------------------
+
+    /** Areostationary semi-major axis a_areo [m]; derived from μ and ω. */
+    public static final double AREOSTATIONARY_SEMIMAJOR_AXIS_M;
+
+    /** Areostationary altitude above mean radius h_areo [m] (a - R_mean). */
+    public static final double AREOSTATIONARY_ALTITUDE_M;
+
+    /**
+     * Ground coverage half-angle ψ for areostationary altitude [rad].
+     * Spherical geometry: ψ = arccos(R / (R + h)).
+     */
+    public static final double AREOSTATIONARY_COVERAGE_HALF_ANGLE_RAD;
+
+    /** Same as above, in degrees. */
+    public static final double AREOSTATIONARY_COVERAGE_HALF_ANGLE_DEG;
+
+    /**
+     * One-way light time from areostat straight down to sub-satellite point [s].
+     * Approximated as h / c (good for planning, not a full link budget).
+     */
+    public static final double AREOSTATIONARY_BORE_SIGHT_OWLT_S;
+
+    /**
+     * Empirical “parking” longitudes (degrees East) often cited as relatively
+     * stable areostationary equilibria under Mars' gravity field.
+     * Convention: degrees East in [-180, +180]; negative = West.
+     * Usage is optional and informational.
+     */
+    public static final double[] AREO_STABLE_LONGITUDES_DEG_EAST = new double[] { -17.92, 167.83 };
+
+    static {
+        // a = cbrt( μ / ω^2 )
+        AREOSTATIONARY_SEMIMAJOR_AXIS_M =
+                Math.cbrt(MARS_GM_M3_S2 / (MARS_ROTATION_RATE_RAD_S * MARS_ROTATION_RATE_RAD_S)); // ≈ 20_427_684 m
+
+        AREOSTATIONARY_ALTITUDE_M = AREOSTATIONARY_SEMIMAJOR_AXIS_M - MARS_MEAN_RADIUS_M; // ≈ 17_038_184 m
+
+        AREOSTATIONARY_COVERAGE_HALF_ANGLE_RAD =
+                Math.acos(MARS_MEAN_RADIUS_M / (MARS_MEAN_RADIUS_M + AREOSTATIONARY_ALTITUDE_M)); // ≈ 1.40410 rad
+
+        AREOSTATIONARY_COVERAGE_HALF_ANGLE_DEG =
+                AREOSTATIONARY_COVERAGE_HALF_ANGLE_RAD * RAD2DEG; // ≈ 80.449°
+
+        AREOSTATIONARY_BORE_SIGHT_OWLT_S = AREOSTATIONARY_ALTITUDE_M / SPEED_OF_LIGHT_M_S; // ≈ 0.05683 s
+    }
+
+    // ---------------------------------------------------------------------
+    // Small utility helpers that are handy in tests and debug UIs
+    // ---------------------------------------------------------------------
+
+    /**
+     * Computes the spherical-planet coverage half-angle ψ [rad] for a satellite
+     * at a given altitude above Mars mean radius.
+     */
+    public static double coverageHalfAngleRad(double altitudeMeters) {
+        double h = Math.max(0.0, altitudeMeters);
+        return Math.acos(MARS_MEAN_RADIUS_M / (MARS_MEAN_RADIUS_M + h));
+    }
+
+    /** Returns a concise one-line summary of key areostationary figures. */
+    public static String summary() {
+        return String.format(Locale.ROOT,
+            "μ=%.6e m^3/s^2, R_mean=%.0f km, ω=%.9f rad/s, a_areo=%.0f km, h_areo=%.0f km, ψ=%.2f°, OWLT=%.3f s",
+            MARS_GM_M3_S2,
+            MARS_MEAN_RADIUS_M / 1_000.0,
+            MARS_ROTATION_RATE_RAD_S,
+            AREOSTATIONARY_SEMIMAJOR_AXIS_M / 1_000.0,
+            AREOSTATIONARY_ALTITUDE_M / 1_000.0,
+            AREOSTATIONARY_COVERAGE_HALF_ANGLE_DEG,
+            AREOSTATIONARY_BORE_SIGHT_OWLT_S
+        );
+    }
+}

--- a/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/GroundPoint.java
+++ b/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/GroundPoint.java
@@ -1,0 +1,272 @@
+/*
+ * This file is part of the Mars Simulation Project (mars-sim).
+ * License: GPL-3.0 (see the project root LICENSE file).
+ *
+ * Purpose:
+ *   Immutable representation of a surface (or near-surface) location on Mars,
+ *   expressed as planetocentric (geocentric) latitude, east-positive longitude,
+ *   and altitude above the Mars mean radius. Includes utilities for common
+ *   geometry used by the orbital/comms layer (surface distance, central angle,
+ *   conversion to/from Mars-fixed (MCMF) vectors, simple visibility/elevation
+ *   tests against a satellite position, and one-way light time).
+ *
+ * Conventions:
+ *   - Latitude is planetocentric (angle from equatorial plane to the radius
+ *     vector) in radians. Longitude is east-positive in (-π, π].
+ *   - Altitude is above the Mars mean (spherical) radius; negative altitudes
+ *     are permitted (e.g., Hellas basin), but R + h must remain > 0.
+ *   - All computations assume a spherical Mars with radius
+ *     AreoBodyConstants.MARS_MEAN_RADIUS_M unless stated otherwise.
+ */
+
+package com.mars_sim.core.orbit;
+
+import java.util.Locale;
+import java.util.Objects;
+
+public final class GroundPoint {
+
+    // ---------------------------------------------------------------------
+    // Fields (immutable)
+    // ---------------------------------------------------------------------
+
+    /** Planetocentric latitude [rad]. */
+    private final double latitudeRad;
+
+    /** East-positive longitude [rad], normalized to (-π, π]. */
+    private final double longitudeRad;
+
+    /** Altitude above mean radius [m]. */
+    private final double altitudeM;
+
+    // ---------------------------------------------------------------------
+    // Construction
+    // ---------------------------------------------------------------------
+
+    /** Construct from radians (lat, lon) and altitude [m]. */
+    public GroundPoint(double latitudeRad, double longitudeRad, double altitudeM) {
+        if (!Double.isFinite(latitudeRad) || !Double.isFinite(longitudeRad) || !Double.isFinite(altitudeM)) {
+            throw new IllegalArgumentException("lat/lon/alt must be finite");
+        }
+        // Keep latitude in [-π, π]; reflect to [-π/2, +π/2] if outside.
+        double lat = normalizeLatitude(latitudeRad);
+        double lon = normalizeLongitude(longitudeRad);
+
+        // Reflect poles if lat was outside principal range
+        if (lat > Math.PI / 2.0) {
+            lat = Math.PI - lat;
+            lon = normalizeLongitude(lon + Math.PI);
+        } else if (lat < -Math.PI / 2.0) {
+            lat = -Math.PI - lat;
+            lon = normalizeLongitude(lon + Math.PI);
+        }
+
+        // Enforce non-degenerate radius (R + h > 0)
+        double minAlt = -AreoBodyConstants.MARS_MEAN_RADIUS_M + 1e-3; // leave a tiny positive radius
+        if (altitudeM < minAlt) {
+            throw new IllegalArgumentException("Altitude too negative; results in non-physical radius.");
+        }
+
+        this.latitudeRad = lat;
+        this.longitudeRad = lon;
+        this.altitudeM = altitudeM;
+    }
+
+    /** Factory: inputs in degrees for angles, meters for altitude. */
+    public static GroundPoint ofDegrees(double latitudeDeg, double longitudeDeg, double altitudeM) {
+        return new GroundPoint(Math.toRadians(latitudeDeg), Math.toRadians(longitudeDeg), altitudeM);
+    }
+
+    /** Factory: from an MCMF (Mars-fixed) position vector [m]. */
+    public static GroundPoint fromFixedVector(double[] rFixed) {
+        Objects.requireNonNull(rFixed, "rFixed");
+        if (rFixed.length != 3) throw new IllegalArgumentException("rFixed must be length 3");
+        double x = rFixed[0], y = rFixed[1], z = rFixed[2];
+        double rho = Math.hypot(x, y);
+        double rmag = Math.hypot(rho, z);
+        double lat = Math.atan2(z, rho);          // planetocentric latitude
+        double lon = Math.atan2(y, x);            // east-positive
+        double alt = rmag - AreoBodyConstants.MARS_MEAN_RADIUS_M;
+        return new GroundPoint(lat, lon, alt);
+    }
+
+    // ---------------------------------------------------------------------
+    // Accessors
+    // ---------------------------------------------------------------------
+
+    public double latitudeRad()   { return latitudeRad; }
+    public double longitudeRad()  { return longitudeRad; }
+    public double altitudeM()     { return altitudeM; }
+
+    public double latitudeDeg()   { return Math.toDegrees(latitudeRad); }
+    public double longitudeDeg()  { return Math.toDegrees(longitudeRad); }
+
+    /** Planet radius at this point (spherical model) = R_mean + altitude. */
+    public double radiusM() { return AreoBodyConstants.MARS_MEAN_RADIUS_M + altitudeM; }
+
+    // ---------------------------------------------------------------------
+    // Conversions
+    // ---------------------------------------------------------------------
+
+    /**
+     * Convert to a Mars-fixed (MCMF) position vector [m], spherical planet model.
+     * r = (R + h) [cosφ cosλ, cosφ sinλ, sinφ]
+     */
+    public double[] toFixedVector() {
+        double R = radiusM();
+        double clat = Math.cos(latitudeRad);
+        double x = R * clat * Math.cos(longitudeRad);
+        double y = R * clat * Math.sin(longitudeRad);
+        double z = R * Math.sin(latitudeRad);
+        return new double[] { x, y, z };
+    }
+
+    /** Local up/zenith unit vector in MCMF (spherical model). */
+    public double[] upUnit() {
+        double[] r = toFixedVector();
+        double R = Math.sqrt(r[0]*r[0] + r[1]*r[1] + r[2]*r[2]);
+        return new double[] { r[0]/R, r[1]/R, r[2]/R };
+    }
+
+    /** Local east unit vector in MCMF (points toward increasing longitude). */
+    public double[] eastUnit() {
+        double lon = longitudeRad;
+        return new double[] { -Math.sin(lon), Math.cos(lon), 0.0 };
+    }
+
+    /** Local north unit vector in MCMF (tangent, toward increasing latitude). */
+    public double[] northUnit() {
+        double lat = latitudeRad, lon = longitudeRad;
+        double slat = Math.sin(lat), clat = Math.cos(lat);
+        double clon = Math.cos(lon), slon = Math.sin(lon);
+        return new double[] { -slat * clon, -slat * slon, clat };
+    }
+
+    // ---------------------------------------------------------------------
+    // Surface geometry (spherical)
+    // ---------------------------------------------------------------------
+
+    /**
+     * Central angle α between this point and another [rad], spherical planet.
+     * Uses the haversine formulation for numerical robustness.
+     */
+    public double centralAngleRad(GroundPoint other) {
+        Objects.requireNonNull(other, "other");
+        double dLat = other.latitudeRad - this.latitudeRad;
+        double dLon = normalizeLongitude(other.longitudeRad - this.longitudeRad);
+        double s1 = Math.sin(dLat * 0.5);
+        double s2 = Math.sin(dLon * 0.5);
+        double a = s1*s1 + Math.cos(latitudeRad) * Math.cos(other.latitudeRad) * s2*s2;
+        a = Math.min(1.0, Math.max(0.0, a));
+        return 2.0 * Math.asin(Math.sqrt(a));
+    }
+
+    /**
+     * Great-circle surface distance [m] between this point and another.
+     * Uses mean Mars radius plus the average altitude of the two points.
+     */
+    public double surfaceDistanceM(GroundPoint other) {
+        double alpha = centralAngleRad(other);
+        double effectiveR = AreoBodyConstants.MARS_MEAN_RADIUS_M + 0.5 * (this.altitudeM + other.altitudeM);
+        return effectiveR * alpha;
+    }
+
+    // ---------------------------------------------------------------------
+    // Satellite visibility / link helpers (spherical Mars)
+    // ---------------------------------------------------------------------
+
+    /**
+     * Elevation angle of a satellite at MCMF position {@code satFixed} as seen
+     * from this ground point [rad]. Positive means above local horizon; 0 at
+       horizon; negative means below.
+     *
+     * Computation:
+     *   e = asin( ( (sat - r_g) · û ) / |sat - r_g| ), where û is local zenith.
+     */
+    public double elevationRad(double[] satFixed) {
+        Objects.requireNonNull(satFixed, "satFixed");
+        if (satFixed.length != 3) throw new IllegalArgumentException("satFixed must be length 3");
+        double[] rg = toFixedVector();
+        double vx = satFixed[0] - rg[0];
+        double vy = satFixed[1] - rg[1];
+        double vz = satFixed[2] - rg[2];
+        double vmag = Math.sqrt(vx*vx + vy*vy + vz*vz);
+        if (!(vmag > 0.0)) return -Math.PI / 2.0; // coincident/degenerate → treat as below horizon
+        double[] up = new double[] { rg[0] / radiusM(), rg[1] / radiusM(), rg[2] / radiusM() };
+        double dot = vx*up[0] + vy*up[1] + vz*up[2];
+        double arg = dot / vmag;
+        // Clamp for safety
+        arg = Math.max(-1.0, Math.min(1.0, arg));
+        return Math.asin(arg);
+    }
+
+    /** True if the satellite at {@code satFixed} is above the local horizon. */
+    public boolean isVisibleFrom(double[] satFixed) {
+        return elevationRad(satFixed) > 0.0;
+    }
+
+    /** Straight-line range [m] to satellite at {@code satFixed}. */
+    public double rangeToM(double[] satFixed) {
+        Objects.requireNonNull(satFixed, "satFixed");
+        if (satFixed.length != 3) throw new IllegalArgumentException("satFixed must be length 3");
+        double[] rg = toFixedVector();
+        double dx = satFixed[0] - rg[0];
+        double dy = satFixed[1] - rg[1];
+        double dz = satFixed[2] - rg[2];
+        return Math.sqrt(dx*dx + dy*dy + dz*dz);
+    }
+
+    /** One-way light time [s] to satellite at {@code satFixed}. */
+    public double oneWayLightTimeSeconds(double[] satFixed) {
+        return rangeToM(satFixed) / AreoBodyConstants.SPEED_OF_LIGHT_M_S;
+    }
+
+    // ---------------------------------------------------------------------
+    // Utilities
+    // ---------------------------------------------------------------------
+
+    /** Normalize longitude to (-π, π]. */
+    public static double normalizeLongitude(double lonRad) {
+        double x = lonRad % (2.0 * Math.PI);
+        if (x <= -Math.PI) x += 2.0 * Math.PI;
+        if (x > Math.PI)   x -= 2.0 * Math.PI;
+        return x;
+    }
+
+    /** Normalize latitude to [-π, π]. (Helper for robust pole handling.) */
+    private static double normalizeLatitude(double latRad) {
+        double x = latRad % (2.0 * Math.PI);
+        if (x < -Math.PI) x += 2.0 * Math.PI;
+        if (x >  Math.PI) x -= 2.0 * Math.PI;
+        return x;
+    }
+
+    // ---------------------------------------------------------------------
+    // Equality & debug
+    // ---------------------------------------------------------------------
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GroundPoint)) return false;
+        GroundPoint that = (GroundPoint) o;
+        return Double.doubleToLongBits(latitudeRad)  == Double.doubleToLongBits(that.latitudeRad)
+            && Double.doubleToLongBits(longitudeRad) == Double.doubleToLongBits(that.longitudeRad)
+            && Double.doubleToLongBits(altitudeM)    == Double.doubleToLongBits(that.altitudeM);
+    }
+
+    @Override
+    public int hashCode() {
+        int h = Double.hashCode(latitudeRad);
+        h = 31 * h + Double.hashCode(longitudeRad);
+        h = 31 * h + Double.hashCode(altitudeM);
+        return h;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(Locale.ROOT,
+            "GroundPoint[lat=%.6f° lon=%.6f° alt=%.1f m]",
+            latitudeDeg(), longitudeDeg(), altitudeM);
+    }
+}

--- a/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/GroundPoint.java
+++ b/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/GroundPoint.java
@@ -19,7 +19,7 @@
  *     AreoBodyConstants.MARS_MEAN_RADIUS_M unless stated otherwise.
  */
 
-package com.mars_sim.core.orbit;
+package org.mars_sim.msp.core.orbit;
 
 import java.util.Locale;
 import java.util.Objects;

--- a/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/KeplerianElements.java
+++ b/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/KeplerianElements.java
@@ -28,7 +28,7 @@
  *     by both a simple two-body propagator and higher-order models.
  */
 
-package com.mars_sim.core.orbit;
+package org.mars_sim.msp.core.orbit;
 
 import java.time.Instant;
 import java.util.Locale;

--- a/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/KeplerianElements.java
+++ b/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/KeplerianElements.java
@@ -1,0 +1,367 @@
+/*
+ * This file is part of the Mars Simulation Project (mars-sim).
+ * License: GPL-3.0 (see the project root LICENSE file).
+ *
+ * Purpose:
+ *   Immutable container and utilities for classical Keplerian orbital
+ *   elements referenced to Mars (areocentric frame).
+ *
+ * Elements:
+ *   - a  : semi-major axis [meters]
+ *   - e  : eccentricity [-] (0 ≤ e < 1 for elliptical orbits)
+ *   - i  : inclination [radians]
+ *   - Ω  : right ascension of ascending node (RAAN) [radians]
+ *   - ω  : argument of periapsis [radians]
+ *   - M0 : mean anomaly at epoch [radians]
+ *   - t0 : epoch (UTC, java.time.Instant)
+ *
+ * Conventions & Notes:
+ *   - Angles are stored in radians. Use the factory methods that accept degrees
+ *     if you prefer degrees on input.
+ *   - On construction, angles are normalized:
+ *        RAAN, ω, M0 ∈ [0, 2π)
+ *     Inclination is normalized to [0, π]. If i > π, we map:
+ *        i' = 2π - i,  Ω' = Ω + π,  ω' = ω + π   (mod 2π)
+ *     which preserves the orbit geometry.
+ *   - The mean motion/period functions default to Mars μ from AreoBodyConstants.
+ *   - This class intentionally avoids any external dependencies and can be used
+ *     by both a simple two-body propagator and higher-order models.
+ */
+
+package com.mars_sim.core.orbit;
+
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Objects;
+
+public final class KeplerianElements {
+
+    // ---------------------------------------------------------------------
+    // Fields (immutable)
+    // ---------------------------------------------------------------------
+
+    private final double semiMajorAxisM;
+    private final double eccentricity;
+    private final double inclinationRad;
+    private final double raanRad;               // Ω
+    private final double argOfPeriapsisRad;     // ω
+    private final double meanAnomalyAtEpochRad; // M0
+    private final Instant epoch;                // t0
+
+    // ---------------------------------------------------------------------
+    // Construction
+    // ---------------------------------------------------------------------
+
+    private KeplerianElements(
+            double semiMajorAxisM,
+            double eccentricity,
+            double inclinationRad,
+            double raanRad,
+            double argOfPeriapsisRad,
+            double meanAnomalyAtEpochRad,
+            Instant epoch) {
+
+        if (!(semiMajorAxisM > 0.0) || !Double.isFinite(semiMajorAxisM)) {
+            throw new IllegalArgumentException("Semi-major axis must be finite and > 0 (meters).");
+        }
+        if (!(eccentricity >= 0.0) || !(eccentricity < 1.0) || !Double.isFinite(eccentricity)) {
+            throw new IllegalArgumentException("Eccentricity must satisfy 0 ≤ e < 1.");
+        }
+        Objects.requireNonNull(epoch, "epoch must not be null");
+
+        // Normalize angles
+        double i = wrapToTwoPi(inclinationRad);
+        double Ω = wrapToTwoPi(raanRad);
+        double ω = wrapToTwoPi(argOfPeriapsisRad);
+        double M0 = wrapToTwoPi(meanAnomalyAtEpochRad);
+
+        // Keep inclination in [0, π]; adjust node/periapsis if > π.
+        if (i > Math.PI) {
+            i = 2.0 * Math.PI - i;
+            Ω = wrapToTwoPi(Ω + Math.PI);
+            ω = wrapToTwoPi(ω + Math.PI);
+        }
+
+        this.semiMajorAxisM = semiMajorAxisM;
+        this.eccentricity = eccentricity;
+        this.inclinationRad = i;
+        this.raanRad = Ω;
+        this.argOfPeriapsisRad = ω;
+        this.meanAnomalyAtEpochRad = M0;
+        this.epoch = epoch;
+    }
+
+    /** Factory: inputs in meters/radians. */
+    public static KeplerianElements ofMetersRadians(
+            double semiMajorAxisM,
+            double eccentricity,
+            double inclinationRad,
+            double raanRad,
+            double argOfPeriapsisRad,
+            double meanAnomalyAtEpochRad,
+            Instant epoch) {
+        return new KeplerianElements(semiMajorAxisM, eccentricity, inclinationRad, raanRad, argOfPeriapsisRad, meanAnomalyAtEpochRad, epoch);
+    }
+
+    /** Factory: inputs in kilometers/degrees. */
+    public static KeplerianElements ofKilometersDegrees(
+            double semiMajorAxisKm,
+            double eccentricity,
+            double inclinationDeg,
+            double raanDeg,
+            double argOfPeriapsisDeg,
+            double meanAnomalyAtEpochDeg,
+            Instant epoch) {
+        return new KeplerianElements(
+                semiMajorAxisKm * 1_000.0,
+                eccentricity,
+                Math.toRadians(inclinationDeg),
+                Math.toRadians(raanDeg),
+                Math.toRadians(argOfPeriapsisDeg),
+                Math.toRadians(meanAnomalyAtEpochDeg),
+                epoch);
+    }
+
+    /**
+     * Convenience: ideal areostationary elements (circular equatorial), RAAN/ω/M0 = 0.
+     * Epoch default is AreoBodyConstants.DEFAULT_EPOCH unless provided.
+     */
+    public static KeplerianElements areostationary() {
+        return areostationary(AreoBodyConstants.DEFAULT_EPOCH);
+    }
+
+    public static KeplerianElements areostationary(Instant epoch) {
+        return ofMetersRadians(
+                AreoBodyConstants.AREOSTATIONARY_SEMIMAJOR_AXIS_M,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                epoch);
+    }
+
+    /**
+     * Factory from mean motion n [rad/s] (elliptical, two-body): a = cbrt( μ / n^2 ).
+     * Uses Mars μ from AreoBodyConstants.
+     */
+    public static KeplerianElements ofMeanMotion(
+            double meanMotionRadPerSec,
+            double eccentricity,
+            double inclinationRad,
+            double raanRad,
+            double argOfPeriapsisRad,
+            double meanAnomalyAtEpochRad,
+            Instant epoch) {
+        if (!(meanMotionRadPerSec > 0.0) || !Double.isFinite(meanMotionRadPerSec)) {
+            throw new IllegalArgumentException("Mean motion must be finite and > 0 [rad/s].");
+        }
+        double a = Math.cbrt(AreoBodyConstants.MARS_GM_M3_S2 / (meanMotionRadPerSec * meanMotionRadPerSec));
+        return ofMetersRadians(a, eccentricity, inclinationRad, raanRad, argOfPeriapsisRad, meanAnomalyAtEpochRad, epoch);
+    }
+
+    // ---------------------------------------------------------------------
+    // Basic accessors
+    // ---------------------------------------------------------------------
+
+    public double getSemiMajorAxisM() {
+        return semiMajorAxisM;
+    }
+
+    public double getEccentricity() {
+        return eccentricity;
+    }
+
+    public double getInclinationRad() {
+        return inclinationRad;
+    }
+
+    public double getRaanRad() {
+        return raanRad;
+    }
+
+    public double getArgOfPeriapsisRad() {
+        return argOfPeriapsisRad;
+    }
+
+    public double getMeanAnomalyAtEpochRad() {
+        return meanAnomalyAtEpochRad;
+    }
+
+    public Instant getEpoch() {
+        return epoch;
+    }
+
+    // ---------------------------------------------------------------------
+    // Derived orbital quantities (two-body)
+    // ---------------------------------------------------------------------
+
+    /** Mean motion n [rad/s] using Mars μ. */
+    public double meanMotionRadPerSec() {
+        return Math.sqrt(AreoBodyConstants.MARS_GM_M3_S2 / (semiMajorAxisM * semiMajorAxisM * semiMajorAxisM));
+    }
+
+    /** Orbital period T [s] using Mars μ. */
+    public double periodSeconds() {
+        return AreoBodyConstants.TWO_PI / meanMotionRadPerSec();
+    }
+
+    /** Semi-latus rectum p [m] = a (1 - e^2). */
+    public double semiLatusRectumM() {
+        return semiMajorAxisM * (1.0 - eccentricity * eccentricity);
+    }
+
+    /** Periapsis radius r_p [m] = a (1 - e). */
+    public double periapsisRadiusM() {
+        return semiMajorAxisM * (1.0 - eccentricity);
+    }
+
+    /** Apoapsis radius r_a [m] = a (1 + e). */
+    public double apoapsisRadiusM() {
+        return semiMajorAxisM * (1.0 + eccentricity);
+    }
+
+    // ---------------------------------------------------------------------
+    // Time & anomaly helpers
+    // ---------------------------------------------------------------------
+
+    /** Seconds (double) from epoch t0 to t (t - t0). */
+    public double secondsSinceEpoch(Instant t) {
+        Objects.requireNonNull(t, "t must not be null");
+        long ds = t.getEpochSecond() - epoch.getEpochSecond();
+        int dns = t.getNano() - epoch.getNano();
+        return (double) ds + dns * 1e-9;
+    }
+
+    /**
+     * Mean anomaly at time t [rad], normalized to [0, 2π).
+     * M(t) = M0 + n (t - t0)
+     */
+    public double meanAnomalyAt(Instant t) {
+        double M = meanAnomalyAtEpochRad + meanMotionRadPerSec() * secondsSinceEpoch(t);
+        return wrapToTwoPi(M);
+    }
+
+    /**
+     * Eccentric anomaly E from mean anomaly M and eccentricity e (elliptic),
+     * solved by Newton-Raphson with a robust starter. Returns E ∈ [0, 2π).
+     */
+    public static double eccentricAnomalyFromMean(double M, double e) {
+        if (e < AreoBodyConstants.EPS) {
+            return wrapToTwoPi(M); // circular limit
+        }
+        M = wrapToTwoPi(M);
+        // Initial guess (good across e):
+        // Danby starter approximation
+        double sinM = Math.sin(M);
+        double cosM = Math.cos(M);
+        double E = M + (e * sinM) / (1.0 - sin(M + e) + sinM);
+
+        // Newton iterations
+        for (int k = 0; k < 50; k++) {
+            double f = E - e * Math.sin(E) - M;
+            double fp = 1.0 - e * Math.cos(E);
+            double dE = -f / fp;
+            E += dE;
+            if (Math.abs(dE) < 1e-12) break;
+        }
+        return wrapToTwoPi(E);
+    }
+
+    /**
+     * True anomaly ν from mean anomaly M and eccentricity e (elliptic).
+     * Returns ν ∈ [0, 2π).
+     */
+    public static double trueAnomalyFromMean(double M, double e) {
+        double E = eccentricAnomalyFromMean(M, e);
+        return trueAnomalyFromEccentric(E, e);
+    }
+
+    /** True anomaly ν from eccentric anomaly E and eccentricity e, ν ∈ [0, 2π). */
+    public static double trueAnomalyFromEccentric(double E, double e) {
+        double cosE = Math.cos(E);
+        double sinE = Math.sin(E);
+        double denom = 1.0 - e * cosE;
+        double sqrt1me2 = Math.sqrt(Math.max(0.0, 1.0 - e * e));
+        double cosNu = (cosE - e) / denom;
+        double sinNu = (sqrt1me2 * sinE) / denom;
+        double nu = Math.atan2(sinNu, cosNu);
+        return wrapToTwoPi(nu);
+    }
+
+    /**
+     * Radius r [m] at true anomaly ν for this orbit: r = p / (1 + e cos ν).
+     */
+    public double radiusAtTrueAnomaly(double trueAnomalyRad) {
+        return semiLatusRectumM() / (1.0 + eccentricity * Math.cos(trueAnomalyRad));
+    }
+
+    /**
+     * Returns a new element set whose epoch is shifted to {@code newEpoch} while
+     * preserving the absolute orbital phase (i.e., M(newEpoch) stays the same,
+     * and becomes the new M0).
+     */
+    public KeplerianElements shiftEpoch(Instant newEpoch) {
+        double M_at_new = meanAnomalyAt(newEpoch);
+        return ofMetersRadians(semiMajorAxisM, eccentricity, inclinationRad, raanRad, argOfPeriapsisRad, M_at_new, newEpoch);
+    }
+
+    /** Returns a new element set with M0 normalized to [0, 2π). */
+    public KeplerianElements normalized() {
+        return ofMetersRadians(semiMajorAxisM, eccentricity, inclinationRad, raanRad, argOfPeriapsisRad, wrapToTwoPi(meanAnomalyAtEpochRad), epoch);
+    }
+
+    // ---------------------------------------------------------------------
+    // Utilities
+    // ---------------------------------------------------------------------
+
+    /** Wrap angle to [0, 2π). */
+    public static double wrapToTwoPi(double angleRad) {
+        double x = angleRad % AreoBodyConstants.TWO_PI;
+        if (x < 0) x += AreoBodyConstants.TWO_PI;
+        return x;
+    }
+
+    // ---------------------------------------------------------------------
+    // Equality & debug
+    // ---------------------------------------------------------------------
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof KeplerianElements)) return false;
+        KeplerianElements that = (KeplerianElements) o;
+        return Double.doubleToLongBits(semiMajorAxisM) == Double.doubleToLongBits(that.semiMajorAxisM)
+                && Double.doubleToLongBits(eccentricity) == Double.doubleToLongBits(that.eccentricity)
+                && Double.doubleToLongBits(inclinationRad) == Double.doubleToLongBits(that.inclinationRad)
+                && Double.doubleToLongBits(raanRad) == Double.doubleToLongBits(that.raanRad)
+                && Double.doubleToLongBits(argOfPeriapsisRad) == Double.doubleToLongBits(that.argOfPeriapsisRad)
+                && Double.doubleToLongBits(meanAnomalyAtEpochRad) == Double.doubleToLongBits(that.meanAnomalyAtEpochRad)
+                && epoch.equals(that.epoch);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Double.hashCode(semiMajorAxisM);
+        result = 31 * result + Double.hashCode(eccentricity);
+        result = 31 * result + Double.hashCode(inclinationRad);
+        result = 31 * result + Double.hashCode(raanRad);
+        result = 31 * result + Double.hashCode(argOfPeriapsisRad);
+        result = 31 * result + Double.hashCode(meanAnomalyAtEpochRad);
+        result = 31 * result + epoch.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(Locale.ROOT,
+                "Kep[a=%.3f km, e=%.6f, i=%.4f deg, Ω=%.4f deg, ω=%.4f deg, M0=%.4f deg, epoch=%s]",
+                semiMajorAxisM / 1_000.0,
+                eccentricity,
+                Math.toDegrees(inclinationRad),
+                Math.toDegrees(raanRad),
+                Math.toDegrees(argOfPeriapsisRad),
+                Math.toDegrees(meanAnomalyAtEpochRad),
+                epoch);
+    }
+}

--- a/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/TwoBodyPropagator.java
+++ b/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/TwoBodyPropagator.java
@@ -19,7 +19,7 @@
  *     later swap in an ellipsoidal model without changing callers.
  */
 
-package com.mars_sim.core.orbit;
+package org.mars_sim.msp.core.orbit;
 
 import java.time.Instant;
 import java.util.Locale;

--- a/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/TwoBodyPropagator.java
+++ b/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/TwoBodyPropagator.java
@@ -1,0 +1,316 @@
+/*
+ * This file is part of the Mars Simulation Project (mars-sim).
+ * License: GPL-3.0 (see the project root LICENSE file).
+ *
+ * Purpose:
+ *   Lightweight two-body (Kepler) propagator for areocentric orbits.
+ *   Produces Mars-centered inertial (MCI) state vectors and converts
+ *   them to Mars-centered, Mars-fixed (MCMF) coordinates using a simple
+ *   uniform-rotation model. Also provides a subsatellite point helper.
+ *
+ * Design notes:
+ *   - No external deps; fast and deterministic.
+ *   - Uses classical elements (a, e, i, Ω, ω, M0 @ epoch) in KeplerianElements.
+ *   - MCI ← PQW transformation is pre-factored via unit vectors p̂ and q̂.
+ *   - MCMF rotation uses θ(t) = θ0 + ωMars * (t - tθ0). By default we take
+ *     θ0 = 0 at tθ0 = elements.epoch(), which keeps things simple/portable.
+ *   - Geodetic vs. geocentric: the subsatellite point uses a spherical Mars
+ *     (mean radius). This is appropriate for comms/coverage gameplay; you can
+ *     later swap in an ellipsoidal model without changing callers.
+ */
+
+package com.mars_sim.core.orbit;
+
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Objects;
+
+public final class TwoBodyPropagator {
+
+    // ---------------------------------------------------------------------
+    // Nested data classes
+    // ---------------------------------------------------------------------
+
+    /** Immutable Cartesian state (position & velocity). */
+    public static final class StateVector {
+        /** Position [m] in chosen frame. */
+        public final double[] r;
+        /** Velocity [m/s] in chosen frame. */
+        public final double[] v;
+
+        public StateVector(double[] r, double[] v) {
+            if (r == null || v == null || r.length != 3 || v.length != 3)
+                throw new IllegalArgumentException("StateVector requires 3D r and v arrays.");
+            this.r = new double[] { r[0], r[1], r[2] };
+            this.v = new double[] { v[0], v[1], v[2] };
+        }
+
+        @Override
+        public String toString() {
+            return String.format(Locale.ROOT,
+                    "State[r=(%.3f, %.3f, %.3f) m, v=(%.6f, %.6f, %.6f) m/s]",
+                    r[0], r[1], r[2], v[0], v[1], v[2]);
+        }
+    }
+
+    /** Spherical lat/lon/alt (geocentric latitude, degrees helpers provided). */
+    public static final class GroundPoint {
+        /** Latitude [rad], geocentric. */
+        public final double latitudeRad;
+        /** Longitude [rad], East-positive, range (-π, π]. */
+        public final double longitudeRad;
+        /** Altitude above mean radius [m]. */
+        public final double altitudeM;
+
+        public GroundPoint(double latitudeRad, double longitudeRad, double altitudeM) {
+            this.latitudeRad = latitudeRad;
+            this.longitudeRad = normalizeToPi(longitudeRad);
+            this.altitudeM = altitudeM;
+        }
+
+        public double latitudeDeg() { return Math.toDegrees(latitudeRad); }
+        public double longitudeDeg() { return Math.toDegrees(longitudeRad); }
+
+        @Override
+        public String toString() {
+            return String.format(Locale.ROOT,
+                    "LLA[lat=%.6f° lon=%.6f° alt=%.1f m]",
+                    latitudeDeg(), longitudeDeg(), altitudeM);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Fields (immutable core)
+    // ---------------------------------------------------------------------
+
+    private final KeplerianElements kep;
+    /** μ for Mars [m^3/s^2] (can be overridden in advanced use). */
+    private final double mu;
+
+    /** Precomputed orbital plane unit vectors (inertial frame). */
+    private final double[] pHat; // unit vector toward periapsis
+    private final double[] qHat; // 90° ahead in direction of motion
+
+    /** Fixed frame rotation reference: θ(t) = θ0 + ω (t - tθ0). */
+    private final Instant fixedFrameEpoch;
+    private final double greenwichAtEpochRad;
+
+    // ---------------------------------------------------------------------
+    // Construction
+    // ---------------------------------------------------------------------
+
+    /**
+     * Construct a propagator using Mars μ and with the fixed-frame rotation
+     * referenced such that θ0 = 0 at the elements' epoch.
+     */
+    public TwoBodyPropagator(KeplerianElements elements) {
+        this(elements, AreoBodyConstants.MARS_GM_M3_S2, elements.getEpoch(), 0.0);
+    }
+
+    /** Construct a propagator with a custom μ (still Mars-centered). */
+    public TwoBodyPropagator(KeplerianElements elements, double mu) {
+        this(elements, mu, elements.getEpoch(), 0.0);
+    }
+
+    /**
+     * Full-control constructor.
+     * @param elements                orbital elements (immutable)
+     * @param mu                      gravitational parameter [m^3/s^2]
+     * @param fixedFrameEpoch         epoch for θ0 (tθ0)
+     * @param greenwichAtEpochRad     θ0 (Greenwich angle at tθ0), rad
+     */
+    public TwoBodyPropagator(KeplerianElements elements,
+                             double mu,
+                             Instant fixedFrameEpoch,
+                             double greenwichAtEpochRad) {
+        this.kep = Objects.requireNonNull(elements, "elements");
+        if (!(mu > 0.0) || !Double.isFinite(mu)) {
+            throw new IllegalArgumentException("μ must be finite and > 0.");
+        }
+        this.mu = mu;
+        this.fixedFrameEpoch = Objects.requireNonNull(fixedFrameEpoch, "fixedFrameEpoch");
+        this.greenwichAtEpochRad = greenwichAtEpochRad;
+
+        // Precompute inertial unit vectors p̂, q̂ (perifocal basis rotated to MCI).
+        double i = kep.getInclinationRad();
+        double O = kep.getRaanRad();
+        double w = kep.getArgOfPeriapsisRad();
+
+        double cO = Math.cos(O), sO = Math.sin(O);
+        double ci = Math.cos(i), si = Math.sin(i);
+        double cw = Math.cos(w), sw = Math.sin(w);
+
+        // p̂ = R3(O) R1(i) R3(w) [1, 0, 0]^T
+        pHat = new double[] {
+                cO * cw - sO * sw * ci,
+                sO * cw + cO * sw * ci,
+                sw * si
+        };
+        // q̂ = R3(O) R1(i) R3(w) [0, 1, 0]^T
+        qHat = new double[] {
+                -cO * sw - sO * cw * ci,
+                -sO * sw + cO * cw * ci,
+                cw * si
+        };
+    }
+
+    // ---------------------------------------------------------------------
+    // Accessors
+    // ---------------------------------------------------------------------
+
+    public KeplerianElements elements() { return kep; }
+    public double standardGravitationalParameter() { return mu; }
+    public Instant fixedFrameEpoch() { return fixedFrameEpoch; }
+    public double greenwichAtEpochRad() { return greenwichAtEpochRad; }
+
+    // ---------------------------------------------------------------------
+    // Propagation (MCI / inertial)
+    // ---------------------------------------------------------------------
+
+    /**
+     * Propagate to time {@code t} and return the MCI (inertial) state.
+     * Two-body, osculating, no perturbations.
+     */
+    public StateVector propagateInertial(Instant t) {
+        // Time-dependent anomalies
+        double e = kep.getEccentricity();
+        double a = kep.getSemiMajorAxisM();
+        double M = kep.meanAnomalyAt(t);
+        double E = KeplerianElements.eccentricAnomalyFromMean(M, e);
+
+        // Numerically stable PQW parameterization via E
+        double cosE = Math.cos(E);
+        double sinE = Math.sin(E);
+        double oneMinusEcosE = 1.0 - e * cosE;
+        double r = a * oneMinusEcosE;
+        double beta = Math.sqrt(Math.max(0.0, 1.0 - e * e)); // √(1-e^2)
+
+        // Position in PQW
+        double x_pqw = a * (cosE - e);
+        double y_pqw = a * beta * sinE;
+
+        // Velocity in PQW
+        double fact = Math.sqrt(mu * a) / r; // = n a^2 / r
+        double vx_pqw = -fact * sinE;
+        double vy_pqw =  fact * beta * cosE;
+
+        // Rotate PQW -> MCI using precomputed p̂, q̂
+        double[] rI = linComb2(x_pqw, pHat, y_pqw, qHat);
+        double[] vI = linComb2(vx_pqw, pHat, vy_pqw, qHat);
+
+        return new StateVector(rI, vI);
+    }
+
+    // ---------------------------------------------------------------------
+    // Frame conversion (MCI -> MCMF)
+    // ---------------------------------------------------------------------
+
+    /**
+     * Convert an inertial state at time {@code t} to Mars-fixed (MCMF).
+     * Uses uniform rotation with rate AreoBodyConstants.MARS_ROTATION_RATE_RAD_S.
+     */
+    public StateVector inertialToFixed(StateVector inertial, Instant t) {
+        double theta = greenwichAngleAt(t);
+        double[] rF = rotateZ(theta, inertial.r);
+
+        // v_fixed = Rz(θ) * (v_inertial - ω × r_inertial)
+        double[] omega = new double[] { 0.0, 0.0, AreoBodyConstants.MARS_ROTATION_RATE_RAD_S };
+        double[] vEff = sub3(inertial.v, cross3(omega, inertial.r));
+        double[] vF = rotateZ(theta, vEff);
+
+        return new StateVector(rF, vF);
+    }
+
+    /** Convenience: propagate to {@code t} and return the Mars-fixed state. */
+    public StateVector propagateFixed(Instant t) {
+        return inertialToFixed(propagateInertial(t), t);
+    }
+
+    // ---------------------------------------------------------------------
+    // Subsatellite point (spherical Mars)
+    // ---------------------------------------------------------------------
+
+    /**
+     * Returns the subsatellite point at time {@code t} on a spherical Mars with
+     * mean radius. Longitude is East-positive in (-π, π].
+     */
+    public GroundPoint subsatellitePoint(Instant t) {
+        StateVector sF = propagateFixed(t);
+        return subsatellitePointFromFixedPosition(sF.r);
+    }
+
+    /** Utility: subsatellite point from a Mars-fixed position vector. */
+    public static GroundPoint subsatellitePointFromFixedPosition(double[] rFixed) {
+        double x = rFixed[0], y = rFixed[1], z = rFixed[2];
+        double rho = Math.hypot(x, y);
+        double rmag = Math.hypot(rho, z);
+
+        double lat = Math.atan2(z, rho);      // geocentric latitude
+        double lon = Math.atan2(y, x);        // East-positive
+        double alt = rmag - AreoBodyConstants.MARS_MEAN_RADIUS_M;
+
+        return new GroundPoint(lat, lon, alt);
+    }
+
+    // ---------------------------------------------------------------------
+    // Rotation angle helper
+    // ---------------------------------------------------------------------
+
+    /**
+     * Greenwich angle θ(t) used for inertial→fixed rotation:
+     * θ(t) = θ0 + ωMars * (t - tθ0).
+     */
+    public double greenwichAngleAt(Instant t) {
+        double dt = secondsBetween(fixedFrameEpoch, t);
+        double theta = greenwichAtEpochRad + AreoBodyConstants.MARS_ROTATION_RATE_RAD_S * dt;
+        // normalize to [0, 2π)
+        double x = theta % AreoBodyConstants.TWO_PI;
+        if (x < 0) x += AreoBodyConstants.TWO_PI;
+        return x;
+    }
+
+    // ---------------------------------------------------------------------
+    // Small vector/matrix utilities (no external deps)
+    // ---------------------------------------------------------------------
+
+    /** linear combination: a*u + b*v */
+    private static double[] linComb2(double a, double[] u, double b, double[] v) {
+        return new double[] {
+                a * u[0] + b * v[0],
+                a * u[1] + b * v[1],
+                a * u[2] + b * v[2]
+        };
+    }
+
+    /** r = Rz(angle) * v */
+    private static double[] rotateZ(double angle, double[] v) {
+        double c = Math.cos(angle), s = Math.sin(angle);
+        return new double[] { c * v[0] - s * v[1], s * v[0] + c * v[1], v[2] };
+        // Note: this matches the standard ECI->ECEF-like convention (eastward positive).
+    }
+
+    private static double[] cross3(double[] a, double[] b) {
+        return new double[] {
+                a[1] * b[2] - a[2] * b[1],
+                a[2] * b[0] - a[0] * b[2],
+                a[0] * b[1] - a[1] * b[0]
+        };
+    }
+
+    private static double[] sub3(double[] a, double[] b) {
+        return new double[] { a[0] - b[0], a[1] - b[1], a[2] - b[2] };
+    }
+
+    private static double secondsBetween(Instant t0, Instant t1) {
+        long ds = t1.getEpochSecond() - t0.getEpochSecond();
+        int dns = t1.getNano() - t0.getNano();
+        return (double) ds + dns * 1e-9;
+    }
+
+    private static double normalizeToPi(double angleRad) {
+        double x = angleRad % (2.0 * Math.PI);
+        if (x <= -Math.PI) x += 2.0 * Math.PI;
+        if (x > Math.PI)   x -= 2.0 * Math.PI;
+        return x;
+    }
+}

--- a/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/TwoBodyPropagator.java
+++ b/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/TwoBodyPropagator.java
@@ -53,32 +53,6 @@ public final class TwoBodyPropagator {
         }
     }
 
-    /** Spherical lat/lon/alt (geocentric latitude, degrees helpers provided). */
-    public static final class GroundPoint {
-        /** Latitude [rad], geocentric. */
-        public final double latitudeRad;
-        /** Longitude [rad], East-positive, range (-π, π]. */
-        public final double longitudeRad;
-        /** Altitude above mean radius [m]. */
-        public final double altitudeM;
-
-        public GroundPoint(double latitudeRad, double longitudeRad, double altitudeM) {
-            this.latitudeRad = latitudeRad;
-            this.longitudeRad = normalizeToPi(longitudeRad);
-            this.altitudeM = altitudeM;
-        }
-
-        public double latitudeDeg() { return Math.toDegrees(latitudeRad); }
-        public double longitudeDeg() { return Math.toDegrees(longitudeRad); }
-
-        @Override
-        public String toString() {
-            return String.format(Locale.ROOT,
-                    "LLA[lat=%.6f° lon=%.6f° alt=%.1f m]",
-                    latitudeDeg(), longitudeDeg(), altitudeM);
-        }
-    }
-
     // ---------------------------------------------------------------------
     // Fields (immutable core)
     // ---------------------------------------------------------------------
@@ -305,12 +279,5 @@ public final class TwoBodyPropagator {
         long ds = t1.getEpochSecond() - t0.getEpochSecond();
         int dns = t1.getNano() - t0.getNano();
         return (double) ds + dns * 1e-9;
-    }
-
-    private static double normalizeToPi(double angleRad) {
-        double x = angleRad % (2.0 * Math.PI);
-        if (x <= -Math.PI) x += 2.0 * Math.PI;
-        if (x > Math.PI)   x -= 2.0 * Math.PI;
-        return x;
     }
 }

--- a/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/Visibility.java
+++ b/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/Visibility.java
@@ -23,7 +23,7 @@
  *     standard horizon half-angle when e_min = 0.
  */
 
-package com.mars_sim.core.orbit;
+package org.mars_sim.msp.core.orbit;
 
 import java.util.Locale;
 import java.util.Objects;

--- a/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/Visibility.java
+++ b/mars-sim-javafx/src/main/java/org/mars_sim/msp/core/orbit/Visibility.java
@@ -1,0 +1,337 @@
+/*
+ * This file is part of the Mars Simulation Project (mars-sim).
+ * License: GPL-3.0 (see the project root LICENSE file).
+ *
+ * Purpose:
+ *   Stateless helpers for orbital visibility and coverage geometry:
+ *     - Ground ↔ satellite line-of-sight (LOS) tests (spherical Mars).
+ *     - Coverage / footprint half-angles (with optional min elevation).
+ *     - Central-angle / great-circle distance helpers.
+ *     - Free-space path loss and light-time utilities.
+ *     - Footprint circle polygon generation (for drawing on maps).
+ *
+ * Conventions:
+ *   - "Fixed" coordinates are Mars-centered, Mars-fixed (MCMF).
+ *   - GroundPoint uses planetocentric lat/lon (east-positive), altitude
+ *     above the Mars mean radius (spherical model).
+ *   - Unless stated, Mars radius refers to AreoBodyConstants.MARS_MEAN_RADIUS_M.
+ *
+ * Notes:
+ *   - LOS tests here ignore terrain occlusion; add terrain masking later.
+ *   - The "minimum elevation" coverage formula below is exact for a spherical
+ *     planet with different altitudes at the two endpoints; it reduces to the
+ *     standard horizon half-angle when e_min = 0.
+ */
+
+package com.mars_sim.core.orbit;
+
+import java.util.Locale;
+import java.util.Objects;
+
+public final class Visibility {
+
+    private Visibility() {
+        throw new AssertionError("No instances");
+    }
+
+    // ---------------------------------------------------------------------
+    // Small result container for LOS queries
+    // ---------------------------------------------------------------------
+
+    public static final class LosResult {
+        /** Ground site used for the query. */
+        public final GroundPoint ground;
+        /** Subsatellite point (lat/lon taken from satellite vector; altitude = sat altitude). */
+        public final GroundPoint subsatellite;
+        /** Satellite altitude above mean radius [m]. */
+        public final double satelliteAltitudeM;
+        /** Geocentric central angle between ground site and subsatellite point [rad]. */
+        public final double centralAngleRad;
+        /** Elevation angle of satellite seen from ground [rad]. */
+        public final double elevationRad;
+        /** Slant range [m]. */
+        public final double rangeM;
+        /** One-way light time [s]. */
+        public final double owltSeconds;
+        /** True if elevation >= minElevationRad passed to evaluate(). */
+        public final boolean visible;
+
+        private LosResult(GroundPoint ground,
+                          GroundPoint subsatellite,
+                          double satelliteAltitudeM,
+                          double centralAngleRad,
+                          double elevationRad,
+                          double rangeM,
+                          double owltSeconds,
+                          boolean visible) {
+            this.ground = ground;
+            this.subsatellite = subsatellite;
+            this.satelliteAltitudeM = satelliteAltitudeM;
+            this.centralAngleRad = centralAngleRad;
+            this.elevationRad = elevationRad;
+            this.rangeM = rangeM;
+            this.owltSeconds = owltSeconds;
+            this.visible = visible;
+        }
+
+        public double elevationDeg() { return Math.toDegrees(elevationRad); }
+        public double centralAngleDeg() { return Math.toDegrees(centralAngleRad); }
+
+        @Override
+        public String toString() {
+            return String.format(Locale.ROOT,
+                    "LOS[vis=%s, elev=%.3f deg, α=%.3f deg, range=%.0f m, OWLT=%.3f s, sub=(%.4f°, %.4f°), h_sat=%.0f m]",
+                    visible ? "YES" : "NO",
+                    elevationDeg(),
+                    centralAngleDeg(),
+                    rangeM,
+                    owltSeconds,
+                    subsatellite.latitudeDeg(),
+                    subsatellite.longitudeDeg(),
+                    satelliteAltitudeM);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Ground ↔ Satellite LOS (vector form, exact on a sphere)
+    // ---------------------------------------------------------------------
+
+    /**
+     * Evaluate geometry between a ground point and a satellite at Mars-fixed position.
+     * Uses exact vector geometry on a spherical planet (ignores terrain).
+     *
+     * @param ground           Ground site (lat/lon/alt)
+     * @param satFixed         Satellite position in MCMF [m], length-3
+     * @param minElevationRad  Minimum required elevation [rad] (e.g., 0 for horizon,
+     *                         or Math.toRadians(5) for a 5° mask)
+     */
+    public static LosResult evaluateGroundToSatellite(GroundPoint ground,
+                                                      double[] satFixed,
+                                                      double minElevationRad) {
+        Objects.requireNonNull(ground, "ground");
+        Objects.requireNonNull(satFixed, "satFixed");
+        if (satFixed.length != 3) throw new IllegalArgumentException("satFixed must be length 3");
+
+        // Subsatellite geocentric lat/lon; altitude is satellite altitude.
+        GroundPoint subsat = GroundPoint.fromFixedVector(satFixed);
+
+        // Geometry
+        double elev = ground.elevationRad(satFixed);
+        double range = ground.rangeToM(satFixed);
+        double owlt = range / AreoBodyConstants.SPEED_OF_LIGHT_M_S;
+        double alpha = ground.centralAngleRad(new GroundPoint(subsat.latitudeRad(), subsat.longitudeRad(), 0.0));
+
+        // Satellite altitude above mean radius:
+        double rmag = Math.sqrt(satFixed[0] * satFixed[0] + satFixed[1] * satFixed[1] + satFixed[2] * satFixed[2]);
+        double hSat = rmag - AreoBodyConstants.MARS_MEAN_RADIUS_M;
+
+        boolean visible = elev >= minElevationRad;
+
+        return new LosResult(ground, subsat, hSat, alpha, elev, range, owlt, visible);
+    }
+
+    /** Convenience overload: horizon mask (min elevation = 0). */
+    public static LosResult evaluateGroundToSatellite(GroundPoint ground, double[] satFixed) {
+        return evaluateGroundToSatellite(ground, satFixed, 0.0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Coverage / footprint half-angle math (spherical)
+    // ---------------------------------------------------------------------
+
+    /**
+     * Horizon half-angle ψ for an observer at altitude h above a sphere of radius R.
+     * ψ(h) = arccos( R / (R + h) )
+     */
+    public static double horizonHalfAngleRad(double planetRadiusM, double altitudeM) {
+        double R = planetRadiusM;
+        double r = R + Math.max(0.0, altitudeM);
+        double cosPsi = clamp(R / r, -1.0, 1.0);
+        return Math.acos(cosPsi);
+    }
+
+    /** Horizon half-angle ψ for Mars using mean radius. */
+    public static double horizonHalfAngleRad(double altitudeM) {
+        return horizonHalfAngleRad(AreoBodyConstants.MARS_MEAN_RADIUS_M, altitudeM);
+    }
+
+    /**
+     * Maximum central angle α_max for mutual visibility between two points at
+     * altitudes h1 and h2 (above the same sphere), using horizon geometry:
+     * α_max ≈ ψ(h1) + ψ(h2).
+     * For ground↔sat this gives a quick approximation (exact LOS is via vectors).
+     */
+    public static double mutualVisibilityMaxCentralAngleRad(double planetRadiusM, double h1, double h2) {
+        return horizonHalfAngleRad(planetRadiusM, h1) + horizonHalfAngleRad(planetRadiusM, h2);
+    }
+
+    /** Convenience for Mars. */
+    public static double mutualVisibilityMaxCentralAngleRad(double h1, double h2) {
+        return mutualVisibilityMaxCentralAngleRad(AreoBodyConstants.MARS_MEAN_RADIUS_M, h1, h2);
+    }
+
+    /**
+     * Exact maximum central angle as a function of minimum elevation e_min.
+     * For a ground site at radius Rg = R + h_g and a satellite at Rs = R + h_s:
+     *
+     *   Let ρ = Rg / Rs and e = e_min.
+     *   Then  cos(α_max) = ρ cos^2 e + sin e * sqrt(1 - ρ^2 cos^2 e).
+     *
+     * Special cases:
+     *   - e = 0 → α_max = arccos(Rg / Rs) (horizon).
+     *   - e = 90° → α_max = 0 (satellite must be at zenith).
+     */
+    public static double maxCentralAngleForMinElevationRad(double planetRadiusM,
+                                                           double groundAltitudeM,
+                                                           double satelliteAltitudeM,
+                                                           double minElevationRad) {
+        double Rg = planetRadiusM + Math.max(groundAltitudeM, -planetRadiusM + 1e-3);
+        double Rs = planetRadiusM + Math.max(0.0, satelliteAltitudeM);
+        double e = clamp(minElevationRad, 0.0, Math.PI / 2.0);
+
+        double cosE = Math.cos(e);
+        double sinE = Math.sin(e);
+        double rho = Rg / Rs;
+
+        double under = 1.0 - (rho * rho) * (cosE * cosE);
+        if (under < 0.0) under = 0.0; // guard tiny negatives
+
+        double cosAlpha = rho * (cosE * cosE) + sinE * Math.sqrt(under);
+        cosAlpha = clamp(cosAlpha, -1.0, 1.0);
+
+        return Math.acos(cosAlpha);
+    }
+
+    /** Convenience for Mars. */
+    public static double maxCentralAngleForMinElevationRad(double groundAltitudeM,
+                                                           double satelliteAltitudeM,
+                                                           double minElevationRad) {
+        return maxCentralAngleForMinElevationRad(
+                AreoBodyConstants.MARS_MEAN_RADIUS_M, groundAltitudeM, satelliteAltitudeM, minElevationRad);
+    }
+
+    /**
+     * Check footprint membership using the min-elevation constraint (exact spherical formula).
+     * Uses only lat/lon for central angle; altitudes enter via the α_max(e_min) formula.
+     */
+    public static boolean isWithinFootprint(GroundPoint ground,
+                                            GroundPoint subsatellite,
+                                            double satelliteAltitudeM,
+                                            double minElevationRad) {
+        Objects.requireNonNull(ground, "ground");
+        Objects.requireNonNull(subsatellite, "subsatellite");
+
+        double alpha = ground.centralAngleRad(new GroundPoint(subsatellite.latitudeRad(), subsatellite.longitudeRad(), 0.0));
+        double alphaMax = maxCentralAngleForMinElevationRad(ground.altitudeM(), satelliteAltitudeM, minElevationRad);
+        return alpha <= alphaMax + 1e-12; // small tolerance
+    }
+
+    /** Check footprint membership with horizon mask (min elevation = 0). */
+    public static boolean isWithinFootprint(GroundPoint ground, GroundPoint subsatellite, double satelliteAltitudeM) {
+        return isWithinFootprint(ground, subsatellite, satelliteAltitudeM, 0.0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Surface geometry helpers
+    // ---------------------------------------------------------------------
+
+    /** Central angle between two ground points [rad]. */
+    public static double centralAngleRad(GroundPoint a, GroundPoint b) {
+        return a.centralAngleRad(b);
+    }
+
+    /** Great-circle distance between two ground points along the surface [m]. */
+    public static double surfaceDistanceM(GroundPoint a, GroundPoint b) {
+        return a.surfaceDistanceM(b);
+    }
+
+    // ---------------------------------------------------------------------
+    // Free-space path loss & light time
+    // ---------------------------------------------------------------------
+
+    /**
+     * Free-space path loss (FSPL) in dB with distance in meters and frequency in Hz:
+     *   FSPL(dB) = 20 log10(d) + 20 log10(f) + 147.55
+     */
+    public static double fsplDbMetersHz(double rangeMeters, double frequencyHz) {
+        if (!(rangeMeters > 0.0) || !(frequencyHz > 0.0)) return Double.POSITIVE_INFINITY;
+        return 20.0 * log10(rangeMeters) + 20.0 * log10(frequencyHz) + 147.55;
+    }
+
+    /** One-way light time [s] from range [m]. */
+    public static double owltSeconds(double rangeMeters) {
+        return rangeMeters / AreoBodyConstants.SPEED_OF_LIGHT_M_S;
+    }
+
+    // ---------------------------------------------------------------------
+    // Footprint circle polygon generation (for map overlays)
+    // ---------------------------------------------------------------------
+
+    /**
+     * Generate a geodesic circle (constant central angle) on the spherical surface.
+     *
+     * @param centerOnSurface  Circle center on the surface (use subsatellite lat/lon with alt=0)
+     * @param halfAngleRad     Circle half-angle (e.g., horizon ψ or α_max(e_min))
+     * @param samples          Number of vertices (minimum 4; typical 64–256 for smoothness)
+     */
+    public static GroundPoint[] circleOnSphere(GroundPoint centerOnSurface, double halfAngleRad, int samples) {
+        Objects.requireNonNull(centerOnSurface, "centerOnSurface");
+        if (samples < 4) throw new IllegalArgumentException("samples must be >= 4");
+        double lat0 = centerOnSurface.latitudeRad();
+        double lon0 = centerOnSurface.longitudeRad();
+        double sinLat0 = Math.sin(lat0);
+        double cosLat0 = Math.cos(lat0);
+        double sinPsi = Math.sin(halfAngleRad);
+        double cosPsi = Math.cos(halfAngleRad);
+
+        GroundPoint[] pts = new GroundPoint[samples];
+        double dTheta = 2.0 * Math.PI / samples;
+        for (int k = 0; k < samples; k++) {
+            double theta = k * dTheta;
+            double sinTheta = Math.sin(theta);
+            double cosTheta = Math.cos(theta);
+
+            // Spherical direct geodesic (from center bearing theta, range ψ)
+            double sinLat = sinLat0 * cosPsi + cosLat0 * sinPsi * cosTheta;
+            double lat = Math.asin(clamp(sinLat, -1.0, 1.0));
+
+            double y = sinTheta * sinPsi * cosLat0;
+            double x = cosPsi - sinLat0 * Math.sin(lat);
+            double dLon = Math.atan2(y, x);
+
+            double lon = GroundPoint.normalizeLongitude(lon0 + dLon);
+
+            // Points lie on the surface (alt = 0 relative to mean radius)
+            pts[k] = new GroundPoint(lat, lon, 0.0);
+        }
+        return pts;
+    }
+
+    /**
+     * Convenience: footprint circle for a satellite given its subsatellite lat/lon and altitude.
+     * If you want a min elevation mask, compute the half-angle via maxCentralAngleForMinElevationRad.
+     *
+     * @param subsatelliteLLA  Subsatellite point (lat/lon used; altitude ignored here)
+     * @param satelliteAltitudeM  Satellite altitude above mean radius [m]
+     * @param samples          Number of vertices
+     */
+    public static GroundPoint[] footprintCircle(GroundPoint subsatelliteLLA,
+                                                double satelliteAltitudeM,
+                                                int samples) {
+        double psi = horizonHalfAngleRad(satelliteAltitudeM);
+        GroundPoint centerSurface = new GroundPoint(subsatelliteLLA.latitudeRad(), subsatelliteLLA.longitudeRad(), 0.0);
+        return circleOnSphere(centerSurface, psi, samples);
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal numeric helpers
+    // ---------------------------------------------------------------------
+
+    private static double log10(double x) {
+        return Math.log(x) / Math.log(10.0);
+    }
+
+    private static double clamp(double x, double lo, double hi) {
+        return (x < lo) ? lo : (x > hi) ? hi : x;
+    }
+}


### PR DESCRIPTION
Inital attempt at a implementation of a structured but basic orbital layer.  5 new basic files with basic functions 

One high‑impact coding change for the orbital layer: Add a lightweight “AreoSat coverage & latency” model (areostationary relay satellites) and hook it into the in‑game comms.

Why this is a good fit for mars‑sim

The project already calls out Communication Channels (noise, intermittent, eclipsed, line‑of‑sight) as a desired system, including Mars comm sats, but it isn’t modeled yet. This proposal delivers the missing backbone for that page.  GitHub

The wiki mentions an Orbit Viewer tool “courtesy of JPL” and plans to show Mars satellites/orbiters. What’s missing is simulation logic that makes those orbits matter for gameplay. This proposal adds exactly that, then reuses the viewer to visualize coverage.  GitHub

Historically, the project had “orbital tracking and day/night tracking” (v2.72). This is a clean way to bring a modern, focused orbital mechanic back into the core loop.  GitHub

It slots naturally into the project’s Java 21 core and XML‑driven config (which the docs encourage), so it can be adopted incrementally.  GitHub
+1

What to build
1) Minimal orbit + coverage math (core, no deps)

Create a tiny orbital subpackage that supports constant‑element propagation (two‑body) and line‑of‑sight coverage. Start with areostationary (Mars’ GEO analog), which is useful for comm relays:

Areostationary parameters (from literature):
Semi‑major axis ≈ 20,428 km, altitude ≈ 17,032 km, period = one Martian sidereal day ≈ 88,642.7 s. There are two stable longitudes near 17.92°W and 167.83°E (good “parking” slots for comm birds).  NASA Technical Reports Server
Wikipedia

Coverage half‑angle (spherical, no terrain):

𝜓
=
arccos
⁡
(
𝑅
𝑀
𝑅
𝑀
+
ℎ
)
ψ=arccos(
R
M
	​

+h
R
M
	​

	​

). With 
𝑅
𝑀
≈
3396
 km
R
M
	​

≈3396 km, 
ℎ
≈
17032
 km
h≈17032 km, 
𝜓
≈
80
∘
ψ≈80
∘
. (This gives you the footprint circle on Mars’ surface.)

Proposed files (namespaces illustrative):

mars-sim-core/
  src/main/java/org/mars_sim/msp/core/orbit/
    AreoBodyConstants.java        // muMars, radius, omegaMarsSidereal
    KeplerianElements.java        // a,e,i,raan,argPeri,meanAnomAtEpoch, epoch
    TwoBodyPropagator.java        // E, ν, r, v; ECI->MCMF rotation with ωMars
    GroundPoint.java              // lat, lon, elev (elev optional now)
    Visibility.java               // central-angle, half-angle, LOS tests