### PR TITLE
fix(ui): Handle Settlement window memory

### DIFF
--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/UIConfig.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/UIConfig.java
@@ -459,4 +459,11 @@ public class UIConfig {
     	return result;
     }
 
+	/**
+	 * Add a window spec to the loaded specs. This is used by tools to add their window details to the config for saving.
+	 * @param windowSpec Spec to load.
+	 */
+	public void addWindowSpec(WindowSpec windowSpec) {
+		loadedSpecs.put(windowSpec.name(), windowSpec);
+	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/desktop/MainDesktopPane.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/desktop/MainDesktopPane.java
@@ -254,14 +254,19 @@ public class MainDesktopPane extends JDesktopPane
 			return null;
 		}
 		ContentWindow w = new ContentWindow(this, content);
-
-		// Close it from the start
+		
+		// Must close before attaching listener to avoid events during setup
 		try {
 			w.setClosed(true);
 		} catch (PropertyVetoException e) {
-			logger.warning("Problem loading tool window " + e.getMessage());
+			// Ignore
 		}
+
+		w.addInternalFrameListener(new ContentWindowListener());
 		toolWindows.add(w);
+
+
+
 		return w;
 	}
 
@@ -346,15 +351,37 @@ public class MainDesktopPane extends JDesktopPane
 		openEntityPanel(entity, null);
     }
 
