### PR TITLE
Localisation fixes

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/environment/LandmarkType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/environment/LandmarkType.java
@@ -18,11 +18,11 @@ public enum LandmarkType {
     private String name;
 
     private LandmarkType() {
-        this.name = Msg.getString("LandmarkType." + name());
+        this.name = Msg.getStringOptional("LandmarkType", name());
     }
 
     /**
-     * Get teh human readable name
+     * Get the human readable name
      * @return
      */
     public String getName() {

--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -8,7 +8,7 @@
 # PersonalityType, PhaseType, StudyStatus, ComputingLoadType, ObjectiveType, VehicleType, UnitType
 # AssignmentType, DustStormType, FoodType, ScienceType, FavoriteType, BuildingCategory, GoodCategory,
 # TrainingType, DishCategory, StatusType, NaturalAttributeType, SkillType, PlanType, CertificationType,
-# SystemType, HealthproblemState, JobType, ComplaintType, PowerMode, TransitState
+# SystemType, HealthproblemState, JobType, ComplaintType, PowerMode, TransitState, LandmarkType
 ##################
 
 ArrivingSettlementDetailPanel.arrivalDate=Arrival Date
@@ -412,17 +412,17 @@ job.medicBot              = Medic
 job.repairBot             = Handyman
 
 LaboratoryTabPanel.title=Laboratory
-LandmarkType.AO = Artificial Object
-LandmarkType.CM = Chasma
-LandmarkType.CH = Chaos
-LandmarkType.AA = Crater
-LandmarkType.FO = Fossa
-LandmarkType.LF = Landing site		
-LandmarkType.ME = Mare
-LandmarkType.MO = Mountain
-LandmarkType.PL = Planitia
-LandmarkType.TH = Tholus
-LandmarkType.VA = Valley
+LandmarkType.ao = Artificial Object
+LandmarkType.cm = Chasma
+LandmarkType.ch = Chaos
+LandmarkType.aa = Crater
+LandmarkType.fo = Fossa
+LandmarkType.lf = Landing site
+LandmarkType.me = Mare
+LandmarkType.mo = Mountain
+LandmarkType.pl = Planitia
+LandmarkType.th = Tholus
+LandmarkType.va = Valley
 
 LocationSituation.decommissioned=decommissioned
 LocationSituation.buried=buried

--- a/mars-sim-core/src/test/java/com/mars_sim/core/map/location/CoordinatesFormatTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/map/location/CoordinatesFormatTest.java
@@ -32,7 +32,7 @@ class CoordinatesFormatTest {
         assertEquals(3D * Math.PI / 2D, CoordinatesFormat.parseLongitude2Theta("90.0" + DEG_SIGN + " " + WEST), 0);
         assertEquals(3D * Math.PI / 2D, CoordinatesFormat.parseLongitude2Theta("90.0 " + WEST), 0);
         assertEquals(3D * Math.PI / 2D, CoordinatesFormat.parseLongitude2Theta("-90.0"), 0);
-        assertEquals(0, CoordinatesFormat.parseLongitude2Theta("0 W"), 0);
+        assertEquals(0, CoordinatesFormat.parseLongitude2Theta("0 " + WEST), 0);
     }
     
     /**
@@ -86,7 +86,7 @@ class CoordinatesFormatTest {
         String latString1 = CoordinatesFormat.getFormattedLatitudeString(loc1);
         DecimalFormat format = new DecimalFormat();
         char decimalPoint = format.getDecimalFormatSymbols().getDecimalSeparator();
-        String s2 = "90"+ decimalPoint + "0000 N";
+        String s2 = "90"+ decimalPoint + "0000 " + NORTH;
         assertEquals(s2, latString1);
     }
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/time/MarsZoneTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/time/MarsZoneTest.java
@@ -4,30 +4,31 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesException;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 
 class MarsZoneTest {
     @Test
-    void testGetMarsZone() {
+    void testGetMarsZone() throws CoordinatesException {
         int range = 360/MarsZone.NUM_ZONES;
 
         // Check East
         for(int i = 0; i < 180; i++) {
             int z = i / range;
-            assertZone(i + "E", "MCT+" + z, z * 50);
+            assertZone(i, "MCT+" + z, z * 50);
         }
 
         // Check West
         for(int i = 1; i <= 180; i++) {
             int z = 1 + ((i-1) / range);
-            assertZone(i + "W", "MCT-" + z, 1000 - (z * 50));
+            assertZone(-i, "MCT-" + z, 1000 - (z * 50));
         }
     }
 
-    private void assertZone(String longitude, String name, int offset) {
-        var coord = new Coordinates("20N", longitude);
+    private void assertZone(int longitude, String name, int offset) throws CoordinatesException {
+        var coord = CoordinatesFormat.fromString("20.0", Integer.toString(longitude));
         var zone =  MarsZone.getMarsZone(coord);
-        assertEquals(longitude, name, zone.getId());
+        assertEquals(longitude + " zone", name, zone.getId());
         assertEquals(longitude + " offset", offset, zone.getMSolOffset());
     }
 }

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/locale/BundleCheck.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/locale/BundleCheck.java
@@ -1,0 +1,296 @@
+/*
+ * Mars Simulation Project
+ * BundleCheck.java
+ * @date 2025-09-28
+ * @author Barry Evans			
+ */
+package com.mars_sim.tools.locale;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.logging.Logger;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.help.HelpFormatter;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import com.mars_sim.core.UnitType;
+import com.mars_sim.core.building.BuildingCategory;
+import com.mars_sim.core.building.function.FunctionType;
+import com.mars_sim.core.building.function.SystemType;
+import com.mars_sim.core.building.function.cooking.DishCategory;
+import com.mars_sim.core.building.function.farming.PhaseType;
+import com.mars_sim.core.building.utility.heating.HeatMode;
+import com.mars_sim.core.building.utility.power.PowerMode;
+import com.mars_sim.core.computing.ComputingLoadType;
+import com.mars_sim.core.environment.DustStormType;
+import com.mars_sim.core.environment.LandmarkType;
+import com.mars_sim.core.equipment.EquipmentType;
+import com.mars_sim.core.events.HistoricalEventCategory;
+import com.mars_sim.core.food.FoodType;
+import com.mars_sim.core.goods.GoodCategory;
+import com.mars_sim.core.interplanetary.transport.TransitState;
+import com.mars_sim.core.location.LocationStateType;
+import com.mars_sim.core.person.ai.NaturalAttributeType;
+import com.mars_sim.core.person.ai.PersonalityTraitType;
+import com.mars_sim.core.person.ai.SkillType;
+import com.mars_sim.core.person.ai.fav.FavoriteType;
+import com.mars_sim.core.person.ai.job.util.AssignmentType;
+import com.mars_sim.core.person.ai.job.util.JobType;
+import com.mars_sim.core.person.ai.mission.PlanType;
+import com.mars_sim.core.person.ai.role.RoleType;
+import com.mars_sim.core.person.ai.training.CertificationType;
+import com.mars_sim.core.person.ai.training.TrainingType;
+import com.mars_sim.core.person.health.ComplaintType;
+import com.mars_sim.core.person.health.HealthProblemState;
+import com.mars_sim.core.person.health.HealthRiskType;
+import com.mars_sim.core.science.ScienceType;
+import com.mars_sim.core.science.StudyStatus;
+import com.mars_sim.core.structure.ObjectiveType;
+import com.mars_sim.core.vehicle.StatusType;
+import com.mars_sim.core.vehicle.VehicleType;
+
+/**
+ * Tool to check locale bundles for missing or redundant keys and parameter mismatches.
+ * This tool assumes that enum types use a standard key format of EnumType.enumvalue in lower case.
+ * This tool will generate a report file for each locale in the target/locale-check folder.
+ */
+public class BundleCheck {
+
+    private static final String SOURCE_ARG = "source";
+
+    private static final String TARGET_ARG = "output";
+
+    public static void main(String[] args) throws IOException {
+        var sourceFolder = "./mars-sim-core/src/main/resources/";
+        var targetFolder = "./target/locale-check/";
+
+		Options options = new Options();
+		options.addOption(Option.builder(SOURCE_ARG).argName("Folder to scan").hasArg()
+				.desc("Location to scan for bundle files.").get());
+		options.addOption(Option.builder(TARGET_ARG).argName("Folder to output reports").hasArg()
+				.desc("Location for final reports.").get());
+
+		DefaultParser commandline = new DefaultParser();
+		try {
+			CommandLine line = commandline.parse(options, args);
+            if (line.hasOption(SOURCE_ARG)) {
+				sourceFolder = line.getOptionValue(SOURCE_ARG);
+			}
+			if (line.hasOption(TARGET_ARG)) {
+				targetFolder = line.getOptionValue(TARGET_ARG);
+			}
+        }
+		catch (ParseException e) {
+            // New non-deprecated HelpFormatter (Commons CLI 1.10+)
+            HelpFormatter fmt = HelpFormatter.builder().get();
+            String header = "\n" + e.getMessage() + "\n";
+            try {
+                fmt.printHelp("bundleCheck [options]", header, options, null, true);
+            } catch (IOException ioe) {
+                // Fallback if printing help fails
+                logger.severe("usage: bundleCheck [options]");
+            }
+            System.exit(1);
+		}
+
+        var checker = new BundleCheck(targetFolder);
+        checker.checkBundles(sourceFolder);
+    }
+
+    private static Logger logger = Logger.getLogger(BundleCheck.class.getName());
+
+    private File outputFolder;
+
+    private BundleCheck(String outputDir) {
+        outputFolder = new File(outputDir);
+    
+        logger.info("Output folder: " + outputFolder.getAbsolutePath());
+        outputFolder.mkdirs();
+    }
+
+    /**
+     * Find any defined locale properties file in the source folder and compare to the base
+     * messages.properties file.
+     * @throws IOException
+     */
+    private void checkBundles(String sourceFolder) throws IOException {
+        var source = new File(sourceFolder);
+
+        // Load the base messages file
+        var baseMessages = loadMessages(new File(source, "messages.properties"));
+
+        // Define keys that are automatically handled by the system
+        Set<String> defaultEnumsKeys = loadDefaultEnumsKeys();
+
+        // Compare each found locale file
+        for(var f : FileUtils.listFiles(source, new String[]{"properties"}, false)) {
+            if (f.getName().startsWith("messages_")) {
+                var name = f.getName().substring("messages_".length(), f.getName().length() - ".properties".length());
+                if (!name.isEmpty()) {
+                    compareBundle(f, name, baseMessages, defaultEnumsKeys);
+                }
+            }
+        }
+        
+    }
+
+    /**
+     * Create an entry for every constant in the enum class using the format
+     * @param <T> the enum type
+     * @param results   the set to add the keys to
+     * @param enumClass the enum class to process
+     */
+    private <T extends Enum<T>>  void loadEnum(Set<String> results, Class<T> enumClass) {
+        String mainKey = enumClass.getSimpleName() + ".";
+        for(var v : enumClass.getEnumConstants()) {
+            results.add(mainKey + v.name().toLowerCase());
+        }
+    }
+
+    /**
+     * Load all the enum keys that use the default naming strategy.
+     * The enums used here should match those in Msg.getStringOptional calls.
+     * @return set of enum keys
+     */
+    private Set<String> loadDefaultEnumsKeys() {
+        Set<String> results = new TreeSet<>();
+
+        // These are all the enums that use a default name strategy
+        loadEnum(results, FunctionType.class);
+        loadEnum(results, EquipmentType.class);
+        loadEnum(results, RoleType.class);
+        loadEnum(results, HeatMode.class);
+        loadEnum(results, LocationStateType.class);
+        loadEnum(results, HealthRiskType.class);
+        loadEnum(results, HistoricalEventCategory.class);
+        loadEnum(results, PersonalityTraitType.class);
+        loadEnum(results, PhaseType.class);
+        loadEnum(results, StudyStatus.class);
+        loadEnum(results, ComputingLoadType.class);
+        loadEnum(results, ObjectiveType.class);
+        loadEnum(results, VehicleType.class);
+        loadEnum(results, UnitType.class);
+        loadEnum(results, AssignmentType.class);
+        loadEnum(results, DustStormType.class);
+        loadEnum(results, FoodType.class);
+        loadEnum(results, ScienceType.class);
+        loadEnum(results, LandmarkType.class);
+        loadEnum(results, FavoriteType.class);
+        loadEnum(results, BuildingCategory.class);
+        loadEnum(results, GoodCategory.class);
+        loadEnum(results, TrainingType.class);
+        loadEnum(results, DishCategory.class);
+        loadEnum(results, StatusType.class);
+        loadEnum(results, NaturalAttributeType.class);
+        loadEnum(results, SkillType.class);
+        loadEnum(results, PlanType.class);
+        loadEnum(results, CertificationType.class);
+        loadEnum(results, SystemType.class);
+        loadEnum(results, HealthProblemState.class);
+        loadEnum(results, JobType.class);
+        loadEnum(results, ComplaintType.class);
+        loadEnum(results, PowerMode.class);
+        loadEnum(results, TransitState.class);
+
+        return results;
+    }
+
+    /**
+     * Compare a locale bundle to the base messages and generate a report file.
+     * @param f             the locale file
+     * @param name          the locale name
+     * @param baseMessages  the base messages map
+     * @param enumKeys      the set of enum keys that are automatically handled
+     * @throws IOException
+     */
+    private void compareBundle(File f, String name, Map<String,Integer> baseMessages,
+                Set<String> enumKeys) throws IOException {
+        var localeMessage = loadMessages(f);
+        int differences = 0;
+        int enumMissing = 0;
+
+        File outputFile = new File(outputFolder, "report_" + name + ".txt");
+        try(var out = new PrintWriter(new FileOutputStream(outputFile))) {
+            out.println("Report for locale " + name);
+
+            // Report on the enum keys
+            out.println();
+            out.println("Enum keys (these will automatically default to internal enum value):");
+            for(var k : enumKeys) {
+                if (!localeMessage.containsKey(k)) {
+                    out.println(k + " : MISSING");
+                    enumMissing++;
+                }
+            }
+
+            // Report on the match with the base keys
+            Set<String> baseKeys = new TreeSet<>(baseMessages.keySet());
+            out.println();
+            out.println("Base keys:");
+            for(var k : baseKeys) {
+                if (localeMessage.containsKey(k)) {
+                    // Check parameter count
+                    var localeCount = localeMessage.get(k);
+                    int baseCount = baseMessages.get(k).intValue();
+                    if (baseCount != localeCount.intValue()) {
+                        out.println(k + " : parameters base=" + baseCount + ", locale=" + localeCount);
+                        differences++;
+                    }
+                } else {
+                    out.println(k + " : MISSING");
+                    differences++;
+                }
+            }
+
+            // Find keys in the locale that are missing in the base but allow any enum keys
+            Set<String> extraKeys = new TreeSet<>(localeMessage.keySet());
+            extraKeys.removeAll(baseMessages.keySet());
+            extraKeys.removeAll(enumKeys);
+            out.println();
+            out.println("Redundant keys:");
+            for(var k : extraKeys) {
+                out.println(k);
+            }
+            logger.info("Report for locale " + name + ":" + differences + " differences "
+                        + enumMissing + " missing enum keys, "
+                        + extraKeys.size() + " redundant keys.");
+        }
+    }
+
+    /**
+     * Load messages from a properties file and count the number of parameters in each message.
+     * @param file  the properties file
+     * @return map of message keys to parameter count
+     * @throws IOException
+     */
+    private Map<String, Integer> loadMessages(File file) throws IOException {
+        Map<String, Integer> results = new HashMap<>();
+
+        try(var input = FileUtils.openInputStream(file)) {  
+            Properties rawMessages = new Properties();
+            rawMessages.load(input);
+        
+            // Tag messages that contain properties
+            rawMessages.forEach( (k,v)-> {
+                var key = (String) k;
+                int count = StringUtils.countMatches((String) v, "{");
+                results.put(key, count);
+            });
+        }
+        
+        return results;
+    }
+}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/navigator/NavigatorWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/navigator/NavigatorWindow.java
@@ -49,6 +49,8 @@ import com.mars_sim.core.map.IntegerMapData;
 import com.mars_sim.core.map.MapDataFactory;
 import com.mars_sim.core.map.MapMetaData;
 import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.map.location.CoordinatesException;
+import com.mars_sim.core.map.location.CoordinatesFormat;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.tool.Msg;
@@ -178,8 +180,7 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 	private static final String MAPTYPE_PROP = "mapType";
 	private static final String RESOLUTION_PROP = "resolution";
 	private static final String LAYER_PROP = "lyr" + MAP_SEPERATOR;
-	private static final String LON_PROP = "longitude";
-	private static final String LAT_PROP = "latitude";
+	private static final String LOCN_PROP = "location";
 
 	/** Tool name. */
 	public static final String NAME = "navigator";
@@ -445,11 +446,15 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 			// Check for layer action and mineral action
 			layerDefined = checkLayerAction(userSettings);
 
-			String latString = userSettings.getProperty(LAT_PROP);
-			String lonString = userSettings.getProperty(LON_PROP);
-			if ((latString != null) && (lonString != null)) {
-				Coordinates userCenter = new Coordinates(latString, lonString);
-				updateCoordsMaps(userCenter);
+			String locnString = userSettings.getProperty(LOCN_PROP);
+			if (locnString != null) {
+				Coordinates userCenter;
+				try {
+					userCenter = CoordinatesFormat.fromString(locnString);
+					updateCoordsMaps(userCenter);
+				} catch (CoordinatesException e) {
+					logger.warning("Cannot use saved locn " + locnString + " " + e.getMessage());
+				}
 			}
 		}
 		
@@ -788,11 +793,8 @@ public class NavigatorWindow extends ToolWindow implements ActionListener, Confi
 		results.setProperty(MAPTYPE_PROP, mapPanel.getMapMetaData().getId());
 		// Record the resolution
 		results.setProperty(RESOLUTION_PROP, "" + mapPanel.getMapResolution());
-		Coordinates center = mapPanel.getCenterLocation();
-		// Record the longitude
-		results.setProperty(LON_PROP, center.getFormattedLongitudeString());
-		// Record the latitude
-		results.setProperty(LAT_PROP, center.getFormattedLatitudeString());
+		// Record the location
+		results.setProperty(LOCN_PROP, CoordinatesFormat.getDecimalString(mapPanel.getCenterLocation()));
 
 		// Additional layers
 		for (var e : mapLayers) {


### PR DESCRIPTION
This pr corrects the final unit test so they run in any language bundle.

In addition there is a new tool ```BundleCheck``` that compares the default bundle to any language properties files and reports differences:

- Missing keys
- Redundancy keys, those in the language bundle that are not needed
- Missing Enum keys, these default to the enum constant name so are not fatal to the running of the simulation

The differences are reported in a report file.

In addition, there is a correct to the map tool so coordinates are saved in the decimal format.

Close #1741 
Ref #1755 