### PR TITLE
build: Consolidate JUnit via BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,23 +83,31 @@
 			</modules>
 		</profile>
 	</profiles>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>${junit.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
-			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>		
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
-			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,7 @@
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>		
 		<sonar.java.source>21</sonar.java.source>
-		
-		<!-- These 3 have an interdepency -->
-		<junit-jupiter.version>5.14.1</junit-jupiter.version>
-		<junit-launcher.version>1.14.1</junit-launcher.version>
-		
+
 		<timestamp>${maven.build.timestamp}</timestamp>
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
 		
@@ -29,6 +25,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		
+		<junit.version>6.0.3</junit.version>
+
 		<lwjgl.version>3.3.6</lwjgl.version>
 		<slf4j.version>2.0.17</slf4j.version>
 
@@ -89,19 +87,19 @@
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
-			<version>${junit-launcher.version}</version>
+			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>		
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
-			<version>${junit-jupiter.version}</version>
+			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Consolidate the Junit Jupiter & Launcher JARs to use the same sync'ed version. This is done by using the JUnit-Bom approach.