### PR TITLE
feat: Improve the number of HistoricalEvents

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/person/PersonHealthCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/person/PersonHealthCommand.java
@@ -16,10 +16,8 @@ import com.mars_sim.console.chat.Conversation;
 import com.mars_sim.console.chat.ConversationRole;
 import com.mars_sim.console.chat.simcommand.CommandHelper;
 import com.mars_sim.console.chat.simcommand.StructuredResponse;
-import com.mars_sim.core.Simulation;
-import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.EntityEventType;
-import com.mars_sim.core.events.HistoricalEvent;
+import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.events.HistoricalEventType;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.PhysicalCondition;
@@ -186,10 +184,8 @@ public class PersonHealthCommand extends AbstractPersonCommand {
 			
 			var rad = exposure.addDose(RadiationType.SEP, regionType, buffer * 1.2);
 			
-			HistoricalEvent hEvent = new HistoricalEvent(HistoricalEventType.HAZARD_RADIATION_EXPOSURE,
-														person, person.getAssociatedSettlement(),
-														rad.toString(), person.getTaskDescription());
-			Simulation.instance().getEventManager().registerNewEvent(hEvent);
+			person.registerHistoricalEvent(HistoricalEventType.HAZARD_RADIATION_EXPOSURE, rad.toString(),
+							person.getTaskDescription(), null, null);
 
 			person.fireUnitUpdate(EntityEventType.RADIATION_EVENT);
 		}

