### PR TITLE
Make Coordinate parsing tolerant of language binding

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/CommandHelper.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/CommandHelper.java
@@ -21,6 +21,8 @@ import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.malfunction.Malfunction;
 import com.mars_sim.core.malfunction.Malfunction.Repairer;
 import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesException;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 import com.mars_sim.core.malfunction.MalfunctionRepairWork;
 import com.mars_sim.core.malfunction.Malfunctionable;
 import com.mars_sim.core.person.Person;
@@ -522,45 +524,26 @@ public class CommandHelper {
 	 * @param context COntext of the conversation
 	 */
 	public static Coordinates getCoordinates(String desc, Conversation context) {
-		double phi = 0;
-		double theta = 0;
-		boolean good = false;
-		
 		do {
-			try {
-				String latitudeStr1 = context.getInput("What is the latitude (e.g. 10.03 N, 5.01 S) of the " 
-						+ desc.toLowerCase() + " coordinate ?");
-				if (latitudeStr1.equalsIgnoreCase("quit") || latitudeStr1.equalsIgnoreCase("/q")
-						|| latitudeStr1.isBlank())
-					return null;
-				else {
-					phi = Coordinates.parseLatitude2Phi(latitudeStr1);
-					good = true;
-				}
-			} catch(IllegalStateException e) {
-				context.println("Not a valid format");
-				good = false;
-			}
-		} while (!good);
-		
-		do {
-			try {
-				String longitudeStr = context.getInput("What is the longitude (e.g. 5.09 E, 18.04 W) of the "
+			String latitudeStr1 = context.getInput("What is the latitude (e.g. 10.03 N, 5.01 S) of the " 
+					+ desc.toLowerCase() + " coordinate ?");
+			if (latitudeStr1.equalsIgnoreCase("quit") || latitudeStr1.equalsIgnoreCase("/q")
+					|| latitudeStr1.isBlank())
+				return null;
+
+			String longitudeStr = context.getInput("What is the longitude (e.g. 5.09 E, 18.04 W) of the "
 						+ desc.toLowerCase() + " coordinate ?");
 				if (longitudeStr.equalsIgnoreCase("quit") || longitudeStr.equalsIgnoreCase("/q")
 						|| longitudeStr.isBlank())
 					return null;
-				else {
-					theta = Coordinates.parseLongitude2Theta(longitudeStr);
-					good = true;
-				}
-			} catch(IllegalStateException e) {
-				context.println("Not a valid format");
-				good = false;
+
+			try {
+				return CoordinatesFormat.fromString(latitudeStr1, longitudeStr);
 			}
-		} while (!good);
-		
-		return new Coordinates(phi, theta);
+			catch(CoordinatesException e) {
+				context.println("Not a valid format : " + e.getMessage());
+			}
+		} while (true);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/SimulationBuilder.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/SimulationBuilder.java
@@ -25,6 +25,7 @@ import com.mars_sim.core.configuration.UserConfigurableConfig;
 import com.mars_sim.core.logging.DiagnosticsManager;
 import com.mars_sim.core.map.common.FileLocator;
 import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 import com.mars_sim.core.person.Crew;
 import com.mars_sim.core.person.CrewConfig;
 import com.mars_sim.core.tool.RandomUtil;
@@ -84,7 +85,7 @@ public class SimulationBuilder {
 	}
 	
 	private void setLatitude(String lat) {
-		String error = Coordinates.checkLat(lat);
+		String error = CoordinatesFormat.checkLat(lat);
 		if (error != null) {
 			throw new IllegalArgumentException(error);
 		}
@@ -92,7 +93,7 @@ public class SimulationBuilder {
 	}
 	
 	private void setLongitude(String lon) {
-		String error = Coordinates.checkLon(lon);
+		String error = CoordinatesFormat.checkLon(lon);
 		if (error != null) {
 			throw new IllegalArgumentException(error);
 		}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/configuration/ScenarioConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/configuration/ScenarioConfig.java
@@ -27,10 +27,10 @@ import com.mars_sim.core.SimulationRuntime;
 import com.mars_sim.core.authority.Authority;
 import com.mars_sim.core.interplanetary.transport.settlement.ArrivingSettlement;
 import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 import com.mars_sim.core.person.Crew;
 import com.mars_sim.core.person.Member;
 import com.mars_sim.core.structure.InitialSettlement;
-import com.mars_sim.core.tool.Msg;
 import com.mars_sim.core.tool.RandomUtil;
 
 /**
@@ -47,8 +47,7 @@ public class ScenarioConfig extends UserConfigurableConfig<Scenario> {
 	private static final String DESCRIPTION_ATTR = "description";
 	private static final String TEMPLATE_ATTR = "template";
 	private static final String LOCATION_EL = "location";
-	private static final String LONGITUDE_ATTR = "longitude";
-	private static final String LATITUDE_ATTR = "latitude";
+	private static final String COORDINATE_ATTR = "coordinates";	
 	private static final String PERSONS_ATTR = "persons";
 	private static final String ROBOTS_ATTR = "robots";
 	private static final String SPONSOR_ATTR = "sponsor";
@@ -58,7 +57,7 @@ public class ScenarioConfig extends UserConfigurableConfig<Scenario> {
 	private static final String ARRIVAL_ATTR = "arrival-in-sols";
 	
 	// Default scenario
-	public static final String[] PREDEFINED_SCENARIOS = {"Default", "Single Settlement"};	
+	public static final String[] PREDEFINED_SCENARIOS = {"Default", "Single Settlement"};
 	
 	public ScenarioConfig(SimulationConfig config) {
 		super(PREFIX);
@@ -370,8 +369,7 @@ public class ScenarioConfig extends UserConfigurableConfig<Scenario> {
 
 	private static Element createLocationElement(Coordinates location) {
 		Element result = new Element(LOCATION_EL);
-		saveOptionalAttribute(result, LONGITUDE_ATTR, location.getFormattedLongitudeString());
-		saveOptionalAttribute(result, LATITUDE_ATTR, location.getFormattedLatitudeString());
+		saveOptionalAttribute(result, COORDINATE_ATTR, CoordinatesFormat.getDecimalString(location));
 		
 		return result;
 	}
@@ -387,19 +385,12 @@ public class ScenarioConfig extends UserConfigurableConfig<Scenario> {
 		List<Coordinates> locations = new ArrayList<>();
 		List<Element> locationNodes = parent.getChildren(LOCATION_EL);
 		for(Element locationElement : locationNodes) {
+			String decimalString = locationElement.getAttributeValue(COORDINATE_ATTR);
+			if (decimalString == null) {
+				throw new IllegalStateException("Settlement Location must have coordinates attribute");
+			}
 
-			String longitudeString = locationElement.getAttributeValue(LONGITUDE_ATTR);
-			String latitudeString = locationElement.getAttributeValue(LATITUDE_ATTR);
-
-			// take care to internationalize the coordinates
-			longitudeString = longitudeString.replace("E", Msg.getString("direction.eastShort")); //$NON-NLS-1$ //$NON-NLS-2$
-			longitudeString = longitudeString.replace("W", Msg.getString("direction.westShort")); //$NON-NLS-1$ //$NON-NLS-2$
-
-			// take care to internationalize the coordinates
-			latitudeString = latitudeString.replace("N", Msg.getString("direction.northShort")); //$NON-NLS-1$ //$NON-NLS-2$
-			latitudeString = latitudeString.replace("S", Msg.getString("direction.southShort")); //$NON-NLS-1$ //$NON-NLS-2$
-
-			locations.add(new Coordinates(latitudeString, longitudeString));
+			locations.add(CoordinatesFormat.fromString(decimalString));
 		}
 		
 		locations.removeAll(occupiedLocations);
@@ -408,6 +399,6 @@ public class ScenarioConfig extends UserConfigurableConfig<Scenario> {
 			return null;
 		}
 		
-		return locations.get(RandomUtil.getRandomInt(locations.size()-1));		
+		return RandomUtil.getRandomElement(locations);	
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/configuration/ScenarioConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/configuration/ScenarioConfig.java
@@ -27,6 +27,7 @@ import com.mars_sim.core.SimulationRuntime;
 import com.mars_sim.core.authority.Authority;
 import com.mars_sim.core.interplanetary.transport.settlement.ArrivingSettlement;
 import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesException;
 import com.mars_sim.core.map.location.CoordinatesFormat;
 import com.mars_sim.core.person.Crew;
 import com.mars_sim.core.person.Member;
@@ -390,7 +391,11 @@ public class ScenarioConfig extends UserConfigurableConfig<Scenario> {
 				throw new IllegalStateException("Settlement Location must have coordinates attribute");
 			}
 
-			locations.add(CoordinatesFormat.fromString(decimalString));
+			try {
+				locations.add(CoordinatesFormat.fromString(decimalString));
+			} catch (CoordinatesException e) {
+				throw new IllegalStateException("Settlement location badly formatted: " + e.getMessage(), e);
+			}
 		}
 		
 		locations.removeAll(occupiedLocations);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/map/location/Coordinates.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/map/location/Coordinates.java
@@ -90,7 +90,7 @@ public final class Coordinates implements Serializable {
 	 * @param longitude String representing longitude value. ex. "63.5532 W"
 	 */
 	public Coordinates(String latitude, String longitude) {
-		this(CoordinatesFormat.parseLatitude2Phi(latitude), CoordinatesFormat.parseLongitude2Theta(longitude));
+		this(CoordinatesFormat.parseLatitude2PhiUncheck(latitude), CoordinatesFormat.parseLongitude2ThetaUncheck(longitude));
 	}
 
 	

--- a/mars-sim-core/src/main/java/com/mars_sim/core/map/location/CoordinatesException.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/map/location/CoordinatesException.java
@@ -1,0 +1,19 @@
+/*
+ * Mars Simulation Project
+ * CoordinatesException.java
+ * @date 2025-09-16
+ * @author Barry Evans
+ */
+package com.mars_sim.core.map.location;
+
+// This should be a checked exception
+public class CoordinatesException extends RuntimeException {
+    
+    /**
+     * This represents an exception with coordinates parsing.
+     * @param message
+     */
+    CoordinatesException(String message) {
+        super(message);
+    }
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/map/location/CoordinatesException.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/map/location/CoordinatesException.java
@@ -6,8 +6,10 @@
  */
 package com.mars_sim.core.map.location;
 
-// This should be a checked exception
-public class CoordinatesException extends RuntimeException {
+/**
+ * Problem parsing coordinates.
+ */
+public class CoordinatesException extends Exception {
     
     /**
      * This represents an exception with coordinates parsing.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/map/location/CoordinatesFormat.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/map/location/CoordinatesFormat.java
@@ -62,6 +62,31 @@ public final class CoordinatesFormat {
     }
 
     /**
+     * Parse latitude string to phi, throwing an unchecked exception if it fails.
+     * @param latitude
+     * @return
+     */
+    static double parseLatitude2PhiUncheck(String latitude) {
+        try {
+            return parseLatitude2Phi(latitude);
+        } catch (CoordinatesException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Parse longitude string to theta, throwing an unchecked exception if it fails.
+     * @param longitude
+     * @return
+     */
+    static double parseLongitude2ThetaUncheck(String longitude) {
+        try {
+            return parseLongitude2Theta(longitude);
+        } catch (CoordinatesException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+    /**
 	 * Parses a latitude string into a phi value. e.g. input: "25.344 N"
 	 * For latitude string: North is positive (+); South is negative (-)
 	 * For phi : it starts from the north pole (phi = 0) to the south pole (phi = PI)

--- a/mars-sim-core/src/main/java/com/mars_sim/core/map/location/CoordinatesFormat.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/map/location/CoordinatesFormat.java
@@ -1,0 +1,235 @@
+/*
+ * Mars Simulation Project
+ * CoordinatesFormat.java
+ * @date 2025-09-16
+ * @author Barry Evans
+ */
+package com.mars_sim.core.map.location;
+
+import java.text.DecimalFormat;
+import java.text.ParseException;
+
+import com.mars_sim.core.tool.Msg;
+
+/**
+ * Provides methods to parse and generate text representations of Coordinates objects.
+ */
+public final class CoordinatesFormat {
+    
+	private static final double DEG_TO_RADIAN  = Math.PI / 180;
+	private static final double PI_HALF = Math.PI / 2;
+    private static final double TWO_PI = Math.PI * 2;
+
+    private static final String DEG_SIGN = Msg.getString("direction.degreeSign");
+
+    private static final String NORTH = Msg.getString("direction.northShort");
+	private static final String EAST = Msg.getString("direction.eastShort");
+	private static final String SOUTH = Msg.getString("direction.southShort");
+	private static final String WEST = Msg.getString("direction.westShort");
+
+	/** Currently, lat and lon are up to 4 decimal places. Thus the decimal format '0.0000' is used. */
+	static final DecimalFormat DIGIT_FORMAT = new DecimalFormat("0.0000"); //$NON-NLS-1$
+
+    private CoordinatesFormat() {
+        // Utility class
+    }   
+
+    /**
+     * Parse a text representation of coordinates into a Coordinates object.
+     * @param latitude
+     * @param longitude
+     * @throws CoordinatesException 
+     */
+    public static Coordinates fromString(String latitude, String longitude) throws CoordinatesException {
+        double phi = parseLatitude2Phi(latitude);
+        double theta = parseLongitude2Theta(longitude);
+        return new Coordinates(phi, theta);
+    }
+    
+    /**
+     * Create a Coordinates object from a string representation.
+     * @param string
+     * @return
+     */
+    public static Coordinates fromString(String string) throws CoordinatesException{
+        String [] parts = string.trim().split("\\s+");
+
+        switch(parts.length) {
+            case 2: return fromString(parts[0], parts[1]);
+            case 4: return fromString(parts[0] + " " + parts[1], parts[2] + " " + parts[3]);
+            default: throw new CoordinatesException(Msg.getString("CoordinatesFormat.error.invalidFormat"));
+        }
+    }
+
+    /**
+	 * Parses a latitude string into a phi value. e.g. input: "25.344 N"
+	 * For latitude string: North is positive (+); South is negative (-)
+	 * For phi : it starts from the north pole (phi = 0) to the south pole (phi = PI)
+	 *
+	 * @param latitude as string
+	 * @return phi value in radians
+	 * @throws ParseException if latitude string could not be parsed.
+	 */
+	static double parseLatitude2Phi(String latitude) throws CoordinatesException {
+        var latValue = parseString(latitude, NORTH, SOUTH);
+        if ((latValue > 90D) || (latValue < -90))
+            throw new CoordinatesException(Msg.getString("CoordinatesFormat.error.latitudeRange"));
+        if (latValue >= 0)
+            latValue = 90D - latValue;
+        else
+            latValue = 90D + (-latValue);  // This is a negative value`
+        return latValue * DEG_TO_RADIAN;
+    }
+
+	/**
+	 * Parses a longitude string into a theta value. e.g. input:  "63.5532 W"
+	 * Note: East is positive (+), West is negative (-)
+	 *
+	 * @param longitude as string
+	 * @return theta value in radians
+	 * @throws ParseException if longitude string could not be parsed.
+	 */
+	static double parseLongitude2Theta(String longitude) throws CoordinatesException {
+        var longValue = parseString(longitude, EAST, WEST);
+        if ((longValue > 360) || (longValue < -360))
+            throw new CoordinatesException(Msg.getString("CoordinatesFormat.error.longitudeRange"));
+        if (longValue < 0)
+            longValue = 360D + longValue;  // This is a negative value
+        return longValue * DEG_TO_RADIAN;
+    }
+
+    public static String checkLat(String latitude) {
+        // Attempt to parse the string; will throw exception if invalid
+        try {
+            parseLatitude2Phi(latitude);
+        } catch (CoordinatesException e) {
+            return e.getMessage();
+        }
+        return null;
+    }
+
+    public static String checkLon(String longitude) {
+        // Attempt to parse the string; will throw exception if invalid
+        try {
+            parseLongitude2Theta(longitude);
+        } catch (CoordinatesException e) {
+            return e.getMessage();
+        }
+        return null;
+    }
+
+    private static final double parseString(String valueStr, String positiveDir, String negativeDir)
+            throws CoordinatesException {
+
+		String cleanValue = valueStr.toUpperCase().trim();
+
+		if (cleanValue.isEmpty())
+			throw new CoordinatesException(Msg.getString("CoordinatesFormat.error.blank"));
+
+		try {
+			return Double.parseDouble(cleanValue);
+
+		} catch (NumberFormatException e) {
+            // Not a pure decimal number, continue to parse.
+		}
+
+        String numberString = cleanValue;
+        int factor = 1;
+        if (cleanValue.endsWith(negativeDir)) {
+            factor = -1;
+            numberString = cleanValue.substring(0, cleanValue.length() - negativeDir.length()).trim();
+        }
+        else if (cleanValue.endsWith(positiveDir)) {
+            numberString = cleanValue.substring(0, cleanValue.length() - positiveDir.length()).trim();
+        }
+
+        // Must have a direction and/or degree sign
+        double value = 0D;
+        try {
+            if (numberString.endsWith(DEG_SIGN)) //$NON-NLS-1$
+                numberString = numberString.substring(0, numberString.length() - 1);
+
+            // Always use a '.' as the decimal separator
+            numberString = numberString.replace(DIGIT_FORMAT.getDecimalFormatSymbols().getDecimalSeparator(), '.');
+            value = Double.parseDouble(numberString);
+        } catch (NumberFormatException e) {
+            throw new CoordinatesException(Msg.getString("CoordinatesFormat.error.badNumber", numberString));
+        }
+
+        value *= factor;
+
+		return value;
+    }
+
+    /**
+	 * Gets a common formatted string to represent longitude for a given theta. 
+	 * e.g. "35.6670 E". This is localised to the language bundle
+	 *
+	 * @param coords This is the Coordinates object
+	 * @return formatted longitude string for this Coordinates object
+	 */
+	static String getFormattedLongitudeString(Coordinates coords) {
+        double theta = coords.getTheta();
+		double degrees = 0;
+		String direction = "";
+
+		if ((theta <= Math.PI) && (theta >= 0D)) {
+			degrees = Math.toDegrees(theta);
+			direction = EAST; //$NON-NLS-1$
+		} else if (theta >= Math.PI) {
+			degrees = Math.toDegrees(TWO_PI - theta);
+			direction = WEST; //$NON-NLS-1$
+		}
+
+		// Add a whitespace in between the degree and its directional sign
+		return DIGIT_FORMAT.format(degrees) + " " + direction;
+	}
+    
+	/**
+	 * Gets a common formatted string to represent latitude for a given phi.
+	 * e.g. "35.6230 S". This will be localised to the language bundle
+	 *
+	 * @param coords the Coordinates object
+	 * @return formatted latitude string for this Coordinates object
+	 */
+	static String getFormattedLatitudeString(Coordinates coords) {
+		double degrees = 0;
+		String direction = "";
+        double phi = coords.getPhi();
+
+		if (phi <= PI_HALF) {
+			degrees = ((PI_HALF - phi) / PI_HALF) * 90D;
+			direction = NORTH; //$NON-NLS-1$
+		} else {
+			degrees = ((phi - PI_HALF) / PI_HALF) * 90D;
+			direction = SOUTH; //$NON-NLS-1$
+		}
+
+		// Add a whitespace in between the degree and its directional sign
+		return DIGIT_FORMAT.format(degrees) + " " + direction; //$NON-NLS-1$
+	}
+
+    /**
+     * This returns a formatted string for both latitude and longitude using any
+     * languages bindings.
+     * @param coords
+     * @return
+     */
+    public static String getFormattedString(Coordinates coords) {
+        StringBuilder buffer = new StringBuilder();
+        buffer.append(getFormattedLatitudeString(coords));
+        buffer.append(' ');
+        buffer.append(getFormattedLongitudeString(coords));
+        return buffer.toString();
+    }
+
+    /**
+     * Get a decimal string representation of the coordinates. This is language independent.
+     * @param coords
+     * @return
+     */
+    public static String getDecimalString(Coordinates coords) {
+        return DIGIT_FORMAT.format(coords.getLatitudeDouble()) + " " + DIGIT_FORMAT.format(coords.getLongitudeDouble());
+    }
+
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/time/MarsTimeFormat.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/time/MarsTimeFormat.java
@@ -31,7 +31,6 @@ public class MarsTimeFormat {
 			"Vadeun", "Wakumi", "Xetual", "Zungo" };
 
 	private static final String[] WEEK_SOL_NAMES = 
-//		{ "Solisol", "Phobosol", "Deimosol", "Terrasol", "Hermesol", "Venusol", "Jovisol" };	
 		{ "Heliosol", "Neriosol", "Libersol", "Terrasol", "Venusol", "Mercusol", "Jovisol" };
 
 	/**
@@ -49,7 +48,7 @@ public class MarsTimeFormat {
 	 */
 	public static MarsTime fromDateString(String dateString) {
 
-		String parts[] = dateString.split(DASH);
+		String []parts = dateString.split(DASH);
 		int orbit = Integer.parseInt(parts[0]);
 		if (orbit < 0)
 			throw new IllegalArgumentException("Invalid orbit number: " + orbit);
@@ -68,7 +67,7 @@ public class MarsTimeFormat {
 		if (sol < 1)
 			throw new IllegalStateException("Invalid sol number: " + sol);
 
-		double millisol = Double.parseDouble(subParts[1]);
+		double millisol = Double.parseDouble(subParts[1].replace(',', '.'));
 		if (millisol < 0D)
 			throw new IllegalStateException("Invalid millisol number: " + millisol);
 

--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -926,6 +926,7 @@ SimulationConfigEditor.error.populationInvalid=population must be a valid intege
 SimulationConfigEditor.error.populationMissing=population is missing or not valid
 SimulationConfigEditor.error.populationTooFew=population must be 0 or larger
 SimulationConfigEditor.error.duplicateCrew=A crew can only be used once
+SimulationConfigEditor.error.latitudeLongitudeRepeating=Latitude and Longitude cannot be the same as another settlement
 SimulationConfigEditor.log.invalidColumn=invalid column index
 SimulationConfigEditor.log.invalidRow=invalid row index
 SimulationConfigEditor.log.settlementTemplateNotFound=No configured settlement templates found

--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -286,15 +286,13 @@ ConstructionMissionCustomInfoPanel.column.material=Material
 ConstructionMissionCustomInfoPanel.constructionMaterials=Materials
 ConstructionMissionCustomInfoPanel.stageLabel=Stage
 ConstructionMissionCustomInfoPanel.titleLabel=Construction Site
-Coordinates.error.latitudeLongitudeRepeating=The lat/lon pair should not be repeated. Also, at the equator '0.00 S' equals '0.00 N'. (Note: both comma and period are valid decimal mark)
-Coordinates.error.latitudeBeginWith=Latitude must be between 0.00 and 90.00 (Note: both comma and period are valid decimal mark)
-Coordinates.error.latitudeEndWith=Latitude must end with the direction notation of ''{0}'' or ''{1}''
-Coordinates.error.latitudeMissing=Latitude is missing or not valid
-Coordinates.error.latitudeBadFormat=Valid latitude format is a two-decimal place number with a space and either N or S. e.g. '0.10 N' or '89,20 S'
-Coordinates.error.longitudeBeginWith=Longitude must be between 0.00 and 360.00 (Note: both comma and period are valid decimal mark)
-Coordinates.error.longitudeEndWith=Longitude must end with direction ''{0}'' or ''{1}''
-Coordinates.error.longitudeMissing=Longitude is missing or not valid
-Coordinates.error.longitudeBadFormat=Valid longitude format is a two-decimal place number with a space with either E or W. e.g. '0.10 E' or '179,20 W'
+
+CoordinatesFormat.error.latitudeRange=Latitude must be between 0.00 and 90.00 (Note: both comma and period are valid decimal mark)
+CoordinatesFormat.error.blank=String representation is missing
+CoordinatesFormat.error.longitudeRange=Longitude must be between 0.00 and 360.00 (Note: both comma and period are valid decimal mark)
+CoordinatesFormat.error.badNumber=Valid format is a two-decimal place number ''{0}''
+CoordinatesFormat.error.badDirection=Value must end with direction ''{0}'' or ''{1}''
+
 CropTableModel.countingCrops={0} Greenhouse(s)
 CropTableModel.tabName=Crops
 

--- a/mars-sim-core/src/main/resources/xml/scenario/scenario.xsd
+++ b/mars-sim-core/src/main/resources/xml/scenario/scenario.xsd
@@ -3,8 +3,7 @@
 
     <xs:element name="location">
         <xs:complexType>
-            <xs:attribute name="longitude" type="xs:string"/>
-            <xs:attribute name="latitude" type="xs:string"/>
+            <xs:attribute name="coordinates" type="xs:string"/>
         </xs:complexType>
     </xs:element>
 

--- a/mars-sim-core/src/main/resources/xml/scenario/scenario_default.xml
+++ b/mars-sim-core/src/main/resources/xml/scenario/scenario_default.xml
@@ -7,16 +7,16 @@
 
 		<settlement name="Tai Ping" template="Phase 1-TW" persons="8" robots="4" sponsor="TASA">
 			<!-- sits between x and x-->	
-			<location longitude="57.26 E" latitude="25.16 N" />
+			<location coordinates="25.16 57.26" />
 		</settlement>
 		
 		<settlement name="Catarina" template="Phase 1-BR" persons="8" robots="4" sponsor="AEB">
 			<!-- sits between Zvezda and Tian Cheng -->	
-			<location longitude="58.8805 E" latitude="25.0892 N" />
+			<location coordinates="25.0892 58.8805" />
 		</settlement>
 
 		<settlement name="Origin" template="Phase 2-BO" persons="8" robots="8" sponsor="BO">
-			<location longitude="20.46 W" latitude="6.26 N" />
+			<location coordinates="6.26 -20.46" />
 		</settlement>
 		
 		<settlement name="Arcadia" template="Phase 2-EU" persons="8" robots="8" sponsor="ESA">
@@ -24,48 +24,48 @@
 				2 landing proposed sites for ESA ExoMars: 
 				(1). Hypanis Vallis at 314.0 E, 11.9 N    
 			    (2). Mawrth Vallis at 342.0 E, 22.4 N
-			<location longitude="342.0 E" latitude="22.4 N" />			    
+			<location longitude="342.0 E" coordinates="22.4 " />			    
 			-->
-			<location longitude="29.7837 W" latitude="24.3612 N" />
+			<location coordinates="24.3612 -29.7837" />
 		</settlement>
 
 		<settlement name="Hong Tian" template="Phase 2-CN" persons="8" robots="8" sponsor="CNSA">
-			<location longitude="47.8419 W" latitude="15.9873 N" />
+			<location coordinates="15.9873 -47.8419" />
 		</settlement>
 
 		<settlement name="Kyocera" template="Phase 2-JP" persons="12" robots="6" sponsor="JAXA">
-			<location longitude="164 E" latitude="6 N" />
+			<location coordinates="6 164" />
 		</settlement>
 
 		<settlement name="New Seoul" template="Phase 2-KR" persons="16" robots="8" sponsor="KASA">
-			<location longitude="105.8939 W" latitude="40.4244 N" />
+			<location coordinates="40.4244 -105.8939" />
 		</settlement>
 	
 		<settlement name="Tian Cheng" template="Phase 3-ISRA" persons="16" robots="8" sponsor="ISRA">
-			<!-- previously, longitude="20.9156 E" latitude="0.7777 N" -->
-			<location longitude="24.57 E" latitude="9.68 N" />	
+			<!-- previously, longitude="20.9156 E" coordinates="0.7777 " -->
+			<location coordinates="9.68 24.57" />	
 		</settlement>		
 				
 		<settlement name="New Pompeii" template="Phase 3-IN" persons="16" robots="8" sponsor="ISRO">
-			<location longitude="70.9710 W" latitude="26.3650 N" />
+			<location coordinates="26.3650 -70.9710" />
 		</settlement>
 
 		<settlement name="Star Base" template="Phase 3-SX" persons="16" robots="8" sponsor="SPACEX">
     	<!-- 52nd Lunar and Planetary Science Conference 2021 (LPI COntrib. No. 2548), 
         "SpaceX Starship Landing Sites on Mars" 2420.pdf -->   
        		<!-- PM-1 site (Elev -3.2 km) in Phelgra Montes, the 1st prime landing -->
-			<location longitude="163.95 E" latitude="35.23 N" />        		
+			<location coordinates="35.23 163.95" />        		
      		<!-- AP-1site (Elev -3.9 km) in Arcadia Planitia, the 2nd prime landing -->
-			<location longitude="202.1 E" latitude="39.8 N" />       
+			<location coordinates="39.8 202.1" />       
       		<!-- AP-9 site (Elev -3.9 km) in Arcadia Planitia, the 3rd prime landing -->
-			<location longitude="203.35 E" latitude="40.02 N" />        		
+			<location coordinates="40.02 203.35" />        		
      		<!-- EM-16 site (Elev -3.9 km) in Erebus Montes, the 4th prime landing -->
-			<location longitude="192.03 E" latitude="39.89 N" />
+			<location coordinates="39.89 192.03" />
 		</settlement>
 
 		<settlement name="Zvezda" template="Phase 3-RU" persons="16" robots="8" sponsor="RKA">
  			<!-- sits between Catarina and Arcadia --> 
-			<location longitude="81.9044 E" latitude="17.3983 N" />
+			<location coordinates="17.3983 81.9044" />
 		</settlement>
 
 		<settlement name="Korolev" template="Alpha Base 2" persons="44" robots="24" sponsor="RKA">
@@ -73,36 +73,36 @@
  				  https://pubs.usgs.gov/publication/70029300 
  				  https://en.wikipedia.org/wiki/Korolev_(Martian_crater) 
  			--> 
-			<location longitude="164.58 E" latitude="72.77 N" />
+			<location coordinates="72.77 164.58" />
 		</settlement>
 
 		<settlement name="Terminus" template="Alpha Base 1" crew="Alpha" persons="36" robots="18" sponsor="NASA">
-			<location longitude="0.0 W" latitude="0.0 N" />
+			<location coordinates="0.0 0.0" />
 		</settlement>
 			
 		<settlement name="Heritage" template="Hub Base" persons="36" robots="18" sponsor="MS">
-			<location longitude="114.1535 E" latitude="15.1255 N" />
+			<location coordinates="15.1255 114.1535" />
 		</settlement>
 
 		<settlement name="Foundation" template="Sector Base 1" crew="Founders" persons="216" robots="84" sponsor="MS">
-			<location longitude="172.29 E" latitude="24.14 N" />
+			<location coordinates="24.14 172.29" />
 		</settlement>
 		
 	</initial-settlement-list>
 	<arriving-settlement-list>
 		<arriving-settlement name="Halley" template="Phase 2-MS" 
 			persons="8" robots="6" sponsor="MS" arrival-in-sols="3">
-			<location longitude="37.0579 E" latitude="22.6532 N" />				 
+			<location coordinates="22.6532 37.0579" />				 
 		</arriving-settlement>
 
 		<arriving-settlement name="New Madinah" template="Phase 1-SA" 
 			persons="4" robots="4" sponsor="SSA" arrival-in-sols="2">
-			<location longitude="141.3300 W" latitude="45.4157 N" />
+			<location coordinates="45.4157 -141.3300" />
 		</arriving-settlement>
 		
 		<arriving-settlement name="New Dubai" template="Phase 0-AE" 
 			persons="2" robots="4" sponsor="UAESA" arrival-in-sols="1">
-			<location longitude="136.4239 E" latitude="13.5488 N" />
+			<location coordinates="13.5488 136.4239" />
 		</arriving-settlement>		
 	</arriving-settlement-list>
 </scenario-configuration>

--- a/mars-sim-core/src/main/resources/xml/scenario/scenario_single_settlement.xml
+++ b/mars-sim-core/src/main/resources/xml/scenario/scenario_single_settlement.xml
@@ -4,7 +4,7 @@
   
   <initial-settlement-list>
     <settlement name="Schiaparelli Point" template="Alpha Base 1" persons="24" robots="12" sponsor="MS" crew="Founders">
-      <location longitude="10.00 W" latitude="10.00 N" />
+      <location coordinates="10.00 -10.00" />
     </settlement>
   </initial-settlement-list>
 </scenario-configuration>

--- a/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/activities/GroupActivityTest.java
@@ -8,7 +8,8 @@ import com.mars_sim.core.activities.GroupActivity.ActivityState;
 import com.mars_sim.core.building.Building;
 import com.mars_sim.core.building.BuildingCategory;
 import com.mars_sim.core.events.ScheduledEventManager.ScheduledEvent;
-import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesException;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 import com.mars_sim.core.map.location.LocalPosition;
 import com.mars_sim.core.person.ai.task.util.MetaTask.TaskScope;
 import com.mars_sim.core.structure.GroupActivityType;
@@ -90,10 +91,10 @@ public class GroupActivityTest extends AbstractMarsSimUnitTest {
         assertNull("Released meeting place", ga.getMeetingPlace());
     }
 
-    public void testInitialEvent() {
+    public void testInitialEvent() throws CoordinatesException {
         // Simplest first with zero time and no offset
         var now = new MarsTime(1, 1, 1, 0, 1);
-        var locn = new Coordinates("0.0 N", "90.0 E");
+        var locn = CoordinatesFormat.fromString("0.0 90.0");
 
         var s = buildSettlement("East", false, locn);
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/environment/LandmarkConfigTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/environment/LandmarkConfigTest.java
@@ -2,6 +2,8 @@ package com.mars_sim.core.environment;
 
 import com.mars_sim.core.AbstractMarsSimUnitTest;
 import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesException;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 
 public class LandmarkConfigTest extends AbstractMarsSimUnitTest {
     public void testGetLandmarks() {
@@ -14,11 +16,11 @@ public class LandmarkConfigTest extends AbstractMarsSimUnitTest {
         assertFalse("No landmarks found", results.isEmpty());
     }
 
-    public void testBeagle() {
+    public void testBeagle() throws CoordinatesException {
         var mgr = getSim().getConfig().getLandmarkConfiguration().getLandmarks();
 
         // Check teh lanmark for beagle
-        var center = new Coordinates("10.6 N", "90.0 E");
+        var center = CoordinatesFormat.fromString("10.6 90.0");
         var results = mgr.getFeatures(center, 0.01);
 
         assertEquals("Beagle found", 1, results.size());

--- a/mars-sim-core/src/test/java/com/mars_sim/core/map/MapDataFactoryTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/map/MapDataFactoryTest.java
@@ -3,7 +3,8 @@ package com.mars_sim.core.map;
 import org.junit.Test;
 
 import com.mars_sim.core.map.MapData.MapState;
-import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesException;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 
 import junit.framework.TestCase;
 
@@ -22,7 +23,7 @@ public class MapDataFactoryTest extends TestCase {
     }
 
     @Test
-    public void testLoadResolution() {
+    public void testLoadResolution() throws CoordinatesException {
         var found = MapDataFactory.getMapMetaData(MapDataFactory.DEFAULT_MAP_TYPE);
         var mapData = found.getData(0);
         assertNotNull("Resolution 0 of default", mapData);
@@ -31,7 +32,7 @@ public class MapDataFactoryTest extends TestCase {
         assertEquals("Correct meta data", found, mapData.getMetaData());
         assertEquals("Correct resolution", 0, mapData.getResolution());
 
-        var center = new Coordinates("10 N", "10 E");
+        var center = CoordinatesFormat.fromString("10.0 10.0");
         var image = mapData.createMapImage(center, 100, 100, mapData.getRhoDefault());
         assertEquals("Image width", 100, image.getWidth(null));
         assertEquals("Image height", 100, image.getHeight(null));

--- a/mars-sim-core/src/test/java/com/mars_sim/core/map/location/CoordinatesFormatTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/map/location/CoordinatesFormatTest.java
@@ -1,0 +1,147 @@
+package com.mars_sim.core.map.location;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.text.DecimalFormat;
+import java.text.ParseException;
+
+import org.junit.jupiter.api.Test;
+
+import com.mars_sim.core.tool.Msg;
+
+class CoordinatesFormatTest {
+    private static final double ERROR_MARGIN_RAD = .005D;
+	private static final double DEG_TO_RADIAN  = Math.PI / 180;
+
+    private static final String DEG_SIGN = Msg.getString("direction.degreeSign");
+
+    private static final String NORTH = Msg.getString("direction.northShort");
+	private static final String EAST = Msg.getString("direction.eastShort");
+	private static final String SOUTH = Msg.getString("direction.southShort");
+	private static final String WEST = Msg.getString("direction.westShort");
+    
+    /**
+     * Test the parseLongitude method.
+     */
+    @Test
+    void testParseLongitude() throws CoordinatesException {
+
+        assertEquals(226.98 * DEG_TO_RADIAN, CoordinatesFormat.parseLongitude2Theta("226.98" + DEG_SIGN + " " + EAST), ERROR_MARGIN_RAD);
+        assertEquals(46.98 * DEG_TO_RADIAN, CoordinatesFormat.parseLongitude2Theta("46.98" + DEG_SIGN + " " + EAST), ERROR_MARGIN_RAD);
+        assertEquals(0D, CoordinatesFormat.parseLongitude2Theta("0" + DEG_SIGN + " " + EAST), 0);
+        assertEquals(3D * Math.PI / 2D, CoordinatesFormat.parseLongitude2Theta("90.0" + DEG_SIGN + " " + WEST), 0);
+        assertEquals(3D * Math.PI / 2D, CoordinatesFormat.parseLongitude2Theta("90.0 " + WEST), 0);
+        assertEquals(3D * Math.PI / 2D, CoordinatesFormat.parseLongitude2Theta("-90.0"), 0);
+    }
+    
+    /**
+     * Test the parseLatitude method.
+     * @throws CoordinatesException 
+     */
+    @Test
+    void testParseLatitude() throws CoordinatesException {
+        assertEquals(Math.PI / 2D, CoordinatesFormat.parseLatitude2Phi("0.0" + DEG_SIGN + " " + NORTH), 0);
+        assertEquals(Math.PI, CoordinatesFormat.parseLatitude2Phi("90.0" + DEG_SIGN + " " + SOUTH), 0);
+        assertEquals(1.27, CoordinatesFormat.parseLatitude2Phi("17.23" + DEG_SIGN + " " + NORTH), ERROR_MARGIN_RAD);
+        assertEquals(0D, CoordinatesFormat.parseLatitude2Phi("90.0 " + NORTH), 0);
+        assertEquals(0D, CoordinatesFormat.parseLatitude2Phi("+90"), 0);
+        assertEquals(Math.PI, CoordinatesFormat.parseLatitude2Phi("-90"), 0);
+    }
+
+    /**
+     * Test the getFormattedLongitudeString method.
+     */
+    @Test
+    void testGetFormattedLongitudeString() {
+        Coordinates loc1 = new Coordinates (0D, 0D);
+        String lonString1 = CoordinatesFormat.getFormattedLongitudeString(loc1);
+        DecimalFormat format = new DecimalFormat();
+        char decimalPoint = format.getDecimalFormatSymbols().getDecimalSeparator();
+        String s2 = "0" + decimalPoint + "0000 " + EAST ;
+        assertEquals(s2, lonString1);
+    }
+    
+    /**
+     * Test the getFormattedLongitudeString method.
+     */
+    @Test
+    void testGetFormattedLongitudeString2() {
+        
+        Coordinates loc1 = new Coordinates (0D, Math.PI/2D);
+        String lonString1 = CoordinatesFormat.getFormattedLongitudeString(loc1);
+        DecimalFormat format = new DecimalFormat();
+        char decimalPoint = format.getDecimalFormatSymbols().getDecimalSeparator();
+        String s2 = "90" + decimalPoint + "0000 " + EAST ;
+        assertEquals(s2, lonString1);
+    }
+    
+    /**
+     * Test the getFormattedLatitudeString method.
+     */
+    @Test
+    void testGetFormattedLatitudeString() {
+        
+        Coordinates loc1 = new Coordinates (0D, 0D);
+        String latString1 = CoordinatesFormat.getFormattedLatitudeString(loc1);
+        DecimalFormat format = new DecimalFormat();
+        char decimalPoint = format.getDecimalFormatSymbols().getDecimalSeparator();
+        String s2 = "90"+ decimalPoint + "0000 N";
+        assertEquals(s2, latString1);
+    }
+
+    
+    @Test
+    void testFormatParseDecimal() {
+        double[][] values = {{10.1000, 20.2000}, {10.1000, -10.0000}, {-10.0000, 20.200}, {-10.0000, -20.2000},
+                           {0.0000, 0.0000}, {90.0000, 180.0000}, {-45.0000, 180.0000},
+                           {45.1234, 100.0000}, {-45.1234, -170.0000}
+                          };
+
+        for(var v : values) {
+            String txt = CoordinatesFormat.DIGIT_FORMAT.format(v[0])
+                        + " "
+                        + CoordinatesFormat.DIGIT_FORMAT.format(v[1]);
+            var coord = CoordinatesFormat.fromString(txt);
+            var formatted = CoordinatesFormat.getDecimalString(coord);
+
+            assertEquals(txt, formatted);
+        }
+    }
+
+    @Test
+    void testFormatParseFull() throws ParseException {
+        double[][] values = {{10.1000,20.2000}, {10.1000,10.0000},
+                           {0.5000,1.0000}, {90.0000,175.0000},
+                           {45.0000 ,179.0000}, {45.1234,100.0000},
+                           {45.1234 ,170.0000}
+                          };
+        // Do North & West
+        for(var v : values) {
+            var s = CoordinatesFormat.DIGIT_FORMAT.format(v[0]);
+            System.out.println("Parsing: " + s);
+            var c = CoordinatesFormat.DIGIT_FORMAT.parse(s).doubleValue();
+            assertEquals(c, v[0], 0.001);
+
+            String txt = CoordinatesFormat.DIGIT_FORMAT.format(v[0])
+                            + " " + NORTH + " "
+                            + CoordinatesFormat.DIGIT_FORMAT.format(v[1])
+                            + " " + WEST;
+            var coord = CoordinatesFormat.fromString(txt);
+            var formatted = CoordinatesFormat.getFormattedString(coord);
+
+            assertEquals(txt, formatted);
+        }
+
+        // Do South & West
+        for(var v : values) {
+            String txt = CoordinatesFormat.DIGIT_FORMAT.format(v[0])
+                            + " " + SOUTH + " "
+                            + CoordinatesFormat.DIGIT_FORMAT.format(v[1])
+                            + " " + EAST;
+            var coord = CoordinatesFormat.fromString(txt);
+            var formatted = CoordinatesFormat.getFormattedString(coord);
+
+            assertEquals(txt, formatted);
+        }
+    }
+}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/map/location/CoordinatesFormatTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/map/location/CoordinatesFormatTest.java
@@ -91,7 +91,7 @@ class CoordinatesFormatTest {
 
     
     @Test
-    void testFormatParseDecimal() {
+    void testFormatParseDecimal() throws CoordinatesException {
         double[][] values = {{10.1000, 20.2000}, {10.1000, -10.0000}, {-10.0000, 20.200}, {-10.0000, -20.2000},
                            {0.0000, 0.0000}, {90.0000, 180.0000}, {-45.0000, 180.0000},
                            {45.1234, 100.0000}, {-45.1234, -170.0000}
@@ -109,7 +109,7 @@ class CoordinatesFormatTest {
     }
 
     @Test
-    void testFormatParseFull() throws ParseException {
+    void testFormatParseFull() throws ParseException, CoordinatesException {
         double[][] values = {{10.1000,20.2000}, {10.1000,10.0000},
                            {0.5000,1.0000}, {90.0000,175.0000},
                            {45.0000 ,179.0000}, {45.1234,100.0000},

--- a/mars-sim-core/src/test/java/com/mars_sim/core/map/location/TestCoordinates.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/map/location/TestCoordinates.java
@@ -3,11 +3,7 @@ package com.mars_sim.core.map.location;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.text.DecimalFormat;
-
 import org.junit.jupiter.api.Test;
-
-import com.mars_sim.core.tool.Msg;
 
 
 /**
@@ -18,7 +14,6 @@ class TestCoordinates {
 	
     private static final double ERROR_MARGIN_KM = .000000001D;
     private static final double ERROR_MARGIN_RAD = .00001D;
-    private static final String DEG_SIGN = Msg.getString("direction.degreeSign");
 	
     /**
      * Finds the distance resolution for one degree at the equator.
@@ -37,7 +32,6 @@ class TestCoordinates {
         double error = Math.abs(dist - expected);
         assertTrue(error < ERROR_MARGIN_KM);
 
-        /////////////////////////////////////////////////////////
         // 5.92 m resolution
         
         Coordinates c2 = new Coordinates("0.0000", "0");
@@ -51,7 +45,6 @@ class TestCoordinates {
         
         assertTrue(error1 < ERROR_MARGIN_KM);
         
-        /////////////////////////////////////////////////////////
         // 4.18 m resolution
         
         Coordinates c4 = new Coordinates("45", "0.0000");
@@ -367,100 +360,5 @@ class TestCoordinates {
         double thetaError8 = Math.abs(loc8.getTheta() - ((2D * Math.PI) - angleDistanceDiagonal));
         assertTrue(phiError8 < ERROR_MARGIN_RAD);
         assertTrue(thetaError8 < ERROR_MARGIN_RAD);
-    }
-    
-    /**
-     * Test the parseLongitude method.
-     */
-    public void testParseLongitude() {
-        
-        String lonString0 = "226.98" + DEG_SIGN + " E";
-        double lon0 = Math.round(Coordinates.parseLongitude2Theta(lonString0)*100.0)/100.0;
-        assertEquals(3.96, lon0, 0);
-        
-        String lonString1 = "46.98" + DEG_SIGN + " E";
-        double lon1 = Math.round(Coordinates.parseLongitude2Theta(lonString1)*100.0)/100.0;
-        assertEquals(.82, lon1, 0);
-        
-        String lonString01 = "0" + DEG_SIGN + " E";
-        double lon01 = Math.round(Coordinates.parseLongitude2Theta(lonString01)*100.0)/100.0;
-        assertEquals(0D, lon01, 0);
-        
-        String lonString2 = "90.0" + DEG_SIGN + " W";
-        double lon2 = Coordinates.parseLongitude2Theta(lonString2);
-        assertEquals(3D * Math.PI / 2D, lon2, 0);
-        
-        String lonString3 = "90.0 W";
-        double lon3 = Coordinates.parseLongitude2Theta(lonString3);
-        assertEquals(3D * Math.PI / 2D, lon3, 0);
-        
-        String lonString4 = "90,0 W";
-        double lon4 = Coordinates.parseLongitude2Theta(lonString4);
-        assertEquals(3D * Math.PI / 2D, lon4, 0);
-    }
-    
-    /**
-     * Test the parseLatitude method.
-     */
-    public void testParseLatitude() {
-        
-        String latString1 = "0.0" + DEG_SIGN + " N";
-        double lat1 = Coordinates.parseLatitude2Phi(latString1);
-        assertEquals(Math.PI / 2D, lat1, 0);
-        
-        String latString2 = "90.0" + DEG_SIGN + " S";
-        double lat2 = Coordinates.parseLatitude2Phi(latString2);
-        assertEquals(Math.PI, lat2, 0);
-        
-        String latString01 = "17.23" + DEG_SIGN + " N";
-        double lat01 = Math.round(Coordinates.parseLatitude2Phi(latString01)*100.0)/100.0;
-        assertEquals(1.27, lat01, 0);
-               
-        String latString3 = "90.0 N";
-        double lat3 = Coordinates.parseLatitude2Phi(latString3);
-        assertEquals(0D, lat3, 0);
-        
-        String latString4 = "90,0 N";
-        double lat4 = Coordinates.parseLatitude2Phi(latString4);
-        assertEquals(0D, lat4, 0);
-    }
-    
-    /**
-     * Test the getFormattedLongitudeString method.
-     */
-    public void testGetFormattedLongitudeString() {
-        
-        Coordinates loc1 = new Coordinates (0D, 0D);
-        String lonString1 = loc1.getFormattedLongitudeString();
-        DecimalFormat format = new DecimalFormat();
-        char decimalPoint = format.getDecimalFormatSymbols().getDecimalSeparator();
-        String s2 = "0" + decimalPoint + "0000 E";
-        assertEquals(s2, lonString1);
-    }
-    
-    /**
-     * Test the getFormattedLongitudeString method.
-     */
-    public void testGetFormattedLongitudeString2() {
-        
-        Coordinates loc1 = new Coordinates (0D, Math.PI/2D);
-        String lonString1 = loc1.getFormattedLongitudeString();
-        DecimalFormat format = new DecimalFormat();
-        char decimalPoint = format.getDecimalFormatSymbols().getDecimalSeparator();
-        String s2 = "90" + decimalPoint + "0000 E";
-        assertEquals(s2, lonString1);
-    }
-    
-    /**
-     * Test the getFormattedLatitudeString method.
-     */
-    public void testGetFormattedLatitudeString() {
-        
-        Coordinates loc1 = new Coordinates (0D, 0D);
-        String latString1 = loc1.getFormattedLatitudeString();
-        DecimalFormat format = new DecimalFormat();
-        char decimalPoint = format.getDecimalFormatSymbols().getDecimalSeparator();
-        String s2 = "90"+ decimalPoint + "0000 N";
-        assertEquals(s2, latString1);
     }
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mineral/MineralConcentrationTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mineral/MineralConcentrationTest.java
@@ -4,12 +4,13 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesException;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 
 class MineralConcentrationTest {
     @Test
-    void testAdjustMineral() {
-        var base = new Coordinates("45 N", "23 E");
+    void testAdjustMineral() throws CoordinatesException {
+        var base = CoordinatesFormat.fromString("45.0 23.0");
         MineralDeposit conc = new MineralDeposit(base);
 
         conc.adjustMineral("A", 10);
@@ -23,8 +24,8 @@ class MineralConcentrationTest {
     }
 
     @Test
-    void testUpdateMineral() {
-        var base = new Coordinates("45 N", "23 E");
+    void testUpdateMineral() throws CoordinatesException {
+        var base = CoordinatesFormat.fromString("45.0 23.0");
         MineralDeposit conc = new MineralDeposit(base);
 
         conc.adjustMineral("A", 10);
@@ -35,8 +36,8 @@ class MineralConcentrationTest {
 
     
     @Test
-    void testAddMineral() {
-        var base = new Coordinates("45 N", "23 E");
+    void testAddMineral() throws CoordinatesException {
+        var base = CoordinatesFormat.fromString("45.0 23.0");
         MineralDeposit conc = new MineralDeposit(base);
 
         conc.addMineral("A", 10);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mineral/MineralMapTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mineral/MineralMapTest.java
@@ -3,12 +3,13 @@ package com.mars_sim.core.mineral;
 import java.util.Set;
 
 import com.mars_sim.core.AbstractMarsSimUnitTest;
-import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesException;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 import com.mars_sim.core.map.location.Direction;
 
 public class MineralMapTest extends AbstractMarsSimUnitTest {
 
-    public void testExactLocation() {
+    public void testExactLocation() throws CoordinatesException {
         var config = simConfig.getMineralMapConfiguration();
         var minerals = config.getMineralTypes();
         var type1 = minerals.get(0);
@@ -17,7 +18,7 @@ public class MineralMapTest extends AbstractMarsSimUnitTest {
 
         MineralMap newMap = new MineralMap(config);
 
-        var center = new Coordinates("3 S", "67 E");
+        var center = CoordinatesFormat.fromString("-3.0 67.0");
         
         newMap.addMineral(center, type1, 10);
         newMap.addMineral(center, type2, 20);
@@ -30,7 +31,7 @@ public class MineralMapTest extends AbstractMarsSimUnitTest {
         assertEquals("Type2 Concentrations", 20, found.getConcentration(type2.getName()));
     }
 
-    public void testTwoLocation() {
+    public void testTwoLocation() throws CoordinatesException {
         var config = simConfig.getMineralMapConfiguration();
         var minerals = config.getMineralTypes();
         var type1 = minerals.get(0);
@@ -39,7 +40,7 @@ public class MineralMapTest extends AbstractMarsSimUnitTest {
 
         MineralMap newMap = new MineralMap(config);
 
-        var center = new Coordinates("3 S", "67 E");
+        var center = CoordinatesFormat.fromString("-3.0 67.0");
         
         newMap.addMineral(center, type1, 10);
         newMap.addMineral(center.getNewLocation(new Direction(0.1), 0.01), type2, 20);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mineral/RandomMineralFactoryTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mineral/RandomMineralFactoryTest.java
@@ -3,13 +3,14 @@ package com.mars_sim.core.mineral;
 import java.util.stream.Collectors;
 
 import com.mars_sim.core.AbstractMarsSimUnitTest;
-import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesException;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 
 public class RandomMineralFactoryTest extends AbstractMarsSimUnitTest {
-    public void testCreateLocalConcentration() {
+    public void testCreateLocalConcentration() throws CoordinatesException {
         var newMap = new MineralMap(simConfig.getMineralMapConfiguration());
 
-        var center = new Coordinates("30 N", "25 W");
+        var center = CoordinatesFormat.fromString("30.0 -25.0");
         RandomMineralFactory.createLocalConcentration(newMap, center);
 
         // Search all types

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mission/objectives/MiningObjectiveTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mission/objectives/MiningObjectiveTest.java
@@ -14,7 +14,7 @@ public class MiningObjectiveTest extends AbstractMarsSimUnitTest {
         var sf = getSim().getSurfaceFeatures();
 
         // Use a huge range for search to guarantee a site
-        var potentials = sf.getMineralMap().findRandomMineralLocation(new Coordinates("0N", "0E"),
+        var potentials = sf.getMineralMap().findRandomMineralLocation(new Coordinates(Math.PI, 0),
                     100000, Collections.emptyList());
 
         // Give big skill to handle small conc

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/EVAOperationTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/EVAOperationTest.java
@@ -10,6 +10,8 @@ import com.mars_sim.core.equipment.Equipment;
 import com.mars_sim.core.equipment.EquipmentFactory;
 import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesException;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 import com.mars_sim.core.map.location.LocalPosition;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.task.EVAOperation.LightLevel;
@@ -75,21 +77,22 @@ public class EVAOperationTest extends AbstractMarsSimUnitTest{
     }
     /**
      * This test does not attempt to check the solar irradiance logic just the light levels.
+     * @throws CoordinatesException 
      */
-    public void testIsSunlightAroundGlobal() {
-        var locn = new Coordinates("0.0 N", "0.0 E");
+    public void testIsSunlightAroundGlobal() throws CoordinatesException {
+        var locn = CoordinatesFormat.fromString("0.0 0.0");
         
         assertLightLevel("zero time, center locn", locn, false, false);
 
         // First 90 degress is on the darkside
         
-        locn = new Coordinates("0.0 N", "120.0 E");
+        locn = CoordinatesFormat.fromString("0.0 120.0");
         assertLightLevel("zero time, quarter locn", locn, true, false);
 
-        locn = new Coordinates("0.0 N", "180.0 E");
+        locn = CoordinatesFormat.fromString("0.0 180.0");
         assertLightLevel("zero time, half locn", locn, true, true);
 
-        locn = new Coordinates("0.0 N", "120.0 W");
+        locn = CoordinatesFormat.fromString("0.0 -120.0");
         assertLightLevel("zero time, three quarters locn", locn, true, false);
     }
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/ExplorationManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/ExplorationManagerTest.java
@@ -5,6 +5,8 @@ import java.util.Collections;
 
 import com.mars_sim.core.AbstractMarsSimUnitTest;
 import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesException;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 import com.mars_sim.core.mineral.RandomMineralFactory;
 
 public class ExplorationManagerTest extends AbstractMarsSimUnitTest {
@@ -35,8 +37,8 @@ public class ExplorationManagerTest extends AbstractMarsSimUnitTest {
 
     }
 
-     public void testCreateUnclaimedARegionOfInterest() {
-        var locn = new Coordinates("10N", "10E");
+     public void testCreateUnclaimedARegionOfInterest() throws CoordinatesException {
+        var locn = CoordinatesFormat.fromString("10.0 10.0");
 
         // Find a random location within 20K with minerals
         var sf = getSim().getSurfaceFeatures();

--- a/mars-sim-core/src/test/java/com/mars_sim/core/time/EventScheduleTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/time/EventScheduleTest.java
@@ -9,10 +9,11 @@ import com.mars_sim.core.map.location.Coordinates;
 
 class EventScheduleTest {
     private static final int NOW_MSOL = 500;
+    private static final double LONG = Math.PI/2;
 
-    private static final Coordinates CENTER = new Coordinates("10N", "0E");
-    private static final Coordinates ONE_THIRD = new Coordinates("10N", "120E");
-    private static final Coordinates TWO_THIRDS = new Coordinates("10N", "120W");
+    private static final Coordinates CENTER = new Coordinates(LONG, 0D);
+    private static final Coordinates ONE_THIRD = new Coordinates(LONG, Math.PI * 2 / 3);
+    private static final Coordinates TWO_THIRDS = new Coordinates(LONG, -Math.PI * 2 / 3);
 
     @Test
     void testBasic() {
@@ -31,7 +32,7 @@ class EventScheduleTest {
 
     @Test
     void testRolloverBig() {
-        assertCalendar("Rollover big", 0, 300, new Coordinates("10N", "5W"));
+        assertCalendar("Rollover big", 0, 300, new Coordinates(LONG, -0.1));
     }
 
     @Test

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/ArrivingSettlementModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/ArrivingSettlementModel.java
@@ -444,7 +444,7 @@ class ArrivingSettlementModel extends AbstractTableModel {
 				if ((latError == null) && (lonError == null)) {
 					Coordinates c = new Coordinates(arrival.latitude, arrival.longitude);
 					if (!usedCoordinates.add(c))
-						setError(Msg.getString("Coordinates.error.latitudeLongitudeRepeating")); //$NON-NLS-1$
+						setError(Msg.getString("SimulationConfigEditor.error.latitudeLongitudeRepeating")); //$NON-NLS-1$
 				}
 			}
 		}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/ArrivingSettlementModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/ArrivingSettlementModel.java
@@ -18,6 +18,7 @@ import com.mars_sim.core.authority.AuthorityFactory;
 import com.mars_sim.core.configuration.Scenario;
 import com.mars_sim.core.interplanetary.transport.settlement.ArrivingSettlement;
 import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 import com.mars_sim.core.structure.SettlementTemplateConfig;
 import com.mars_sim.core.tool.Msg;
 import com.mars_sim.core.tool.RandomUtil;
@@ -289,7 +290,7 @@ class ArrivingSettlementModel extends AbstractTableModel {
 					else {
 						info.latitude = (String) aValue;
 					}
-					String latError = Coordinates.checkLat(info.latitude);
+					String latError = CoordinatesFormat.checkLat(info.latitude);
 					if (latError != null)
 						setError(latError);
 					break;
@@ -311,7 +312,7 @@ class ArrivingSettlementModel extends AbstractTableModel {
 					else {
 						info.longitude = (String) aValue;
 					}
-					String lonError = Coordinates.checkLon(info.longitude);
+					String lonError = CoordinatesFormat.checkLon(info.longitude);
 					if (lonError != null)
 						setError(lonError);
 					break;
@@ -432,10 +433,10 @@ class ArrivingSettlementModel extends AbstractTableModel {
 			}
 			
 			if ((arrival.latitude != null) && (arrival.longitude != null)) {
-				String latError = Coordinates.checkLat(arrival.latitude);
+				String latError = CoordinatesFormat.checkLat(arrival.latitude);
 				if (latError != null)
 					setError(latError);
-				String lonError = Coordinates.checkLon(arrival.longitude);
+				String lonError = CoordinatesFormat.checkLon(arrival.longitude);
 				if (lonError != null)
 					setError(lonError);
 				

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/InitialSettlementModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/InitialSettlementModel.java
@@ -18,6 +18,7 @@ import com.mars_sim.core.authority.Authority;
 import com.mars_sim.core.authority.AuthorityFactory;
 import com.mars_sim.core.configuration.Scenario;
 import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 import com.mars_sim.core.structure.InitialSettlement;
 import com.mars_sim.core.structure.SettlementTemplateConfig;
 import com.mars_sim.core.tool.Msg;
@@ -97,13 +98,9 @@ class InitialSettlementModel extends AbstractTableModel {
 	 */
 	public void loadDefaultSettlements(Scenario selected) {
 		settlementInfoList.clear();
-		List<String> usedNames = new ArrayList<>();
 
 		for (InitialSettlement spec : selected.getSettlements()) {
 			SettlementInfo info = toSettlementInfo(spec);
-
-			// Save this name to the list
-			usedNames.add(info.name);
 				
 			settlementInfoList.add(info);
 		}
@@ -172,6 +169,7 @@ class InitialSettlementModel extends AbstractTableModel {
 	 * cell. If we didn't implement this method, then the last column would contain
 	 * text ("true"/"false"), rather than a check box.
 	 */
+	@Override
 	public Class<?> getColumnClass(int c) {
 		return getValueAt(0, c).getClass();
 	}
@@ -275,7 +273,7 @@ class InitialSettlementModel extends AbstractTableModel {
 					else {
 						info.latitude = (String) aValue;
 					}
-					String latError = Coordinates.checkLat(info.latitude);
+					String latError = CoordinatesFormat.checkLat(info.latitude);
 					if (latError != null)
 						setError(latError);
 					break;
@@ -297,7 +295,7 @@ class InitialSettlementModel extends AbstractTableModel {
 					else {
 						info.longitude = (String) aValue;
 					}
-					String lonError = Coordinates.checkLon(info.longitude);
+					String lonError = CoordinatesFormat.checkLon(info.longitude);
 					if (lonError != null)
 						setError(lonError);
 					break;
@@ -331,7 +329,7 @@ class InitialSettlementModel extends AbstractTableModel {
 		}
 
 		// Gets a list of settlement names that are tailored to this country
-		List<String> candidateNames = new ArrayList<String>(ra.getSettlementNames());
+		List<String> candidateNames = new ArrayList<>(ra.getSettlementNames());
 		candidateNames.removeAll(usedNames);
 
 		if (candidateNames.isEmpty())
@@ -407,10 +405,10 @@ class InitialSettlementModel extends AbstractTableModel {
 				}
 			}
 			
-			String latError = Coordinates.checkLat(settlement.latitude);
+			String latError = CoordinatesFormat.checkLat(settlement.latitude);
 			if (latError != null)
 				setError(latError);
-			String lonError = Coordinates.checkLon(settlement.longitude);
+			String lonError = CoordinatesFormat.checkLon(settlement.longitude);
 			if (lonError != null)
 				setError(lonError);
 			

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/InitialSettlementModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/InitialSettlementModel.java
@@ -416,7 +416,7 @@ class InitialSettlementModel extends AbstractTableModel {
 			if ((latError == null) && (lonError == null)) {
 				Coordinates c = new Coordinates(settlement.latitude, settlement.longitude);
 				if (!usedCoordinates.add(c))
-					setError(Msg.getString("Coordinates.error.latitudeLongitudeRepeating")); //$NON-NLS-1$
+					setError(Msg.getString("SimulationConfigEditor.error.latitudeLongitudeRepeating")); //$NON-NLS-1$
 			}
 			
 			if (settlement.crew != null) {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/resupply/ArrivingSettlementEditingPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/resupply/ArrivingSettlementEditingPanel.java
@@ -44,6 +44,7 @@ import com.mars_sim.core.interplanetary.transport.TransportManager;
 import com.mars_sim.core.interplanetary.transport.settlement.ArrivingSettlement;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.SettlementTemplate;
 import com.mars_sim.core.time.MarsTime;
@@ -65,11 +66,11 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 	private static final int MAX_FUTURE_ORBITS = 10;
 	
 	// Data members
-	private String errorString = new String();
+	private String errorString = "";
 	// the degree sign 
 	private String deg = Msg.getString("direction.degreeSign"); //$NON-NLS-1$
 	
-	private boolean validation_result = true;
+	private boolean validationResult = true;
 
 	private JTextField nameTF;
 	private JComboBoxMW<String> templateCB;
@@ -131,39 +132,28 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		JPanel topEditPane = new JPanel(new BorderLayout(10, 10));
 		add(topEditPane, BorderLayout.NORTH);
 
-		JPanel topPane = new JPanel(new BorderLayout(10, 10));// GridLayout(2, 1));
+		JPanel topPane = new JPanel(new BorderLayout(10, 10));
 		topEditPane.add(topPane, BorderLayout.NORTH);
 
 		// Create top spring layout.
-		JPanel topSpring = new JPanel(new SpringLayout());// GridLayout(3, 1, 0, 10));
+		JPanel topSpring = new JPanel(new SpringLayout());
 		topPane.add(topSpring, BorderLayout.NORTH);
-
-		// Create name pane.
-		// JPanel namePane = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
-		// topInnerEditPane.add(namePane);
 
 		// Create name title label.
 		JLabel nameTitleLabel = new JLabel(Msg.getString("ArrivingSettlementEditingPanel.settlementName"), //$NON-NLS-1$
 				SwingConstants.TRAILING);
-		// namePane.add(nameTitleLabel);
 		topSpring.add(nameTitleLabel);
 
 		// Create name text field.
-		nameTF = new JTextField(new String(), 25);
+		nameTF = new JTextField("", 25);
 		if (settlement != null) {
 			nameTF.setText(settlement.getName());
 		}
-		// namePane.add(nameTF);
 		topSpring.add(nameTF);
-
-		// Create the template pane.
-		// JPanel templatePane = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
-		// topInnerEditPane.add(templatePane);
 
 		// Create template title label.
 		JLabel templateTitleLabel = new JLabel(Msg.getString("ArrivingSettlementEditingPanel.layoutTemplate"), //$NON-NLS-1$
 				SwingConstants.TRAILING);
-		// templatePane.add(templateTitleLabel);
 		topSpring.add(templateTitleLabel);
 
 		// Create template combo box.
@@ -175,7 +165,6 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		}
 		templateCB.addActionListener(e -> updateTemplateDependentFields((String) templateCB.getSelectedItem()));
 		
-		// templatePane.add(templateCB);
 		topSpring.add(templateCB);
 
 		// 2017-02-11 Create sponsor label.
@@ -197,7 +186,6 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 				10, 10); // xPad, yPad
 
 		JPanel numPane = new JPanel(new GridLayout(1, 2));
-		// topInnerEditPane.add(numPane);
 		topPane.add(numPane, BorderLayout.CENTER);
 
 		// Create population panel.
@@ -236,12 +224,12 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		}
 		populationTF = new JTextField(4);
 		populationTF.setText(Integer.toString(populationNum));
-		populationTF.setHorizontalAlignment(JTextField.RIGHT);
+		populationTF.setHorizontalAlignment(SwingConstants.RIGHT);
 		populationPane.add(populationTF);
 
 		numOfRobotsTF = new JTextField(4);
 		numOfRobotsTF.setText(Integer.toString(numOfRobots));
-		numOfRobotsTF.setHorizontalAlignment(JTextField.RIGHT);
+		numOfRobotsTF.setHorizontalAlignment(SwingConstants.RIGHT);
 		numOfRobotsPane.add(numOfRobotsTF);
 
 		// Create arrival date pane.
@@ -356,7 +344,7 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		int solsDiff = (int) Math.round((arrivingTime.getTimeDiff(currentTime) / 1000D));
 		solsTF = new JTextField(4);
 		solsTF.setText(Integer.toString(solsDiff));
-		solsTF.setHorizontalAlignment(JTextField.RIGHT);
+		solsTF.setHorizontalAlignment(SwingConstants.RIGHT);
 		solsTF.setEnabled(false);
 		timeUntilArrivalPane.add(solsTF);
 
@@ -371,7 +359,7 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		topEditPane.add(southPane, BorderLayout.SOUTH);
 
 		// Create landing location panel.
-		JPanel landingLocationPane = new JPanel(new SpringLayout());// new GridLayout(2, 5, 0, 10));
+		JPanel landingLocationPane = new JPanel(new SpringLayout());
 
 		landingLocationPane
 				.setBorder(new TitledBorder(Msg.getString("ArrivingSettlementEditingPanel.landingLocation"))); //$NON-NLS-1$
@@ -387,8 +375,7 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		latitudeTF = new JTextField(4);
 		latitudeTitleLabel.setLabelFor(latitudeTF);
 
-		latitudeTF.setHorizontalAlignment(JTextField.RIGHT);
-		// latitudePane.add(latitudeTF);
+		latitudeTF.setHorizontalAlignment(SwingConstants.RIGHT);
 		landingLocationPane.add(latitudeTF);
 
 		// Create latitude direction combo box.
@@ -405,7 +392,6 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 			String dirString = latString.substring(latString.length() - 1, latString.length());
 			latitudeDirectionCB.setSelectedItem(dirString);
 		}
-		// latitudePane.add(latitudeDirectionCB);
 		landingLocationPane.add(latitudeDirectionCB);
 
 		// Create longitude title label.
@@ -418,12 +404,11 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		longitudeTitleLabel.setLabelFor(longitudeTF);
 
 
-		longitudeTF.setHorizontalAlignment(JTextField.RIGHT);
-		// longitudePane.add(longitudeTF);
+		longitudeTF.setHorizontalAlignment(SwingConstants.RIGHT);
 		landingLocationPane.add(longitudeTF);
 
 		// Create longitude direction combo box.
-		longitudeDirectionCB = new JComboBox<String>();
+		longitudeDirectionCB = new JComboBox<>();
 		longitudeDirectionCB.addItem(deg + Msg.getString("direction.westShort")); //$NON-NLS-1$
 		longitudeDirectionCB.addItem(deg + Msg.getString("direction.eastShort")); //$NON-NLS-1$
 		if (settlement != null) {
@@ -448,7 +433,7 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		add(errorPane, BorderLayout.SOUTH);
 
 		// Create error label
-		errorLabel = new JLabel(new String());
+		errorLabel = new JLabel("");
 		errorLabel.setForeground(Color.RED);
 		errorPane.add(errorLabel);
 
@@ -502,16 +487,16 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 	 * @return true if data is valid.
 	 */
 	private boolean validateData() {
-		validation_result = true;
+		validationResult = true;
 		errorString = null;
 
 		// Validate settlement name.
 		if (nameTF.getText().trim().isEmpty()) {
-			validation_result = false;
+			validationResult = false;
 			errorString = Msg.getString("ArrivingSettlementEditingPanel.error.noName"); //$NON-NLS-1$
 		}
 
-		if (!validation_result) {
+		if (!validationResult) {
 			errorLabel.setText(errorString);
 			return false;
 		}
@@ -519,11 +504,11 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		// Validate template.
 		String templateName = (String) templateCB.getSelectedItem();
 		if ((templateName == null) || templateName.trim().isEmpty()) {
-			validation_result = false;
+			validationResult = false;
 			errorString = Msg.getString("ArrivingSettlementEditingPanel.error.noTemplate"); //$NON-NLS-1$
 		}
 
-		if (!validation_result) {
+		if (!validationResult) {
 			errorLabel.setText(errorString);
 			return false;
 		}
@@ -531,22 +516,22 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		// Validate population number.
 		String populationNumString = populationTF.getText();
 		if (populationNumString.trim().isEmpty()) {
-			validation_result = false;
+			validationResult = false;
 			errorString = Msg.getString("ArrivingSettlementEditingPanel.error.noPopulation"); //$NON-NLS-1$
 		} else {
 			try {
 				int popNum = Integer.parseInt(populationNumString);
 				if (popNum < 0) {
-					validation_result = false;
+					validationResult = false;
 					errorString = Msg.getString("ArrivingSettlementEditingPanel.error.negativePopulation"); //$NON-NLS-1$
 				}
 			} catch (NumberFormatException e) {
-				validation_result = false;
+				validationResult = false;
 				errorString = Msg.getString("ArrivingSettlementEditingPanel.error.invalidPopulation"); //$NON-NLS-1$
 			}
 		}
 		
-		if (!validation_result) {
+		if (!validationResult) {
 			errorLabel.setText(errorString);	
 			return false;
 		}
@@ -554,22 +539,22 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		// Validate numOfRobots.
 		String numOfRobotsString = numOfRobotsTF.getText();
 		if (numOfRobotsString.trim().isEmpty()) {
-			validation_result = false;
+			validationResult = false;
 			errorString = Msg.getString("ArrivingSettlementEditingPanel.error.nonumOfRobots"); //$NON-NLS-1$
 		} else {
 			try {
 				int numOfRobots = Integer.parseInt(numOfRobotsString);
 				if (numOfRobots < 0) {
-					validation_result = false;
+					validationResult = false;
 					errorString = Msg.getString("ArrivingSettlementEditingPanel.error.negativenumOfRobots"); //$NON-NLS-1$
 				}
 			} catch (NumberFormatException e) {
-				validation_result = false;
+				validationResult = false;
 				errorString = Msg.getString("ArrivingSettlementEditingPanel.error.invalidnumOfRobots"); //$NON-NLS-1$
 			}
 		}
 
-		if (!validation_result) {
+		if (!validationResult) {
 			errorLabel.setText(errorString);
 			return false;
 		}
@@ -578,19 +563,17 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		if (solsTF.isEnabled()) {
 			String timeArrivalString = solsTF.getText().trim();
 			if (timeArrivalString.isEmpty()) {
-				validation_result = false;
+				validationResult = false;
 				errorString = Msg.getString("ArrivingSettlementEditingPanel.error.noSols"); //$NON-NLS-1$
 				enableButton(false);
-//				System.out.println("ArrivingSettlementEditingPanel : Invalid sol. It cannot be empty.");
 			} 
 			
 			else {
-				// System.out.println("calling addChangeListener()");
 				addChangeListener(solsTF, e -> validateSolsTF(timeArrivalString));
 			}
 		}
 
-		if (!validation_result) {
+		if (!validationResult) {
 			errorLabel.setText(errorString);
 			return false;
 		}
@@ -598,86 +581,47 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		// Validate latitude value.
 		String latitudeString = latitudeTF.getText().trim() + " " 
 				+ ((String)latitudeDirectionCB.getSelectedItem()).substring(1, 2);
-		
-//		System.out.println("latitudeString: " + latitudeString);
-		
-		String error0 = Coordinates.checkLat(latitudeString);
+				
+		String error0 = CoordinatesFormat.checkLat(latitudeString);
 		if (error0 != null) {
-			validation_result = false;
+			validationResult = false;
 			errorString = error0;
 		}
 		
-		if (!validation_result) {
+		if (!validationResult) {
 			errorLabel.setText(errorString);
 			return false;
 		}
-		
-//		if (latitudeString.isEmpty()) {
-//			validation_result = false;
-//			errorString = Msg.getString("ArrivingSettlementEditingPanel.error.noLatitude"); //$NON-NLS-1$
-//		} else {
-//			try {
-//				Double latitudeValue = Double.parseDouble(latitudeString);
-//				if ((latitudeValue < 0D) || (latitudeValue > 90D)) {
-//					validation_result = false;
-//					errorString = Msg.getString("ArrivingSettlementEditingPanel.error.rangeLatitude"); //$NON-NLS-1$
-//				}
-//			} catch (NumberFormatException e) {
-//				validation_result = false;
-//				errorString = Msg.getString("ArrivingSettlementEditingPanel.error.invalidLatitude"); //$NON-NLS-1$
-//			}
-//		}
+
 
 		// Validate longitude value.
 		String longitudeString = longitudeTF.getText().trim() + " " 
 				+ ((String)longitudeDirectionCB.getSelectedItem()).substring(1, 2);
 		
-		String error1 = Coordinates.checkLon(longitudeString);
+		String error1 = CoordinatesFormat.checkLon(longitudeString);
 		if (error1 != null) {
-			validation_result = false;
+			validationResult = false;
 			errorString = error1;
 		}
-		
-//		System.out.println("longitudeString: " + longitudeString);
-		
-		if (!validation_result) {
+				
+		if (!validationResult) {
 			errorLabel.setText(errorString);
 			return false;
 		}
 		
-//		if (longitudeString.isEmpty()) {
-//			validation_result = false;
-//			errorString = Msg.getString("ArrivingSettlementEditingPanel.error.noLongitude"); //$NON-NLS-1$
-//		} else {
-//			try {
-//				Double longitudeValue = Double.parseDouble(longitudeString);
-//				if ((longitudeValue < 0D) || (longitudeValue > 180D)) {
-//					validation_result = false;
-//					errorString = Msg.getString("ArrivingSettlementEditingPanel.error.rangeLongitude"); //$NON-NLS-1$
-//				}
-//			} catch (NumberFormatException e) {
-//				validation_result = false;
-//				errorString = Msg.getString("ArrivingSettlementEditingPanel.error.invalidLongitude"); //$NON-NLS-1$
-//			}
-//		}
-
-//		System.out.println("latitudeString: " + latitudeString + "   longitudeString: " + longitudeString);
-		
 		String repeated = checkRepeatingLatLon(latitudeString, longitudeString);
 		if (repeated != null) {
-			validation_result = false;
+			validationResult = false;
 			errorString = Msg.getString("ArrivingSettlementEditingPanel.error.collision"); //$NON-NLS-1$
 		}
 		
 
-		if (!validation_result) {
+		if (!validationResult) {
 			errorLabel.setText(errorString);	
 			return false;
 		}
-		
-//		System.out.println("validation_result: " + validation_result + "   " + errorString);
-		
-		return validation_result;
+				
+		return validationResult;
 	}
 
 	/***
@@ -689,15 +633,12 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		boolean repeated = false;
 	
 		Collection<Settlement> list = unitManager.getSettlements();
-		
-//		int size = list.size();
-		
+				
 		Set<Coordinates> coordinatesSet = new HashSet<>();
 		coordinatesSet.add(new Coordinates(latStr, longStr));
 		
 		for (Settlement s: list) {
 			if (!coordinatesSet.add(s.getCoordinates())) {
-//				System.out.println("Repeated coordinates: " + s.getCoordinates());
 				repeated = true;
 				break;
 			}
@@ -716,7 +657,6 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 	 * @param timeArrivalString
 	 */
 	public void validateSolsTF(String timeArrivalString) {
-		// System.out.println("running validateSolsTF()");
 		errorString = null;
 
 		try {
@@ -725,65 +665,18 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 				timeArrivalString = "-1";
 			double timeArrival = Double.parseDouble(timeArrivalString);
 			if (timeArrival < 0D) {
-				validation_result = false;
+				validationResult = false;
 				enableButton(false);
 				errorString = Msg.getString("ArrivingSettlementEditingPanel.error.negativeSols"); //$NON-NLS-1$
 				errorLabel.setText(errorString);
 			} else {
-				boolean good = true;
-				// // Add checking if that sol has already been taken
-				// JList<?> jList = resupplyWindow.getIncomingListPane().getIncomingList();
-				// ListModel<?> model = jList.getModel();
-
-				// for (int i = 0; i < model.getSize(); i++) {
-				// 	Transportable transportItem = (Transportable) model.getElementAt(i);
-
-				// 	if ((transportItem != null)) {
-				// 		if (transportItem instanceof Resupply) {
-				// 			// Create modify resupply mission dialog.
-				// 			Resupply resupply = (Resupply) transportItem;
-				// 			MarsTime arrivingTime = resupply.getArrivalDate();
-				// 			int solsDiff = (int) Math.round((MarsTime.getTimeDiff(arrivingTime, MarsTime) / 1000D));
-				// 			sols.add(solsDiff);
-
-				// 		} else if (transportItem instanceof ArrivingSettlement) {
-				// 			// Create modify arriving settlement dialog.
-				// 			ArrivingSettlement newS = (ArrivingSettlement) transportItem;
-				// 			if (!newS.equals(settlement)) {
-				// 				MarsTime arrivingTime = newS.getArrivalDate();
-				// 				int solsDiff = (int) Math
-				// 						.round((MarsTime.getTimeDiff(arrivingTime, MarsTime) / 1000D));
-				// 				sols.add(solsDiff);
-				// 			}
-				// 		}
-				// 	}
-				//}
-
-				// System.out.println("sols.size() : " + sols.size() );
-
-// 				Iterator<Integer> i = sols.iterator();
-// 				while (i.hasNext()) {
-// 					int sol = i.next();
-// 					if (sol == (int) timeArrival) {
-// //						System.out.println("Invalid entry! Sol " + sol + " has already been taken.");
-// 						validation_result = false;
-// 						good = false;
-// 						enableButton(false);
-// 						errorString = Msg.getString("ArrivingSettlementEditingPanel.error.duplicatedSol"); //$NON-NLS-1$
-// 						errorLabel.setText(errorString);
-// 						break;
-// 					}
-// 				}
-
-				if (good) {
-					validation_result = true;
-					errorString = null;
+					validationResult = true;
+					errorString = "";
 					errorLabel.setText(errorString);
 					enableButton(true);
-				}
 			}
 		} catch (NumberFormatException e) {
-			validation_result = false;
+			validationResult = false;
 			errorString = Msg.getString("ArrivingSettlementEditingPanel.error.invalidSols"); //$NON-NLS-1$
 			enableButton(false);
 			errorLabel.setText(errorString);
@@ -818,7 +711,8 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 		Objects.requireNonNull(text);
 		Objects.requireNonNull(changeListener);
 		DocumentListener dl = new DocumentListener() {
-			private int lastChange = 0, lastNotifiedChange = 0;
+			private int lastChange = 0;
+			private int lastNotifiedChange = 0;
 
 			@Override
 			public void insertUpdate(DocumentEvent e) {
@@ -831,7 +725,6 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 			}
 
 			public void changedUpdate(DocumentEvent e) {
-				// System.out.println("calling addChangeListener()'s changedUpdate()");
 				lastChange++;
 				SwingUtilities.invokeLater(() -> {
 					if (lastNotifiedChange != lastChange) {
@@ -972,10 +865,8 @@ public class ArrivingSettlementEditingPanel extends TransportItemEditingPanel {
 	private Coordinates getLandingLocation() {
 		String fullLatString = latitudeTF.getText().trim() + " " 
 				+ ((String)latitudeDirectionCB.getSelectedItem()).substring(1, 2);
-		// System.out.println("fullLatString : " + fullLatString);
 		String fullLonString = longitudeTF.getText().trim() + " " 
 				+ ((String)longitudeDirectionCB.getSelectedItem()).substring(1, 2);
-		// System.out.println("fullLonString : " + fullLonString);
 		return new Coordinates(fullLatString, fullLonString);
 	}
 }


### PR DESCRIPTION
This PR makes Coordinates parsing more independent of the language binding. It achieves this in a number of ways:

- Isolate output and parsing of Coordinates to new CoordinatesFormat class
- Create a new Decimal style of Coordinate that avoid use of compass names
- Decimal style is used in scenario templates
- Reduce the use of the Coordinate constructor that takes 2 Strings

close #1741 