### PR TITLE
build: Update pom

### DIFF
--- a/mars-sim-fxgl/pom.xml
+++ b/mars-sim-fxgl/pom.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.mars-sim</groupId>
-    <artifactId>mars-sim</artifactId>
-    <version>3.11.0</version>
-  </parent>
-  <artifactId>mars-sim-fxgl</artifactId>
-  <name>mars-sim-fxgl</name>
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.mars-sim</groupId>
+		<artifactId>mars-sim</artifactId>
+		<version>3.11.0</version>
+	</parent>
+	<artifactId>mars-sim-fxgl</artifactId>
+	<name>mars-sim-fxgl</name>
 	<dependencies>
- 		<dependency>
+		<dependency>
 			<groupId>com.mars-sim</groupId>
 			<artifactId>mars-sim-tools</artifactId>
 			<version>${project.version}</version>
@@ -23,27 +20,15 @@
 			<artifactId>mars-sim-ui</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.openjfx/javafx -->
-		<!--dependency>
-		    <groupId>org.openjfx</groupId>
-		    <artifactId>javafx</artifactId>
-		    <version>17.0.0.1</version>
-		    <type>pom</type>
-		</dependency-->
-        <!--dependency>
-            <groupId>de.codecentric.centerdevice</groupId>
-            <artifactId>javafxsvg</artifactId>
-            <version>1.3.0</version>
-        </dependency-->	
 		<dependency>
 			<groupId>com.github.almasb</groupId>
 			<artifactId>fxgl</artifactId>
 			<version>${fxgl.version}</version>
 		</dependency>	
-        <dependency>
-            <groupId>com.github.almasb</groupId>
-            <artifactId>fxgl-controllerinput</artifactId>
-            <version>${fxgl.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>com.github.almasb</groupId>
+			<artifactId>fxgl-controllerinput</artifactId>
+			<version>${fxgl.version}</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,9 @@
 	<url>https://github.com/mars-sim/mars-sim</url>
 	<inceptionYear>2009</inceptionYear>
 	<properties>
-		<release>21</release>
-		
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>		
 		<sonar.java.source>21</sonar.java.source>
 
 		<fxgl.version>11.17</fxgl.version>
@@ -173,101 +174,4 @@
 		<module>mars-sim-ui</module>
     	<module>mars-sim-dist</module>
 	</modules>
-  
-	<!-- ************************************************************************************************* -->
-	<!-- * Build Section * -->
-	<!-- ************************************************************************************************* -->
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-				    <groupId>org.codehaus.mojo</groupId>
-				    <artifactId>versions-maven-plugin</artifactId>
-				    <version>2.20.1</version>
-				    <configuration>
-				        <generateBackupPoms>false</generateBackupPoms>
-				    </configuration>
-				</plugin>
-				<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
-				<plugin>
-				    <groupId>org.apache.maven.plugins</groupId>
-				    <artifactId>maven-surefire-plugin</artifactId>
-				    <version>3.5.4</version>
-				   <!-- surefire-junit-platform below is needed for maven-surefire-plugin -->
-			        <dependencies>
-				        <dependency>
-				            <groupId>org.apache.maven.surefire</groupId>
-				            <artifactId>surefire-junit-platform</artifactId>
-				            <version>3.5.4</version>
-				        </dependency>
-			        </dependencies>
-				    <configuration>
-                        <!--<argLine>-Duser.language=en -Duser.region=US</argLine>-->
-						<includes>
-							<include>%regex[.*]</include>
-						</includes>
-				    </configuration>
-				</plugin>				
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.14.1</version>
-					<configuration>
-						<release>${release}</release>
-						<compilerArgs>
-			            	<arg>-Xlint:unchecked</arg>
-			            	<arg>-Xlint:deprecation</arg>
-			            	<arg>-Xlint:removal</arg>
-						</compilerArgs>
-						<showWarnings>false</showWarnings>
-                        <showDeprecation>false</showDeprecation>
-						<verbose>false</verbose>
-					</configuration>
-					<!-- see https://www.baeldung.com/kotlin-maven-java-project -->
-					<!-- see https://kotlinlang.org/docs/reference/using-maven.html -->
-	       			<executions>
-		                <!-- Replacing default-compile as it is treated specially by maven -->
-		                <execution>
-		                    <id>default-compile</id>
-		                    <phase>none</phase>
-		                </execution>
-		                <!-- Replacing default-testCompile as it is treated specially by maven -->
-		                <execution>
-		                    <id>default-testCompile</id>
-		                    <phase>none</phase>
-		                </execution>
-		                <execution>
-		                    <id>java-compile</id>
-		                    <phase>compile</phase>
-		                    <goals> <goal>compile</goal> </goals>
-		                </execution>
-		                <execution>
-		                    <id>java-test-compile</id>
-		                    <phase>test-compile</phase>
-		                    <goals> <goal>testCompile</goal> </goals>
-		                </execution>
-	            	</executions>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
-	<!-- ************************************************************************************************* -->
-	<!-- * Reporting Section * -->
-	<!-- ************************************************************************************************* -->
-	<reporting>
-		<plugins>
-			<plugin>
-				<!-- https://maven.apache.org/plugins/maven-dependency-plugin/examples/copying-project-dependencies.html -->
-				<!-- See https://maven.apache.org/plugins/maven-dependency-plugin/usage.html -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.9.0</version>
-				<configuration>
-					<outputDirectory>
-						${project.build.directory}
-					</outputDirectory>
-				</configuration>
-			</plugin>
-		</plugins>
-	</reporting>
 </project>


### PR DESCRIPTION
The latest VSCode Maven extension fails to load the project now. # It becomes confussed with the complex parent POM making the loaded projects Java8.

Changes:
- Remove plugin from main pom and allow Maven to configure
- Remove rogue propert in fxgl module