--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/ExploredCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/ExploredCommand.java
@@ -60,7 +60,7 @@ public class ExploredCommand extends AbstractSettlementCommand {
 		
 		boolean addSite = true;
 		while(addSite) {
-			int searchRange = 50;
+			int searchRange = 200;
 
 			var found = eMgr.acquireNearbyMineralLocation(searchRange);
 			if (found != null) {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
@@ -364,7 +364,7 @@ public class Simulation implements ClockPulseListener, Serializable {
 
 		malfunctionFactory = new MalfunctionFactory();
 		MalfunctionManager.initializeInstances(masterClock, malfunctionFactory,
-												medicalManager, eventManager,
+												medicalManager,
 												simulationConfig.getPartConfiguration());
 
 		// Initialize ScientificStudy
@@ -518,7 +518,7 @@ public class Simulation implements ClockPulseListener, Serializable {
 		
 		// Initialize instances prior to UnitManager initiation
 		MalfunctionManager.initializeInstances(masterClock, malfunctionFactory,
-											medicalManager, eventManager,
+											medicalManager,
 											simulationConfig.getPartConfiguration());
 
 		Relation.initializeInstances(unitManager);
@@ -637,7 +637,7 @@ public class Simulation implements ClockPulseListener, Serializable {
 		JobSpec.initializeInstances(unitManager, missionManager);
 		
 		MalfunctionManager.initializeInstances(masterClock, malfunctionFactory,
-				medicalManager, eventManager,
+				medicalManager,
 				simulationConfig.getPartConfiguration());
 	
 		Relation.initializeInstances(unitManager);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/Unit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Unit.java
@@ -13,7 +13,10 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.mars_sim.core.environment.Weather;
+import com.mars_sim.core.events.HistoricalEvent;
+import com.mars_sim.core.events.HistoricalEventType;
 import com.mars_sim.core.logging.SimLogger;
+import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.person.ai.mission.MissionManager;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.time.ClockPulse;
@@ -292,6 +295,28 @@ public abstract class Unit implements MonitorableEntity, UnitIdentifer, Comparab
 			return Collections.emptySet();
 		}
 		return Collections.unmodifiableSet(listeners);
+	}
+
+	
+	/**
+	 * Create a historical event for this Unit.
+	 * @param eventType the type of event.
+	 * @param message the message to include in the event.
+	 * @param doing the action being done in the event, maybe null.
+     * @param affected the entity affected by the event, maybe null.
+	 * @param where the coordinates of the event, maybe null
+	 */
+	public void registerHistoricalEvent(HistoricalEventType eventType, String message, String doing, Entity affected,
+			Coordinates where) {
+		var base = getAssociatedSettlement();
+
+		// Not briliant but Settlements logging are their own home base
+		if (base == null && this instanceof Settlement settlement) {
+			base = settlement;
+		}
+
+		var event = new HistoricalEvent(eventType, this, base, message, doing, affected, where);
+		Simulation.instance().getEventManager().registerNewEvent(event);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/Unit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Unit.java
@@ -310,7 +310,7 @@ public abstract class Unit implements MonitorableEntity, UnitIdentifer, Comparab
 			Coordinates where) {
 		var base = getAssociatedSettlement();
 
-		// Not briliant but Settlements logging are their own home base
+		// Not brilliant but Settlements logging are their own home base
 		if (base == null && this instanceof Settlement settlement) {
 			base = settlement;
 		}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/construction/ConstructionSite.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/construction/ConstructionSite.java
@@ -11,12 +11,16 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.mars_sim.core.Entity;
+import com.mars_sim.core.Simulation;
 import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.UnitType;
 import com.mars_sim.core.building.Building;
 import com.mars_sim.core.building.BuildingManager;
 import com.mars_sim.core.building.config.BuildingSpec;
 import com.mars_sim.core.building.construction.ConstructionStageInfo.Stage;
+import com.mars_sim.core.events.HistoricalEvent;
+import com.mars_sim.core.events.HistoricalEventType;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.map.location.BoundedObject;
 import com.mars_sim.core.map.location.LocalBoundedObject;
@@ -90,6 +94,8 @@ public class ConstructionSite extends FixedUnit {
         this.length = placement.getLength();
         this.facing = placement.getFacing();
         this.position = placement.getPosition();
+
+        registerHistoricalEvent(HistoricalEventType.CONSTRUCTION_STAGE_STARTED, initPhase.stageInfo().getName(), null);
     }
 
     @Override
@@ -215,6 +221,8 @@ public class ConstructionSite extends FixedUnit {
                 + (isConstruction ? "construction" : "salvage"));
 
         fireUnitUpdate(ConstructionSite.ADD_CONSTRUCTION_STAGE_EVENT, currentStage);
+        registerHistoricalEvent(HistoricalEventType.CONSTRUCTION_STAGE_STARTED, nextPhase.stageInfo().getName(), null);
+
         return phases.isEmpty();
     }
 
@@ -247,6 +255,7 @@ public class ConstructionSite extends FixedUnit {
         // Fire construction event.
         fireUnitUpdate(ConstructionSite.FINISH_CONSTRUCTION_BUILDING_EVENT, newBuilding);
 
+        registerHistoricalEvent(HistoricalEventType.BUILDING_CREATED, uniqueName, newBuilding);
         return newBuilding;
     }
 
@@ -318,6 +327,18 @@ public class ConstructionSite extends FixedUnit {
         
 
 	}
+
+	/**
+	 * Create a historical event for this scientific study.
+	 * @param eventType the type of event.
+	 * @param message the message to include in the event.
+     * @param affected the entity affected by the event, if applicable.
+	 */
+	private void registerHistoricalEvent(HistoricalEventType eventType, String message, Entity affected) {
+		var event = new HistoricalEvent(eventType, this, getAssociatedSettlement(), message, null, affected);
+		Simulation.instance().getEventManager().registerNewEvent(event);
+	}
+
 
 	@Override
 	public UnitType getUnitType() {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/construction/ConstructionSite.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/construction/ConstructionSite.java
@@ -11,15 +11,12 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.mars_sim.core.Entity;
-import com.mars_sim.core.Simulation;
 import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.UnitType;
 import com.mars_sim.core.building.Building;
 import com.mars_sim.core.building.BuildingManager;
 import com.mars_sim.core.building.config.BuildingSpec;
 import com.mars_sim.core.building.construction.ConstructionStageInfo.Stage;
-import com.mars_sim.core.events.HistoricalEvent;
 import com.mars_sim.core.events.HistoricalEventType;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.map.location.BoundedObject;
@@ -95,7 +92,8 @@ public class ConstructionSite extends FixedUnit {
         this.facing = placement.getFacing();
         this.position = placement.getPosition();
 
-        registerHistoricalEvent(HistoricalEventType.CONSTRUCTION_STAGE_STARTED, initPhase.stageInfo().getName(), null);
+        registerHistoricalEvent(HistoricalEventType.CONSTRUCTION_STAGE_STARTED, initPhase.stageInfo().getName(),
+                    null, null, null);
     }
 
     @Override
@@ -221,7 +219,8 @@ public class ConstructionSite extends FixedUnit {
                 + (isConstruction ? "construction" : "salvage"));
 
         fireUnitUpdate(ConstructionSite.ADD_CONSTRUCTION_STAGE_EVENT, currentStage);
-        registerHistoricalEvent(HistoricalEventType.CONSTRUCTION_STAGE_STARTED, nextPhase.stageInfo().getName(), null);
+        registerHistoricalEvent(HistoricalEventType.CONSTRUCTION_STAGE_STARTED, nextPhase.stageInfo().getName(),
+        null, null, null);
 
         return phases.isEmpty();
     }
@@ -255,7 +254,7 @@ public class ConstructionSite extends FixedUnit {
         // Fire construction event.
         fireUnitUpdate(ConstructionSite.FINISH_CONSTRUCTION_BUILDING_EVENT, newBuilding);
 
-        registerHistoricalEvent(HistoricalEventType.BUILDING_CREATED, uniqueName, newBuilding);
+        registerHistoricalEvent(HistoricalEventType.BUILDING_CREATED, uniqueName, null, newBuilding, null);
         return newBuilding;
     }
 
@@ -324,21 +323,7 @@ public class ConstructionSite extends FixedUnit {
 		logger.info(this, "Manually relocated by player from " 
 				+ existingPosn + " to "
 				+ position);
-        
-
 	}
-
-	/**
-	 * Create a historical event for this scientific study.
-	 * @param eventType the type of event.
-	 * @param message the message to include in the event.
-     * @param affected the entity affected by the event, if applicable.
-	 */
-	private void registerHistoricalEvent(HistoricalEventType eventType, String message, Entity affected) {
-		var event = new HistoricalEvent(eventType, this, getAssociatedSettlement(), message, null, affected);
-		Simulation.instance().getEventManager().registerNewEvent(event);
-	}
-
 
 	@Override
 	public UnitType getUnitType() {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/environment/SurfaceFeatures.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/environment/SurfaceFeatures.java
@@ -526,10 +526,9 @@ public class SurfaceFeatures implements Serializable, Temporal {
 	 *
 	 * @param location		the location coordinates.
 	 * @param skill			the skill
-	 * @return the explored location
+	 * @return the explored location or null if the location is not suitable for exploration.
 	 */
-	public synchronized MineralSite declareROI(Coordinates location,
-			int skill) {
+	public synchronized MineralSite declareNewROI(Coordinates location, int skill) {
 		
 		MineralSite result = null;
 				
@@ -577,35 +576,14 @@ public class SurfaceFeatures implements Serializable, Temporal {
 	/**
 	 * Gets a location already been declared/considered as a Region Of Interest (ROI).
 	 * 
-	 * @param coord
-	 * @return
+	 * @param coord Coordinates of the location to check.
+	 * @return Site or null if not found.
 	 */
 	public MineralSite getDeclaredROI(Coordinates coord) {
 		return regionOfInterestLocations.stream()
 				  .filter(e -> e.getCoordinates().equals(coord))
 				  .findFirst()
 				  .orElse(null);
-	}
-
-	
-	/**
-	 * Creates a Region of Interest (ROI) at a given location and
-	 * estimate its mineral concentrations.
-	 * 
-	 * @param siteLocation
-	 * @param skill
-	 * @return ExploredLocation
-	 */
-	public MineralSite createROI(Coordinates siteLocation, int skill) {
-
-		// Check if this siteLocation has already been added or not to SurfaceFeatures
-		MineralSite el = getDeclaredROI(siteLocation);
-		if (el == null) {
-			// If it hasn't been claimed yet, then claim it
-			el = declareROI(siteLocation, skill);
-		}
-		
-		return el;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEvent.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEvent.java
@@ -202,4 +202,18 @@ public class HistoricalEvent implements Serializable {
 	public void setAcknowledged(boolean acknowledged) {
 		this.acknowledged = acknowledged;
 	}
+
+	/**
+	 * Determines if this event is equivalent to another event. This is used to determine if an event is a repeat of recent events.
+	 * @param newEvent The event to be compared with recent events.
+	 * @return True if they are equivalent, false otherwise.
+	 */
+	public boolean isEquivalent(HistoricalEvent newEvent) {
+		return (type == newEvent.getType()
+				&& source.equals(newEvent.getSource())
+
+				// Cause maybe be null so check for null before equals
+				&& ((whatCause == null && newEvent.getWhatCause() == null)
+					|| (whatCause != null && whatCause.equals(newEvent.getWhatCause()))));
+	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEvent.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEvent.java
@@ -7,6 +7,7 @@
 package com.mars_sim.core.events;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import com.mars_sim.core.Entity;
 import com.mars_sim.core.map.location.Coordinates;
@@ -86,6 +87,9 @@ public class HistoricalEvent implements Serializable {
 	 */
 	public HistoricalEvent(HistoricalEventType type, Entity source, Settlement homeTown, String whatCause,
 			String whileDoing, Entity affected, Coordinates coordinates) {
+		Objects.requireNonNull(type, "Event type cannot be null");
+		Objects.requireNonNull(source, "Event source cannot be null");
+
 		this.type = type;
 		this.source = source;
 		this.whatCause = whatCause;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventCategory.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventCategory.java
@@ -13,7 +13,7 @@ import com.mars_sim.core.tool.Msg;
 public enum HistoricalEventCategory implements Named{
 	CONSTRUCTION, EXPLORATION, HAZARD,
 	MALFUNCTION, MEDICAL, MISSION,
-	SCIENCE_STUDY, TRANSPORT;
+	ORGANIZATION, SCIENCE_STUDY, TRANSPORT;
 	
 	private String name;
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventCategory.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventCategory.java
@@ -11,10 +11,9 @@ import com.mars_sim.core.Named;
 import com.mars_sim.core.tool.Msg;
 
 public enum HistoricalEventCategory implements Named{
-
-	MEDICAL, MALFUNCTION, MISSION,
-	SCIENCE_STUDY,
-	TRANSPORT, HAZARD, CONSTRUCTION;
+	CONSTRUCTION, EXPLORATION, HAZARD,
+	MALFUNCTION, MEDICAL, MISSION,
+	SCIENCE_STUDY, TRANSPORT;
 	
 	private String name;
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventCategory.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventCategory.java
@@ -13,7 +13,8 @@ import com.mars_sim.core.tool.Msg;
 public enum HistoricalEventCategory implements Named{
 
 	MEDICAL, MALFUNCTION, MISSION,
-	TRANSPORT, HAZARD;
+	SCIENCE_STUDY,
+	TRANSPORT, HAZARD, CONSTRUCTION;
 	
 	private String name;
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventManager.java
@@ -74,11 +74,11 @@ public class HistoricalEventManager implements Serializable {
 	}
 
 	/**
-	 * Is this new event distinct from recent events?
-	 * @param newEvent
-	 * @return
+	 * Is this new event a repeat of recent events?
+	 * @param newEvent Event to be compared with recent events.
+	 * @return true if the new event is a repeat of recent events, false otherwise.
 	 */
-	private boolean isDistinct(HistoricalEvent newEvent) {
+	private boolean isRepeat(HistoricalEvent newEvent) {
 		if (lastEvents != null) {
 			int index = Math.max(0, lastEvents.size() - (MATCH_RANGE + 1)); // Start at beginning of check range
 			for (; index < lastEvents.size(); index++) {
@@ -104,11 +104,8 @@ public class HistoricalEventManager implements Serializable {
 
 		HistoricalEventType type = newEvent.getType();
 
-		if (type == HistoricalEventType.MISSION_JOINING)
-			return;
-		else if (type == HistoricalEventType.MISSION_NOT_ENOUGH_RESOURCES)
-			return;
-		else if (isDistinct(newEvent))
+		if (type == HistoricalEventType.MISSION_NOT_ENOUGH_RESOURCES
+			|| isRepeat(newEvent))
 			return;
 
 		newEvent.setTimestamp(masterClock.getMarsTime());

--- a/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventManager.java
@@ -83,10 +83,7 @@ public class HistoricalEventManager implements Serializable {
 			int index = Math.max(0, lastEvents.size() - (MATCH_RANGE + 1)); // Start at beginning of check range
 			for (; index < lastEvents.size(); index++) {
 				HistoricalEvent e = lastEvents.get(index);
-				if (e.getType() == newEvent.getType()
-						&& e.getSource().equals(newEvent.getSource())
-						&& e.getWhatCause().equals(newEvent.getWhatCause())
-						&& e.getWhileDoing().equals(newEvent.getWhileDoing())) {
+				if (e.isEquivalent(newEvent)) {
 					return true;
 				}
 			}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventType.java
@@ -53,7 +53,10 @@ public enum HistoricalEventType {
 	CONSTRUCTION_STAGE_STARTED	(HistoricalEventCategory.CONSTRUCTION),
 
 	SITE_CLAIMED				(HistoricalEventCategory.EXPLORATION),
-	SITE_DISCOVERED				(HistoricalEventCategory.EXPLORATION);
+	SITE_DISCOVERED				(HistoricalEventCategory.EXPLORATION),
+	
+	CHANGE_ROLE					(HistoricalEventCategory.ORGANIZATION),
+	CHANGE_JOB					(HistoricalEventCategory.ORGANIZATION);
 
 	private String name;
 	private HistoricalEventCategory category;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventType.java
@@ -50,7 +50,10 @@ public enum HistoricalEventType {
 	HAZARD_RADIATION_EXPOSURE	(HistoricalEventCategory.HAZARD),
 	
 	BUILDING_CREATED			(HistoricalEventCategory.CONSTRUCTION),
-	CONSTRUCTION_STAGE_STARTED	(HistoricalEventCategory.CONSTRUCTION);
+	CONSTRUCTION_STAGE_STARTED	(HistoricalEventCategory.CONSTRUCTION),
+
+	SITE_CLAIMED				(HistoricalEventCategory.EXPLORATION),
+	SITE_DISCOVERED				(HistoricalEventCategory.EXPLORATION);
 
 	private String name;
 	private HistoricalEventCategory category;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/events/HistoricalEventType.java
@@ -19,16 +19,14 @@ public enum HistoricalEventType {
 	MEDICAL_CURED				(HistoricalEventCategory.MEDICAL),
 	MEDICAL_STARTS				(HistoricalEventCategory.MEDICAL),
 	MEDICAL_DEGRADES			(HistoricalEventCategory.MEDICAL),
-	MEDICAL_RECOVERY			(HistoricalEventCategory.MEDICAL),
-	MEDICAL_TREATED				(HistoricalEventCategory.MEDICAL),
+	MEDICAL_START_RECOVERY		(HistoricalEventCategory.MEDICAL),
+	MEDICAL_START_TREATMENT		(HistoricalEventCategory.MEDICAL),
 	MEDICAL_DEATH				(HistoricalEventCategory.MEDICAL),
 	MEDICAL_POSTMORTEM_EXAM		(HistoricalEventCategory.MEDICAL),
 	MEDICAL_RESCUE				(HistoricalEventCategory.MEDICAL),
 	MEDICAL_RESUSCITATED		(HistoricalEventCategory.MEDICAL),
 
-	MISSION_START					(HistoricalEventCategory.MISSION),
 	MISSION_PHASE					(HistoricalEventCategory.MISSION),
-	MISSION_JOINING					(HistoricalEventCategory.MISSION),
 	MISSION_FINISH					(HistoricalEventCategory.MISSION),
 	MISSION_EMERGENCY_DESTINATION	(HistoricalEventCategory.MISSION),
 	MISSION_NOT_ENOUGH_RESOURCES	(HistoricalEventCategory.MISSION),
@@ -41,14 +39,18 @@ public enum HistoricalEventType {
 	MISSION_ONLY_ONE_MEMBER			(HistoricalEventCategory.MISSION),
 	MISSION_LEAD_NO_SHOW			(HistoricalEventCategory.MISSION),
 
-	TRANSPORT_ITEM_CREATED		(HistoricalEventCategory.TRANSPORT),
+	STUDY_START_PHASE				(HistoricalEventCategory.SCIENCE_STUDY),
+	STUDY_FINISH					(HistoricalEventCategory.SCIENCE_STUDY),
+
 	TRANSPORT_ITEM_CANCELLED	(HistoricalEventCategory.TRANSPORT),
 	TRANSPORT_ITEM_LAUNCHED		(HistoricalEventCategory.TRANSPORT),
 	TRANSPORT_ITEM_ARRIVED		(HistoricalEventCategory.TRANSPORT),
-	TRANSPORT_ITEM_MODIFIED		(HistoricalEventCategory.TRANSPORT),
 
 	HAZARD_ACTS_OF_GOD			(HistoricalEventCategory.HAZARD), 
-	HAZARD_RADIATION_EXPOSURE	(HistoricalEventCategory.HAZARD);
+	HAZARD_RADIATION_EXPOSURE	(HistoricalEventCategory.HAZARD),
+	
+	BUILDING_CREATED			(HistoricalEventCategory.CONSTRUCTION),
+	CONSTRUCTION_STAGE_STARTED	(HistoricalEventCategory.CONSTRUCTION);
 
 	private String name;
 	private HistoricalEventCategory category;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/TransportManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/TransportManager.java
@@ -107,8 +107,6 @@ public class TransportManager implements Serializable {
 	 */
 	public void addNewTransportItem(Transportable transportItem) {
 		transportItems.add(transportItem);
-
-		fireEvent(TransportManager.createEvent(transportItem, HistoricalEventType.TRANSPORT_ITEM_CREATED));
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/TransportManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/interplanetary/transport/TransportManager.java
@@ -128,7 +128,7 @@ public class TransportManager implements Serializable {
 	public static HistoricalEvent createEvent(Transportable transportItem, HistoricalEventType action) {
 		Settlement base = (transportItem instanceof Resupply r ? r.getSettlement() : null);
 		return new HistoricalEvent(action, transportItem, base,
-						null, null, base,
+						null, null, null,
 						transportItem.getLandingLocation()
 		);
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/malfunction/Malfunction.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/malfunction/Malfunction.java
@@ -14,8 +14,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.mars_sim.core.equipment.EquipmentOwner;
 import com.mars_sim.core.logging.SimLogger;
@@ -523,31 +521,6 @@ public class Malfunction implements Serializable {
 	}
 
 	/**
-	 * Gets the name of the person who spent most time repairing this malfunction.
-	 *
-	 * @return the name of the person
-	 */
-	public String getMostProductiveRepairer() {
-		// Collate all values
-		Map<String, Double> totalWork = work.values().stream()
-			.flatMap(w -> w.activeWorkers.entrySet().stream())
-			.collect(Collectors.toMap(Map.Entry::getKey,
-								  Map.Entry::getValue,
-								  Double::sum								  
-								  ));
-
-		// Find the max
-		Map.Entry<String, Double> maxEntry = totalWork.entrySet()
-				.stream()
-				.max(Map.Entry.comparingByValue())
-				.orElse(null); // .get()
-    	if (maxEntry != null && maxEntry.getKey() != null)
-    		return maxEntry.getKey();
-    	else
-    		return null;
-	}
-
-	/**
 	 * Gets a list of repairers who have worked on this type of malfunction repair.
 	 * 
 	 * @param type
@@ -639,21 +612,6 @@ public class Malfunction implements Serializable {
 			}
 		}
 		return selectedScope;
-	}
-	
-	/**
-	 * Randomly picks one of the scopes.
-	 * 
-	 * @return
-	 */
-	private String pickOneScope() {
-		Set<String> scopes = definition.getSystems();
-
-		int rand = RandomUtil.getRandomInt(scopes.size() - 1);
-		return scopes.stream()
-				     .skip(rand)
-				     .findFirst()
-				     .orElse(null);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/malfunction/MalfunctionManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/malfunction/MalfunctionManager.java
@@ -20,17 +20,14 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 
-import com.mars_sim.core.Unit;
 import com.mars_sim.core.EntityEventType;
+import com.mars_sim.core.Unit;
 import com.mars_sim.core.UnitType;
 import com.mars_sim.core.building.Building;
 import com.mars_sim.core.building.BuildingCategory;
 import com.mars_sim.core.equipment.EVASuit;
 import com.mars_sim.core.equipment.EquipmentOwner;
 import com.mars_sim.core.equipment.ResourceHolder;
-import com.mars_sim.core.events.HistoricalEvent;
-
-import com.mars_sim.core.events.HistoricalEventManager;
 import com.mars_sim.core.events.HistoricalEventType;
 import com.mars_sim.core.goods.Good;
 import com.mars_sim.core.goods.GoodsUtil;
@@ -98,9 +95,9 @@ public class MalfunctionManager implements Serializable, Temporal {
 	/** Factor for chance of malfunction by time since last maintenance. */
 	private static final double MAINT_TO_MAL_RATIO = 5;
 	/** The lower limit factor for maintenance. 1.000_033_516_95 will result in 10 % certainty per orbit. */	
-	private static final double MAINTENANCE_LOWER_LIMIT = 0; //MALFUNCTION_LOWER_LIMIT; // * MAINT_TO_MAL_RATIO; //1.000_033_516_95;
+	private static final double MAINTENANCE_LOWER_LIMIT = 0; 
 	/** The upper limit factor for both malfunction and maintenance. 1.000_335_221_5 will result in 100% certainty per orbit. */
-	private static final double UPPER_LIMIT = 2;//1.000_335_221_5;
+	private static final double UPPER_LIMIT = 2;
 	
 	/** Wear-and-tear points earned from a low quality inspection. */
 	private static final double LOW_QUALITY_INSPECTION = 200;
@@ -189,7 +186,6 @@ public class MalfunctionManager implements Serializable, Temporal {
 	private static MasterClock masterClock;
 	private static MedicalManager medic;
 	private static MalfunctionFactory factory;
-	private static HistoricalEventManager eventManager;
 	private static PartConfig partConfig;
 	
 	/**
@@ -218,25 +214,16 @@ public class MalfunctionManager implements Serializable, Temporal {
 		boolean isMainPowerGen = false;
 		boolean isHallway = false;
 		
-		if (UnitType.BUILDING == entity.getUnitType()) {
-
-			Building building = (Building)entity;
+		if (entity instanceof Building building) {
 			if (building.isInhabitable()) {
 				// Usually power building gets deployed first.
 				isInhabitable = true;
 				
-				if (BuildingCategory.ERV == building.getCategory()) {
-					// Next is resource processing building such as ERV 
-					isERV = true;
-				}
-				else if (BuildingCategory.POWER == building.getCategory()) {
-					// Next is the main power generator
-					isMainPowerGen = true;
-				}
+				isERV = BuildingCategory.ERV == building.getCategory();
+				isMainPowerGen = BuildingCategory.POWER == building.getCategory();
 			}
-			else if (BuildingCategory.CONNECTION == building.getCategory()) {
-				// Next is resource processing building such as ERV 
-				isHallway = true;
+			else {
+				isHallway = BuildingCategory.CONNECTION == building.getCategory();
 			}
 		}
 
@@ -716,33 +703,14 @@ public class MalfunctionManager implements Serializable, Temporal {
 			}
 		}
 
-		HistoricalEvent newEvent = createMalfunctionEvent(
-								eventType, 
-								malfunction, 
-								whileDoing, 
-								whoAffected);
+		getUnit().registerHistoricalEvent(eventType, malfunction.getName(), whileDoing, actor, null);
 		
-		eventManager.registerNewEvent(newEvent);
-
-		if (eventType.getName().equalsIgnoreCase("Acts of God"))
-			logger.log(entity, Level.WARNING, 0, 
-								malfunction.getName()
-								+ PROBABLE_CAUSE 
-								+ eventType.getName() 
-								+ ".");
-		else
-			logger.log(entity, Level.WARNING, 0, 
+		logger.log(entity, Level.WARNING, 0, 
 					malfunction.getName()
 					+ PROBABLE_CAUSE 
 					+ eventType.getName() 
 					+ "."
 					+ (actor != null ? CAUSED_BY + whoAffected + "'." : "."));
-	}
-
-	private HistoricalEvent createMalfunctionEvent(HistoricalEventType type, Malfunction malfunction, String whileDoing,
-			String whoAffected) {
-		return new HistoricalEvent(type, entity, entity.getAssociatedSettlement(), malfunction.getName(),
-									whileDoing, null);
 	}
 	
 	/**
@@ -795,7 +763,7 @@ public class MalfunctionManager implements Serializable, Temporal {
 			
 			double inspectFactor = (effTimeSinceLastMaint/standardInspectionWindow) + .1D;
 			double wearFactor = (100 - currentWearCondPercent) * WEAR_MALFUNCTION_FACTOR;		
-			double malfunctionChance = time * inspectFactor * wearFactor; // * FREQUENCY;
+			double malfunctionChance = time * inspectFactor * wearFactor;
 
 			// Keep for debugging: logger.info(entity, "MalfunctionChance min: " + Math.round(malfunctionChance * 100_000.0)/100_000.0 + " %")
 			
@@ -809,7 +777,6 @@ public class MalfunctionManager implements Serializable, Temporal {
 			malfunctionProbability = 1.0 - Math.exp(-malfunctionChance) ;
 			// Keep for debugging: logger.info(entity, "MalfunctionChance log10: " + Math.round(malfunctionChance * 100_000.0)/100_000.0 + " %")
 				
-			boolean hasMal = false;
 			// Check for malfunction due to lack of maintenance and wear condition.
 			if (time > 0 && RandomUtil.lessThanRandPercent(malfunctionProbability)) {
 				// Reset delay back to MAX_DELAY. 
@@ -817,17 +784,10 @@ public class MalfunctionManager implements Serializable, Temporal {
 	
 				// Note: call selectMalfunction is just checking for the possibility 
 				// of having malfunction and doesn't necessarily mean it has to result in a malfunction
-				hasMal = selectMalfunction((Unit)entity);
+				selectMalfunction((Unit)entity);
 			}
 
 			// FUTURE : how to connect maintenance to field reliability statistics of parts used in this units	
-			
-			if (hasMal) {
-				// Note: If it already has a malfunction in this tick,
-				// do inhibit any task of inspection over this entity for maintenance so that 
-				// settlers can handle the stress.
-				return;
-			}
 		}
 	}
 		
@@ -976,19 +936,13 @@ public class MalfunctionManager implements Serializable, Temporal {
 		}
 		else {
 			Map<String, Double> effects = fixed.getLifeSupportEffects();
-			if (!effects.isEmpty()) {
-				if (effects.containsKey(OXYGEN))
-					resetModifiers(0);
-			}
+			if (effects.containsKey(OXYGEN))
+				resetModifiers(0);
 
-			getUnit().fireUnitUpdate(MALFUNCTION_EVENT, fixed);
+			var u = getUnit();
+			u.fireUnitUpdate(MALFUNCTION_EVENT, fixed);
 
-			String chiefRepairer = fixed.getMostProductiveRepairer();
-
-			HistoricalEvent newEvent = createMalfunctionEvent(HistoricalEventType.MALFUNCTION_FIXED, fixed,
-					null, chiefRepairer);
-
-			eventManager.registerNewEvent(newEvent);
+			u.registerHistoricalEvent(HistoricalEventType.MALFUNCTION_FIXED, fixed.getName(), null, null, null);
 
 			logger.log(entity, Level.INFO, 20_000L, "The malfunction '" + fixed.getName() + "' had been dealt with.");
 		}
@@ -1003,9 +957,6 @@ public class MalfunctionManager implements Serializable, Temporal {
 	public void setLifeSupportModifiers(double time) {
 
 		double tempOxygenFlowModifier = 0D;
-//		double tempWaterFlowModifier = 0D;
-//		double tempAirPressureModifier = 0D;
-//		double tempTemperatureModifier = 0D;
 
 		// Make any life support modifications.
 		if (hasMalfunction()) {
@@ -1023,12 +974,6 @@ public class MalfunctionManager implements Serializable, Temporal {
 					
 					if (effects.get(OXYGEN) != null)
 						tempOxygenFlowModifier += effects.get(OXYGEN) * (100D - malfunction.getPercentageFixed())/100D;
-//					if (effects.get(WATER) != null)
-//						tempWaterFlowModifier += effects.get(WATER) * (100D - malfunction.getPercentageFixed())/100D;
-//					if (effects.get(PRESSURE) != null)
-//						tempAirPressureModifier += effects.get(PRESSURE) * (100D - malfunction.getPercentageFixed())/100D;
-//					if (effects.get(TEMPERATURE) != null)
-//						tempTemperatureModifier += effects.get(TEMPERATURE) * (100D - malfunction.getPercentageFixed())/100D;
 				}
 			}
 
@@ -1087,8 +1032,7 @@ public class MalfunctionManager implements Serializable, Temporal {
 	 */
 	public void createASeriesOfMalfunctions(String location, Unit actor) {
 		int nervousness = SCORE_DEFAULT;
-		if (actor instanceof Person) {
-			Person p = (Person) actor;
+		if (actor instanceof Person p) {
 			nervousness = p.getMind().getTraitManager()
 					.getPersonalityTrait(PersonalityTraitType.NEUROTICISM);
 		}
@@ -1133,12 +1077,7 @@ public class MalfunctionManager implements Serializable, Temporal {
 
 			// Add stress to people affected by the accident.
 			Collection<Person> people = entity.getAffectedPeople();
-			Iterator<Person> i = people.iterator();
-			while (i.hasNext()) {
-				Person p = i.next();
-//	            logger.info(p, 10_000, "Adding " + Math.round(ACCIDENT_STRESS * 100.0)/100.0 + " to the stress.");
-				p.getPhysicalCondition().addStress(ACCIDENT_STRESS);
-			}
+			people.forEach(p -> p.getPhysicalCondition().addStress(ACCIDENT_STRESS));
 		}
 	}
 
@@ -1199,20 +1138,15 @@ public class MalfunctionManager implements Serializable, Temporal {
 		
 		if (partsPosted) {
 			
-			int shortfall = consumeMaintenanceParts((EquipmentOwner) containerUnit);
+			int shortfall = consumeMaintenanceParts(containerUnit);
 			
-			if (shortfall == -1) {
-				logger.warning(entity, 30_000L, "No spare part(s) available for maintenance on " 
-						+ entity + ".");
-			}
-			else if (shortfall == 0) {
-				logger.warning(entity, 30_000L, "No spare part posted yet on " 
-						+ entity + ".");
-			}
-			else {
-				logger.info(entity, 30_000L, "Spare part(s) consumed on a maintenance task on " 
-						+ entity + ".");
-			}
+			String shortfallMsg = switch(shortfall) {
+				case -1 -> "No spare part(s) available for maintenance on " + entity + ".";
+				case 0 -> "No spare part posted yet on " + entity + ".";
+				default -> "Spare part(s) consumed on a maintenance task on " + entity + ".";
+			};
+
+			logger.info(entity, 30_000L, shortfallMsg);
 		}
 		else {
 			// Performs the inspection maintenance to see if any parts need to be replaced
@@ -1262,7 +1196,6 @@ public class MalfunctionManager implements Serializable, Temporal {
 	 * @return
 	 */
 	public double getAdjustedCondition() { 
-		// Compare with currentWearCondPercent = currentWearLifeTime/baseWearLifeTime * 100;
 		return currentWearLifeTime / (baseWearLifeTime + cumulativeTime) * 100;
 	}
 
@@ -1326,12 +1259,11 @@ public class MalfunctionManager implements Serializable, Temporal {
 	 * Gets the unit.
 	 */
 	private Unit getUnit() {
-		if (entity instanceof Unit u)
-			return u;
-		else if (entity instanceof Building b)
-			return b.getSettlement();
-		else
+		if (entity instanceof Unit unit) {
+			return unit;
+		} else {
 			throw new IllegalStateException("Could not find unit associated with malfunctionable.");
+		}
 	}
 
 	/**
@@ -1364,7 +1296,6 @@ public class MalfunctionManager implements Serializable, Temporal {
 	 * @return
 	 */
 	public List<MaintenanceScope> getMaintenanceScopeList(String scope) {
-//		May add back for debugging: logger.info("scope: " + scope + "  scopeMap: " + scopeMap.keySet().toString());
 		return scopeMap.getOrDefault(scope, Collections.emptyList());
 	}
 	
@@ -1515,9 +1446,7 @@ public class MalfunctionManager implements Serializable, Temporal {
 	 * @return
 	 */
 	public boolean areMaintenancePartsNeeded() {
-		if (partsNeededForMaintenance == null || partsNeededForMaintenance.isEmpty())
-			return false;
-		return true;
+		return (partsNeededForMaintenance != null && !partsNeededForMaintenance.isEmpty());
 	}
 	
 	/**
@@ -1756,17 +1685,12 @@ public class MalfunctionManager implements Serializable, Temporal {
 	/**
 	 * Initializes instances after loading from a saved sim.
 	 *
-	 * @param c0 {@link MasterClock}
-	 * @param mf {@link MalfunctionFactory}
-	 * @param m {@link MedicalManager}
-	 * @param e {@link HistoricalEventManager}
 	 */
 	public static void initializeInstances(MasterClock c0, MalfunctionFactory mf,
-										   MedicalManager mm, HistoricalEventManager em, PartConfig pc) {
+										   MedicalManager mm, PartConfig pc) {
 		masterClock = c0;
 		factory = mf;
 		medic = mm;
-		eventManager = em;
 		partConfig = pc;
 	}
 
@@ -1775,7 +1699,6 @@ public class MalfunctionManager implements Serializable, Temporal {
 	 */
 	public static void setNoFailures(boolean newFlag) {
 		noFailures = newFlag;
-//		logger.info("No failures flag set to " + noFailures);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/Mind.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/Mind.java
@@ -9,6 +9,7 @@ package com.mars_sim.core.person.ai;
 import java.io.Serializable;
 
 import com.mars_sim.core.EntityEventType;
+import com.mars_sim.core.events.HistoricalEventType;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.job.util.AssignmentHistory;
@@ -38,7 +39,6 @@ public class Mind implements Serializable, Temporal {
 	/** default logger. */
 	private static final SimLogger logger = SimLogger.getLogger(Mind.class.getName());
 
-	private static final int MAX_EXECUTE = 100; // Maximum number of iterations of a Task per pulse
 	private static final int MAX_ZERO_EXECUTE = 100; // Maximum number of executeTask action that consume no time
 	private static final int RELATION_UPDATE_CYCLE = 250;
 	private static final int EMOTION_UPDATE_CYCLE = 250;
@@ -192,7 +192,6 @@ public class Mind implements Serializable, Temporal {
 	private void takeAction(double time) {
 		double pulseTime = time;
 		int zeroCount = 0;    // Count the number of conseq. zero executions
-		int callCount = 0;
 		// Loop around using up time; recursion can blow stack memory
 		do {
 			// Perform a task if the person has one, or determine a new task/mission.
@@ -219,13 +218,6 @@ public class Mind implements Serializable, Temporal {
 				}
 
 				// Safety check to track a repeating Task loop
-				if (callCount >= MAX_EXECUTE) {
-					logger.warning(person, 20_000, "Calling '"
-							+ taskManager.getTaskName() + "' for "
-							+ callCount + " iterations.");
-					callCount++;
-					return;
-				}
 				if (remainingTime == pulseTime) {
 					// No time has been consumed previously
 					// This is not supposed to happen but still happens a lot.
@@ -348,18 +340,22 @@ public class Mind implements Serializable, Temporal {
 		AssignmentHistory jh = person.getJobHistory();
 
 		// Future: check if the initiator's role allows the job to be changed
-		if (newJob != jobType) {
+		if (newJob != jobType && (bypassingJobLock || !jobLock)) {
+			// Set to the new job
+			var oldJob = jobType;
+			jobType = newJob;
+			jh.saveJob(newJob, assignedBy, status, approvedBy);
 
-			if (bypassingJobLock || !jobLock) {
-				// Set to the new job
-				jobType = newJob;
-				jh.saveJob(newJob, assignedBy, status, approvedBy);
+			person.fireUnitUpdate(EntityEventType.JOB_EVENT, newJob);
 
-				person.fireUnitUpdate(EntityEventType.JOB_EVENT, newJob);
-
-				// Note: the new job will be Locked in until the beginning of the next day
-				jobLock = true;
+			// Record the job change as a historical event
+			if (oldJob != null) {
+				person.registerHistoricalEvent(HistoricalEventType.CHANGE_JOB, newJob.getName(),
+								null, null, null);
 			}
+
+			// Note: the new job will be Locked in until the beginning of the next day
+			jobLock = true;
 		}
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/AbstractMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/AbstractMission.java
@@ -199,22 +199,8 @@ public abstract class AbstractMission implements Mission, Temporal {
 		Person person = (Person) startingMember;
 
 		if (person.isInSettlement()) {
-
-			// Created mission starting event.
-			registerHistoricalEvent(person, HistoricalEventType.MISSION_START, "Mission Starting");
-
-			// Log mission starting.
-			int n = members.size();
-			String appendStr = "";
-			if (n == 0)
-				appendStr = ".";
-			else if (n == 1)
-				appendStr = "' with 1 other.";
-			else
-				appendStr = "' with " + n + " others.";
-
 			logger.log(startingMember, Level.INFO, 0,
-					"Began organizing " + missionString + appendStr);
+					"Began organizing " + missionString + ", members " + members.size());
 
 			// Add starting member to mission.
 			startingMember.setMission(this);
@@ -331,9 +317,7 @@ public abstract class AbstractMission implements Mission, Temporal {
 			members.add(member);
 
 			signUp.add(member);
-			registerHistoricalEvent(member, HistoricalEventType.MISSION_JOINING,
-									"Adding a member");
-	
+
 			fireMissionUpdate(ADD_MEMBER_EVENT, member);
 
 			logger.log(member, Level.FINER, 0, "Just got added to " + missionString + ".");
@@ -519,7 +503,6 @@ public abstract class AbstractMission implements Mission, Temporal {
 		}
 
 		// Move phase on
-		var oldPhase = phase;
  		phase = newPhase;
 		setPhaseEnded(false);
 		phaseStartTime = clock.getMarsTime();
@@ -535,9 +518,7 @@ public abstract class AbstractMission implements Mission, Temporal {
 		// Add entry to the log
 		addMissionLog(newPhase.getName(), getStartingPerson().getName());
 
-		if (!oldPhase.equals(INIT_PHASE)) {
-			registerHistoricalEvent(getStartingPerson(), HistoricalEventType.MISSION_PHASE, phaseDescription);
-		}
+		registerHistoricalEvent(getStartingPerson(), HistoricalEventType.MISSION_PHASE, phaseDescription);
 
 		fireMissionUpdate(PHASE_EVENT, newPhase);
 	}
@@ -1306,8 +1287,11 @@ public abstract class AbstractMission implements Mission, Temporal {
 	 */
 	protected void startReview() {
 		setPhase(REVIEWING, null);
-		plan = new MissionPlanning(this, getMarsTime().getMissionSol(), getAssociatedSettlement().getMinimumPassingScore());
+
+		var minScore = getAssociatedSettlement().getMinimumPassingScore();
+		plan = new MissionPlanning(this, getMarsTime().getMissionSol(), minScore);
 	}
+	
 	/**
 	 * Returns the mission plan.
 	 *

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/role/Role.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/role/Role.java
@@ -14,6 +14,7 @@ import com.mars_sim.core.Simulation;
 import com.mars_sim.core.activities.GroupActivity;
 import com.mars_sim.core.data.History;
 import com.mars_sim.core.data.History.HistoryItem;
+import com.mars_sim.core.events.HistoricalEventType;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.structure.GroupActivityType;
 
@@ -73,12 +74,13 @@ public class Role implements Serializable {
 
 		if (newType != oldType) {
 			var home = person.getAssociatedSettlement();
+			var command = home.getChainOfCommand();
 
 			// Note : if this is a leadership role, only one person should occupy this position 
 			List<Person> predecessors = Collections.emptyList();
 			if (newType.isChief() || newType.isCouncil()) {
 				// Find a list of predecessors who are occupying this role
-				predecessors = home.getChainOfCommand().findPeopleWithRole(newType);
+				predecessors = command.findPeopleWithRole(newType);
 				if (!predecessors.isEmpty()) {
 					Person p = predecessors.get(0);
 					// Predecessors to seek for a new role to fill
@@ -94,14 +96,17 @@ public class Role implements Serializable {
 			roleType = newType;
 			roleHistory.add(roleType);
 			
-			if (home.getChainOfCommand() != null) {
-				// Check for null in case of maven test ConstructionMissionMetaTest
-				// Save the role in the settlement Registry
-				home.getChainOfCommand().registerRole(roleType);
-			}
+			// Save the role in the settlement Registry
+			command.registerRole(roleType);
 
 			// Records the role change and fire unit update
 			person.fireUnitUpdate(ROLE_EVENT, roleType);
+
+			// If a change then create event
+			if (oldType != null) {
+				person.registerHistoricalEvent(HistoricalEventType.CHANGE_ROLE, roleType.getName(),
+					null, null, null);
+			}
 
 			// For Council members being changed have a meeting
 			if (roleType.isCouncil() && !predecessors.isEmpty()

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/EVAOperation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/EVAOperation.java
@@ -19,7 +19,6 @@ import com.mars_sim.core.environment.SurfaceFeatures;
 import com.mars_sim.core.equipment.Container;
 import com.mars_sim.core.equipment.EVASuit;
 import com.mars_sim.core.equipment.Equipment;
-import com.mars_sim.core.events.HistoricalEvent;
 import com.mars_sim.core.events.HistoricalEventType;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.map.location.Coordinates;
@@ -427,19 +426,16 @@ public abstract class EVAOperation extends Task {
 
 		// Check for any EVA problems.
 		if (hasEVASuitProblem(person)) {
-//			May add back for testing : logger.info(worker, 10_000L, getName() + "': EVA problems.");
 			return true;
 		}
 
 		// Check if it is at meal time and the person is doubly hungry
 		if (isHungryAtMealTime(person, 0)) {
-//			May add back for future testing : logger.info(worker, 10_000L, "Ending '" + getName() + "': Doubly hungry at meal time.");
 			return true;
 		}
 
         // Checks if the person is physically drained
 		if (isExhausted(person)) {
-//			May add back for future testing : logger.info(worker, 10_000L, "Ending '" + getName() + "': Exhausted.");
 			return true;
 		}
 		
@@ -460,7 +456,6 @@ public abstract class EVAOperation extends Task {
 
 		// Check for sunlight
 		if (!isSunlightAboveLevel(person.getCoordinates(), minEVASunlight)) {
-//			May add back for future testing : logger.info(worker, 10_000L, getName() + "': too dark already.");
 			return true;
 		}
 
@@ -546,10 +541,6 @@ public abstract class EVAOperation extends Task {
 	 * @param reason Reason for ending.
 	 */
 	protected void endEVA(String reason) {
-		if (reason != null) {
-// 			May add back for future testing :logger.info(worker, 20_000, "Ending EVA '" + getName() + "': " + reason);
-		}
-		
 		if (person.isOutside()) {
             setPhase(WALK_BACK_INSIDE);
 		}
@@ -892,14 +883,9 @@ public abstract class EVAOperation extends Task {
 		HealthProblem problem = p.getPhysicalCondition().getMostSerious();
 				
 		if (problem == null) {
-			var rescueEvent = new HistoricalEvent(HistoricalEventType.MISSION_RESCUE_PERSON,
-				p, p.getAssociatedSettlement(),
-				PhysicalConditionFormat.getHealthSituation(p.getPhysicalCondition()),
-				p.getTaskDescription(),
-				p.getMission(),
-				p.getCoordinates()
-				);
-			registerNewEvent(rescueEvent);
+			p.registerHistoricalEvent(HistoricalEventType.MISSION_RESCUE_PERSON,
+										PhysicalConditionFormat.getHealthSituation(p.getPhysicalCondition()),
+										p.getTaskDescription(), p.getMission(), p.getCoordinates());
 
 		}
 		else {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/EVAOperation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/EVAOperation.java
@@ -525,17 +525,6 @@ public abstract class EVAOperation extends Task {
 	}
 	
 	/**
-	 * Checks to see if the person is supposed to be outside. This is used to abort an EVA.
-	 * Any call to this method that relates to a problem should be replaced with {@link #endEVA(String)}
-	 * 
-	 * @param reason
-	 * @deprecated Use {@link #endEVA(String)}
-	 */
-	protected void checkLocation(String reason) {
-		endEVA(reason);
-	}
-
-	/**
 	 * Aborts an EVA, if the Person is outside get them to return otherwise end the Task.
 	 * 
 	 * @param reason Reason for ending.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/Task.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/util/Task.java
@@ -27,8 +27,6 @@ import com.mars_sim.core.building.function.FunctionType;
 import com.mars_sim.core.building.function.farming.CropConfig;
 import com.mars_sim.core.environment.OrbitInfo;
 import com.mars_sim.core.environment.SurfaceFeatures;
-import com.mars_sim.core.events.HistoricalEvent;
-import com.mars_sim.core.events.HistoricalEventManager;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.malfunction.Malfunctionable;
 import com.mars_sim.core.map.location.LocalBoundedObject;
@@ -129,8 +127,6 @@ public abstract class Task implements Serializable, Comparable<Task> {
 
 	/** The static instance of the master clock */
 	protected static MasterClock masterClock;
-	/** The static instance of the event manager */
-	protected static HistoricalEventManager eventManager;
 	/** The static instance of the UnitManager */
 	protected static UnitManager unitManager;
 	/** The static instance of the ScientificStudyManager */
@@ -312,15 +308,6 @@ public abstract class Task implements Serializable, Comparable<Task> {
 	 * Subclasses should override to receive callback when the Task is ending.
 	 */
 	protected void clearDown() {
-	}
-
-	/**
-	 * Helper method for Event subclasses to register historical events.
-	 * 
-	 * @param newEvent the new event
-	 */
-	public static void registerNewEvent(HistoricalEvent newEvent) {
-		eventManager.registerNewEvent(newEvent);
 	}
 	
 	/**
@@ -945,7 +932,7 @@ public abstract class Task implements Serializable, Comparable<Task> {
 		} 
 		if (!success) {
 			// If no available activity spot, go to an empty location in building
-			success = walkToEmptyActivitySpotInBuilding(building, allowFail);
+			walkToEmptyActivitySpotInBuilding(building, allowFail);
 		}
 	}
 
@@ -1042,14 +1029,12 @@ public abstract class Task implements Serializable, Comparable<Task> {
 		if (originBuilding != null && originBuilding.equals(building)
 			// Check if this worker has already occupied a spot for this function
 			&& f.checkWorkerActivitySpot(worker)) {
-//			logger.info(worker, "Already at a spot for " + f.getFunctionType().getName() + ". No need to go further to claim one.");
 				return true;
 		}
 		
 		LocalPosition loc = f.getAvailableActivitySpot();
 		
 		if (loc == null) {
-//			logger.info(worker, 10_000L, getDescription() + ". No available spots for " + f.getFunctionType().getName() + " in " + building +  ".");
 			return false;
 		}
 			
@@ -1062,20 +1047,11 @@ public abstract class Task implements Serializable, Comparable<Task> {
 			boolean canWalk = createWalkingSubtask(building, loc, allowFail, true);
 			
 			if (canWalk) {
-//					logger.info(worker, "Walking toward " + building + ".");
-
-				// Q: how to make it the building only after it has arrived ?
-				// Use setToBuilding() to both add to life support/robotic station and the building itself
-				// BuildingManager.setToBuilding(worker, building);
-				
-//					logger.info(worker, "Claimed the spot. Walking toward " + building + ".");
 				return true;
 			}
 			else {
 				// Reverse the walk and go back to the original building
-//				createWalkingSubtask(originBuilding, originLoc, allowFail, true);
-//				logger.info(worker, 10_000L, "Failed to claim the spot. Walking back to " + originBuilding + ".");
-				
+		
 				// Unclaim the activity spot.
 				worker.leaveActivitySpot(true);
 				
@@ -1489,7 +1465,6 @@ public abstract class Task implements Serializable, Comparable<Task> {
 		// Set standard pulse time to a quarter of the value of the current pulse width
 		setStandardPulseTime(Math.min(masterClock.geTaskPulseWidth(), masterClock.getLeadPulseTime()));
 		
-		eventManager = s.getEventManager();
 		unitManager = s.getUnitManager();
 		scientificStudyManager = s.getScientificStudyManager();
 		surfaceFeatures = s.getSurfaceFeatures();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/health/HealthProblem.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/health/HealthProblem.java
@@ -9,8 +9,6 @@ package com.mars_sim.core.person.health;
 import java.io.Serializable;
 
 import com.mars_sim.core.EntityEventType;
-import com.mars_sim.core.events.HistoricalEvent;
-
 import com.mars_sim.core.events.HistoricalEventManager;
 import com.mars_sim.core.events.HistoricalEventType;
 import com.mars_sim.core.logging.SimLogger;
@@ -80,11 +78,9 @@ public class HealthProblem implements Serializable {
 		if (!sufferer.isInSettlement()) {
 			location = sufferer.getCoordinates();
 		}
-		var event = new HistoricalEvent(eventType, sufferer, sufferer.getAssociatedSettlement(), getComplaint().getName(),
-				sufferer.getTaskDescription(), null, location);
 
-
-		eventManager.registerNewEvent(event);
+		sufferer.registerHistoricalEvent(eventType, getComplaint().getName(), sufferer.getTaskDescription(),
+							null, location);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/health/HealthProblem.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/health/HealthProblem.java
@@ -204,7 +204,7 @@ public class HealthProblem implements Serializable {
 		setState(HealthProblemState.BEING_TREATED);
 
 		// Create medical event for treatment.
-		registerHistoricalEvent(HistoricalEventType.MEDICAL_TREATED);
+		registerHistoricalEvent(HistoricalEventType.MEDICAL_START_TREATMENT);
 
 		logger.info(getSufferer(), "Began to receive treatment for " + getComplaint().getName() + ".");
 	}
@@ -257,7 +257,7 @@ public class HealthProblem implements Serializable {
 				requiresBedRest = getComplaint().requiresBedRestRecovery();
 				
 				// Create medical event for recovering.
-				registerHistoricalEvent(HistoricalEventType.MEDICAL_RECOVERY);
+				registerHistoricalEvent(HistoricalEventType.MEDICAL_START_RECOVERY);
 			} else {
 				setCured();
 			}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/health/RadiationExposure.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/health/RadiationExposure.java
@@ -11,10 +11,9 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.mars_sim.core.Simulation;
 import com.mars_sim.core.EntityEventType;
+import com.mars_sim.core.Simulation;
 import com.mars_sim.core.UnitManager;
-import com.mars_sim.core.events.HistoricalEvent;
 import com.mars_sim.core.events.HistoricalEventType;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.person.Person;
@@ -166,7 +165,7 @@ public class RadiationExposure implements Serializable, Temporal {
 			return career > limit.career;
 		}
 		
-	};
+	}
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
@@ -244,7 +243,9 @@ public class RadiationExposure implements Serializable, Temporal {
 	private static final String DOSE_OF = " mSv cumulativeDoses of ";
 	private static final String EVA_OPERATION = " during an EVA operation.";
 
-	private int solCache = 1, counter30 = 1, counter360 = 1;
+	private int solCache = 1;
+	private int counter30 = 1;
+	private int counter360 = 1;
 
 	private boolean isSick;
 
@@ -357,7 +358,7 @@ public class RadiationExposure implements Serializable, Temporal {
 
 
 	private int rand(int ceil) {
-		int base = (int)(ceil / 2);
+		int base = (ceil / 2);
 		return RandomUtil.getRandomInt(base, ceil);
 	}
 
@@ -375,12 +376,6 @@ public class RadiationExposure implements Serializable, Temporal {
 			}
 		}
 		
-		// Checks radiation
-		// Note: if a person is outside, it's handled by EVAOperation's isRadiationDetected()
-//		if (!person.isOutside()) {
-//			isRadiationDetected(pulse.getElapsed());
-//		}
-			
 		return true;
 	}
 
@@ -422,8 +417,6 @@ public class RadiationExposure implements Serializable, Temporal {
 			counter30 = 0;
 		}
 
-		// TODO: convert to Martian system. For now, use 360 sol for simplicity and
-		// synchronization with the 30-day carryover
 		if (counter360 == 360) {
 			carryOverDosage(true);
 			counter360 = 0;
@@ -636,10 +629,8 @@ public class RadiationExposure implements Serializable, Temporal {
 					logger.info(person, str + " while " + activity);
 				}
 
-				HistoricalEvent hEvent = new HistoricalEvent(HistoricalEventType.HAZARD_RADIATION_EXPOSURE,
-												person, person.getAssociatedSettlement(),
-												rad.toString(), person.getTaskDescription());
-				Simulation.instance().getEventManager().registerNewEvent(hEvent);
+				person.registerHistoricalEvent(HistoricalEventType.HAZARD_RADIATION_EXPOSURE, rad.toString(),
+							person.getTaskDescription(), null, null);
 
 				person.fireUnitUpdate(EntityEventType.RADIATION_EVENT);
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/science/ScientificStudy.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/science/ScientificStudy.java
@@ -24,6 +24,8 @@ import com.mars_sim.core.MonitorableEntity;
 import com.mars_sim.core.Simulation;
 import com.mars_sim.core.UnitManager;
 import com.mars_sim.core.data.UnitSet;
+import com.mars_sim.core.events.HistoricalEvent;
+import com.mars_sim.core.events.HistoricalEventType;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.NaturalAttributeType;
@@ -61,15 +63,15 @@ public class ScientificStudy implements MonitorableEntity, Temporal, Comparable<
 	private static final SimLogger logger = SimLogger.getLogger(ScientificStudy.class.getName());
 
 	// Scientific study event types
-	public static final String STUDY_COMPLETION_EVENT = "study completion event";
+	private static final String STUDY_COMPLETION_EVENT = "study completion event";
 	public static final String PHASE_CHANGE_EVENT = "study phase change event";
-	public static final String PROPOSAL_WORK_EVENT = "study proposal work event";
+	private static final String PROPOSAL_WORK_EVENT = "study proposal work event";
 	public static final String ADD_COLLABORATOR_EVENT = "add study collaborator event";
 	public static final String REMOVE_COLLABORATOR_EVENT = "remove study collaborator event";
-	public static final String PRIMARY_RESEARCH_WORK_EVENT = "study primary research work event";
-	public static final String COLLABORATION_RESEARCH_WORK_EVENT = "study collaboration research work event";
-	public static final String PRIMARY_PAPER_WORK_EVENT = "study primary paper work event";
-	public static final String COLLABORATION_PAPER_WORK_EVENT = "study collaboration paper work event";
+	private static final String PRIMARY_RESEARCH_WORK_EVENT = "study primary research work event";
+	private static final String COLLABORATION_RESEARCH_WORK_EVENT = "study collaboration research work event";
+	private static final String PRIMARY_PAPER_WORK_EVENT = "study primary paper work event";
+	private static final String COLLABORATION_PAPER_WORK_EVENT = "study collaboration paper work event";
 
 	// Data members
 	/** The assigned study number. */
@@ -181,6 +183,9 @@ public class ScientificStudy implements MonitorableEntity, Temporal, Comparable<
 		peerReviewStartTime = null;
 		listeners = new HashSet<>();
 		topics = new ArrayList<>();
+
+		// Register the initial phase
+		registerHistoricalEvent(HistoricalEventType.STUDY_START_PHASE, phase.getName());
 	}
 
 	/**
@@ -245,6 +250,18 @@ public class ScientificStudy implements MonitorableEntity, Temporal, Comparable<
 
 		// Fire scientific study update event.
 		fireScientificStudyUpdate(PHASE_CHANGE_EVENT);
+
+		registerHistoricalEvent(HistoricalEventType.STUDY_START_PHASE, phase.getName());
+	}
+
+	/**
+	 * Create a historical event for this scientific study.
+	 * @param eventType the type of event.
+	 * @param message the message to include in the event.
+	 */
+	private void registerHistoricalEvent(HistoricalEventType eventType, String message) {
+		var event = new HistoricalEvent(eventType, this, getPrimarySettlement(), message, null);
+		Simulation.instance().getEventManager().registerNewEvent(event);
 	}
 
 	/**
@@ -817,6 +834,7 @@ public class ScientificStudy implements MonitorableEntity, Temporal, Comparable<
 		
 		// Fire scientific study update event.
 		fireScientificStudyUpdate(STUDY_COMPLETION_EVENT);
+		registerHistoricalEvent(HistoricalEventType.STUDY_FINISH, reason);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/ExplorationManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/ExplorationManager.java
@@ -17,8 +17,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.mars_sim.core.Simulation;
 import com.mars_sim.core.environment.MineralSite;
 import com.mars_sim.core.environment.SurfaceFeatures;
+import com.mars_sim.core.events.HistoricalEvent;
+import com.mars_sim.core.events.HistoricalEventType;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.mineral.MineralMap;
@@ -225,25 +228,16 @@ public class ExplorationManager implements Serializable {
 		List<Double> list = new ArrayList<>();
 		for (var e : interestingLocns) {
 			if (e.site != null) {
-				switch(status) {
-					case SITE_STAT: 
-						list.add(e.distance);
-						break;
-					
-					case CLAIMED_STAT:
-						if (e.site.isClaimed() && e.site.getOwner().equals(base.getReportingAuthority())) {
-							list.add(e.distance);
-						}
-						break;
-					
-					case UNCLAIMED_STAT:
-						if (!e.site.isClaimed()) {
-							list.add(e.distance);
-						}
-						break;
-					
-					default:
-						break;
+				boolean add = switch(status) {
+					case SITE_STAT -> true;
+					case CLAIMED_STAT -> e.site.isClaimed()
+								&& e.site.getOwner().equals(base.getReportingAuthority());
+					case UNCLAIMED_STAT -> !e.site.isClaimed();
+					default -> false;
+				};
+
+				if (add) {
+					list.add(e.distance);
 				}
 			}	
 		}
@@ -276,13 +270,22 @@ public class ExplorationManager implements Serializable {
 	 * @return ExploredLocation
 	 */
 	public MineralSite createROI(Coordinates siteLocation, int skill) {
-		var el = surfaceFeatures.createROI(siteLocation, skill);
-		if (el != null) {
-			// Record this site locally
-			var p = findProspect(siteLocation);
+		var el = surfaceFeatures.getDeclaredROI(siteLocation);
 
-			p.site = el;
+		// Could already been declared by another settlement, so only declare if not already declared
+		if (el == null) {
+			el = surfaceFeatures.declareNewROI(siteLocation, skill);
+			if (el == null) {
+				logger.warning(base, "Failed to declare ROI at " + siteLocation);
+				return null;
+			}
+			registerHistoricalEvent(HistoricalEventType.SITE_DISCOVERED, el);
 		}
+
+		// Record this site locally
+		var p = findProspect(siteLocation);
+		p.site = el;
+
 		return el;
 	}
 	
@@ -291,7 +294,7 @@ public class ExplorationManager implements Serializable {
 					.filter(s -> s.locn.equals(siteLocation))
 					.findAny().orElse(null);
 		if (p == null) {
-			// Odd as all potential Coordinates shoudl be known
+			// Odd as all potential Coordinates should be known
 			var distance = base.getCoordinates().getDistance(siteLocation);
 			p = new Prospect(siteLocation, distance);
 			interestingLocns.add(p);
@@ -412,7 +415,21 @@ public class ExplorationManager implements Serializable {
 	 */
     public void claimSite(MineralSite newSite) {
 		newSite.setClaimed(base.getReportingAuthority());
+		registerHistoricalEvent(HistoricalEventType.SITE_CLAIMED, newSite);
 		var p = findProspect(newSite.getCoordinates());
 		p.site = newSite;
     }	
+
+	
+	/**
+	 * Create a historical event for the associated Settlement covering a Mineral site. The site's coordinates
+	 * are used as the Coordinates of the event.
+	 * @param eventType the type of event.
+	 * @param site the mineral site associated with the event.
+	 */
+	private void registerHistoricalEvent(HistoricalEventType eventType, MineralSite site) {
+		var event = new HistoricalEvent(eventType, base, base, site.getName(),
+				null, null, site.getCoordinates());
+		Simulation.instance().getEventManager().registerNewEvent(event);
+	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -120,7 +120,7 @@ public class Settlement extends Unit implements Temporal,
 	private static final SimLogger logger = SimLogger.getLogger(Settlement.class.getName());
 
 	// Static members
-	public static enum MeasureType {ICE_PROBABILITY, REGOLITH_PROBABILITY};
+	public enum MeasureType {ICE_PROBABILITY, REGOLITH_PROBABILITY};
 	
 	private static final int NUM_BACKGROUND_IMAGES = 20;
 
@@ -403,6 +403,7 @@ public class Settlement extends Unit implements Temporal,
 	
 		// Add chain of command
 		chainOfCommand = new ChainOfCommand(this);
+		eqmInventory = new EquipmentInventory(this, MAX_STOCK_CAP);
 
 		// Mock use the default shifts
 		// Initialize schedule event manager
@@ -435,11 +436,9 @@ public class Settlement extends Unit implements Temporal,
 		indoorPeople = new UnitSet<>();
 		touristPool = new UnitSet<>();
 		robotsWithin = new UnitSet<>();
-
-		final double GEN_MAX = 1_000_000;
 		
 		// Create equipment inventory
-		eqmInventory = new EquipmentInventory(this, GEN_MAX);
+		eqmInventory = new EquipmentInventory(this, MAX_STOCK_CAP);
 		futureEvents = new ScheduledEventManager(masterClock);
 		creditManager = new CreditManager(this, unitManager);
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/events/HistoricalEventManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/events/HistoricalEventManagerTest.java
@@ -67,7 +67,7 @@ class HistoricalEventManagerTest extends MarsSimUnitTest {
         // Add distinct events up to the match range
         for(int id=0; id<HistoricalEventManager.MATCH_RANGE; id++) {
             var event1 = new HistoricalEvent(HistoricalEventType.MEDICAL_CURED, s, s,
-                                "Test Source", "Cause " + id);
+                                "Cause " + id, null);
             manager.registerNewEvent(event1);
             assertEquals(id + 1, manager.getEvents().size());
         }
@@ -75,7 +75,7 @@ class HistoricalEventManagerTest extends MarsSimUnitTest {
         // Repeat the events and no increase
         for(int id=0; id<HistoricalEventManager.MATCH_RANGE; id++) {
             var event1 = new HistoricalEvent(HistoricalEventType.MEDICAL_CURED, s, s,
-                                "Test Source", "Cause " + id);
+                                "Cause " + id, null);
             manager.registerNewEvent(event1);
             assertEquals(HistoricalEventManager.MATCH_RANGE, manager.getEvents().size());
         }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mission/objectives/MiningObjectiveTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mission/objectives/MiningObjectiveTest.java
@@ -24,7 +24,7 @@ public class MiningObjectiveTest extends MarsSimUnitTest {
                     100000, Collections.emptyList());
 
         // Give big skill to handle small conc
-        var site = sf.declareROI(potentials.getKey(), 10);
+        var site = sf.declareNewROI(potentials.getKey(), 10);
 
         LightUtilityVehicle l = null;
 		var obj = new MiningObjective(l, site);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mission/objectives/MiningObjectiveTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mission/objectives/MiningObjectiveTest.java
@@ -13,10 +13,10 @@ import com.mars_sim.core.test.MarsSimUnitTest;
 import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.vehicle.LightUtilityVehicle;
 
-public class MiningObjectiveTest extends MarsSimUnitTest {
+class MiningObjectiveTest extends MarsSimUnitTest {
     
     @Test
-    public void testExtractedMineral() {
+    void testExtractedMineral() {
         var sf = getSim().getSurfaceFeatures();
 
         // Use a huge range for search to guarantee a site

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/mission/meta/ConstructionMissionMetaTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/mission/meta/ConstructionMissionMetaTest.java
@@ -15,12 +15,13 @@ import com.mars_sim.core.person.ai.mission.ConstructionMission;
 import com.mars_sim.core.person.ai.role.RoleType;
 import com.mars_sim.core.structure.Settlement;
 
-public class ConstructionMissionMetaTest extends MarsSimUnitTest {
+class ConstructionMissionMetaTest extends MarsSimUnitTest {
     private static final String LANDER_HAB = "Lander Hab";
 
     @Test
-    public void testProbabiltyArchitectSite() {
-        var s = buildSettlement("mock");
+    void testProbabiltyArchitectSite() {
+        // Having inital pop. create Chain of Command
+        var s = buildSettlement("mock", 10);
         var architect = buildPerson("worker", s, JobType.ARCHITECT);
         architect.setRole(RoleType.ENGINEERING_SPECIALIST);
         for(int i = 0; i < ConstructionMission.MIN_PEOPLE; i++) {
@@ -46,8 +47,8 @@ public class ConstructionMissionMetaTest extends MarsSimUnitTest {
     }
 
     @Test
-    public void testProbabiltySalvageSite() {
-        var s = buildSettlement("mock");
+    void testProbabiltySalvageSite() {
+        var s = buildSettlement("mock", 10);
         var a = buildAccommodation(s.getBuildingManager(), LocalPosition.DEFAULT_POSITION, 0D);
 
         var architect = buildPerson("worker", s, JobType.ARCHITECT);
@@ -67,8 +68,8 @@ public class ConstructionMissionMetaTest extends MarsSimUnitTest {
     }
 
     @Test
-    public void testProbabiltyDoctor() {
-        var s = buildSettlement("mock");
+    void testProbabiltyDoctor() {
+        var s = buildSettlement("mock", 10);
         var doctor = buildPerson("worker", s, JobType.DOCTOR);
         doctor.setRole(RoleType.AGRICULTURE_SPECIALIST);
         for(int i = 0; i < ConstructionMission.MIN_PEOPLE; i++) {
@@ -94,8 +95,8 @@ public class ConstructionMissionMetaTest extends MarsSimUnitTest {
     }
     
     @Test
-    public void testProbabiltyArchitectQueue() {
-        var s = buildSettlement("mock");
+    void testProbabiltyArchitectQueue() {
+        var s = buildSettlement("mock", 10);
         var architect = buildPerson("worker", s, JobType.ARCHITECT);
         architect.setRole(RoleType.ENGINEERING_SPECIALIST);
         for(int i = 0; i < ConstructionMission.MIN_PEOPLE; i++) {

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/ExplorationManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/ExplorationManagerTest.java
@@ -16,9 +16,9 @@ import com.mars_sim.core.map.location.CoordinatesException;
 import com.mars_sim.core.map.location.CoordinatesFormat;
 import com.mars_sim.core.mineral.RandomMineralFactory;
 
-public class ExplorationManagerTest extends MarsSimUnitTest {
+class ExplorationManagerTest extends MarsSimUnitTest {
     @Test
-    public void testCreateARegionOfInterest() {
+    void testCreateARegionOfInterest() {
         var s = buildSettlement("mock");
 
         var eMgr = new ExplorationManager(s);
@@ -46,7 +46,7 @@ public class ExplorationManagerTest extends MarsSimUnitTest {
     }
 
      @Test
-     public void testCreateUnclaimedARegionOfInterest() throws CoordinatesException {
+    void testCreateUnclaimedARegionOfInterest() throws CoordinatesException {
         var locn = CoordinatesFormat.fromString("10.0 10.0");
 
         // Find a random location within 20K with minerals
@@ -57,7 +57,7 @@ public class ExplorationManagerTest extends MarsSimUnitTest {
 
         // Create a site 1KM from the base, no settlemetn as unclaimed
         var siteLocn = found.getKey();
-        var newRoI = sf.createROI(siteLocn, 100);
+        var newRoI = sf.declareNewROI(siteLocn, 100);
 
         assertNotNull(newRoI, "New RoI created");
         assertEquals(siteLocn, newRoI.getCoordinates(), "New ROI coordinates");
@@ -66,7 +66,7 @@ public class ExplorationManagerTest extends MarsSimUnitTest {
     }
 
     @Test
-    public void testStatistics() {
+    void testStatistics() {
         var s = buildSettlement("Test", false, Coordinates.getRandomLocation());
 
         var eMgr = new ExplorationManager(s);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/transport/TabPanelGeneral.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/transport/TabPanelGeneral.java
@@ -24,6 +24,7 @@ import com.mars_sim.ui.swing.StyleManager;
 import com.mars_sim.ui.swing.UIContext;
 import com.mars_sim.ui.swing.entitywindow.EntityTabPanel;
 import com.mars_sim.ui.swing.utils.AttributePanel;
+import com.mars_sim.ui.swing.utils.CoordinatesLabel;
 import com.mars_sim.ui.swing.utils.SwingHelper;
 
 /**
@@ -37,7 +38,7 @@ class TabPanelGeneral extends EntityTabPanel<Transportable> {
 	private JLabel stateTextField;
 	private JLabel launchDateTextField;
 	private JLabel arrivalDateTextField;
-	private JLabel landingLocationTextField;
+	private CoordinatesLabel landingLocation;
 
     public TabPanelGeneral(Transportable entity, UIContext context) {
 		super(
@@ -61,7 +62,8 @@ class TabPanelGeneral extends EntityTabPanel<Transportable> {
 		stateTextField = attributesPanel.addTextField(Msg.getString("transportable.state"), null, null);
 		launchDateTextField = attributesPanel.addTextField(Msg.getString("transportable.launchDate"), null, null);
 		arrivalDateTextField = attributesPanel.addTextField(Msg.getString("transportable.arrivalDate"), null, null);
-		landingLocationTextField = attributesPanel.addTextField(Msg.getString("transportable.landingLocation"), null, null);
+		landingLocation = new CoordinatesLabel(getContext());
+        attributesPanel.addLabelledItem(Msg.getString("transportable.landingLocation"), landingLocation, null);
 
         if (getEntity() instanceof Resupply r && r.getTemplate() != null) {            
             contentPanel.add(buildSchedulePanel(r.getTemplate()));
@@ -102,7 +104,7 @@ class TabPanelGeneral extends EntityTabPanel<Transportable> {
             arrivalDateTextField.setText(entity.getArrivalDate().getDateTimeStamp());
         }
         if (entity.getLandingLocation() != null) {
-            landingLocationTextField.setText(entity.getLandingLocation().getFormattedString());
+            landingLocation.setCoordinates(entity.getLandingLocation());
         } 
 	}
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/eventviewer/CollapsibleEventPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/eventviewer/CollapsibleEventPanel.java
@@ -31,6 +31,7 @@ import com.mars_sim.core.events.HistoricalEvent;
 import com.mars_sim.ui.swing.StyleManager;
 import com.mars_sim.ui.swing.UIContext;
 import com.mars_sim.ui.swing.components.EntityLabel;
+import com.mars_sim.ui.swing.utils.CoordinatesLabel;
 
 /**
  * A collapsible panel that displays a HistoricalEvent.
@@ -157,19 +158,19 @@ class CollapsibleEventPanel extends JPanel {
             }   
         });
         addDetailRow("Source:", new EntityLabel(event.getSource(), uiContext), gbc, row++);
-        addDetailRow("Acknowledged:", acknowledgedCheckBox, gbc, row++);
+        addDetailRow("Acknowledge:", acknowledgedCheckBox, gbc, row++);
         
         // Category
         addDetailRow("Category:", new JLabel(event.getCategory().getName()), gbc, row++);
         
         // What Cause
         if (event.getWhatCause() != null && !event.getWhatCause().isEmpty()) {
-            addDetailRow("What Cause:", new JLabel(event.getWhatCause()), gbc, row++);
+            addDetailRow("Cause:", new JLabel(event.getWhatCause()), gbc, row++);
         }
         
         // While Doing
         if (event.getWhileDoing() != null && !event.getWhileDoing().isEmpty()) {
-            addDetailRow("While Doing:", new JLabel(event.getWhileDoing()), gbc, row++);
+            addDetailRow("Doing:", new JLabel(event.getWhileDoing()), gbc, row++);
         }
         
         // Who
@@ -177,9 +178,14 @@ class CollapsibleEventPanel extends JPanel {
             addDetailRow("Affected:", new EntityLabel(event.getAffected(), uiContext), gbc, row++);
         }
         
+        // Base
+        if (event.getHomeTown() != null) {
+            addDetailRow("Base:", new EntityLabel(event.getHomeTown(), uiContext), gbc, row++);
+        }
+
         // Coordinates but not both
         if (event.getCoordinates() != null) {
-            addDetailRow("Location:", new JLabel(event.getCoordinates().getFormattedString()), gbc, row++);
+            addDetailRow("Location:", new CoordinatesLabel(event.getCoordinates(), uiContext), gbc, row);
         }
     }
     

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/CoordinatesLabel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/CoordinatesLabel.java
@@ -27,6 +27,10 @@ import com.mars_sim.ui.swing.tool.MapSelector;
 @SuppressWarnings("serial")
 public class CoordinatesLabel extends JPanel {
 	
+    private JLabel label;
+    private Coordinates displayed;
+    private JButton mapButton;
+
     /**
      * Constructor for creating
      * 
@@ -34,17 +38,42 @@ public class CoordinatesLabel extends JPanel {
      * @param uiContext the UI context for launcher windows
      */
     public CoordinatesLabel(Coordinates location, UIContext uiContext) {
+        this(uiContext);
+        setCoordinates(location);
+    }
+
+    /**
+     * Constructor for creating an empty CoordinatesLabel with just the map button.
+     * Useful for cases where the coordinates may not be known at the time of creation.
+     * @param uiContext the UI context for launcher windows
+     */
+    public CoordinatesLabel(UIContext uiContext) {
 
         setLayout(new BoxLayout(this, BoxLayout.LINE_AXIS));
-        var label = new JLabel(location.getFormattedString(), SwingConstants.LEFT);
+        label = new JLabel("", SwingConstants.LEFT);
         add(label);
         add(Box.createRigidArea(new Dimension(5, 0)));
 
         // Some entities have a physical location
-        var mapButton = new JButton(EntityLabel.LOCATE); 
+        mapButton = new JButton(EntityLabel.LOCATE); 
         mapButton.setToolTipText(Msg.getString("EntityLabel.locate"));
-        mapButton.addActionListener(e -> MapSelector.displayCoords(uiContext, location));
+        mapButton.addActionListener(e -> MapSelector.displayCoords(uiContext, displayed));
 
         add(mapButton);
+    }
+
+    /**
+     * Sets the coordinates to display and updates the label text and map button state accordingly.
+     * @param location Location to display
+     */
+    public void setCoordinates(Coordinates location) {
+        this.displayed = location;
+        if (location == null) {
+            label.setText("...");
+        }
+        else {
+            label.setText(location.getFormattedString());
+        }
+        mapButton.setEnabled(location != null);
     }
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/CoordinatesLabel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/CoordinatesLabel.java
@@ -1,0 +1,50 @@
+/*
+ * Mars Simulation Project
+ * CoordinatesLabel.java
+ * @date 2025-06-22
+ * @author Barry Evans
+ */
+package com.mars_sim.ui.swing.utils;
+
+import java.awt.Dimension;
+
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
+import com.mars_sim.core.map.location.Coordinates;
+import com.mars_sim.core.tool.Msg;
+import com.mars_sim.ui.swing.UIContext;
+import com.mars_sim.ui.swing.components.EntityLabel;
+import com.mars_sim.ui.swing.tool.MapSelector;
+
+/**
+ * A label that displays a Coordinate and provides buttons to show location on the map.
+ */
+@SuppressWarnings("serial")
+public class CoordinatesLabel extends JPanel {
+	
+    /**
+     * Constructor for creating
+     * 
+     * @param location the Coordinate to display.
+     * @param uiContext the UI context for launcher windows
+     */
+    public CoordinatesLabel(Coordinates location, UIContext uiContext) {
+
+        setLayout(new BoxLayout(this, BoxLayout.LINE_AXIS));
+        var label = new JLabel(location.getFormattedString(), SwingConstants.LEFT);
+        add(label);
+        add(Box.createRigidArea(new Dimension(5, 0)));
+
+        // Some entities have a physical location
+        var mapButton = new JButton(EntityLabel.LOCATE); 
+        mapButton.setToolTipText(Msg.getString("EntityLabel.locate"));
+        mapButton.addActionListener(e -> MapSelector.displayCoords(uiContext, location));
+
+        add(mapButton);
+    }
+}


### PR DESCRIPTION
This PR increases the number of Historical Events generated for significant actions. This provides more content for the Event Viewer.

Keys events are:
- Discovery of a new MineralSite
- Claiming of a MineralSite
- Person change of Job
- Person change of Role
- ScientificStudy - Start of a new phase
- ScientificStudy - Completed
- Start of a new Stage in a Construction Site
- Construction site completed and a Building created

close #1862