### PR TITLE
fix(ui): Docking layout

### DIFF
--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -77,6 +77,7 @@ mission.designation=Designation
 person.singular=Person
 person.plural=People
 person.birthDate=Birth Date
+person.age=Age
 person.bloodType=Blood Type
 person.emotion=Emotion
 person.energy=Energy
@@ -1178,7 +1179,6 @@ TabPanelFoodProduction.tooltip.overrideProduction=Prevents Settlers from Startin
 TabPanelFoodProduction.tooltip.selectAvailableProcess=Select an Available Food Production Process
 TabPanelFoodProduction.tooltip.selectBuilding=Select a Food Production Facility
 
-TabPanelGeneral.birthDateAndAge={0} ({1} years old)
 TabPanelGeneral.bmi=BMI
 TabPanelGeneral.bmi.normal=Normal
 TabPanelGeneral.bmi.obese1=Obese Class I
@@ -1194,7 +1194,6 @@ TabPanelGeneral.storedMass.tooltip=The stored mass on this person
 EntityGeneral.title=General
 EntityGeneral.tooltip=General Info about Entity
 
-TabPanelGeneral.weight=Weight
 TabPanelGeneralEquipment.regOwner=Registered Owner
 TabPanelPersonality.title=Personality
 TabPanelPersonality.mbti.title=Myers-Briggs Type Indicator (MBTI)

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/MarsPanelBorder.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/MarsPanelBorder.java
@@ -6,6 +6,7 @@
  */
 package com.mars_sim.ui.swing;
 
+import javax.swing.BorderFactory;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EtchedBorder;
 
