### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/delete-packages.yml
+++ b/.github/workflows/delete-packages.yml
@@ -1,4 +1,6 @@
 name: Remove Untagged Packages
+permissions:
+  packages: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/mars-sim/mars-sim/security/code-scanning/29](https://github.com/mars-sim/mars-sim/security/code-scanning/29)

To fix the problem, we need to add an explicit `permissions` block to the workflow or job definition in `.github/workflows/delete-packages.yml`. Since the only step uses the `actions/delete-package-versions` action, which requires write access to the packages, the minimal permissions should be `packages: write`. This can be applied globally at the workflow root or to the individual job for fine-grained control. Given there is only one job, adding it at the workflow root is clear and future-proof. Add the following block after the workflow name and before the `on:` trigger:

```yaml
permissions:
  packages: write
```

No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
