### PR TITLE
Update MarsProjectHeadless.java

### DIFF
--- a/mars-sim-headless/src/main/java/com/mars_sim/headless/MarsProjectHeadless.java
+++ b/mars-sim-headless/src/main/java/com/mars_sim/headless/MarsProjectHeadless.java
@@ -16,10 +16,13 @@ import java.util.logging.Logger;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
+// Deprecated old API removed:
+// import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
+// Use the non-deprecated HelpFormatter in the new package:
+import org.apache.commons.cli.help.HelpFormatter;
 
 import com.mars_sim.console.chat.service.Credentials;
 import com.mars_sim.console.chat.service.RemoteChatService;
@@ -34,206 +37,207 @@ import com.mars_sim.core.tool.RandomStringUtils;
  */
 public class MarsProjectHeadless {
 
-	private static final String REMOTE = "remote";
-	private static final String NOREMOTE = "noremote";
-	private static final String DISPLAYHELP = "help";
-	private static final String RESETADMIN = "resetadmin";
-	private static final String LOAD_ARG = "load";
+    private static final String REMOTE = "remote";
+    private static final String NOREMOTE = "noremote";
+    private static final String DISPLAYHELP = "help";
+    private static final String RESETADMIN = "resetadmin";
+    private static final String LOAD_ARG = "load";
 
+    /** initialized logger for this class. */
+    private static final Logger logger = Logger.getLogger(MarsProjectHeadless.class.getName());
 
-	/** initialized logger for this class. */
-	private static final Logger logger = Logger.getLogger(MarsProjectHeadless.class.getName());
+    // Location of service files
+    private static final String SERVICE_DIR = "service";
 
-	// Location of service files
-	private static final String SERVICE_DIR = "service";
+    private static final String CREDENTIALS_FILE = "credentials.ser";
 
-	private static final String CREDENTIALS_FILE = "credentials.ser";
+    /**
+     * Constructor 1.
+     *
+     * @param args command line arguments.
+     */
+    public MarsProjectHeadless(String[] args) {
+        logger.config("Starting " + SimulationRuntime.LONG_TITLE);
+        logger.config("List of input args : " + Arrays.toString(args));
 
-	/**
-	 * Constructor 1.
-	 *
-	 * @param args command line arguments.
-	 */
-	public MarsProjectHeadless(String[] args) {
-		logger.config("Starting " + SimulationRuntime.LONG_TITLE);
-		logger.config("List of input args : " + Arrays.toString(args));
+        // Initialize the simulation.
+        initializeSimulation(args);
+    }
 
-		// Initialize the simulation.
-		initializeSimulation(args);
-	}
+    /**
+     * Initializes the simulation.
+     *
+     * @param args the command arguments.
+     * @return true if new simulation (not loaded)
+     */
+    private boolean initializeSimulation(String[] args) {
 
+        boolean startServer = true;
+        int serverPort = 18080;
 
-	/**
-	 * Initializes the simulation.
-	 *
-	 * @param args the command arguments.
-	 * @return true if new simulation (not loaded)
-	 */
-	private boolean initializeSimulation(String[] args) {
+        SimulationBuilder builder = new SimulationBuilder();
 
-		boolean startServer = true;
-		int serverPort = 18080;
+        Options options = new Options();
+        for (Option o : builder.getCmdLineOptions()) {
+            options.addOption(o);
+        }
 
-		SimulationBuilder builder = new SimulationBuilder();
-		
-		Options options = new Options();
-		for(Option o : builder.getCmdLineOptions()) {
-			options.addOption(o);
-		}
+        options.addOption(Option.builder(LOAD_ARG).argName("path to simulation file").hasArg().optionalArg(true)
+                .desc("Load a previously saved sim. No argument then the default is used").get());
+        options.addOption(Option.builder(DISPLAYHELP)
+                .desc("Help of the options").get());
+        OptionGroup remoteGrp = new OptionGroup();
+        remoteGrp.setRequired(false); // REMOTE is the internal default
+        remoteGrp.addOption(Option.builder(REMOTE).argName("port number").hasArg().optionalArg(true)
+                .desc("Run the remote console service [default]").get());
+        remoteGrp.addOption(Option.builder(NOREMOTE)
+                .desc("Do not start a remote console service").get());
+        options.addOptionGroup(remoteGrp);
+        options.addOption(Option.builder(RESETADMIN)
+                .desc("Reset the internal admin password").get());
 
-		options.addOption(Option.builder(LOAD_ARG).argName("path to simulation file").hasArg().optionalArg(true)
-				.desc("Load the a previously saved sim. No argument then the default is used").get());
-		options.addOption(Option.builder(DISPLAYHELP)
-				.desc("Help of the options").get());
-		OptionGroup remoteGrp = new OptionGroup();
-		remoteGrp.setRequired(false); // REMOTE is the internal default
-		remoteGrp.addOption(Option.builder(REMOTE).argName("port number").hasArg().optionalArg(true)
-								.desc("Run the remote console service [default]").get());
-		remoteGrp.addOption(Option.builder(NOREMOTE)
-				.desc("Do not start a remote console service").get());
-		options.addOptionGroup(remoteGrp);
-		options.addOption(Option.builder(RESETADMIN)
-				.desc("Reset the internal admin password").get());
+        CommandLineParser commandline = new DefaultParser();
+        boolean resetAdmin = false;
+        try {
+            CommandLine line = commandline.parse(options, args);
 
-		CommandLineParser commandline = new DefaultParser();
-		boolean resetAdmin = false;
-		try {
-			CommandLine line = commandline.parse(options, args);
+            builder.parseCommandLine(line);
 
-			builder.parseCommandLine(line);
+            if (line.hasOption(REMOTE)) {
+                startServer = true;
+                String portValue = line.getOptionValue(REMOTE);
+                if (portValue != null) {
+                    serverPort = Integer.parseInt(portValue);
+                }
+            }
+            if (line.hasOption(NOREMOTE)) {
+                startServer = false;
+            }
 
-			if (line.hasOption(REMOTE)) {
-				startServer = true;
-				String portValue = line.getOptionValue(REMOTE);
-				if (portValue != null) {
-					serverPort = Integer.parseInt(portValue);
-				}
-			}
-			if (line.hasOption(NOREMOTE)) {
-				startServer = false;
-			}
+            if (line.hasOption(DISPLAYHELP)) {
+                usage("Available options", options);
+            }
+            if (line.hasOption(RESETADMIN)) {
+                resetAdmin = true;
+            }
+            if (line.hasOption(LOAD_ARG)) {
+                String simFile = line.getOptionValue(LOAD_ARG);
+                if (simFile == null) {
+                    simFile = Simulation.SAVE_FILE + Simulation.SAVE_FILE_EXTENSION;
+                }
+                builder.setSimFile(simFile);
+            }
+        }
+        catch (Exception e1) {
+            usage("Problem with arguments: " + e1.getMessage(), options);
+        }
 
-			if (line.hasOption(DISPLAYHELP)) {
-				usage("Available options", options);
-			}
-			if (line.hasOption(RESETADMIN)) {
-				resetAdmin = true;
-			}
-			if (line.hasOption(LOAD_ARG)) {
-				String simFile = line.getOptionValue(LOAD_ARG);
-				if (simFile == null) {
-					simFile = Simulation.SAVE_FILE + Simulation.SAVE_FILE_EXTENSION;
-				}
-				builder.setSimFile(simFile);
-			}
-		}
-		catch (Exception e1) {
-			usage("Problem with arguments: " + e1.getMessage(), options);
-		}
+        // Do it
+        try {
+            // Build and run the simulator
+            builder.start();
 
-		// Do it
-		try {
-			// Build and run the simulator
-			builder.start();
+            if (startServer) {
+                startRemoteConsole(serverPort, resetAdmin);
+            }
+        }
+        catch (Exception e) {
+            // Catch everything
+            exitWithError("Problem starting " + e.getMessage(), e);
+        }
 
-			if (startServer) {
-				startRemoteConsole(serverPort, resetAdmin);
-			}
-		}
-		catch(Exception e) {
-			// Catch everything
-			exitWithError("Problem starting " + e.getMessage(), e);
+        return true;
+    }
 
-		}
+    private void usage(String message, Options options) {
+        // New non-deprecated HelpFormatter (Commons CLI 1.10+)
+        final HelpFormatter fmt = HelpFormatter.builder().get();
+        final String header = "\n" + message + "\n";
+        final String footer = "";
+        try {
+            fmt.printHelp("mars-sim-headless [options]", header, options, footer, true);
+        } catch (IOException ioe) {
+            // Fallback if printing help fails
+            System.out.println();
+            System.out.println(message);
+            System.out.println("usage: mars-sim-headless [options]");
+        }
+        System.exit(1);
+    }
 
-		return true;
-	}
+    /**
+     * Exit the simulation with an error message.
+     *
+     * @param message the error message.
+     * @param e       the thrown exception or null if none.
+     */
+    private void exitWithError(String message, Exception e) {
+        if (e != null) {
+            logger.log(Level.SEVERE, message, e);
+        }
+        else {
+            logger.log(Level.SEVERE, message);
+        }
+        System.exit(1);
+    }
 
-	private void usage(String message, Options options) {
-		HelpFormatter format = new HelpFormatter();
-		System.out.println();
-		System.out.println(message);
-		format.printHelp(" [for mars-sim headless edition]", options);
-		System.exit(1);
-	}
+    /**
+     * Starts the simulation instance.
+     *
+     * @param serverPort
+     * @param changePassword
+     */
+    private void startRemoteConsole(int serverPort, boolean changePassword) {
+        try {
+            File serviceDataDir = new File(SimulationRuntime.getDataDir(), SERVICE_DIR);
+            if (!serviceDataDir.exists()) {
+                logger.info("Build " + serviceDataDir);
+                serviceDataDir.mkdirs();
+            }
 
-	/**
-	 * Exit the simulation with an error message.
-	 *
-	 * @param message the error message.
-	 * @param e       the thrown exception or null if none.
-	 */
-	private void exitWithError(String message, Exception e) {
-		if (e != null) {
-			logger.log(Level.SEVERE, message, e);
-		} else {
-			logger.log(Level.SEVERE, message);
-		}
-		System.exit(1);
-	}
+            // Load the credential file
+            File credFile = new File(serviceDataDir, CREDENTIALS_FILE);
+            Credentials credentials = null;
+            String adminPassword;
+            if (credFile.exists()) {
+                credentials = Credentials.load(credFile);
+                if (changePassword) {
+                    adminPassword = RandomStringUtils.random(8, true, true);
+                    credentials.setPassword(Credentials.ADMIN, adminPassword);
+                }
+                else {
+                    adminPassword = credentials.getPassword(Credentials.ADMIN);
+                }
+            }
+            else {
+                credentials = new Credentials(credFile);
+                adminPassword = RandomStringUtils.random(8, true, true);
+                credentials.addUser(Credentials.ADMIN, adminPassword);
+                credentials.addUser("normal", "test456");
+            }
 
+            // This should be dropped eventually
+            logger.info("User " + Credentials.ADMIN + " has password " + adminPassword);
 
+            logger.info("Start console service on port " + serverPort);
+            RemoteChatService service = new RemoteChatService(serverPort, serviceDataDir, credentials);
 
-	/**
-	 * Starts the simulation instance.
-	 * 
-	 * @param serverPort
-	 * @param changePassword
-	 */
-	private void startRemoteConsole(int serverPort, boolean changePassword) {
-		try {
-			File serviceDataDir = new File(SimulationRuntime.getDataDir() , SERVICE_DIR);
-			if (!serviceDataDir.exists()) {
-				logger.info("Build " + serviceDataDir);
-				serviceDataDir.mkdirs();
-			}
+            service.start();
+        } catch (IOException e) {
+            exitWithError("Problem starting remote service", e);
+        }
+    }
 
-			// Load the credential file
-			File credFile = new File(serviceDataDir, CREDENTIALS_FILE);
-			Credentials credentials = null;
-			String adminPassword;
-			if (credFile.exists()) {
-				credentials  = Credentials.load(credFile);
-				if (changePassword) {
-					adminPassword = RandomStringUtils.random(8, true, true);
-					credentials.setPassword(Credentials.ADMIN, adminPassword);
-				}
-				else {
-					adminPassword = credentials.getPassword(Credentials.ADMIN);
-				}
-			}
-			else {
-				credentials = new Credentials(credFile);
-				adminPassword = RandomStringUtils.random(8, true, true);
-				credentials.addUser(Credentials.ADMIN, adminPassword);
-				credentials.addUser("normal", "test456");
+    /**
+     * The starting method for the application.
+     *
+     * @param args the command line arguments
+     */
+    public static void main(String[] args) throws IOException {
 
-			}
+        SimulationRuntime.initialseLogging();
 
-			// This should be dropped eventually
-			logger.info("User " + Credentials.ADMIN + " has password " + adminPassword);
-
-			logger.info("Start console service on port " + serverPort);
-			RemoteChatService service = new RemoteChatService(serverPort, serviceDataDir, credentials);
-
-			service.start();
-		} catch (IOException e) {
-			exitWithError("Problem starting remote service", e);
-		}
-	}
-
-
-	/**
-	 * The starting method for the application.
-	 *
-	 * @param args the command line arguments
-	 */
-	public static void main(String[] args) throws IOException {
-
-		SimulationRuntime.initialseLogging();
-
-		// starting the simulation
-		new MarsProjectHeadless(args);
-	}
+        // starting the simulation
+        new MarsProjectHeadless(args);
+    }
 }
