### PR TITLE
Update MaintainBuildingEVATest.java (quick fix)

### DIFF
--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/task/MaintainBuildingEVATest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/task/MaintainBuildingEVATest.java
@@ -1,6 +1,5 @@
 package com.mars_sim.core.building.task;
 
-
 import com.mars_sim.core.AbstractMarsSimUnitTest;
 import com.mars_sim.core.building.Building;
 import com.mars_sim.core.building.BuildingCategory;
@@ -14,9 +13,16 @@ import com.mars_sim.core.person.ai.task.EVAOperationTest;
 import com.mars_sim.core.time.MasterClock;
 
 public class MaintainBuildingEVATest extends AbstractMarsSimUnitTest {
-	
+
     private Building buildERV(BuildingManager buildingManager, LocalPosition localPosition) {
-        return buildFunction(buildingManager, "ERV-A", BuildingCategory.ERV, FunctionType.EARTH_RETURN, localPosition, 0D, false);
+        return buildFunction(
+                buildingManager,
+                "ERV-A",
+                BuildingCategory.ERV,
+                FunctionType.EARTH_RETURN,
+                localPosition,
+                0D,
+                false);
     }
 
     public void testMetaTask() {
@@ -24,38 +30,28 @@ public class MaintainBuildingEVATest extends AbstractMarsSimUnitTest {
         var b1 = buildERV(s.getBuildingManager(), LocalPosition.DEFAULT_POSITION);
         // 2nd building check logic
         var b2 = buildERV(s.getBuildingManager(), new LocalPosition(10, 10));
-
         var mt = new MaintainBuildingMeta();
         var tasks = mt.getSettlementTasks(s);
         // Note: there is a chance that tasks are made since scoreMaintenance currently has a probability component
-//        assertTrue("No tasks found", tasks.isEmpty());
-
+        // assertTrue("No tasks found", tasks.isEmpty());
         // One building needs maintenance
         MaintainBuildingTest.buildingNeedMaintenance(b1, this);
         tasks = mt.getSettlementTasks(s);
-        
-        
-       	// Question : why would sometimes both buildings (b1, b2) will incur the need for maintenance ?
+        // Question : why would sometimes both buildings (b1, b2) will incur the need for maintenance ?
         // Answer : getSettlementTasks() will consider both buildings always
-        
-        // Note: tasks may have the size of 0, 1, 2. It depends on the result of  scoreMaintenance()
+        // Note: tasks may have the size of 0, 1, 2. It depends on the result of scoreMaintenance()
         if (tasks.size() == 2) {
-
-	        var found1 = tasks.get(0);
-	        var found2 = tasks.get(1);
-	        
-	        var foundB1 = found1.getFocus();
-	        var foundB2 = found2.getFocus();
-	        
-	        if (found1.isEVA()) {
-	        	assertEquals("Found building B1 with maintenance", b1, foundB1);
-	        }
-	        
-	        assertEquals("Found building B2", b2, foundB2);
+            var found1 = tasks.get(0);
+            var found2 = tasks.get(1);
+            var foundB1 = found1.getFocus();
+            var foundB2 = found2.getFocus();
+            if (found1.isEVA()) {
+                assertEquals("Found building B1 with maintenance", b1, foundB1);
+            }
+            assertEquals("Found building B2", b2, foundB2);
         }
-
     }
-    
+
     public void testCreateEVATask() {
         var s = buildSettlement("EVA Maintenance");
 
@@ -65,42 +61,42 @@ public class MaintainBuildingEVATest extends AbstractMarsSimUnitTest {
 
         var p = buildPerson("Mechanic", s, JobType.TECHNICIAN);
         p.getSkillManager().addNewSkill(SkillType.MECHANICS, 10); // Skilled
+
         var eva = EVAOperationTest.prepareForEva(this, p);
-        
         // DigLocal uses the Settlement airlock tracking logic.... it shouldn't
         s.checkAvailableAirlocks();
 
         var b = buildERV(s.getBuildingManager(), new LocalPosition(20, 20));
-
         MaintainBuildingTest.buildingNeedMaintenance(b, this);
+
         var manager = b.getMalfunctionManager();
         assertGreaterThan("Maintenance due", 0D, manager.getEffectiveTimeSinceLastMaintenance());
 
         var task = new MaintainBuildingEVA(p, b);
-        
-        assertFalse("Task created", task.isDone()); 
+        assertFalse("Task created", task.isDone());
 
-        // Note: currently, EVAOperation set duration to 0;  assertGreaterThan("Duration", 0D, task.getDuration());
-//      // Not used:  assertEquals("EVA walk completed", MaintainBuildingEVA.MAINTAIN, task.getPhase());
+        // Note: currently, EVAOperation set duration to 0; but MaintainBuildingEVA supplies site duration
+        assertGreaterThan("Duration", 0D, task.getDuration()); // EVAOperation site duration proxy
+
+        // Initial phase is walking outside
         assertEquals("EVA walking outside", EVAOperation.WALK_TO_OUTSIDE_SITE, task.getPhase());
-        
+
         // Move onsite
         int callUsed = EVAOperationTest.executeEVAWalk(this, eva, task);
-
         assertGreaterThan("Calls Used ", 0, callUsed);
-        
         assertFalse("Task still active", task.isDone());
-        
         assertGreaterThan("Maintenance due", 0D, manager.getEffectiveTimeSinceLastMaintenance());
 
-        // Start maintenance
+        // Confirm we are now in onsite MAINTAIN phase
+        assertEquals("EVA walk completed", MaintainBuildingEVA.MAINTAIN, task.getPhase());
+
+        // Start maintenance (run one tick). Do NOT assert on inspectionWorkTimeCompleted:
+        // it may be reset to zero immediately when an inspection completes (same as MaintainBuildingTest).
         executeTaskUntilPhase(p, task, 1);
         assertFalse("Task still active", task.isDone());
-        assertGreaterThan("Maintenance started", 0D, manager.getInspectionWorkTimeCompleted());
 
         // Complete maintenance
         executeTaskForDuration(p, task, manager.getBaseMaintenanceWorkTime() * 1.1);
         assertGreaterThan("Maintenance count", 0, manager.getNumberOfMaintenances());
-
     }
 }


### PR DESCRIPTION
The fix

Change the test, not the runtime logic. Replace the fragile assertion with reliable checks:

Assert that after finishing the walk, the task phase is the onsite MAINTAIN phase.

Remove the assertion on getInspectionWorkTimeCompleted() (or keep a comment explaining why it’s not reliable).

Keep the final assertion that the maintenance count increased after running for the required duration.

This aligns the EVA test with the already-updated indoor maintenance test and avoids regressions.

Why this is correct

MaintainBuildingEVA uses the same inspection/finish/reset pattern as MaintainBuilding, so testing the accumulator mid-flight is brittle. The indoor test already removed that check with an explanatory comment; this aligns the EVA test accordingly.  GitHub
+1

The new assertion (“EVA walk completed → MAINTAIN phase”) verifies the onsite transition reliably without depending on a volatile internal counter. The test still verifies eventual maintenance completion by checking manager.getNumberOfMaintenances() after running the required work time.