### PR TITLE
Correct duplicate entries for MissionLog

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/MissionLog.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/MissionLog.java
@@ -81,13 +81,13 @@ public class MissionLog implements Serializable  {
      */
     public void addEntry(String entry, String enterBy) {
 		if (!log.isEmpty()) {
-			int comapareSize = Math.min(log.size(), MAX_COMPARE);
-			for(int i=1; i <= comapareSize; i++) {
+			int compareSize = Math.min(log.size(), MAX_COMPARE);
+			for(int i=1; i <= compareSize; i++) {
 				MissionLogEntry log0 = log.get(log.size() - i);
 				String entry0 = log0.getEntry();
 				
 				if (entry0.equals(entry)) {
-					// Same as one of the choosen one, do not add
+					// Same as one of the chosen ones, do not add
 					return;
 				}
 			}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/MissionLog.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/MissionLog.java
@@ -21,6 +21,11 @@ public class MissionLog implements Serializable  {
 	private static final long serialVersionUID = 1L;
 
 	/**
+	 * The maximum number of log entries to compare for duplicates.
+	 */
+	static final int MAX_COMPARE = 2;
+
+	/**
      * POJO class for a log entry.
      */
     public static class MissionLogEntry implements Serializable {
@@ -58,10 +63,6 @@ public class MissionLog implements Serializable  {
     
     private boolean done = false;
     
-    private String lastEntry = "";
-    
-    private String lastEnterBy = "";
-    
     private List<MissionLogEntry> log;
     
     private MarsTime timestampEmbarked;
@@ -73,72 +74,27 @@ public class MissionLog implements Serializable  {
     }
     
     /**
-     * Compares with the previous log entry. 
-     * 
-     * @param entry
-     * @param enterBy
-     * @param i
-     */
-    private void compareLog(String entry, String enterBy, int i) {
-    	MissionLogEntry log0 = log.get(i);
-    	String entry0 = log0.getEntry();
-    	String enterBy0 = log0.getEnterBy();
-    	
-    	if (!entry0.equals(entry)
-    		|| !enterBy0.equals(enterBy)) {
-    		// Add new log entry
-    		log.add(new MissionLogEntry(clock.getMarsTime(), entry, enterBy));
-    	}
-    	
-		// if not meeting above criteria, do not add a new log entry
-    }
-    
-    /**
      * Adds an entry.
      * 
      * @param entry
 	 * @param enterBy the name of the person who logs this
      */
     public void addEntry(String entry, String enterBy) {
-    	if (lastEntry.equals(entry) && lastEnterBy.equals(enterBy)) {
-    		return;
-    	}
-    	
-    	lastEntry = entry;
-    	lastEnterBy = enterBy;
-    	
-    	int size = log.size();
-
-    	if (size == 0) {
-    		// Add new log entry
-	        log.add(new MissionLogEntry(clock.getMarsTime(), entry, enterBy));
-    	}
-    	else if (size == 1) {
-    		// Check on log1
-    		compareLog(entry, enterBy, size - 1);
-    	}
-    	else if (size == 2) {
-    		// Check on log2
-    		compareLog(entry, enterBy, size - 1);
-    		// Check on log1
-    		compareLog(entry, enterBy, size - 2);
-    		
+		if (!log.isEmpty()) {
+			int comapareSize = Math.min(log.size(), MAX_COMPARE);
+			for(int i=1; i <= comapareSize; i++) {
+				MissionLogEntry log0 = log.get(log.size() - i);
+				String entry0 = log0.getEntry();
+				
+				if (entry0.equals(entry)) {
+					// Same as one of the choosen one, do not add
+					return;
+				}
+			}
 		}
-    	else if (size == 3) {
-    		// Compare with the last 3 log entries
-       		// Compare with the last 4 log entries
-    		for (int i=1; i < 4; i++) {
-    			// Check on log_
-        		compareLog(entry, enterBy, size - i);
-    		}
-    	}
-    	else {
-    		// Compare with the last 4 log entries
-    		for (int i=1; i < 5; i++) {
-    			// Check on log_
-        		compareLog(entry, enterBy, size - i);
-    		}
-    	}
+
+		// Add entry
+		log.add(new MissionLogEntry(clock.getMarsTime(), entry, enterBy));
     }
 
     /**

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/mission/MissionLogTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/mission/MissionLogTest.java
@@ -1,0 +1,98 @@
+package com.mars_sim.core.person.ai.mission;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.mars_sim.core.test.MarsSimUnitTest;
+
+class MissionLogTest extends MarsSimUnitTest{
+    @Test
+    void testAddEntryBasic() {
+        MissionLog missionLog = new MissionLog();
+        int count = 4;
+        for (int i = 0; i < count; i++) {
+            missionLog.addEntry("Test entry" + i, "UnitTest");
+        }
+
+        var enntries = missionLog.getEntries();
+        assertEquals(count, enntries.size());
+
+        var entriesText = enntries.stream().map(e -> e.getEntry()).toList();
+        for (int i = 0; i < count; i++) {
+            assertEquals("Test entry" + i, entriesText.get(i));
+        }
+    }
+
+    @Test
+    void testAddEntryOverTime() {
+        var master = getContext().getSim().getMasterClock();
+        var startTime = master.getMarsTime();
+        var entryTime = startTime;
+
+        MissionLog missionLog = new MissionLog();
+        int count = 4;
+        for (int i = 0; i < count; i++) {
+            entryTime = entryTime.addTime(10);
+            master.setMarsTime(entryTime);
+
+            missionLog.addEntry("Test entry" + i, "UnitTest");
+
+            var lastEntry = missionLog.getLastEntry();
+            assertEquals(entryTime, lastEntry.getTime());
+        }
+    }
+
+    @Test
+    void testAddDuplicate() {
+        MissionLog missionLog = new MissionLog();
+
+        missionLog.addEntry("Test entry", "UnitTest");
+        missionLog.addEntry("Test entry", "UnitTest");
+
+        var enntries = missionLog.getEntries();
+        assertEquals(1, enntries.size());
+    }
+
+    
+    @Test
+    void testAddDuplicateHistory() {
+        MissionLog missionLog = new MissionLog();
+
+        for (int i = 0; i < MissionLog.MAX_COMPARE; i++) {
+            missionLog.addEntry("Test entry" + i, "UnitTest");
+        }
+
+        // Add entry #0
+        missionLog.addEntry("Test entry 0", "UnitTest");
+
+
+        var entries = missionLog.getEntries();
+        assertEquals(MissionLog.MAX_COMPARE+1, entries.size());
+    }
+
+    @Test
+    void testAddDuplicateValid() {
+        MissionLog missionLog = new MissionLog();
+
+        missionLog.addEntry("Test entry dup", "UnitTest");
+        missionLog.addEntry("Test entry unique", "UnitTest");
+
+        missionLog.addEntry("Test entry dup", "UnitTest");
+
+        var entries = missionLog.getEntries();
+        assertEquals(2, entries.size());
+    }
+
+    @Test
+    void testGetLastEntry() {
+        MissionLog missionLog = new MissionLog();
+        int count = 10;
+        for (int i = 0; i < count; i++) {
+            missionLog.addEntry("Test entry" + i, "UnitTest");
+        }
+
+        var lastEntry = missionLog.getLastEntry();
+        assertEquals("Test entry" + (count - 1), lastEntry.getEntry());
+    }
+}


### PR DESCRIPTION
Changes:
- MissionLog no longer considers the enterBy field when checking for duplicates
- Define a MAX_COMPARE as the number of previous entries to check for duplicates
- Add UnitTest for MissionLog to test various cases

Related to c5a48963d825a40e264faf4ca904de9662615dba