### PR TITLE
Update sonarqube.yml

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,32 +1,52 @@
 name: SonarQube Analysis
+
 on:
-  # Trigger analysis when pushing in master
+  # Trigger analysis when pushing in master (canonical repo only; job-level if guards below)
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   sonarqube:
-    # Dependabot actor does not have access to secrets so skill the analysis
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    # Only run in the canonical repository and not for Dependabot
+    if: ${{ github.repository == 'mars-sim/mars-sim' && github.actor != 'dependabot[bot]' }}
     name: SonarQube Trigger
     runs-on: ubuntu-latest
+
     steps:
-            
-    - name: Checkout
-      uses: actions/checkout@v4
-    
-    # Setup java 21
-    - name: Setup Java JDK
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: 21
-                  
-    - name: SonarCloud Analysis
-      env:
-        SONAR_ORGANISATION: ${{ secrets.SONAR_ORGANISATION }}
-        SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-      run:
-        mvn --file pom.xml -B -Pcoverage -Dsonar.token=$SONAR_LOGIN -Dsonar.projectKey=com.mars-sim:mars-sim -Dsonar.organization=$SONAR_ORGANISATION verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history improves Sonar blame data
+          fetch-depth: 0
+
+      # Setup Java 21
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: SonarCloud Analysis
+        # Run only if at least one of the expected secrets is present
+        if: ${{ secrets.SONAR_TOKEN != '' || secrets.SONAR_LOGIN != '' }}
+        env:
+          SONAR_ORGANISATION: ${{ secrets.SONAR_ORGANISATION }}
+          # Support both secret names; prefer SONAR_TOKEN if present
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TOKEN="${SONAR_TOKEN:-$SONAR_LOGIN}"
+          if [ -z "$TOKEN" ]; then
+            echo "No Sonar token available; skipping analysis."
+            exit 0
+          fi
+          mvn --file pom.xml -B -Pcoverage \
+            -Dsonar.token="$TOKEN" \
+            -Dsonar.host.url="https://sonarcloud.io" \
+            -Dsonar.projectKey="com.mars-sim:mars-sim" \
+            -Dsonar.organization="$SONAR_ORGANISATION" \
+            -Dsonar.skip=false \
+            verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar


### PR DESCRIPTION
**Ran into some issues when i was making changes on my forked version and the sonar error kept popping up - forking and matching changes there does allow me to not have to seek a review for every single committ at least and i can do bigger more complex changes and with the stuff like the 3d renderer can finish  a batch of files and then file one committ push rather than 10-20 seperate ones, its a workaround as i dont have the ability to push changes to the main without needing a review, so forking to a seperate project, doing the batch changes and then pushing is the work around i have.  The sonar isnt doing the checking thing on each change on the forked version just the master** You're hitting a SonarCloud authentication failure (HTTP 401). That happens when the Sonar step runs without a valid token — typically on forks (no secrets available) or when the token secret name doesn’t match what the workflow expects. Your current workflow (.github/workflows/sonarqube.yml) triggers on pushes to master for any fork and passes -Dsonar.token=$SONAR_LOGIN, which 401s if the secret is missing.  GitHub

Below is a safe fix that:

Runs Sonar only in the canonical repo (mars-sim/mars-sim) and skips it for forks.

Skips the step if no token secret is present (works whether you use SONAR_TOKEN or the legacy SONAR_LOGIN).

Passes the token to Maven and explicitly sets sonar.host.url.

Keeps everything else as-is.

I’m also including a small shell fallback to use either secret name.

Why this fixes the 401

Forks don’t get repository secrets, so their Sonar steps fail with 401. The job now runs only in the canonical repo and additionally checks for a token before invoking the scanner.  GitHub

The scanner needs a valid token (sonar.token or SONAR_TOKEN). The updated step accepts either SONAR_TOKEN (recommended) or legacy SONAR_LOGIN and passes it to Maven. The sonar.host.url is set explicitly.  GitHub

Optional hardening (not strictly required): If you also want to prevent accidental local/CI failures when someone runs mvn sonar:sonar without a token, you can default-skip analysis and only enable it in CI by setting -Dsonar.skip=false. Sonar’s Maven scanner honors the sonar.skip property.  SonarQube Documentation

What you (or maintainers) may need to do once

Ensure the SonarCloud secrets exist in the main repository settings:

SONAR_ORGANISATION (your SonarCloud organization key)

Either SONAR_TOKEN (preferred) or SONAR_LOGIN (legacy)

No changes are needed in forks. The Sonar job will skip there automatically.

If you’d like, I can also add the optional sonar.skip default in the root pom.xml (so local devs never trip over Sonar), but the workflow fix above already stops the 401 from breaking your builds.