@@ -22,6 +23,6 @@ public class MarsPanelBorder extends CompoundBorder {
 	 */
 	public MarsPanelBorder() {
 
-		super(new EtchedBorder(), StyleManager.newEmptyBorder());
+		super(new EtchedBorder(), BorderFactory.createEmptyBorder(1, 1, 1, 1));
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/StyleManager.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/StyleManager.java
@@ -181,6 +181,8 @@ public class StyleManager {
     private static Font smallLabelFont;
 
     private static Map<String,Properties> styles = new HashMap<>();
+
+    private static boolean debugEnabled = false;
     
     // Creates the built-in defaults.
     static {
@@ -523,5 +525,21 @@ public class StyleManager {
 		listScroller.setBorder(StyleManager.createLabelBorder(title));
 
         return listScroller;
+    }
+
+    /**
+     * Enabled the UI debug mode.
+     * @param debug New debug setting.
+     */
+    public static void setDebug(boolean debug) {
+        debugEnabled = debug;
+    }
+
+    /**
+     * Is the UI in debug mode.
+     * @return Debug enabled
+     */
+    public static boolean isDebug() {
+        return debugEnabled;
     }
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/StyleManager.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/StyleManager.java
@@ -7,7 +7,6 @@
 package com.mars_sim.ui.swing;
 
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Font;
 import java.awt.Image;
 import java.text.DecimalFormat;
@@ -19,17 +18,12 @@ import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
-import javax.swing.JScrollPane;
 import javax.swing.SwingConstants;
 import javax.swing.UIDefaults;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
-import javax.swing.border.Border;
-import javax.swing.border.EmptyBorder;
-import javax.swing.border.TitledBorder;
 import javax.swing.plaf.ColorUIResource;
 
 import com.formdev.flatlaf.FlatLaf;
@@ -277,11 +271,10 @@ public class StyleManager {
         // Adjust colors on JTable
         UIDefaults defaults = UIManager.getLookAndFeelDefaults();
         Color selBackground = (Color) defaults.get("Table.selectionBackground");
-        if (defaults.get(TABLE_ALTERNATE_ROW_COLOR) == null) {
+        defaults.computeIfAbsent(TABLE_ALTERNATE_ROW_COLOR, k -> {
             Color tabBackground = (Color) defaults.get("Table.background");
-
-            defaults.put(TABLE_ALTERNATE_ROW_COLOR, getTableAlternativeColor(selBackground, tabBackground));
-        }
+            return getTableAlternativeColor(selBackground, tabBackground);
+        });
 
         // Table Header is a shade off from the inactive select colour
         if (accentColor != null) {
@@ -437,20 +430,7 @@ public class StyleManager {
     public static void applySubHeading(JComponent item) {
         item.setFont(subHeadingFont);
     }
-
-    /**
-     * Creates a titled border that uses the sub title font.
-     * 
-     * @param title
-     * @return
-     */
-    public static Border createLabelBorder(String title) {
-        return BorderFactory.createTitledBorder(null, title, TitledBorder.DEFAULT_JUSTIFICATION,
-                                                        TitledBorder.DEFAULT_POSITION,
-                                                        subTitleFont, (Color)null);
-    }
-
-    /**
+ /**
      * Gets the tab placement for JTabbedPanes.
      */
     public static int getTabPlacement() {
@@ -504,27 +484,6 @@ public class StyleManager {
      */
     public static Image getIconImage() {
     	return ImageLoader.getImage("lander_hab91.png");
-    }
-
-    /**
-     * Creates a standardized empty border.
-     */
-    public static Border newEmptyBorder() {
-    	return new EmptyBorder(1, 1, 1, 1);
-    }
-
-    /**
-     * Creates a scroll pane with border and title
-     * 
-     * @param title
-     * @param content
-     * @return
-     */
-    public static JScrollPane createScrollBorder(String title, Component content) {
-		JScrollPane listScroller = new JScrollPane(content);
-		listScroller.setBorder(StyleManager.createLabelBorder(title));
-
-        return listScroller;
     }
 
     /**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/astroarts/DateDialog.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/astroarts/DateDialog.java
@@ -28,7 +28,7 @@ import javax.swing.WindowConstants;
 import javax.swing.border.EmptyBorder;
 
 import com.mars_sim.core.astroarts.ATime;
-import com.mars_sim.ui.swing.StyleManager;
+import com.mars_sim.ui.swing.utils.SwingHelper;
 import com.mars_sim.ui.swing.utils.AttributePanel;
 
 
@@ -62,14 +62,11 @@ public class DateDialog extends JDialog {
 		setLayout(new BorderLayout());
 		
 		JPanel currentPanel = new JPanel(new BorderLayout());
-		currentPanel.setBorder(new EmptyBorder(5, 5, 5, 5));
+		currentPanel.setBorder(SwingHelper.createLabelBorder("Current Date"));
 		add(currentPanel, BorderLayout.CENTER);
-
-		currentPanel.setBorder(StyleManager.createLabelBorder("Current Date"));	
 
 		AttributePanel attrPanel = new AttributePanel();
 		currentPanel.add(attrPanel, BorderLayout.NORTH);
-		
 		// Controls
 		monthCB = new JComboBox<>();
 		for (int i = 0; i < 12; i++) {
@@ -100,12 +97,13 @@ public class DateDialog extends JDialog {
 		add(choosePanel, BorderLayout.NORTH);
 		
 		JPanel chooseDatePanel = new JPanel(new GridLayout(4, 1, 0, 0));			
-		chooseDatePanel.setBorder(StyleManager.createLabelBorder("Choose Your Date"));	
-		choosePanel.add(chooseDatePanel, BorderLayout.CENTER);
+	chooseDatePanel.setBorder(SwingHelper.createLabelBorder("Choose Your Date"));	
 		
 		buttonSimDate = new JRadioButton("Simulation Date");
 		buttonSimDate.setBorder(new EmptyBorder(0, 15, 0, 0));
 		chooseDatePanel.add(buttonSimDate);
+		choosePanel.add(chooseDatePanel, BorderLayout.CENTER);
+
 		buttonSimDate.addActionListener(e -> {
 				monthCB.setSelectedIndex(earthTime.getMonthValue() - 1);
 				tfDate.setText(Integer.toString(earthTime.getDayOfMonth()));

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/AuthorityEditor.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/AuthorityEditor.java
@@ -144,13 +144,13 @@ public class AuthorityEditor  {
 
 		// Create main panel.
 		JPanel mainPane = new JPanel(new BorderLayout());
-		mainPane.setBorder(StyleManager.newEmptyBorder());
+		mainPane.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
 		f.getContentPane().add(mainPane);
 		
 		// Create main panel.
 		JPanel contentPane = new JPanel();
 		contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.X_AXIS));
-		contentPane.setBorder(StyleManager.newEmptyBorder());
+		contentPane.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
 		mainPane.add(contentPane, BorderLayout.CENTER);
 				
 		JPanel leftPanel = new JPanel(new BorderLayout());
@@ -202,7 +202,7 @@ public class AuthorityEditor  {
 		genderRatio.setMinorTickSpacing(5);
 		genderRatio.setPaintTicks(true);
 		genderRatio.setPaintLabels(true);
-		Hashtable<Integer,JComponent> labelTable = new Hashtable<>();
+		var labelTable = new Hashtable<Integer, JComponent>();
 		labelTable.put(0, new JLabel("All Female") );
 		labelTable.put(50, new JLabel("Even") );
 		labelTable.put(100, new JLabel("All Male") );

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/CrewEditor.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/CrewEditor.java
@@ -160,7 +160,53 @@ public class CrewEditor implements ActionListener {
 			int num = i + 1;
 			displayPanel.setBorder(BorderFactory.createTitledBorder("Crewman " + num + " "));
 		}
+			
+		/**
+		 * Set up the sponsor comboxbox model
+		 * 
+		 * @return DefaultComboBoxModel<String>
+		 */
+		private DefaultComboBoxModel<String> setUpSponsorCBModel() {
+						
+			DefaultComboBoxModel<String> m = new DefaultComboBoxModel<>();
+			m.addElement(SETTLEMENT_SPONSOR);
+			m.addAll(raFactory.getItemNames());
+			return m;
+		}
+	
+		/**
+		 * Set up the country comboxbox model
+		 * 
+		 * @return DefaultComboBoxModel<String>
+		 */
+		private DefaultComboBoxModel<String> setUpCountryCBModel() {
+			DefaultComboBoxModel<String> m = new DefaultComboBoxModel<>();
+
+			populateCountryCombo(SETTLEMENT_SPONSOR, m);
+			return m;
+		}
 		
+		/**
+		 * Load the country model from a ReportingAuthority
+		 * @param sponsor
+		 * @param model
+		 */
+		private void populateCountryCombo(String sponsorCode, DefaultComboBoxModel<String> model) {
+			// removing old data
+			model.removeAllElements();
+
+			if ((sponsorCode == null) || SETTLEMENT_SPONSOR.equals(sponsorCode)) {
+				// Load all known countries
+				NationSpecConfig nameConfig = new NationSpecConfig(SimulationConfig.instance());
+				model.addAll(nameConfig.getItemNames());			
+			}
+			else {
+				// Load the countries from RA
+				Authority ra = raFactory.getItem(sponsorCode);
+				model.addAll(ra.getCountries());
+			}
+		}
+	
 		@Override
 		public void actionPerformed(ActionEvent e) {
 			removeMember(this);
@@ -427,13 +473,13 @@ public class CrewEditor implements ActionListener {
 		// Create main panel.
 		mainPane = new JPanel(new BorderLayout());
 		mainPane.setPreferredSize(new Dimension(WIDTH, HEIGHT));
-		mainPane.setBorder(StyleManager.newEmptyBorder());
+		mainPane.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
 		f.getContentPane().add(mainPane);
 		
 		// Create main panel.
 		scrollPane = new JPanel();
 		scrollPane.setLayout(new BoxLayout(scrollPane, BoxLayout.X_AXIS));
-		scrollPane.setBorder(StyleManager.newEmptyBorder());
+		scrollPane.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
 
 		// Prepare scroll panel.
 		JScrollPane scrollPanel = new JScrollPane(scrollPane);
@@ -542,18 +588,14 @@ public class CrewEditor implements ActionListener {
 	 * @param loadFromXML
 	 * @return
 	 */
-	private static boolean retrieveCrewMBTI(Member m , int row) {
-				
-		if (row == 0)
-			return m.isExtrovert();
-		else if (row == 1)
-			return m.isIntuitive();
-		else if (row == 2)
-			return m.isFeeler();
-		else if (row == 3)
-			return m.isJudger();
-		else
-			return false;		
+	private static boolean retrieveCrewMBTI(Member m , int row) {		
+		return switch (row) {
+			case 0 -> m.isExtrovert();
+			case 1 -> m.isIntuitive();
+			case 2 -> m.isFeeler();
+			case 3 -> m.isJudger();
+			default -> false;
+		};		
 	}
 
 	/**
@@ -616,55 +658,6 @@ public class CrewEditor implements ActionListener {
 		return m;
 	}
 
-	/**
-	 * Set up the country comboxbox model
-	 * 
-	 * @return DefaultComboBoxModel<String>
-	 */
-	private DefaultComboBoxModel<String> setUpCountryCBModel() {
-		DefaultComboBoxModel<String> m = new DefaultComboBoxModel<>();
-
-		populateCountryCombo(SETTLEMENT_SPONSOR, m);
-		return m;
-	}
-	
-	/**
-	 * Set up the sponsor comboxbox model
-	 * 
-	 * @param country
-	 * @return DefaultComboBoxModel<String>
-	 */
-	private DefaultComboBoxModel<String> setUpSponsorCBModel() {
-					
-		DefaultComboBoxModel<String> m = new DefaultComboBoxModel<>();
-		m.addElement(SETTLEMENT_SPONSOR);
-		m.addAll(raFactory.getItemNames());
-		return m;
-	}
- 
-
-	/**
-	 * Load the country model from a ReportingAuthority
-	 * @param sponsor
-	 * @param model
-	 */
-	private void populateCountryCombo(String sponsorCode, DefaultComboBoxModel<String> model) {
-		// removing old data
-		model.removeAllElements();
-
-		if ((sponsorCode == null) || SETTLEMENT_SPONSOR.equals(sponsorCode)) {
-			// Load all known countries
-			NationSpecConfig nameConfig = new NationSpecConfig(SimulationConfig.instance());
-			model.addAll(nameConfig.getItemNames());			
-		}
-		else {
-			// Load the countries from RA
-			Authority ra = raFactory.getItem(sponsorCode);
-			model.addAll(ra.getCountries());
-		}
-	}
-	
-	
 	private void designateCrew(Crew newCrew) {		
 		String crewName = newCrew.getName();
 		List<Member> members = newCrew.getTeam();

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/desktop/MainDesktopPane.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/desktop/MainDesktopPane.java
@@ -52,6 +52,7 @@ import com.mars_sim.ui.swing.tool.commander.CommanderWindow;
 import com.mars_sim.ui.swing.tool.monitor.EntityMonitorModel;
 import com.mars_sim.ui.swing.tool.monitor.MonitorWindow;
 import com.mars_sim.ui.swing.tool.time.TimeTool;
+import com.mars_sim.ui.swing.utils.SwingHelper;
 
 /**
  * The MainDesktopPane class is the desktop part of the project's UI. It
@@ -153,7 +154,7 @@ public class MainDesktopPane extends JDesktopPane
 
 		if (screenSize == null || screenSize.getWidth() == 0 || screenSize.getHeight() == 0) {
 			screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-			logger.config("Toolkit default screen size is " + screenSize.getWidth() + " x " + screenSize.getHeight());
+			logger.config("Toolkit default screen size is " + SwingHelper.toString(screenSize));
 		}
 
 		Image backgroundImage = createImage((int) screenSize.getWidth(), (int) screenSize.getHeight());

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/desktop/MainWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/desktop/MainWindow.java
@@ -185,7 +185,7 @@ public class MainWindow
 		if (selectedSize != null) {
 			// Set frame size
 			frame.setSize(selectedSize);
-			logger.config("Last saved window dimension: " + selectedSize);
+			logger.config("Last saved window dimension: " + SwingHelper.toString(selectedSize));
 		}
 
 		return true;
@@ -208,11 +208,7 @@ public class MainWindow
 
 		frame.setSize(selectedSize);
 
-		logger.config("Default main window dimension: "
-				+ selectedSize.width
-				+ " x "
-				+ selectedSize.height
-				+ ".");
+		logger.config("Default main window dimension: " + SwingHelper.toString(selectedSize));
 
 		initX = (int)(screenWidth - selectedSize.width) / 2;
 		initY = (int)(screenHeight - selectedSize.height) / 2;
@@ -220,9 +216,9 @@ public class MainWindow
 
 		logger.config("Use default configuration to set main window's frame to the center of the screen.");
 		logger.config("The main window frame is centered and starts at ("
-				+ (screenWidth - selectedSize.width) / 2
+				+ initX
 				+ ", "
-				+ (screenHeight - selectedSize.height) / 2
+				+ initY
 				+ ").");
 	}
 
@@ -244,16 +240,16 @@ public class MainWindow
 			var mode = gd.getDisplayMode();
 			frameSize = new Dimension(mode.getWidth(), mode.getHeight());
 			logger.config("Use default screen configuration.");
-			logger.config("Selected screen size is " + frameSize.width + " x " + frameSize.height);
+			logger.config("Selected screen size is " + SwingHelper.toString(frameSize));
 		} else {
 			// Use any stored size
 			frameSize = dimension;
-			logger.config("Use last saved window size " + frameSize.width + " x " + frameSize.height);
+			logger.config("Use last saved window size " + SwingHelper.toString(frameSize));
 		}
 
 		Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
 		if (screenSize != null) {
-			logger.config("Current toolkit screen size is " + screenSize.width + " x " + screenSize.height);
+			logger.config("Current toolkit screen size is " + SwingHelper.toString(screenSize));
 
 			if (frameSize != null) {
 				// Check selected is not bigger than the screen
@@ -270,11 +266,10 @@ public class MainWindow
 					frameSize = new Dimension(
 							(int) Math.round(screenSize.getWidth() * .8),
 							(int) Math.round(screenSize.getHeight() * .8));
-					logger.config("New window size is " + frameSize.width + " x " + frameSize.height);
 				} else {
 					frameSize = new Dimension(screenSize);
-					logger.config("New window size is " + frameSize.width + " x " + frameSize.height);
 				}
+				logger.config("New window size is " + SwingHelper.toString(frameSize));
 			}
 		}
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/docking/DockingAdapter.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/docking/DockingAdapter.java
@@ -9,11 +9,11 @@ package com.mars_sim.ui.swing.docking;
 import java.awt.BorderLayout;
 
 import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 
 import com.mars_sim.ui.swing.ContentPanel;
 
 import io.github.andrewauclair.moderndocking.Dockable;
-import io.github.andrewauclair.moderndocking.app.Docking;
 
 /**
  * Adapter class to wrap a ContentPanel as a Dockable for use in the docking framework.
@@ -24,7 +24,6 @@ class DockingAdapter extends JPanel implements Dockable {
 
     public DockingAdapter(ContentPanel contentPanel) {
         this.content = contentPanel;
-        Docking.registerDockable(this);
 
         setLayout(new BorderLayout());
         add(contentPanel, BorderLayout.CENTER);
@@ -38,6 +37,22 @@ class DockingAdapter extends JPanel implements Dockable {
     @Override
     public String getTabText() {
         return content.getTitle();
+    }
+
+    /**
+     * There is no listener to trap when a Dockable is closed so this method is used to 
+     * notify the DockingWindow that the content panel is being closed so it can be deregistered and destroyed.
+     */
+    @Override
+    public boolean requestClose() {
+
+        // Line up the close in the future
+        DockingWindow window = (DockingWindow) getTopLevelAncestor();
+        SwingUtilities.invokeLater(() ->
+            window.closeContentPanel(this)
+        );
+        // Return true to allow the close to proceed.
+        return true;
     }
 
     /**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/docking/DockingAdapter.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/docking/DockingAdapter.java
@@ -102,10 +102,12 @@ class DockingAdapter extends JPanel implements Dockable {
     public boolean requestClose() {
 
         // Line up the close in the future, cannot deregister until after the call stack unwinds
-        DockingWindow window = (DockingWindow) getTopLevelAncestor();
-        SwingUtilities.invokeLater(() ->
-            window.closeContentPanel(this)
-        );
+        var topLevelAncestor = getTopLevelAncestor();
+        if (topLevelAncestor instanceof DockingWindow window) {
+            SwingUtilities.invokeLater(() ->
+                window.closeContentPanel(this)
+            );
+        }
         // Return true to allow the close to proceed.
         return true;
     }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/docking/DockingAdapter.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/docking/DockingAdapter.java
@@ -7,11 +7,18 @@
 package com.mars_sim.ui.swing.docking;
 
 import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 
 import com.mars_sim.ui.swing.ContentPanel;
+import com.mars_sim.ui.swing.StyleManager;
+import com.mars_sim.ui.swing.utils.SwingHelper;
 
 import io.github.andrewauclair.moderndocking.Dockable;
 
@@ -21,12 +28,60 @@ import io.github.andrewauclair.moderndocking.Dockable;
 class DockingAdapter extends JPanel implements Dockable {
 
     private ContentPanel content;
+    private JLabel contentLabel;
+    private JLabel contentSize;
 
+    /**
+     * Create a new DockingAdapter to wrap the given content panel.
+     * @param contentPanel Panel holding the content.
+     */
     public DockingAdapter(ContentPanel contentPanel) {
         this.content = contentPanel;
 
         setLayout(new BorderLayout());
         add(contentPanel, BorderLayout.CENTER);
+
+        // Add a diagnostic panel if debug mode
+        if (StyleManager.isDebug()) {
+            add(createDiagPanel(), BorderLayout.SOUTH);
+        }
+    }
+
+    /**
+     * Create a panel to display diagnostic information about the content panel. This is only shown in debug mode.
+     * @return the diagnostic panel
+     */
+    private Component createDiagPanel() {
+        var header = new JPanel(new FlowLayout());
+
+        contentLabel = new JLabel();
+        contentLabel.setFont(StyleManager.getSmallLabelFont());
+        header.add(contentLabel);
+
+        contentSize = new JLabel();
+        contentSize.setFont(StyleManager.getSmallLabelFont());
+        header.add(contentSize);
+
+        updateDiagPanel();
+
+        // Listen for size changes to update the diagnostic info        
+        addComponentListener(new ComponentAdapter() {
+            @Override
+            public void componentResized(ComponentEvent evt) {
+                updateDiagPanel();
+            }
+
+            @Override
+            public void componentShown(ComponentEvent evt) {
+                updateDiagPanel();
+            }
+        });
+        return header;
+    }
+
+    private void updateDiagPanel() {
+        contentLabel.setText("Content Min: " + SwingHelper.toString(content.getMinimumSize()));
+        contentSize.setText("Content Size: " + SwingHelper.toString(content.getSize()));
     }
 
     @Override
@@ -46,7 +101,7 @@ class DockingAdapter extends JPanel implements Dockable {
     @Override
     public boolean requestClose() {
 
-        // Line up the close in the future
+        // Line up the close in the future, cannot deregister until after the call stack unwinds
         DockingWindow window = (DockingWindow) getTopLevelAncestor();
         SwingUtilities.invokeLater(() ->
             window.closeContentPanel(this)

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/docking/DockingWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/docking/DockingWindow.java
@@ -27,6 +27,7 @@ import javax.swing.WindowConstants;
 
 import com.mars_sim.core.Entity;
 import com.mars_sim.core.Simulation;
+import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.ClockPulseListener;
 import com.mars_sim.core.time.CompressedClockListener;
@@ -88,6 +89,8 @@ public class DockingWindow extends JFrame
             return DockableStyle.CENTER_ONLY;
         }
     }
+
+    private static SimLogger logger = SimLogger.getLogger(DockingWindow.class.getName());
 
     private Simulation sim;
     private Set<DockingAdapter> windows = new HashSet<>();
@@ -184,12 +187,28 @@ public class DockingWindow extends JFrame
     }
 
     /**
+     * This method is called by a DockingAdapter when its content panel is closed. It will deregister the Dockable
+     * and destroy the ContentPanel.
+     * 
+     * @param panel Panel being closed.
+     */
+    void closeContentPanel(DockingAdapter panel) {
+        logger.info("Closing content panel: " + panel.getPersistentID());
+        Docking.deregisterDockable(panel);
+        windows.remove(panel);
+        panel.getContent().destroy();
+    }
+
+    /**
      * Add a content panel to the docking window. This will wrap the panel in a DockingAdapter
      * and dock it to the appropriate region based on its placement.
      * @param panel Content to add
      */
     private void addContentPanel(ContentPanel panel) {
         var w = new DockingAdapter(panel);
+        
+        Docking.registerDockable(w);
+        logger.info("Content Panel registered: " + w.getPersistentID() + " " + panel.getTitle());
 
         // Check if there is a target for dockering already in the Placement
         var target = anchors.get(panel.getPlacement());

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/EntityContentPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/EntityContentPanel.java
@@ -154,7 +154,7 @@ public class EntityContentPanel<T extends Entity> extends ContentPanel
      */
     protected void applyProps(Properties props) {
         // Add the listener panel if the entity is MonitorableEntity
-        if (entity instanceof MonitorableEntity m) {
+        if (StyleManager.isDebug() &&entity instanceof MonitorableEntity m) {
             addTabPanel(new ListenerTabPanel(m, context));
         }
         

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/EntityContentPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/EntityContentPanel.java
@@ -154,7 +154,7 @@ public class EntityContentPanel<T extends Entity> extends ContentPanel
      */
     protected void applyProps(Properties props) {
         // Add the listener panel if the entity is MonitorableEntity
-        if (StyleManager.isDebug() &&entity instanceof MonitorableEntity m) {
+        if (StyleManager.isDebug() && entity instanceof MonitorableEntity m) {
             addTabPanel(new ListenerTabPanel(m, context));
         }
         

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/construction/TabPanelSiteGeneral.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/construction/TabPanelSiteGeneral.java
@@ -32,6 +32,7 @@ import com.mars_sim.ui.swing.entitywindow.EntityTabPanel;
 import com.mars_sim.ui.swing.tool.svg.SVGMapUtil;
 import com.mars_sim.ui.swing.utils.AttributePanel;
 import com.mars_sim.ui.swing.utils.ConstructionStageFormat;
+import com.mars_sim.ui.swing.utils.SwingHelper;
 import com.mars_sim.ui.swing.utils.ToolTipTableModel;
 
 /**
@@ -103,7 +104,7 @@ class TabPanelSiteGeneral extends EntityTabPanel<ConstructionSite>
 		};
 		phaseTable.setPreferredScrollableViewportSize(new Dimension(225, -1));
 
-		var scrollPane = StyleManager.createScrollBorder("Remaining Phases", phaseTable);
+		var scrollPane = SwingHelper.createScrollBorder("Remaining Phases", phaseTable, null);
 		scrollPane.getVerticalScrollBar().setUnitIncrement(16);
 		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
 		content.add(scrollPane, BorderLayout.CENTER);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/mission/TabPanelAssigned.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/mission/TabPanelAssigned.java
@@ -40,6 +40,7 @@ import com.mars_sim.ui.swing.components.TableModelUpdater;
 import com.mars_sim.ui.swing.entitywindow.EntityTableTabPanel;
 import com.mars_sim.ui.swing.utils.AttributePanel;
 import com.mars_sim.ui.swing.utils.EntityModel;
+import com.mars_sim.ui.swing.utils.SwingHelper;
 
 /**
  * Tab panel for assigned mission members and Vehicles.
@@ -84,7 +85,7 @@ class TabPanelAssigned extends EntityTableTabPanel<Mission>
 		
 		// Prepare attribute panel.
 		AttributePanel attributePanel = new AttributePanel();
-        attributePanel.setBorder(StyleManager.createLabelBorder(Msg.getString("vehicle.singular")));
+        attributePanel.setBorder(SwingHelper.createLabelBorder(Msg.getString("vehicle.singular")));
 
 		attributePanel.addLabelledItem(Msg.getString("entity.name"), new EntityLabel(v, getContext()));
 		vehicleStatusLabel = attributePanel.addTextField(Msg.getString("vehicle.status"), "", null);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/mission/objectives/CollectResourcePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/mission/objectives/CollectResourcePanel.java
@@ -21,6 +21,7 @@ import com.mars_sim.core.mission.objectives.CollectResourceObjective;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.ui.swing.StyleManager;
 import com.mars_sim.ui.swing.utils.AttributePanel;
+import com.mars_sim.ui.swing.utils.SwingHelper;
 
 /**
  * A panel for displaying collect resources objectives information.
@@ -69,7 +70,7 @@ public class CollectResourcePanel extends JPanel implements EntityListener {
 		list.setVisibleRowCount(-1);
 
 
-		return StyleManager.createScrollBorder(title, list);
+		return SwingHelper.createScrollBorder(title, list, null);
 	}
 
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/mission/objectives/ConstructionPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/mission/objectives/ConstructionPanel.java
@@ -38,6 +38,7 @@ import com.mars_sim.ui.swing.UIContext;
 import com.mars_sim.ui.swing.components.EntityLabel;
 import com.mars_sim.ui.swing.utils.AttributePanel;
 import com.mars_sim.ui.swing.utils.ConstructionStageFormat;
+import com.mars_sim.ui.swing.utils.SwingHelper;
 
 /**
  * A panel for displaying construction custom mission information.
@@ -87,7 +88,7 @@ public class ConstructionPanel extends JPanel implements EntityListener, Objecti
         
         // Create remaining construction materials label.
         String remainingMaterialsLabelString = Msg.getString("ConstructionMissionCustomInfoPanel.constructionMaterials"); //$NON-NLS-1$
-        Border blackline = StyleManager.createLabelBorder(remainingMaterialsLabelString);
+        Border blackline = SwingHelper.createLabelBorder(remainingMaterialsLabelString);
         remainingMaterialsLabelPane.setBorder(blackline);
         
         // Create the materials table and model.

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/mission/objectives/ExplorationPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/mission/objectives/ExplorationPanel.java
@@ -26,6 +26,7 @@ import com.mars_sim.core.mission.objectives.ExplorationObjective;
 import com.mars_sim.core.person.ai.mission.Exploration;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.ui.swing.StyleManager;
+import com.mars_sim.ui.swing.utils.SwingHelper;
 
 
 /**
@@ -65,7 +66,7 @@ public class ExplorationPanel extends JPanel
 		sitesPane = new JPanel();
 		sitesPane.setLayout(new BoxLayout(sitesPane, BoxLayout.PAGE_AXIS));
 
-		horz.add(StyleManager.createScrollBorder("Sites", sitesPane));
+		horz.add(SwingHelper.createScrollBorder("Sites", sitesPane, null));
 
 		sitePanes = new HashMap<>();
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/mission/objectives/MiningPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/mission/objectives/MiningPanel.java
@@ -28,6 +28,7 @@ import com.mars_sim.ui.swing.UIContext;
 import com.mars_sim.ui.swing.components.EntityLabel;
 import com.mars_sim.ui.swing.components.NumberCellRenderer;
 import com.mars_sim.ui.swing.utils.AttributePanel;
+import com.mars_sim.ui.swing.utils.SwingHelper;
 
 /**
  * A panel for displaying mining mission information.
@@ -66,7 +67,7 @@ public class MiningPanel extends JPanel
 		excavationTableModel = new MineralTableModel(objective.getMineralStats());
 		JTable excavationTable = new JTable(excavationTableModel);
 		excavationTable.setDefaultRenderer(Double.class, new NumberCellRenderer(2));
-		add(StyleManager.createScrollBorder("Minerals Excavated", excavationTable), BorderLayout.CENTER);
+		add(SwingHelper.createScrollBorder("Minerals Excavated", excavationTable, null), BorderLayout.CENTER);
 	}
 
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/main/MarsProject.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/main/MarsProject.java
@@ -49,15 +49,14 @@ public class MarsProject {
 	private static final String NEW = "new";
 	private static final String DOCKINGUI = "dockingui";
 	private static final String CLEANUI = "cleanui";
-	private static final String SANDBOX = "sandbox";
 	private static final String SITE_EDITOR = "site";
 	private static final String LOAD_ARG = "load";
+	private static final String DEBUGUI = "debugui";
 	
 	/** true if displaying graphic user interface. */
 	private boolean useNew = false;
 	private boolean useCleanUI = false;
 	private boolean useSiteEditor;
-	private boolean isSandbox = false;
 	private boolean useDockingUI = false;
 	private boolean useAudio = true;
 
@@ -256,8 +255,8 @@ public class MarsProject {
 				.desc("Disable loading stored UI configurations").get());
 		options.addOption(Option.builder(DOCKINGUI)
 				.desc("Enable the docking UI").get());
-		options.addOption(Option.builder(SANDBOX)
-				.desc("Start in Sandbox Mode").get());
+		options.addOption(Option.builder(DEBUGUI)
+				.desc("Enable debug UI").get());
 		options.addOption(Option.builder(NEW)
 				.desc("Enable quick start").get());
 		options.addOption(Option.builder(SITE_EDITOR)
@@ -278,6 +277,7 @@ public class MarsProject {
 				usage("See available options below", options);
 			}
 			useNew = line.hasOption(NEW);
+			StyleManager.setDebug(line.hasOption(DEBUGUI));
 			useCleanUI = line.hasOption(CLEANUI);
 			useDockingUI = line.hasOption(DOCKINGUI);
 
@@ -289,7 +289,6 @@ public class MarsProject {
 			}
 			
 			useSiteEditor = line.hasOption(SITE_EDITOR);
-			isSandbox = line.hasOption(SANDBOX);
 		}
 		catch (ParseException e) {
 			usage("Problem with arguments: " + e.getMessage(), options);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/main/SelectionDialog.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/main/SelectionDialog.java
@@ -29,9 +29,9 @@ import javax.swing.JTextArea;
 
 import com.mars_sim.core.configuration.UserConfigurable;
 import com.mars_sim.core.tool.Msg;
-import com.mars_sim.ui.swing.StyleManager;
 import com.mars_sim.ui.swing.components.UserConfigurableListRenderer;
 import com.mars_sim.ui.swing.utils.SortedComboBoxModel;
+import com.mars_sim.ui.swing.utils.SwingHelper;
 
 /**
  * This is a modal dialog used to allow the user to complete a selection of a list of options.
@@ -66,7 +66,7 @@ class SelectionDialog extends JDialog {
     protected static<T extends UserConfigurable> JPanel createComboPane(String label, Collection<T> potentials,
                                                     Consumer<T> listener) {
         var contentPane = new JPanel();
-        contentPane.setBorder(StyleManager.createLabelBorder(label));
+        contentPane.setBorder(SwingHelper.createLabelBorder(label));
         contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.Y_AXIS));
 
         var selectPanel = new JPanel();

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/ToolRegistry.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/ToolRegistry.java
@@ -6,6 +6,7 @@
  */
 package com.mars_sim.ui.swing.tool;
 
+import java.util.List;
 import java.util.Properties;
 
 import com.mars_sim.core.Simulation;
@@ -44,7 +45,7 @@ public class ToolRegistry {
     public record ToolInfo(String name, ToolCategory category, String title, String iconName) {}
 
     // List of all available tools
-    public static final ToolInfo[] TOOL_INFOS = {
+    public static final List<ToolInfo> TOOL_INFOS = List.of(
         new ToolInfo(NavigatorWindow.NAME, ToolCategory.GENERIC, NavigatorWindow.TITLE, NavigatorWindow.ICON),
         new ToolInfo(SettlementWindow.NAME, ToolCategory.GENERIC, SettlementWindow.TITLE, SettlementWindow.ICON),
         new ToolInfo(EntityBrowser.NAME, ToolCategory.GENERIC, EntityBrowser.TITLE, EntityBrowser.ICON),
@@ -56,7 +57,7 @@ public class ToolRegistry {
         new ToolInfo(GuideWindow.NAME, ToolCategory.HELP, GuideWindow.TITLE, GuideWindow.ICON),
         new ToolInfo(SearchWindow.NAME, ToolCategory.UTILITY, SearchWindow.TITLE, SearchWindow.ICON),
         new ToolInfo(ConsolePanel.NAME, ToolCategory.GENERIC, ConsolePanel.TITLE, ConsolePanel.ICON)
-    };
+    );
 
     /**
      * Build a tool for the given tool name.
@@ -78,7 +79,7 @@ public class ToolRegistry {
 			case SettlementWindow.NAME -> new SettlementWindow(context, toolProps);
             case NavigatorWindow.NAME -> new NavigatorWindow(context, toolProps);
             case MonitorWindow.NAME -> new MonitorWindow(context, toolProps);
-            case ConsolePanel.NAME -> new ConsolePanel(context, toolProps);
+            case ConsolePanel.NAME -> new ConsolePanel(context);
 			default -> null;
 		};
     }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/commander/CommanderWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/commander/CommanderWindow.java
@@ -259,7 +259,7 @@ public class CommanderWindow extends ContentPanel {
 				
 		// Create content panel.
 		JPanel mainPane = new JPanel(new BorderLayout());
-		mainPane.setBorder(StyleManager.newEmptyBorder());
+		mainPane.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
 		add(mainPane);
 
 		JPanel topPane = new JPanel(new FlowLayout());

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/console/ConsolePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/console/ConsolePanel.java
@@ -15,7 +15,6 @@ import java.awt.event.KeyEvent;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -58,11 +57,12 @@ public class ConsolePanel extends ContentPanel {
     private JTextArea textArea;
     private int inputStart;
     private boolean bypassDocumentInputRestriction;
-    private Conversation conversation;
-    private Thread consoleThread;
-    private TextAreaChannel channel;
 
-    public ConsolePanel(UIContext context, Properties toolProps) {
+    private transient Conversation conversation;
+    private transient Thread consoleThread;
+    private transient TextAreaChannel channel;
+
+    public ConsolePanel(UIContext context) {
         super(NAME, TITLE, Placement.BOTTOM);
 
         buildUI();
@@ -75,7 +75,7 @@ public class ConsolePanel extends ContentPanel {
                         context.getSimulation());
         
         // Run the conversation in a Virtual thread because it is a blocking operation
-        consoleThread = Thread.ofVirtual().name("Console").start(() ->
+        consoleThread = Thread.ofVirtual().name(TITLE).start(() ->
             conversation.interact()
         );
     }
@@ -146,9 +146,8 @@ public class ConsolePanel extends ContentPanel {
         scrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
         add(scrollPane, BorderLayout.CENTER);
 
-        Dimension dim = new Dimension(700, 200);
-        //setMinimumSize(dim);
-        setPreferredSize(dim);
+        setMinimumSize(new Dimension(500, 150));
+        setPreferredSize(new Dimension(700, 200));
     }
 
     @Override
@@ -159,15 +158,6 @@ public class ConsolePanel extends ContentPanel {
         }
 
         super.destroy();
-    }
-
-    private void appendOutput(String output) {
-        if ((output == null) || output.isEmpty()) {
-            return;
-        }
-        
-        moveCaretToEnd();
-        runBypassingDocumentInputRestriction(() -> textArea.append(output));
     }
 
     /**
@@ -187,42 +177,6 @@ public class ConsolePanel extends ContentPanel {
         }
         catch (BadLocationException e) {
             // Ignore invalid caret locations
-        }
-    }
-
-    /**
-     * Check if the character is a restricted input character that should not be added to the input buffer, but should still be passed to the channel for hotkey processing.
-     * @param character Inbound character
-     * @return is restricted.
-     */
-    private boolean isRestrictedInputCharacter(char character) {
-        return (character != '\n' && Character.isISOControl(character))  
-                || character == '\t';
-    }
-
-    private String removeRestrictedInputCharacters(String text) {
-        if (text == null || text.isEmpty()) {
-            return text;
-        }
-
-        StringBuilder filtered = new StringBuilder(text.length());
-        for (int i = 0; i < text.length(); i++) {
-            char character = text.charAt(i);
-            if (!isRestrictedInputCharacter(character)) {
-                filtered.append(character);
-            }
-        }
-        return filtered.toString();
-    }
-
-    private void runBypassingDocumentInputRestriction(Runnable action) {
-        boolean previous = bypassDocumentInputRestriction;
-        bypassDocumentInputRestriction = true;
-        try {
-            action.run();
-        }
-        finally {
-            bypassDocumentInputRestriction = previous;
         }
     }
 
@@ -280,7 +234,7 @@ public class ConsolePanel extends ContentPanel {
                         break;
                     }
                     else if (character == DELETE_CHAR || character == BACKSPACE_CHAR) {
-                        if (buffer.length() > 0) {
+                        if (!buffer.isEmpty()) {
                             buffer = buffer.substring(0, buffer.length() - 1);
                         }
                     }
@@ -307,6 +261,37 @@ public class ConsolePanel extends ContentPanel {
             appendOutput(text);
         }
 
+        /**
+         * Handles writting to the text area. Ensures new text is added at the end.
+         * @param output Content to add
+         */
+        private void appendOutput(String output) {
+            if ((output == null) || output.isEmpty()) {
+                return;
+            }
+            
+            moveCaretToEnd();
+            runBypassingDocumentInputRestriction(() -> textArea.append(output));
+        }
+
+        /**
+         * Handler method to run a block of code while bypassing the document input restriction. This is necessary to allow programmatic updates to the text area (such as appending output) without being blocked by the DocumentFilter, while still enforcing input restrictions on user-typed content.
+         * @param action The block of code to execute
+         */
+        private void runBypassingDocumentInputRestriction(Runnable action) {
+            boolean previous = bypassDocumentInputRestriction;
+            bypassDocumentInputRestriction = true;
+            try {
+                action.run();
+            }
+            finally {
+                bypassDocumentInputRestriction = previous;
+            }
+        }
+
+        /**
+         * Special keystroke trigger a handler.
+         */
         @Override
         public boolean registerHandler(String keyStroke, UserOutbound listener, boolean interuptExecution) {
             hotkeys.put(keyStroke.toLowerCase(), listener);
@@ -340,7 +325,6 @@ public class ConsolePanel extends ContentPanel {
             } catch (InterruptedException e) {
                 // Restore interrupt status and exit without noisy logging
                 Thread.currentThread().interrupt();
-                return;
             }
         }
     }
@@ -413,6 +397,31 @@ public class ConsolePanel extends ContentPanel {
                 return;
             }
             super.replace(fb, offset, length, filtered, attrs);
+        }
+
+        private String removeRestrictedInputCharacters(String text) {
+            if (text == null || text.isEmpty()) {
+                return text;
+            }
+
+            StringBuilder filtered = new StringBuilder(text.length());
+            for (int i = 0; i < text.length(); i++) {
+                char character = text.charAt(i);
+                if (!isRestrictedInputCharacter(character)) {
+                    filtered.append(character);
+                }
+            }
+            return filtered.toString();
+        }
+ 
+        /**
+         * Check if the character is a restricted input character that should not be added to the input buffer, but should still be passed to the channel for hotkey processing.
+         * @param character Inbound character
+         * @return is restricted.
+         */
+        private boolean isRestrictedInputCharacter(char character) {
+            return (character != '\n' && Character.isISOControl(character))  
+                    || character == '\t';
         }
     }
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/console/ConsolePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/console/ConsolePanel.java
@@ -262,7 +262,7 @@ public class ConsolePanel extends ContentPanel {
         }
 
         /**
-         * Handles writting to the text area. Ensures new text is added at the end.
+         * Handles writing to the text area. Ensures new text is added at the end.
          * @param output Content to add
          */
         private void appendOutput(String output) {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/entitybrowser/EntityBrowser.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/entitybrowser/EntityBrowser.java
@@ -83,7 +83,7 @@ public class EntityBrowser extends ContentPanel implements EntityManagerListener
     private DefaultMutableTreeNode globalNode;
 
     public EntityBrowser(UIContext context) {
-        super(NAME, "Entity Browser", Placement.LEFT);
+        super(NAME, TITLE, Placement.LEFT);
 
         this.context = context;
         this.scienceMgr = context.getSimulation().getScientificStudyManager();
@@ -115,9 +115,8 @@ public class EntityBrowser extends ContentPanel implements EntityManagerListener
         // List for new Settlements
         unitManager.addEntityManagerListener(UnitType.SETTLEMENT, this);
 
-        var dims = new Dimension(250, 300);
-        setMinimumSize(dims);
-        setPreferredSize(dims);
+        setMinimumSize(new Dimension(250, 200));
+        setPreferredSize(new Dimension(250, 300));
     }
 
     private void buildUI(JPanel mainPane, DefaultTreeModel model) {
@@ -327,7 +326,7 @@ public class EntityBrowser extends ContentPanel implements EntityManagerListener
             case TRANSPORT -> {
                         if (settlement == null) {
                             yield transportMgr.getTransportItems().stream()
-                                                .filter(it -> it instanceof ArrivingSettlement)
+                                                .filter(ArrivingSettlement.class::isInstance)
                                                 .filter(as -> as.getTransitState() != TransitState.ARRIVED)
                                                 .toList();
                         }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/eventviewer/EventViewer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/eventviewer/EventViewer.java
@@ -126,23 +126,14 @@ public class EventViewer extends ContentPanel implements ConfigurableWindow, His
         
         add(scrollPane, BorderLayout.CENTER);
 
-        var dim = new Dimension(270, 300);
-        setPreferredSize(dim);
-        setMinimumSize(dim);
+        setPreferredSize(new Dimension(270, 400));
+        setMinimumSize(new Dimension(270, 200));
     }
     
     private boolean isEventVisible(HistoricalEvent event) {
-        // Check category filter
-        if (!selectedCategories.contains(event.getCategory())) {
-            return false;
-        }
-        
-        // Check acknowledged filter - if checkbox is unchecked, hide acknowledged events
-        if (!showAcknowledgedCheckBox.isSelected() && event.isAcknowledged()) {
-            return false;
-        }
-        
-        return true;
+        // Check category filter and acknowledged filter
+        return (selectedCategories.contains(event.getCategory())
+                && (showAcknowledgedCheckBox.isSelected() || !event.isAcknowledged()));
     }
 
     /**
@@ -156,10 +147,8 @@ public class EventViewer extends ContentPanel implements ConfigurableWindow, His
         // Filter and sort events by timestamp, most recent first
         List<HistoricalEvent> sortedEvents = events.stream()
             .filter(this::isEventVisible)
-            .sorted((e1, e2) -> {
-                return e2.getTimestamp().compareTo(e1.getTimestamp());
-            })
-            .collect(Collectors.toList());
+            .sorted((e1, e2) -> e2.getTimestamp().compareTo(e1.getTimestamp()))
+            .toList();
         
         // Create collapsible panel for each event
         for (HistoricalEvent event : sortedEvents) {
@@ -230,11 +219,11 @@ public class EventViewer extends ContentPanel implements ConfigurableWindow, His
         
         // Add acknowledged filter checkbox                
         String showAcknowledgedStr = userSettings.getProperty(SHOW_ACKNOWLEDGED, "false");
-        showAcknowledgedCheckBox = new JCheckBox("Show Acknowledged", Boolean.parseBoolean(showAcknowledgedStr));
+        showAcknowledgedCheckBox = new JCheckBox("Acknowledged", Boolean.parseBoolean(showAcknowledgedStr));
         showAcknowledgedCheckBox.setToolTipText("Show or hide acknowledged events");
-        showAcknowledgedCheckBox.addActionListener(e -> {
-            loadEvents(); // Refresh the event list when checkbox changes
-        });
+        showAcknowledgedCheckBox.addActionListener(e -> 
+            loadEvents() // Refresh the event list when checkbox changes
+        );
         toolbar.add(showAcknowledgedCheckBox);
         
         // Create filter popup menu

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/RoutePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/RoutePanel.java
@@ -111,17 +111,21 @@ class RoutePanel extends WizardStep<MissionDataBean> {
 		// Always add unit layer
 		mapPanel.addMapLayer(new UnitMapLayer(mapPanel));
 
+        // Focus on the starting settlement
+        var starting = state.getStartingSettlement();
+        mapPanel.showMap(starting.getCoordinates());
+
 		// Lastly add navpoint layer
 		navpointLayer = new RoutePathLayer(mapPanel);
 		mapPanel.addMapLayer(navpointLayer);
-        mapPanel.setMouseClickListener(c -> setPointSelection(c));
+        mapPanel.setMouseClickListener(this::setPointSelection);
 
         // Add a single route path that is a proxy to the leg model
         routePath = new RoutePathAdapter(state.getStartingSettlement().getCoordinates(), legTableModel);
         navpointLayer.addPath(routePath);
 
 		var mapPane = new JPanel(new BorderLayout());
-		mapPane.setBorder(SwingHelper.createLabelBorder("Route"));
+		mapPane.setBorder(SwingHelper.createLabelBorder("Proposed Route"));
         
 		var dims = new Dimension(10, 200);
 		mapPane.setPreferredSize(dims);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorFilter.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorFilter.java
@@ -11,6 +11,7 @@ import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+import javax.swing.BorderFactory;
 import javax.swing.JCheckBox;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
@@ -19,7 +20,6 @@ import javax.swing.WindowConstants;
 
 import com.mars_sim.core.tool.Msg;
 import com.mars_sim.ui.swing.MarsPanelBorder;
-import com.mars_sim.ui.swing.StyleManager;
 
 
 /**
@@ -31,7 +31,7 @@ class MonitorFilter extends JDialog
 implements ActionListener {
 
 	// Data members
-	private FilteredTableModel model;
+	private transient FilteredTableModel model;
 
 	/**
 	 * Constructor.
@@ -50,7 +50,7 @@ implements ActionListener {
 		// Prepare content pane
 		JPanel mainPane = new JPanel();
 		mainPane.setLayout(new BorderLayout());
-		mainPane.setBorder(StyleManager.newEmptyBorder());
+		mainPane.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
 		setContentPane(mainPane);
 
 		var filters = model.getActiveFilters();

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorWindow.java
@@ -778,11 +778,18 @@ public class MonitorWindow extends ContentPanel
 
 	/**
 	 * Prepares tool window for deletion.
+	 * Remove listeners and references to allow for garbage collection.
 	 */
 	@Override
 	public void destroy() {
-		super.destroy();
-
 		unitManager.removeEntityManagerListener(UnitType.SETTLEMENT, umListener);
+
+		// Remove listeners for the active tab
+		MonitorModel activeModel = activeTab.getModel();
+		if (activeModel != null) {
+			activeModel.setMonitorEntities(false);
+		}
+			
+		super.destroy();
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorWindow.java
@@ -166,7 +166,7 @@ public class MonitorWindow extends ContentPanel
 	 */
 	public MonitorWindow(UIContext context, Properties uiProps) {
 		// Use TableWindow constructor
-		super(NAME, TITLE, Placement.BOTTOM);
+		super(NAME, TITLE, Placement.CENTER);
 		
 		this.context = context;
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorWindow.java
@@ -784,8 +784,8 @@ public class MonitorWindow extends ContentPanel
 	public void destroy() {
 		unitManager.removeEntityManagerListener(UnitType.SETTLEMENT, umListener);
 
-		// Remove listeners for the active tab
-		MonitorModel activeModel = activeTab.getModel();
+		// Remove listeners for the active tab; should already be present but just in case
+		MonitorModel activeModel = (activeTab != null) ? activeTab.getModel() : null;
 		if (activeModel != null) {
 			activeModel.setMonitorEntities(false);
 		}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TableProperties.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TableProperties.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 
+import javax.swing.BorderFactory;
 import javax.swing.JCheckBox;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
@@ -25,7 +26,6 @@ import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 
 import com.mars_sim.ui.swing.MarsPanelBorder;
-import com.mars_sim.ui.swing.StyleManager;
 
 /**
  * The TableProperties class display the columns of a specific table.
@@ -34,7 +34,7 @@ import com.mars_sim.ui.swing.StyleManager;
 @SuppressWarnings("serial")
 class TableProperties extends JDialog {
 
-    private TableColumnModel model;
+    private transient TableColumnModel model;
     private List<JCheckBox> columnButtons = new ArrayList<>();
 
     /**
@@ -54,7 +54,7 @@ class TableProperties extends JDialog {
         // Prepare content pane
         JPanel mainPane = new JPanel();
         mainPane.setLayout(new BorderLayout());
-        mainPane.setBorder(StyleManager.newEmptyBorder());
+        mainPane.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
         setContentPane(mainPane);
 
         // Create column pane

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/navigator/NavigatorWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/navigator/NavigatorWindow.java
@@ -71,6 +71,7 @@ import com.mars_sim.ui.swing.tool.map.MissionMapLayer;
 import com.mars_sim.ui.swing.tool.map.ShadingMapLayer;
 import com.mars_sim.ui.swing.tool.map.UnitMapLayer;
 import com.mars_sim.ui.swing.tool.map.VehicleTrailMapLayer;
+import com.mars_sim.ui.swing.utils.SwingHelper;
 import com.mars_sim.ui.swing.utils.TreeCheckFactory;
 import com.mars_sim.ui.swing.utils.TreeCheckFactory.SelectableNode;
 
@@ -250,7 +251,7 @@ public class NavigatorWindow extends ContentPanel
 		mapPanel = new MapPanel(context);
 		mapPanel.setPreferredSize(new Dimension(MAP_BOX_WIDTH, MAP_BOX_HEIGHT));
 		wholePane.add(mapPanel, BorderLayout.CENTER);
-		mapPanel.setMouseMoveListener(c -> updateStatusBar(c));
+		mapPanel.setMouseMoveListener(this::updateStatusBar);
 
 		// Create map layers.
 		mapLayers.add(new NamedLayer(DAYLIGHT_LAYER, new ShadingMapLayer(mapPanel)));
@@ -287,7 +288,7 @@ public class NavigatorWindow extends ContentPanel
 		
 		JPanel searchPane = new JPanel();
 		searchPane.setLayout(new BoxLayout(searchPane, BoxLayout.Y_AXIS));
-		searchPane.setBorder(StyleManager.createLabelBorder("Search"));
+		searchPane.setBorder(SwingHelper.createLabelBorder("Search"));
 
 		controlPane.add(searchPane, BorderLayout.NORTH);
         
@@ -298,11 +299,11 @@ public class NavigatorWindow extends ContentPanel
 		JTree layers = TreeCheckFactory.createCheckTree(layerRoot);
 		JScrollPane treeView = new JScrollPane(layers);
 		controlPane.add(treeView, BorderLayout.CENTER);
-		treeView.setBorder(StyleManager.createLabelBorder("Layers"));
+		treeView.setBorder(SwingHelper.createLabelBorder("Layers"));
 
 		JPanel buttonPane = new JPanel();
 		buttonPane.setLayout(new BoxLayout(buttonPane, BoxLayout.X_AXIS));
-		buttonPane.setBorder(StyleManager.createLabelBorder("Graphics"));
+		buttonPane.setBorder(SwingHelper.createLabelBorder("Graphics"));
 		controlPane.add(buttonPane, BorderLayout.SOUTH);
 
 		// Prepare gpu button

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/time/TimeTool.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/time/TimeTool.java
@@ -200,7 +200,7 @@ public class TimeTool extends ContentPanel {
 		martianTimeLabel.setText("");
 		martianTimeLabel.setToolTipText("Mars Timestamp in Universal Mean Time (UMT)");
 		martianTimePane.add(martianTimeLabel, BorderLayout.CENTER);
-		martianTimePane.setBorder(StyleManager.createLabelBorder(Msg.getString("TimeWindow.martianTime"))); //$NON-NLS-1$
+		martianTimePane.setBorder(SwingHelper.createLabelBorder(Msg.getString("TimeWindow.martianTime"))); //$NON-NLS-1$
 
 		JButton wikiButton = new JButton(GuideWindow.wikiIcon);
 		wikiButton.setAlignmentX(.5f);
@@ -215,7 +215,7 @@ public class TimeTool extends ContentPanel {
 		// Create Martian month panel
 		JPanel martianMonthPane = new JPanel(new BorderLayout());
 		martianMonthPane.setPreferredSize(new Dimension(WIDTH, 160));
-		martianMonthPane.setBorder(StyleManager.createLabelBorder(Msg.getString("TimeWindow.martianMonth"))); //$NON-NLS-1$
+		martianMonthPane.setBorder(SwingHelper.createLabelBorder(Msg.getString("TimeWindow.martianMonth"))); //$NON-NLS-1$
 		martianPane.add(martianMonthPane, BorderLayout.CENTER);
 		
 		// Create Martian calendar label panel
@@ -253,7 +253,7 @@ public class TimeTool extends ContentPanel {
 		// Create Martian hemisphere panel
 		AttributePanel hemiPane = new AttributePanel(3);
 		seasonPane.add(hemiPane, BorderLayout.NORTH);		
-		hemiPane.setBorder(StyleManager.createLabelBorder(Msg.getString("TimeWindow.martianSeasons"))); //$NON-NLS-1$
+		hemiPane.setBorder(SwingHelper.createLabelBorder(Msg.getString("TimeWindow.martianSeasons"))); //$NON-NLS-1$
 
 		String str =
 				"<html>&#8201;Earth (days) vs Mars (sols)" +
@@ -285,7 +285,7 @@ public class TimeTool extends ContentPanel {
 		
 		// Create speed panel
 		AttributePanel speedPane = new AttributePanel(8);
-		speedPane.setBorder(StyleManager.createLabelBorder(Msg.getString("TimeWindow.simParam"))); //$NON-NLS-1$
+		speedPane.setBorder(SwingHelper.createLabelBorder(Msg.getString("TimeWindow.simParam"))); //$NON-NLS-1$
 		attributePane.add(speedPane, BorderLayout.NORTH);
 
 		ticksPerSecLabel = speedPane.addTextField(Msg.getString("TimeWindow.ticksPerSecond"), "", //$NON-NLS-1$
@@ -309,7 +309,7 @@ public class TimeTool extends ContentPanel {
 	
 		// Create pulse panel
 		AttributePanel pulsePane = new AttributePanel(5);
-		pulsePane.setBorder(StyleManager.createLabelBorder(Msg.getString("TimeWindow.pulseParams"))); //$NON-NLS-1$
+		pulsePane.setBorder(SwingHelper.createLabelBorder(Msg.getString("TimeWindow.pulseParams"))); //$NON-NLS-1$
 		attributePane.add(pulsePane, BorderLayout.CENTER);
 		
 		taskPulseLabel = pulsePane.addTextField(TASK_PULSE_TIME, "", 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelGeneral.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelGeneral.java
@@ -26,8 +26,6 @@ import com.mars_sim.ui.swing.utils.AttributePanel;
  */
 @SuppressWarnings("serial")
 class TabPanelGeneral extends EntityTabPanel<Person> {
-	
-	private static final String TAB_BIRTH_DATE_AGE = "TabPanelGeneral.birthDateAndAge";
 			
 	/**
 	 * Constructor.
@@ -58,12 +56,10 @@ class TabPanelGeneral extends EntityTabPanel<Person> {
 		infoPanel.addTextField(Msg.getString("person.bloodType"), person.getBloodType(), null);
 				
 		// Prepare birthdate and age textfield
+		infoPanel.addTextField(Msg.getString("person.age"), Integer.toString(person.getAge()), null);
 		var birthDate = person.getBirthDate();
-		String birthTxt = Msg.getString(
-			TAB_BIRTH_DATE_AGE,
-			birthDate.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG)),
-			Integer.toString(person.getAge())); //$NON-NLS-1$
-		infoPanel.addTextField(Msg.getString("person.birthDate"), birthTxt, null);
+		infoPanel.addTextField(Msg.getString("person.birthDate"),
+					birthDate.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG)), null);
 		
 		// Prepare country of origin textfield
 		String country = person.getCountry();

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelPersonality.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/person/TabPanelPersonality.java
@@ -1,149 +1,136 @@
-/*
- * Mars Simulation Project
- * TabPanelPersonality.java
- * @date 2025-08-12
- * @author Manny Kung
- */
-package com.mars_sim.ui.swing.unit_window.person;
+	/*
+	* Mars Simulation Project
+	* TabPanelPersonality.java
+	* @date 2025-08-12
+	* @author Manny Kung
+	*/
+	package com.mars_sim.ui.swing.unit_window.person;
 
-import java.awt.BorderLayout;
-import java.awt.Component;
-import java.awt.FlowLayout;
-import java.awt.GridLayout;
+	import java.awt.BorderLayout;
+	import java.awt.GridLayout;
 
-import javax.swing.JPanel;
+	import javax.swing.JPanel;
 
-import com.mars_sim.core.person.Person;
-import com.mars_sim.core.person.ai.MBTIPersonality;
-import com.mars_sim.core.person.ai.PersonalityTraitManager;
-import com.mars_sim.core.person.ai.PersonalityTraitType;
-import com.mars_sim.core.tool.Msg;
-import com.mars_sim.ui.swing.ImageLoader;
-import com.mars_sim.ui.swing.UIContext;
-import com.mars_sim.ui.swing.entitywindow.EntityTabPanel;
-import com.mars_sim.ui.swing.utils.AttributePanel;
-import com.mars_sim.ui.swing.utils.SwingHelper;
-
-/**
- * The TabPanelPersonality is a tab panel for personality information about a person.
- */
-@SuppressWarnings("serial")
-class TabPanelPersonality extends EntityTabPanel<Person> {
-
-	private static final String PER_ICON = "personality"; //$NON-NLS-1$
+	import com.mars_sim.core.person.Person;
+	import com.mars_sim.core.person.ai.MBTIPersonality;
+	import com.mars_sim.core.person.ai.PersonalityTraitManager;
+	import com.mars_sim.core.person.ai.PersonalityTraitType;
+	import com.mars_sim.core.tool.Msg;
+	import com.mars_sim.ui.swing.ImageLoader;
+	import com.mars_sim.ui.swing.UIContext;
+	import com.mars_sim.ui.swing.entitywindow.EntityTabPanel;
+	import com.mars_sim.ui.swing.utils.AttributePanel;
+	import com.mars_sim.ui.swing.utils.SwingHelper;
 
 	/**
-	 * Constructor.
-	 * 
-	 * @param person the person to display.
-	 * @param context the UI context.
+	 * The TabPanelPersonality is a tab panel for personality information about a person.
 	 */
-	public TabPanelPersonality(Person person, UIContext context) {
-		
-		// Use the TabPanel constructor
-		super(
-			Msg.getString("TabPanelPersonality.title"), //$NON-NLS-1$
-			ImageLoader.getIconByName(PER_ICON), null,		
-			context, person
-		);
-	}
-	
-	@Override
-	protected void buildUI(JPanel content) {
+	@SuppressWarnings("serial")
+	class TabPanelPersonality extends EntityTabPanel<Person> {
 
-		// Prepare spring layout info panel.
-		JPanel infoPanel = new JPanel(new BorderLayout());
-		content.add(infoPanel, BorderLayout.NORTH);
+		private static final String PER_ICON = "personality"; //$NON-NLS-1$
 
-		JPanel scorePanel = new JPanel(new GridLayout(2, 1));
-		infoPanel.add(scorePanel, BorderLayout.NORTH);
-		
-		// Create the text area for displaying the Big Five scores
-		scorePanel.add(createBigFive(getEntity()));
-		// Create the text area for displaying the MBTI scores
-		scorePanel.add(createMBTI(getEntity()));
-	}
-	
-	private static record TraitScore(String traitName, int score) {}
-
-	/**
-	 * Creates the MBTI text area.
-	 * 
-	 * @param person Person for MBTI
-	 * @return
-	 */
-	private JPanel createMBTI(Person person) {
-		MBTIPersonality p = person.getMind().getMBTI();
-		int ie = p.getIntrovertExtrovertScore();
-		int ns = p.getScores().get(1);
-		int ft = p.getScores().get(2);
-		int jp = p.getScores().get(3);
-		
-		TraitScore[] traits = new TraitScore[4];
-
-		// Prepare attribute panel.
-		AttributePanel attributePanel = new AttributePanel();
-		
-		JPanel listPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
-		listPanel.setAlignmentX(Component.CENTER_ALIGNMENT);
-		listPanel.setAlignmentY(Component.CENTER_ALIGNMENT);
-		listPanel.add(attributePanel, BorderLayout.CENTER);
-		listPanel.setBorder(SwingHelper.createLabelBorder(Msg.getString("TabPanelPersonality.mbti.title")));
-		
-		traits[0] = new TraitScore((ie < 0) ? "Introvert (I)" : "Extrovert (E)", ie);
-		traits[1] = new TraitScore((ns < 0) ? "Intuitive (N)" : "Sensing (S)", ns);
-		traits[2] = new TraitScore((ft < 0) ? "Feeling (F)" : "Thinking (T)", ft);
-		traits[3] = new TraitScore((jp < 0) ? "Judging (J)" : "Perceiving (P)", jp);
-		
-		String tip =  "<html>Introvert (I) / Extrovert  (E) : -50 to 0 / 0 to 50" 
-				  + "<br>Intuitive (N) / Sensing    (S) : -50 to 0 / 0 to 50"
-				  + "<br>  Feeling (F) / Thinking   (T) : -50 to 0 / 0 to 50"
-				  + "<br>  Judging (J) / Perceiving (P) : -50 to 0 / 0 to 50</html>";
-		
-		for (var t : traits) {
-			attributePanel.addTextField(t.traitName(), Math.round(t.score() * 10.0)/10.0 + " %", tip);
+		/**
+		 * Constructor.
+		 * 
+		 * @param person the person to display.
+		 * @param context the UI context.
+		 */
+		public TabPanelPersonality(Person person, UIContext context) {
+			
+			// Use the TabPanel constructor
+			super(
+				Msg.getString("TabPanelPersonality.title"), //$NON-NLS-1$
+				ImageLoader.getIconByName(PER_ICON), null,		
+				context, person
+			);
 		}
 		
-		String type = p.getTypeString();
-		String descriptor = p.getDescriptor();
-		
-		attributePanel.addTextField(type, descriptor, Msg.getString("TabPanelPersonality.mbti.descriptor.tip"));
-		
-		return listPanel;
-	}
+		@Override
+		protected void buildUI(JPanel content) {
 
-	/**
-	 * Creates the text area for the Big Five.
-	 * 
-	 * @return
-	 */
-	private JPanel createBigFive(Person person) {
-		PersonalityTraitManager p = person.getMind().getTraitManager();
-		
-		TraitScore[] traits = new TraitScore[PersonalityTraitType.values().length];
-    	for (PersonalityTraitType t : PersonalityTraitType.values()) {
-    		traits[t.ordinal()] = new TraitScore(t.getName(), p.getPersonalityTrait(t));
-    	}
+			// Prepare spring layout info panel.
+			JPanel infoPanel = new JPanel(new BorderLayout());
+			content.add(infoPanel, BorderLayout.NORTH);
 
-		// Prepare attribute panel.
-		AttributePanel attributePanel = new AttributePanel();
-    	
-		JPanel listPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
-		listPanel.setAlignmentY(Component.CENTER_ALIGNMENT);
-		listPanel.setToolTipText(Msg.getString("TabPanelPersonality.bigFive.tip"));//$NON-NLS-1$
-		listPanel.add(attributePanel, BorderLayout.CENTER);
-		
-		listPanel.setBorder(SwingHelper.createLabelBorder(Msg.getString("TabPanelPersonality.bigFive.title")));
-		
-		String tip =  "<html>          Openness : 0 to 100" 
-			  	  + "<br> Conscientiousness : 0 to 100"
-			  	  + "<br>      Extraversion : 0 to 100"
-			  	  + "<br>       Neuroticism : 0 to 100</html>";
-
-		for (var t : traits) {
-			attributePanel.addTextField(t.traitName(), Math.round(t.score() * 10.0)/10.0 + " %", tip);
+			JPanel scorePanel = new JPanel(new GridLayout(2, 1));
+			infoPanel.add(scorePanel, BorderLayout.NORTH);
+			
+			// Create the text area for displaying the Big Five scores
+			scorePanel.add(createBigFive(getEntity()));
+			// Create the text area for displaying the MBTI scores
+			scorePanel.add(createMBTI(getEntity()));
 		}
 		
-		return listPanel;
+		private static record TraitScore(String traitName, int score) {}
+
+		/**
+		 * Creates the MBTI text area.
+		 * 
+		 * @param person Person for MBTI
+		 * @return
+		 */
+		private JPanel createMBTI(Person person) {
+			MBTIPersonality p = person.getMind().getMBTI();
+			int ie = p.getIntrovertExtrovertScore();
+			int ns = p.getScores().get(1);
+			int ft = p.getScores().get(2);
+			int jp = p.getScores().get(3);
+			
+			TraitScore[] traits = new TraitScore[4];
+
+			// Prepare attribute panel.
+			AttributePanel attributePanel = new AttributePanel();
+			attributePanel.setBorder(SwingHelper.createLabelBorder(Msg.getString("TabPanelPersonality.mbti.title")));
+			
+			traits[0] = new TraitScore((ie < 0) ? "Introvert (I)" : "Extrovert (E)", ie);
+			traits[1] = new TraitScore((ns < 0) ? "Intuitive (N)" : "Sensing (S)", ns);
+			traits[2] = new TraitScore((ft < 0) ? "Feeling (F)" : "Thinking (T)", ft);
+			traits[3] = new TraitScore((jp < 0) ? "Judging (J)" : "Perceiving (P)", jp);
+			
+			String tip =  "<html>Introvert (I) / Extrovert  (E) : -50 to 0 / 0 to 50" 
+					+ "<br>Intuitive (N) / Sensing    (S) : -50 to 0 / 0 to 50"
+					+ "<br>  Feeling (F) / Thinking   (T) : -50 to 0 / 0 to 50"
+					+ "<br>  Judging (J) / Perceiving (P) : -50 to 0 / 0 to 50</html>";
+			
+			for (var t : traits) {
+				attributePanel.addTextField(t.traitName(), Math.round(t.score() * 10.0)/10.0 + " %", tip);
+			}
+			
+			String type = p.getTypeString();
+			String descriptor = p.getDescriptor();
+			
+			attributePanel.addTextField(type, descriptor, Msg.getString("TabPanelPersonality.mbti.descriptor.tip"));
+			
+			return attributePanel;
+		}
+
+		/**
+		 * Creates the text area for the Big Five.
+		 * 
+		 * @return
+		 */
+		private JPanel createBigFive(Person person) {
+			PersonalityTraitManager p = person.getMind().getTraitManager();
+			
+			TraitScore[] traits = new TraitScore[PersonalityTraitType.values().length];
+			for (PersonalityTraitType t : PersonalityTraitType.values()) {
+				traits[t.ordinal()] = new TraitScore(t.getName(), p.getPersonalityTrait(t));
+			}
+
+			// Prepare attribute panel.
+			AttributePanel attributePanel = new AttributePanel();
+			attributePanel.setBorder(SwingHelper.createLabelBorder(Msg.getString("TabPanelPersonality.bigFive.title")));
+			
+			String tip =  "<html>          Openness : 0 to 100" 
+					+ "<br> Conscientiousness : 0 to 100"
+					+ "<br>      Extraversion : 0 to 100"
+					+ "<br>       Neuroticism : 0 to 100</html>";
+
+			for (var t : traits) {
+				attributePanel.addTextField(t.traitName(), Math.round(t.score() * 10.0)/10.0 + " %", tip);
+			}
+			
+			return attributePanel;
+		}
 	}
-}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelManufacture.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/structure/TabPanelManufacture.java
@@ -59,6 +59,7 @@ import com.mars_sim.ui.swing.utils.AttributePanel;
 import com.mars_sim.ui.swing.utils.ProcessInfoRenderer;
 import com.mars_sim.ui.swing.utils.ProcessListPanel;
 import com.mars_sim.ui.swing.utils.RatingScoreRenderer;
+import com.mars_sim.ui.swing.utils.SwingHelper;
 import com.mars_sim.ui.swing.utils.ToolTipTableModel;
 
 /**
@@ -165,7 +166,7 @@ class TabPanelManufacture extends EntityTabPanel<Settlement>
 		// Create parameter controls
 		var pMgr = target.getPreferences();
 		var parameterPanel = new AttributePanel();
-		parameterPanel.setBorder(StyleManager.createLabelBorder("Controls"));
+		parameterPanel.setBorder(SwingHelper.createLabelBorder("Controls"));
 		addParameter(parameterPanel, pMgr, ManufacturingParameters.NEW_MANU_VALUE, 30);
 		addParameter(parameterPanel, pMgr, ManufacturingParameters.NEW_MANU_LIMIT, 200);
 		addParameter(parameterPanel, pMgr, ManufacturingParameters.MAX_QUEUE_SIZE, 200);
@@ -212,13 +213,6 @@ class TabPanelManufacture extends EntityTabPanel<Settlement>
 		queueTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
 		queueTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		queueTable.getSelectionModel().addListSelectionListener(this::queueSelectionChanged);
-
-		// Can result in java.lang.ArrayIndexOutOfBoundsException when a process is done and its row is deleted
-//		queueTable.setAutoCreateRowSorter(true);
-		
-//		TableRowSorter<TableModel> sorter = new TableRowSorter<>(queueTable.getModel());
-//		sorter.setSortsOnUpdates(true);
-//		queueTable.setRowSorter(sorter);
 		
 		scrollPane.setViewportView(queueTable);
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/DynamicAttributeLayout.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/DynamicAttributeLayout.java
@@ -8,6 +8,7 @@ package com.mars_sim.ui.swing.utils;
 
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 
@@ -24,8 +25,9 @@ import javax.swing.JPanel;
 class DynamicAttributeLayout implements AttributePanel.AttributePanelLayout {
 
     private static final int X_PAD = 4;
-    private static final int Y_PAD = 4;
-    private static final int COLUMN_PAD = 2;
+
+    private static final Insets LABEL_INSETS = new Insets(1, X_PAD, 1, 0);
+    private static final Insets VALUE_INSETS = new Insets(1, 0, 1, X_PAD);
 
     private int gridPerValue;
     private int gridPerLabel;
@@ -37,16 +39,6 @@ class DynamicAttributeLayout implements AttributePanel.AttributePanelLayout {
     // The position of a cell in terms of the grid
     private record CellPosition(int col, int row) {}
     
-    /**
-     * Handles resizing of the parent panel
-     */
-    private class Resizer extends ComponentAdapter {
-        @Override
-        public void componentResized(ComponentEvent e) {
-            adjustLayout();
-        }
-    }
-
     public DynamicAttributeLayout(JPanel container, int cols) {
         gbl = new GridBagLayout();
         container.setLayout(gbl);
@@ -56,7 +48,18 @@ class DynamicAttributeLayout implements AttributePanel.AttributePanelLayout {
         gridPerValue = 1;
         gridPerColumn = gridPerLabel + gridPerValue;
         
-        container.addComponentListener(new Resizer());
+        // Get notified when the container is resized or shown so we can adjust the layout
+        container.addComponentListener(new ComponentAdapter() {
+            @Override
+            public void componentResized(ComponentEvent e) {
+                adjustLayout();
+            }
+
+            @Override
+            public void componentShown(ComponentEvent e) {
+                adjustLayout();
+            }
+        });
     }
 
     /**
@@ -96,12 +99,9 @@ class DynamicAttributeLayout implements AttributePanel.AttributePanelLayout {
         var constraints = new GridBagConstraints();
         constraints.gridx = cell.col * gridPerColumn;
         constraints.gridy = cell.row;
-        constraints.weightx = 0;
 
-        //constraints.gridwidth = gridPerLabel;
         constraints.anchor = GridBagConstraints.LINE_END;
-        // constraints.ipadx = X_PAD;
-        // constraints.ipady = Y_PAD;
+        constraints.insets = LABEL_INSETS;
 
         return constraints;
     }
@@ -114,12 +114,8 @@ class DynamicAttributeLayout implements AttributePanel.AttributePanelLayout {
         var constraints = new GridBagConstraints();
         constraints.gridx = (cell.col * gridPerColumn) + gridPerLabel;
         constraints.gridy = cell.row;
-        constraints.weightx = 1;
-
-        //constraints.gridwidth = gridPerValue;
+        constraints.insets = VALUE_INSETS;
         constraints.anchor = GridBagConstraints.LINE_START;
-        //constraints.ipadx = X_PAD + (cell.col != (currentColumns-1) ? COLUMN_PAD : 0);
-        //constraints.ipady = Y_PAD;
         return constraints;
     }
     
@@ -145,7 +141,7 @@ class DynamicAttributeLayout implements AttributePanel.AttributePanelLayout {
         }
 
         // Add a 10% margin
-        int maxColumnWidth = (int)((maxLabel + maxValue + (X_PAD * 2) + COLUMN_PAD) * 1.1);
+        int maxColumnWidth = (int)(maxLabel + maxValue + (X_PAD * 2) * 1.1);
         int potentialColumns = container.getWidth()/maxColumnWidth;
         if ((potentialColumns == 0) || (currentColumns == potentialColumns)) {
             return;

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/DynamicAttributeLayout.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/DynamicAttributeLayout.java
@@ -141,7 +141,7 @@ class DynamicAttributeLayout implements AttributePanel.AttributePanelLayout {
         }
 
         // Add a 10% margin
-        int maxColumnWidth = (int)(maxLabel + maxValue + (X_PAD * 2) * 1.1);
+        int maxColumnWidth = (int)((maxLabel + maxValue + (X_PAD * 2)) * 1.1);
         int potentialColumns = container.getWidth()/maxColumnWidth;
         if ((potentialColumns == 0) || (currentColumns == potentialColumns)) {
             return;

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/SwingHelper.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/SwingHelper.java
@@ -192,4 +192,13 @@ public final class SwingHelper {
 		}
         return listScroller;
     }
+
+	/**
+	 * Helper method to convert a Dimension to a string for display.
+	 * @param size Dimension to convert
+	 * @return String representation of the dimension
+	 */
+    public static String toString(Dimension minimumSize) {
+        return (int) minimumSize.getWidth() + "x" + (int) minimumSize.getHeight();
+    }
 }


### PR DESCRIPTION
This focuses on improving the layout of the Docking window approach. Highlights are:
- Docking Windows can be reopened after closing
- Changed layout of AttributePanel in dynamic mode
- Prevent Docking framework adding an extra scroll pane
- Some Tab Panels adjusted to improve layout

In addition there is now a '-debugui' command argument to switch on size displaying and the Entity Listener panel

Close #1808