-

--- a/mars-sim-headless/src/main/java/com/mars_sim/headless/MarsProjectHeadlessStarter.java
+++ b/mars-sim-headless/src/main/java/com/mars_sim/headless/MarsProjectHeadlessStarter.java
@@ -9,263 +9,267 @@ package com.mars_sim.headless;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
+// import org.apache.commons.lang3.StringUtils; // Deprecated APIs replaced
+import org.apache.commons.lang3.Strings;
 
 /**
- * MarsProjectHeadlessStarter is the default class for starting the mars-sim Headless jar. 
- * It creates a new virtual machine with logging properties. 
+ * MarsProjectHeadlessStarter is the default class for starting the mars-sim Headless jar.
+ * It creates a new virtual machine with logging properties.
  */
 public class MarsProjectHeadlessStarter {
 
-//	private final static String ERROR_PREFIX = "? ";
+//  private final static String ERROR_PREFIX = "? ";
 
-	private static final String JAVA = "java";
-	private static final String JAVA_HOME = "JAVA_HOME";
-	private static final String BIN = "bin";
-	private static final String ONE_WHITESPACE = " ";
-	
-	private static String OS = System.getProperty("os.name").toLowerCase();
-	
-	public static void main(String[] args) {
-	    // Add checking for input args
-		List<String> argList = Arrays.asList(args);
-		
-		StringBuilder command = new StringBuilder();
-
-		String javaHome = System.getenv(JAVA_HOME);
-		
-	    System.out.println("      JAVA_HOME : " + javaHome);
+    private static final String JAVA = "java";
+    private static final String JAVA_HOME = "JAVA_HOME";
+    private static final String BIN = "bin";
+    private static final String ONE_WHITESPACE = " ";
+    
+    private static String OS = System.getProperty("os.name").toLowerCase();
+    
+    public static void main(String[] args) {
+        // Add checking for input args
+        List<String> argList = Arrays.asList(args);
         
-//        System.out.println(" File.separator : " + File.separator);
-        
- 		if (javaHome != null) {
- 			if (javaHome.contains(ONE_WHITESPACE))
- 				javaHome = "\"" + javaHome;
+        StringBuilder command = new StringBuilder();
 
- 			String lastChar = javaHome.substring(javaHome.length() - 1);
- 			
- 			if (lastChar.equalsIgnoreCase(File.separator)) {
- 				if (javaHome.contains(BIN)) {
- 					command
- 					.append(javaHome)
- 					.append(JAVA);
- 				}
- 				else {
- 					command
- 					.append(javaHome)
- 					.append(BIN)
- 					.append(File.separator)
- 					.append(JAVA);
- 				}	
- 			}
- 			else {
- 				if (javaHome.contains(BIN)) {
- 					command
- 					.append(javaHome)
- 					.append(File.separator)
- 					.append(JAVA);
- 				}
- 				else {
- 					command
- 					.append(javaHome)
- 					.append(File.separator)
- 					.append(BIN)
- 					.append(File.separator)
- 					.append(JAVA);
- 				}		
- 			}
- 			
- 			if (javaHome.contains(ONE_WHITESPACE))
- 				command.append("\"");
-
-// 		    System.out.println("      JAVA_HOME : " + javaHome);
- 	        System.out.println("   Java Command : " + command.toString());
- 	        
- 		}
-		else {
-			command.append(JAVA);
-		}
-		
- 		
- 		// Set up 1.5GB heap space
- 		command.append(" -Xmx1536m");
- 		
-//		command.append(" --illegal-access=deny");
+        String javaHome = System.getenv(JAVA_HOME);
         
-        // Check OS
-        if (OS.contains("win"))
-        	command.append("\n --add-opens java.desktop/com.sun.java.swing.plaf.windows=ALL-UNNAMED");
-        else if (OS.contains("mac"))
-        	command.append("\n --add-opens java.desktop/com.apple.laf=ALL-UNNAMED");
-        else if (OS.contains("nix") || OS.contains("nux") || OS.contains("aix") || OS.contains("sunos"))
+        System.out.println("      JAVA_HOME : " + javaHome);
+        
+//      System.out.println(" File.separator : " + File.separator);
+        
+        if (javaHome != null) {
+            if (javaHome.contains(ONE_WHITESPACE))
+                javaHome = "\"" + javaHome;
+
+            String lastChar = javaHome.substring(javaHome.length() - 1);
+            
+            if (lastChar.equalsIgnoreCase(File.separator)) {
+                if (javaHome.contains(BIN)) {
+                    command
+                    .append(javaHome)
+                    .append(JAVA);
+                }
+                else {
+                    command
+                    .append(javaHome)
+                    .append(BIN)
+                    .append(File.separator)
+                    .append(JAVA);
+                }   
+            }
+            else {
+                if (javaHome.contains(BIN)) {
+                    command
+                    .append(javaHome)
+                    .append(File.separator)
+                    .append(JAVA);
+                }
+                else {
+                    command
+                    .append(javaHome)
+                    .append(File.separator)
+                    .append(BIN)
+                    .append(File.separator)
+                    .append(JAVA);
+                }       
+            }
+            
+            if (javaHome.contains(ONE_WHITESPACE))
+                command.append("\"");
+
+//          System.out.println("      JAVA_HOME : " + javaHome);
+            System.out.println("   Java Command : " + command.toString());
+            
+        }
+        else {
+            command.append(JAVA);
+        }
+        
+        // Set up 1.5GB heap space
+        command.append(" -Xmx1536m");
+        
+//      command.append(" --illegal-access=deny");
+        
+        // Check OS (use non-deprecated case-insensitive API)
+        if (Strings.CI.contains(OS, "win"))
+            command.append("\n --add-opens java.desktop/com.sun.java.swing.plaf.windows=ALL-UNNAMED");
+        else if (Strings.CI.contains(OS, "mac"))
+            command.append("\n --add-opens java.desktop/com.apple.laf=ALL-UNNAMED");
+        else if (Strings.CI.contains(OS, "nix") || Strings.CI.contains(OS, "nux") || Strings.CI.contains(OS, "aix") || Strings.CI.contains(OS, "sunos"))
             command.append("\n --add-opens java.desktop/com.sun.java.swing.plaf.gtk=ALL-UNNAMED");
-		
-		// command.append(" -Dswing.aatext=true");
-		// command.append(" -Dswing.plaf.metal.controlFont=Tahoma"); // the compiled jar
-		// won't run
-		// command.append(" -Dswing.plaf.metal.userFont=Tahoma"); // the compiled jar
-		// won't run
-		// command.append(" -generateHelp");
-		// command.append(" -new");
+        
+        // command.append(" -Dswing.aatext=true");
+        // command.append(" -Dswing.plaf.metal.controlFont=Tahoma"); // the compiled jar
+        // won't run
+        // command.append(" -Dswing.plaf.metal.userFont=Tahoma"); // the compiled jar
+        // won't run
+        // command.append(" -generateHelp");
+        // command.append(" -new");
 
         // Use new Shenandoah Garbage Collector from Java 12 
-//        command.append(" -XX:+UnlockExperimentalVMOptions")
-//        	.append(" -XX:+UseShenandoahGC");
-//        	.append(" -Xlog:gc*");
+//      command.append(" -XX:+UnlockExperimentalVMOptions")
+//          .append(" -XX:+UseShenandoahGC");
+//          .append(" -Xlog:gc*");
         
         // Set up logging
-		command.append("\n -Djava.util.logging.config.file=logging.properties");
-		
+        command.append("\n -Djava.util.logging.config.file=logging.properties");
+        
         // The following few appends create this option string that is being used up to v3.07
         // -cp .;*;jars\*
         command.append(" -cp .")
-    	.append(File.pathSeparator) // File.pathSeparator is a semi-colon ';' in windows or a colon ':' in linux
-    	.append("*")
-    	.append(File.pathSeparator) // File.pathSeparator is a semi-colon ';' in windows or a colon ':' in linux
-    	.append("jars")
-    	.append(File.separator)     // File.separator is a backslash '\' in windows or a forward slash '/' in linux
-    	.append("*");
-    // v3.1.0 started distributing a single jar binary, instead of having a hierarchy of folders and files.
+        .append(File.pathSeparator) // File.pathSeparator is a semi-colon ';' in windows or a colon ':' in linux
+        .append("*")
+        .append(File.pathSeparator) // File.pathSeparator is a semi-colon ';' in windows or a colon ':' in linux
+        .append("jars")
+        .append(File.separator)     // File.separator is a backslash '\' in windows or a forward slash '/' in linux
+        .append("*");
+        // v3.1.0 started distributing a single jar binary, instead of having a hierarchy of folders and files.
 
-    	
         command.append(" com.mars_sim.headless.MarsProjectHeadless");
 
-		
-		boolean isNew = false;
-		
+        boolean isNew = false;
+        
         if (argList.isEmpty()) {
-        	// by default, use gui and 1.5 GB
-//            command.append(" -Xms256m");
-//            command.append(" -Xmx1536m");
-        	command.append(" -new");
+            // by default, use gui and 1.5 GB
+//          command.append(" -Xms256m");
+//          command.append(" -Xmx1536m");
+            command.append(" -new");
         }
 
         else {
-        	
-        	if (argList.contains("-noremote")) {
- 	            command.append(" -noremote");
- 	        }
-        	
-        	if (argList.contains("-resetadmin")) {
- 	            command.append(" -resetadmin");
- 	        }
+            
+            if (argList.contains("-noremote")) {
+                command.append(" -noremote");
+            }
+            
+            if (argList.contains("-resetadmin")) {
+                command.append(" -resetadmin");
+            }
 
-//	        if (argList.contains("-3")) {
-////	            command.append(" -Xms256m");
-//	            command.append(" -Xmx3072m");
-//	        }
-//	        else if (argList.contains("-2.5")) {
-////	            command.append(" -Xms256m");
-//	            command.append(" -Xmx2560m");
-//	        }
-//	        else if (argList.contains("-2")) {
-////	            command.append(" -Xms256m");
-//	            command.append(" -Xmx2048m");
-//	        }
-//	        else if (argList.contains("-1.5")) {
-////	            command.append(" -Xms256m");
-//	            command.append(" -Xmx1536m");
-//	        }
-//	        else if (argList.contains("-1")) {
-////	            command.append(" -Xms256m");
-//	            command.append(" -Xmx1024m");
-//	        }
-//	        else {
-//	        	//  use 1.5 GB by default
-////	            command.append(" -Xms256m");
-//	            command.append(" -Xmx1536m");
-//	        }
+//          if (argList.contains("-3")) {
+////             command.append(" -Xms256m");
+//              command.append(" -Xmx3072m");
+//          }
+//          else if (argList.contains("-2.5")) {
+////             command.append(" -Xms256m");
+//              command.append(" -Xmx2560m");
+//          }
+//          else if (argList.contains("-2")) {
+////             command.append(" -Xms256m");
+//              command.append(" -Xmx2048m");
+//          }
+//          else if (argList.contains("-1.5")) {
+////             command.append(" -Xms256m");
+//              command.append(" -Xmx1536m");
+//          }
+//          else if (argList.contains("-1")) {
+////             command.append(" -Xms256m");
+//              command.append(" -Xmx1024m");
+//          }
+//          else {
+//              //  use 1.5 GB by default
+////             command.append(" -Xms256m");
+//              command.append(" -Xmx1536m");
+//          }
 
-	        if (argList.contains("-help")) {
-	        	command.append(" -help");
-	        }
+            if (argList.contains("-help")) {
+                command.append(" -help");
+            }
 
-	        else if (argList.contains("-html")) {
-	        	command.append(" -html");
-	        }
+            else if (argList.contains("-html")) {
+                command.append(" -html");
+            }
 
-	        else {
-				// Check for the headless switch
-		        if (argList.contains("-headless"))
-		        	command.append(" -headless");
+            else {
+                // Check for the headless switch
+                if (argList.contains("-headless"))
+                    command.append(" -headless");
 
-				// Check for the new switch
-				if (argList.contains("-new")) {
-					isNew = true;	
-				}
-				
-		        else if (argList.contains("-load")) {
-		        	command.append(" -load");
+                // Check for the new switch
+                if (argList.contains("-new")) {
+                    isNew = true; 
+                }
+                
+                else if (argList.contains("-load")) {
+                    command.append(" -load");
 
-		        	// Appended the name of loadFile to the end of the command stream so that MarsProjectFX can read it.
-		        	int index = argList.indexOf("load");
-		        	int size = argList.size();
-		        	String fileName = null;
-		        	if (size > index + 1) { // TODO : will it help to catch IndexOutOfBoundsException
-		            // Get the next argument as the filename.
-		        		fileName = argList.get(index + 1);
-		        		command.append(" " + fileName);
-		        	}
-		        }
+                    // Appended the name of loadFile to the end of the command stream so that MarsProjectFX can read it.
+                    int index = argList.indexOf("load"); // NOTE: Existing code uses "load" (without '-') – preserved as-is.
+                    int size = argList.size();
+                    String fileName = null;
+                    if (size > index + 1) { // TODO : will it help to catch IndexOutOfBoundsException
+                        // Get the next argument as the filename.
+                        fileName = argList.get(index + 1);
+                        command.append(" " + fileName);
+                    }
+                }
 
-		        else {
-					// System.out.println("Note: it's missing 'new' or 'load'. Assume you want to
-					// start a new sim now.");
-						
-					isNew = true;
-				}
-			}
+                else {
+                    // System.out.println("Note: it's missing 'new' or 'load'. Assume you want to
+                    // start a new sim now.");
+                        
+                    isNew = true;
+                }
+            }
         }
 
-		if (isNew) {
-			command.append(" -new");
-			
-			for (String s: argList) {
+        if (isNew) {
+            command.append(" -new");
+            
+            for (String s: argList) {
 
-				if (StringUtils.containsIgnoreCase(s, "-remote ")) {
-					command.append(" " + s);
-				}
-				
-				if (StringUtils.containsIgnoreCase(s, "-sponsor ")) {
-					command.append(" " + s);
-				}
-						
-				if (StringUtils.containsIgnoreCase(s, "-template ")) {
-					command.append(" " + s);
-				}
-				
-				if (StringUtils.containsIgnoreCase(s, "-lat ")) {
-					command.append(" " + s);
-				}
-				
-				if (StringUtils.containsIgnoreCase(s, "-lon ")) {
-					command.append(" " + s);
-				}	
-				
-				if (StringUtils.containsIgnoreCase(s, "-timeratio ")) {
-					command.append(" " + s);
-				}	
-				
-				if (StringUtils.containsIgnoreCase(s, "-datadir ")) {
-					command.append(" " + s);
-				}	
-			}		
-		}
+                if (Strings.CI.contains(s, "-remote ")) {
+                    command.append(" " + s);
+                }
+                
+                if (Strings.CI.contains(s, "-sponsor ")) {
+                    command.append(" " + s);
+                }
+                        
+                if (Strings.CI.contains(s, "-template ")) {
+                    command.append(" " + s);
+                }
+                
+                if (Strings.CI.contains(s, "-lat ")) {
+                    command.append(" " + s);
+                }
+                
+                if (Strings.CI.contains(s, "-lon ")) {
+                    command.append(" " + s);
+                }   
+                
+                if (Strings.CI.contains(s, "-timeratio ")) {
+                    command.append(" " + s);
+                }   
+                
+                if (Strings.CI.contains(s, "-datadir ")) {
+                    command.append(" " + s);
+                }   
+            }       
+        }
 
         if (argList.contains("-noaudio")) 
-        	command.append(" -noaudio");
+            command.append(" -noaudio");
         
         if (argList.contains("-nogui")) 
-        	command.append(" -nogui");
+            command.append(" -nogui");
 
         String commandStr = command.toString();
         System.out.println("Command: " + commandStr);
 
         try {
-            Process process = Runtime.getRuntime().exec(commandStr);
+            // Use ProcessBuilder instead of deprecated Runtime.exec(String).
+            // Tokenize the command string into arguments, honoring quotes.
+            List<String> tokens = tokenizeCommand(commandStr);
+            ProcessBuilder pb = new ProcessBuilder(tokens);
+            // Keep stderr/stdout separate, mirroring the original two-consumer setup:
+            Process process = pb.start();
 
             // Creating stream consumers for processes.
             StreamConsumer errorConsumer = new StreamConsumer(process.getErrorStream(), "");
@@ -282,13 +286,63 @@ public class MarsProjectHeadlessStarter {
             outputConsumer.join();
 
         } catch (IOException e) {
-        	System.out.println(e.getMessage());
+            System.out.println(e.getMessage());
         } catch (InterruptedException e1) {
-        	System.out.println(e1.getMessage());
-        	// Restore interrupted state
+            System.out.println(e1.getMessage());
+            // Restore interrupted state
             Thread.currentThread().interrupt();
         } catch (Exception e2) {
-        	System.out.println(e2.getMessage());      	
+            System.out.println(e2.getMessage());       
         }
+    }
+
+    /**
+     * Tokenizes a shell-like command string into arguments for ProcessBuilder.
+     * Supports:
+     *  - Whitespace separation outside of quotes
+     *  - Double-quoted segments to preserve spaces
+     *  - Simple backslash escape for quotes inside a quoted segment (\")
+     */
+    private static List<String> tokenizeCommand(String command) {
+        List<String> tokens = new ArrayList<>();
+        StringBuilder cur = new StringBuilder();
+        boolean inQuotes = false;
+        char quoteChar = '"';
+
+        for (int i = 0; i < command.length(); i++) {
+            char c = command.charAt(i);
+
+            if (inQuotes) {
+                if (c == '\\') {
+                    // Handle simple escapes inside quotes: \" -> "
+                    if (i + 1 < command.length() && command.charAt(i + 1) == quoteChar) {
+                        cur.append(quoteChar);
+                        i++; // skip next char
+                    } else {
+                        cur.append(c);
+                    }
+                } else if (c == quoteChar) {
+                    inQuotes = false; // consume closing quote
+                } else {
+                    cur.append(c);
+                }
+            } else {
+                if (c == '"' || c == '\'') {
+                    inQuotes = true;
+                    quoteChar = c;
+                } else if (Character.isWhitespace(c)) {
+                    if (cur.length() > 0) {
+                        tokens.add(cur.toString());
+                        cur.setLength(0);
+                    }
+                } else {
+                    cur.append(c);
+                }
+            }
+        }
+        if (cur.length() > 0) {
+            tokens.add(cur.toString());
+        }
+        return tokens;
     }
 }


### PR DESCRIPTION
Here’s MarsProjectHeadless.java with the Commons‑CLI HelpFormatter deprecation fix applied (migrated to the new org.apache.commons.cli.help.HelpFormatter and the builder().get() construction). I also updated the usage(...) method to use the non‑deprecated printHelp overload; since that method can throw IOException, it’s wrapped in a small try/catch while preserving the original exit behavior.

Edit Side Note **When i tried to sync my personal repository fork i was using for the new 3d renderer i could sync it for any committs i was behind in, but in the process of trying to figure out how to remove new files i had submitted but wanted to get ride of to do a new pull committ on an unrelated issue it was still including all of them, so i deleted the fork and thought that it wouldnt affect all unmerged outstanding pull requests, but it auto closed the lot of them, the ideas in them and the file changes are still there in the closed section , so if any of them are interesting in the future, resurrecting and redoing them is easy enough.  Just an oopsy, github could do with a lot of new features and expanding its ways of having more subtle options.  Anyway this is a fix for the marven checks that for a while now have generated some old deprecated yellow codes, so this is to fix one of them**