-	private class EntityPanelListener extends InternalFrameAdapter {
+	/**
+	 * Listens for internal frame closing events on content windows and disposes of them properly when they are closed.
+	 */
+	private class ContentWindowListener extends InternalFrameAdapter {
 		/**
-		 * Removes unit button from toolbar when unit window is closed.
+		 * Internal frame has closed.
 		 *
 		 * @param e internal frame event.
 		 */
 		@Override
 		public void internalFrameClosing(InternalFrameEvent e) {
-			disposeEntityPanel((ContentWindow) e.getSource());
+			var source = (ContentWindow) e.getSource();
+			var content = source.getContent();
+			
+			// Check Entity windows first
+			if (entityWindows.contains(source)) {
+				entityWindows.remove(source);
+				if (content instanceof EntityContentPanel<?> panel) {
+					Entity unit = panel.getEntity();
+					if (unit != null) {
+						mainWindow.getUnitToolBar().disposeButton(unit);
+					}
+				}
+			}
+			else if (toolWindows.contains(source)) {
+				// Remember settings for tool windows
+				UIConfig config = mainWindow.getConfig();
+				config.addWindowSpec(toWindowSpec(source));
+				toolWindows.remove(source);
+			}
+			source.destroy();
 		}
 	}
 	
@@ -381,7 +408,7 @@ public class MainDesktopPane extends JDesktopPane
 		if (panel != null) {
 			var cw = new ContentWindow(this, panel);
 			// Set internal frame listener
-			cw.addInternalFrameListener(new EntityPanelListener());
+			cw.addInternalFrameListener(new ContentWindowListener());
 
 			add(cw, 0);
 
@@ -417,21 +444,6 @@ public class MainDesktopPane extends JDesktopPane
 		if (soundPlayer != null) {
 			soundPlayer.playSound(soundName);
 		}
-	}
-	
-	/**
-	 * Entity panel has been closed
-	 * @param source Parent comntent window
-	 */
-	private void disposeEntityPanel(ContentWindow source) {
-		if (source.getContent() instanceof EntityContentPanel panel) {
-			Entity unit = panel.getEntity();
-			if (unit != null) {
-				mainWindow.getUnitToolBar().disposeButton(unit);
-			}
-		}
-		entityWindows.remove(source);
-		source.destroy();
 	}
 
 	/**  
@@ -640,27 +652,34 @@ public class MainDesktopPane extends JDesktopPane
 		JInternalFrame[] windows = getAllFrames();
 		for (var window1 : windows) {
 			if (window1 instanceof ContentWindow tw) {
-
-				Point winPosn = window1.getLocation();
-				Dimension winSize = window1.getSize();
-
-				var winOrder = getComponentZOrder(window1);
-
-				Properties props = null;
-				if (window1 instanceof ConfigurableWindow cw) {
-					props = cw.getUIProps();
-				}
-				else {
-					props = new Properties();
-				}
-
-				var winName = tw.getContent().getName();
-				var winType = tw.getContent() instanceof EntityContentPanel ? UIConfig.UNIT : UIConfig.TOOL;
-				var wp = new WindowSpec(winName, winPosn, winSize, winOrder, winType, props);
-				results.add(wp);
+				results.add(toWindowSpec(tw));
 			}
 		}
 
 		return results;
+	}
+
+	/**
+	 * Gets the details of a content window. This is used to save the UI configuration.
+	 * @param tw Content window to get the details of
+	 * @return Key details of the content window for saving in the UI configuration
+	 */
+	private WindowSpec toWindowSpec(ContentWindow tw) {
+		Point winPosn = tw.getLocation();
+		Dimension winSize = tw.getSize();
+
+		var winOrder = getComponentZOrder(tw);
+
+		Properties props = null;
+		if (tw instanceof ConfigurableWindow cw) {
+			props = cw.getUIProps();
+		}
+		else {
+			props = new Properties();
+		}
+
+		var winName = tw.getContent().getName();
+		var winType = tw.getContent() instanceof EntityContentPanel ? UIConfig.UNIT : UIConfig.TOOL;
+		return new WindowSpec(winName, winPosn, winSize, winOrder, winType, props);
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/map/MapPanel.java
@@ -659,7 +659,7 @@ public class MapPanel extends JPanel implements MouseWheelListener {
 	 */
 	public void destroy() {
 		mapLayers.forEach(ml -> ml.layer.release());
-		mapLayers = null;
+		mapLayers.clear();
 		
 		if (executor != null) {
 			// Stop anything running

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementMapPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementMapPanel.java
@@ -118,8 +118,6 @@ public class SettlementMapPanel extends JPanel {
 
 	private Settlement settlement;
 
-	private PopUpUnitMenu menu;
-
 	private SettlementTransparentPanel settlementTransparentPanel;
 
 	private DayNightMapLayer dayNightMapLayer;
@@ -142,11 +140,7 @@ public class SettlementMapPanel extends JPanel {
 	/** Coalesces simulation-tick UI updates so we don't flood the EDT. */
 	private final AtomicBoolean uiUpdateScheduled = new AtomicBoolean(false);
 
-	// -------- Listener lifecycle management --------
-	private boolean listenersInstalled = false;
 	
-	
-
 	// -------- Shared cache hook for layers that rasterize scalable art --------
 	private final ScaledIconCache iconCache = new ScaledIconCache();
 	private UIContext context;
@@ -268,9 +262,7 @@ public class SettlementMapPanel extends JPanel {
 	/**
 	 * Installs mouse listeners once; safe to call multiple times.
 	 */
-	public void detectMouseMovement() {
-
-		if (listenersInstalled) return;
+	private void detectMouseMovement() {
 
 		var motionListener = new MouseMotionAdapter() {
 			@Override
@@ -346,15 +338,6 @@ public class SettlementMapPanel extends JPanel {
 
 		addMouseMotionListener(motionListener);
 		addMouseListener(mouseListener);
-
-		listenersInstalled = true;
-	}
-
-	@Override
-	public void addNotify() {
-		super.addNotify();
-		// Ensure listeners are attached if panel is re-added to a container
-		detectMouseMovement();
 	}
 
 	/**
@@ -390,7 +373,7 @@ public class SettlementMapPanel extends JPanel {
 	}
 
 	private void setPopUp(final MouseEvent evt, int x, int y, Unit unit) {
-		menu = new PopUpUnitMenu(unit, context);
+		var menu = new PopUpUnitMenu(unit, context);
 		menu.show(evt.getComponent(), x, y);
 	}
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementTransparentPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/SettlementTransparentPanel.java
@@ -12,10 +12,7 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.GridLayout;
-import java.awt.event.HierarchyEvent;
-import java.awt.event.HierarchyListener;
 import java.awt.event.ItemEvent;
-import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,7 +23,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
 
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.Icon;
@@ -49,11 +45,11 @@ import javax.swing.event.ChangeListener;
 import org.jdesktop.swingx.JXTaskPane;
 import org.jdesktop.swingx.JXTaskPaneContainer;
 
+import com.mars_sim.core.Entity;
+import com.mars_sim.core.EntityManagerListener;
 import com.mars_sim.core.GameManager;
 import com.mars_sim.core.GameManager.GameMode;
 import com.mars_sim.core.Simulation;
-import com.mars_sim.core.Entity;
-import com.mars_sim.core.EntityManagerListener;
 import com.mars_sim.core.UnitManager;
 import com.mars_sim.core.UnitType;
 import com.mars_sim.core.building.BuildingManager;
@@ -126,21 +122,12 @@ public class SettlementTransparentPanel extends JComponent {
     private Font sunFont = new Font(Font.MONOSPACED, Font.PLAIN, 12);
     private Font sunBoldFont = new Font(Font.MONOSPACED, Font.BOLD, 12);
 
-    // Thread-safe: simulation thread may update, EDT reads
-    private Map<Settlement, String> resourceCache = new ConcurrentHashMap<>();
+    private String resourceCache = "";
 
     private GameMode mode;
 
     private DisplaySingle bannerBar;
     private JSlider zoomSlider;
-
-    private javax.swing.Timer zoomDebounce;
-    private ChangeListener zoomListener;
-    private MouseWheelListener mouseWheelListener;
-
-    // Patch 1: idempotent installation + cleanup on detach
-    private boolean listenersInstalled;
-    private HierarchyListener mapPanelHierarchyListener;
 
     private JLabel emptyLabel;
     /** label for projected sunrise time. */
@@ -170,8 +157,6 @@ public class SettlementTransparentPanel extends JComponent {
     private JPopupMenu labelsMenu;
     /** Settlement Combo box */
     private JComboBox<Settlement> settlementListBox;
-    /** Settlement Combo box model. */
-    private SettlementComboBoxModel settlementCBModel;
 
     private SettlementMapPanel mapPanel;
     private UIContext context;
@@ -289,16 +274,6 @@ public class SettlementTransparentPanel extends JComponent {
         eastPane.add(controlPane, BorderLayout.CENTER);
 
         centerPanel.add(eastPane, BorderLayout.EAST);
-
-        // Patch 1: listen for mapPanel displayability change to detach listeners to avoid leaks
-        if (mapPanelHierarchyListener == null) {
-            mapPanelHierarchyListener = e -> {
-                if ((e.getChangeFlags() & HierarchyEvent.DISPLAYABILITY_CHANGED) != 0 && !mapPanel.isDisplayable()) {
-                    detachListeners();
-                }
-            };
-            mapPanel.addHierarchyListener(mapPanelHierarchyListener);
-        }
 
         mapPanel.setVisible(true);
     }
@@ -427,7 +402,7 @@ public class SettlementTransparentPanel extends JComponent {
      */
     private void buildSettlementNameComboBox() {
 
-        settlementCBModel = new SettlementComboBoxModel();
+        var settlementCBModel = new SettlementComboBoxModel();
         settlementListBox = new JComboBox<>(settlementCBModel);
         settlementListBox.setPreferredSize(new Dimension(getNameLength() * 9, 30));
         settlementListBox.setToolTipText(Msg.getString("SettlementWindow.tooltip.selectSettlement")); //$NON-NLS-1$
@@ -471,6 +446,8 @@ public class SettlementTransparentPanel extends JComponent {
      * Changes the map display to the selected settlement.
      */
     private void changeSettlement(Settlement s) {
+        resourceCache = "";
+
         // Set the selected settlement in SettlementMapPanel
         mapPanel.setSettlement(s);
         // Set the population label in the status bar
@@ -537,14 +514,12 @@ public class SettlementTransparentPanel extends JComponent {
      * Builds the banner text from current caches (does *not* touch UI).
      */
     private String buildBannerText(Settlement s) {
-        String resources = (resourceCache != null) ? resourceCache.get(s) : null;
-        if (resources == null) resources = "";
         StringBuilder sb = new StringBuilder();
         var ds = s.getDustStorm();
         if (ds != null) {
             sb.append(ds.getDescription());
         }
-        sb.append(resources);
+        sb.append(resourceCache);
         sb.append(TEMPERATURE).append(tString);
         sb.append(WINDSPEED).append(wsString);
         sb.append(ZENITH_ANGLE).append(zaString);
@@ -648,8 +623,6 @@ public class SettlementTransparentPanel extends JComponent {
         temperatureIcon.setIcon(updatedIcon);
         temperatureIcon.setToolTipText(tooltip);
 
-        ///////////////////////////////////////////////
-
         if (windSpeedCache > 120) {
             if (opticalDepthCache > 0.7) {
                 updatedIcon = ImageLoader.getIconByName("weather/sandstorm");
@@ -682,8 +655,6 @@ public class SettlementTransparentPanel extends JComponent {
 
         windIcon.setIcon(updatedIcon);
         windIcon.setToolTipText(tooltip);
-
-        ///////////////////////////////////////////////
 
         if (opticalDepthCache > 1.0) {
             updatedIcon = ImageLoader.getIconByName("weather/sand");
@@ -737,116 +708,49 @@ public class SettlementTransparentPanel extends JComponent {
         initDebounce(zoomSlider);
 
         // Prepare mouse wheel listener for zooming (install idempotently elsewhere).
-        mouseWheelListener = new MouseWheelListener() {
-            @Override
-            public void mouseWheelMoved(MouseWheelEvent evt) {
+        MouseWheelListener mouseWheelListener = evt -> {
 
-                int numClicks = evt.getWheelRotation();
-                int value = zoomSlider.getValue();
-                int min = zoomSlider.getMinimum();
-                int max = zoomSlider.getMaximum();
+            int numClicks = evt.getWheelRotation();
+            int value = zoomSlider.getValue();
+            int min = zoomSlider.getMinimum();
+            int max = zoomSlider.getMaximum();
 
-                if (numClicks > 0) {
-                    // wheel down -> zoom out
-                    if (value - 1 >= min) {
-                        zoomSlider.setValue(value - 1);
-                    }
+            if (numClicks > 0) {
+                // wheel down -> zoom out
+                if (value - 1 >= min) {
+                    zoomSlider.setValue(value - 1);
                 }
-                else if (numClicks < 0) {
-                    // wheel up -> zoom in
-                    if (value + 1 <= max) {
-                        zoomSlider.setValue(value + 1);
-                    }
-                }
-
-                evt.consume();
             }
+            else if (numClicks < 0) {
+                // wheel up -> zoom in
+                if (value + 1 <= max) {
+                    zoomSlider.setValue(value + 1);
+                }
+            }
+
+            evt.consume();
         };
 
-        // Patch 1: install the wheel listener idempotently to avoid duplicates
-        if (mapPanel != null && !listenersInstalled) {
-            mapPanel.addMouseWheelListener(mouseWheelListener);
-            listenersInstalled = true;
-        }
+        mapPanel.addMouseWheelListener(mouseWheelListener);
     }
 
     /**
      * Sets up the zoom slider with a timer to debounce any redundant re-rendering work.
      */
     private void initDebounce(JSlider slider) {
-        zoomListener = e -> {
+        ChangeListener zoomListener = e -> {
             int value = ((JSlider) e.getSource()).getValue();
-            if (zoomDebounce == null) {
-                zoomDebounce = new javax.swing.Timer(50, ae -> convertTo(value));
-                zoomDebounce.setRepeats(false);
-                zoomDebounce.start();
-            }
-            else if (zoomDebounce.isRunning()) {
-                zoomDebounce.restart();
-            }
-            else {
-                zoomDebounce = null;
-                zoomDebounce = new javax.swing.Timer(50, ae -> convertTo(value));
-                zoomDebounce.setRepeats(false);
-                zoomDebounce.start();
-            }
+            mapPanel.setScale(value);
+
         };
         slider.addChangeListener(zoomListener);
-    }
-
-    /**
-     * Converts the zoom value found on the slider to a map scale.
-     */
-    private void convertTo(int value) {
-        // Slider min is 1; mapPanel clamps & quantizes internally.
-        mapPanel.setScale(value);
-    }
-
-    /**
-     * Ensure we stop timers and detach listeners when removed from a container.
-     * (Fixed: avoid calling super.removeNotify() twice.)
-     */
-    @Override
-    public void removeNotify() {
-        try {
-            destroy();
-        } finally {
-            super.removeNotify();
-        }
-    }
-
-
-    /**
-     * Detach the listeners this panel installs, idempotently.
-     * (Patch 1 core: prevent retained references when the map window closes)
-     */
-    private void detachListeners() {
-        // Stop and clear debounce timer
-        if (zoomDebounce != null) {
-            zoomDebounce.stop();
-        }
-        // Remove our slider change listener
-        if (zoomSlider != null && zoomListener != null) {
-            zoomSlider.removeChangeListener(zoomListener);
-        }
-        // Remove mouse wheel listener from mapPanel
-        if (mapPanel != null && mouseWheelListener != null) {
-            mapPanel.removeMouseWheelListener(mouseWheelListener);
-        }
-        listenersInstalled = false;
     }
 
     /**
      * Sets the zoom slider value. Avoids redundant change events.
      */
     public void setZoomValue(int value) {
-        if (zoomSlider != null && zoomSlider.getValue() != value) {
-            if (zoomDebounce != null && zoomDebounce.isRunning()) {
-            	// Prevent a stale convertTo firing
-                zoomDebounce.stop(); 
-            }
-            zoomSlider.setValue(value);
-        }
+        zoomSlider.setValue(value);
     }
 
     private void buildInfoP() {
@@ -1230,23 +1134,12 @@ public class SettlementTransparentPanel extends JComponent {
         if (yestersolResources.isEmpty())
             return;
 
-        resourceCache.put(s, text.toString());
+        resourceCache = text.toString();
     }
 
     /**
      * Prepare class for deletion (idempotent, EDT-safe).
      */
     public void destroy() {
-
-        // Ensure Swing teardown happens on the EDT
-        if (!javax.swing.SwingUtilities.isEventDispatchThread()) {
-            javax.swing.SwingUtilities.invokeLater(this::destroy);
-            return;
-        }
-
-        // --- Core patch cleanup: detach installed listeners ---
-        detachListeners();
-
-        mapPanelHierarchyListener = null;
     }
 }


### PR DESCRIPTION
The memory increase is mainly a result of the extra images at different resolution being loaded.

Changes:
- Fix the zooming button in the SettlementMapPanel.
- Closing a tool window will destroy the tool and release the memory.
- MainDesktopPane isolate converting a ContentWindow to the WindowSpec
- When a ToolWindow is closed the position and state is saved to the UIConfig
- UIConfig allows WindowSpec to be added

close #1665