### PR TITLE
fix(ui): Improve filtering on EventViewer

### DIFF
--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/eventviewer/EventViewer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/eventviewer/EventViewer.java
@@ -84,6 +84,7 @@ public class EventViewer extends ContentPanel implements ConfigurableWindow, His
         loadInitialFilter(userSettings);
 
         initializeUI(userSettings);
+        selectedSettlements = settlementSelector.getSelectedSettlements();
         loadEvents();
         
         // Register as listener for new events
@@ -340,6 +341,7 @@ public class EventViewer extends ContentPanel implements ConfigurableWindow, His
         if (eventManager != null) {
             eventManager.removeListener(this);
         }
+        settlementSelector.unregister();
         super.destroy();
     }
 
@@ -357,10 +359,11 @@ public class EventViewer extends ContentPanel implements ConfigurableWindow, His
         String settlementString = switch(settlementSelector.getSelectedItem()) {
             case Entity s -> s.getName();
             case String str -> str;
-            default -> "";
+            default -> null;
         };
-        props.setProperty(SELECTED_SETTLEMENT, settlementString);
-
+        if (settlementString != null) {
+            props.setProperty(SELECTED_SETTLEMENT, settlementString);
+        }
 
         return props;
     }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/eventviewer/EventViewer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/eventviewer/EventViewer.java
@@ -9,7 +9,9 @@ package com.mars_sim.ui.swing.tool.eventviewer;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -20,24 +22,27 @@ import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
-import javax.swing.JToolBar;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
 
+import com.mars_sim.core.Entity;
 import com.mars_sim.core.events.HistoricalEvent;
 import com.mars_sim.core.events.HistoricalEventCategory;
 import com.mars_sim.core.events.HistoricalEventListener;
 import com.mars_sim.core.events.HistoricalEventManager;
+import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.ui.swing.ConfigurableWindow;
 import com.mars_sim.ui.swing.ContentPanel;
 import com.mars_sim.ui.swing.StyleManager;
 import com.mars_sim.ui.swing.UIContext;
 import com.mars_sim.ui.swing.displayinfo.EntityDisplayInfoFactory;
+import com.mars_sim.ui.swing.utils.SettlementsSelector;
 
 /**
  * EventViewer displays historical events in a collapsible panel format.
@@ -46,19 +51,23 @@ import com.mars_sim.ui.swing.displayinfo.EntityDisplayInfoFactory;
 @SuppressWarnings("serial")
 public class EventViewer extends ContentPanel implements ConfigurableWindow, HistoricalEventListener {
 
-    private static final String SELECTED_CATEGORIES = "selectedCategories";
-    private static final String SHOW_ACKNOWLEDGED = "showAcknowledged";
     public static final String NAME = "eventviewer";
 	public static final String ICON = "event";
 	public static final String TITLE = "Event Viewer";
     
+    private static final String SELECTED_SETTLEMENT = "selectedSettlement";
+    private static final String SELECTED_CATEGORIES = "selectedCategories";
+    private static final String SHOW_ACKNOWLEDGED = "showAcknowledged";
+
     private HistoricalEventManager eventManager;
     private JPanel eventListPanel;
     private UIContext uiContext;
-    private JButton filterButton;
+    private JButton catButton;
     private JPopupMenu filterMenu;
     private JCheckBox showAcknowledgedCheckBox;
     private Set<HistoricalEventCategory> selectedCategories;
+    private Set<Settlement> selectedSettlements = Collections.emptySet();
+    private SettlementsSelector settlementSelector;
     
     /**
      * Constructor.
@@ -126,13 +135,14 @@ public class EventViewer extends ContentPanel implements ConfigurableWindow, His
         
         add(scrollPane, BorderLayout.CENTER);
 
-        setPreferredSize(new Dimension(270, 400));
-        setMinimumSize(new Dimension(270, 200));
+        setPreferredSize(new Dimension(300, 400));
+        setMinimumSize(new Dimension(300, 200));
     }
     
     private boolean isEventVisible(HistoricalEvent event) {
         // Check category filter and acknowledged filter
         return (selectedCategories.contains(event.getCategory())
+                && ((event.getHomeTown() == null) || selectedSettlements.contains(event.getHomeTown()))
                 && (showAcknowledgedCheckBox.isSelected() || !event.isAcknowledged()));
     }
 
@@ -197,34 +207,48 @@ public class EventViewer extends ContentPanel implements ConfigurableWindow, His
     /**
      * Create the toolbar with filter controls.
      */
-    private JToolBar createToolbar(Properties userSettings) {
-        JToolBar toolbar = new JToolBar();
-        toolbar.setFloatable(false);
-        toolbar.setLayout(new FlowLayout(FlowLayout.LEFT));
+    private JComponent createToolbar(Properties userSettings) {
+        var toolbar = Box.createVerticalBox();
         
         // Add filter label
-        JLabel filterLabel = new JLabel("Filter:");
-        filterLabel.setFont(StyleManager.getLabelFont());
-        toolbar.add(filterLabel);
+        var categoryPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        toolbar.add(categoryPanel);
+        JLabel catLabel = new JLabel("Category:");
+        catLabel.setFont(StyleManager.getLabelFont());
+        categoryPanel.add(catLabel);
         
-        // Create filter button
-        filterButton = new JButton();
-        filterButton.setToolTipText("Click to filter events by category");
-        filterButton.addActionListener(e -> showFilterMenu());
-        toolbar.add(filterButton);
-        updateFilterButton();  // Aligned with any preloaded filter settings
-        
-        // Add some spacing
-        toolbar.add(Box.createHorizontalStrut(20));
-        
+        // Create category filter
+        catButton = new JButton();
+        catButton.setToolTipText("Click to filter events by category");
+        catButton.addActionListener(e -> showFilterMenu());
+        categoryPanel.add(catButton);
+
         // Add acknowledged filter checkbox                
         String showAcknowledgedStr = userSettings.getProperty(SHOW_ACKNOWLEDGED, "false");
         showAcknowledgedCheckBox = new JCheckBox("Acknowledged", Boolean.parseBoolean(showAcknowledgedStr));
         showAcknowledgedCheckBox.setToolTipText("Show or hide acknowledged events");
+        showAcknowledgedCheckBox.setFont(StyleManager.getLabelFont());
         showAcknowledgedCheckBox.addActionListener(e -> 
             loadEvents() // Refresh the event list when checkbox changes
         );
-        toolbar.add(showAcknowledgedCheckBox);
+        categoryPanel.add(showAcknowledgedCheckBox);
+
+        updateFilterButton();  // Aligned with any preloaded filter settings
+
+        // add Settlements selector
+        var settlementPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        toolbar.add(settlementPanel);
+        JLabel settlementLabel = new JLabel("Settlement:");
+        settlementLabel.setFont(StyleManager.getLabelFont());
+        settlementPanel.add(settlementLabel);
+        String settlementString = userSettings.getProperty(SELECTED_SETTLEMENT, null);
+        settlementSelector = new SettlementsSelector(uiContext.getSimulation().getUnitManager(), settlementString,
+                                false);
+        settlementSelector.setSelectionListener("settlementChanged", e -> {
+            selectedSettlements = settlementSelector.getSelectedSettlements();
+            loadEvents(); // Refresh the event list when settlement selection changes
+        });        
+        settlementPanel.add(settlementSelector);
         
         // Create filter popup menu
         createFilterMenu();
@@ -238,17 +262,24 @@ public class EventViewer extends ContentPanel implements ConfigurableWindow, His
     private void createFilterMenu() {
         filterMenu = new JPopupMenu("Category Filter");
         
-        // Add "All" option
+        // Add control options
         JMenuItem allItem = new JMenuItem("All");
         allItem.addActionListener(e -> {
-            selectedCategories.clear();
             selectedCategories.addAll(EnumSet.allOf(HistoricalEventCategory.class));
             updateFilterButton();
             loadEvents();
-            filterMenu.setVisible(false);
         });
         filterMenu.add(allItem);
-        
+
+        JMenuItem toggleItem = new JMenuItem("Toggle All");
+        toggleItem.addActionListener(e -> {
+            var newSelected = new HashSet<>(EnumSet.allOf(HistoricalEventCategory.class));
+            newSelected.removeAll(selectedCategories);
+            selectedCategories = newSelected;
+            updateFilterButton();
+            loadEvents();
+        });
+        filterMenu.add(toggleItem);
         filterMenu.addSeparator();
         
         // Add checkbox for each category
@@ -272,14 +303,15 @@ public class EventViewer extends ContentPanel implements ConfigurableWindow, His
      */
     private void showFilterMenu() {
         // Update checkbox states based on current selection
-        for (int i = 2; i < filterMenu.getComponentCount(); i++) { // Skip All and separator
-            if (filterMenu.getComponent(i) instanceof JCheckBoxMenuItem item) {
-                HistoricalEventCategory category = HistoricalEventCategory.values()[i - 2];
+        int idx = 3;
+        for (HistoricalEventCategory category : HistoricalEventCategory.values()) { // Skip All and separator
+            if (filterMenu.getComponent(idx) instanceof JCheckBoxMenuItem item) {
                 item.setSelected(selectedCategories.contains(category));
             }
+            idx++;
         }
         
-        filterMenu.show(filterButton, 0, filterButton.getHeight());
+        filterMenu.show(catButton, 0, catButton.getHeight());
     }
     
     /**
@@ -290,12 +322,12 @@ public class EventViewer extends ContentPanel implements ConfigurableWindow, His
         int totalCount = HistoricalEventCategory.values().length;
         
         if (selectedCount == totalCount) {
-            filterButton.setText("All Categories");
+            catButton.setText("All Categories");
         } else if (selectedCount == 1) {
             HistoricalEventCategory category = selectedCategories.iterator().next();
-            filterButton.setText(category.getName() + " ");
+            catButton.setText(category.getName() + " ");
         } else {
-            filterButton.setText(selectedCount + " Categories ");
+            catButton.setText(selectedCount + " Categories ");
         }
     }
     
@@ -320,8 +352,15 @@ public class EventViewer extends ContentPanel implements ConfigurableWindow, His
             .collect(Collectors.joining(","));
         props.setProperty(SELECTED_CATEGORIES, selectedCategoryNames);
         
-        // Save show acknowledged setting
         props.setProperty(SHOW_ACKNOWLEDGED, String.valueOf(showAcknowledgedCheckBox.isSelected()));
+
+        String settlementString = switch(settlementSelector.getSelectedItem()) {
+            case Entity s -> s.getName();
+            case String str -> str;
+            default -> "";
+        };
+        props.setProperty(SELECTED_SETTLEMENT, settlementString);
+
 
         return props;
     }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorWindow.java
@@ -10,39 +10,22 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
-import java.awt.event.ItemEvent;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
-import javax.swing.JComboBox;
 import javax.swing.JLabel;
-import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
 import javax.swing.JTabbedPane;
-import javax.swing.ListCellRenderer;
 import javax.swing.SwingConstants;
 import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
 
 import com.mars_sim.core.Entity;
-import com.mars_sim.core.EntityManagerListener;
-import com.mars_sim.core.GameManager;
-import com.mars_sim.core.GameManager.GameMode;
-import com.mars_sim.core.UnitManager;
-import com.mars_sim.core.UnitType;
-import com.mars_sim.core.authority.Authority;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.tool.Msg;
@@ -53,7 +36,7 @@ import com.mars_sim.ui.swing.MarsPanelBorder;
 import com.mars_sim.ui.swing.StyleManager;
 import com.mars_sim.ui.swing.UIContext;
 import com.mars_sim.ui.swing.tool.MapSelector;
-import com.mars_sim.ui.swing.utils.SortedComboBoxModel;
+import com.mars_sim.ui.swing.utils.SettlementsSelector;
 
 /**
  * The MonitorWindow is a tool window that displays a selection of tables each
@@ -63,38 +46,6 @@ import com.mars_sim.ui.swing.utils.SortedComboBoxModel;
 public class MonitorWindow extends ContentPanel
 			implements ConfigurableWindow, TableModelListener{
 
-	/**
-	 * This is a comparator that sorts in the following order:
-	 * 1) String
-	 * 2) Authority
-	 * 3) Settlement
-	 */
-	private static class SelectionComparator implements Comparator<Object> {
-
-		@Override
-		public int compare(Object o1, Object o2) {
-			// String are always first
-			if (o1 instanceof String) {
-				return -1;
-			}
-			else if (o2 instanceof String) {
-				return 1;
-			}
-			if ((o1 instanceof Settlement) && (o2 instanceof Authority)) {
-				return 1;
-			}
-			else if ((o1 instanceof Authority) && (o2 instanceof Settlement)) {
-				return -1;
-			}
-			else if ((o1 instanceof Entity e1) && (o2 instanceof Entity e2)) {
-				return e1.getName().compareTo(e2.getName());
-			}
-
-			// Should never get here
-			return 0;
-		}
-	}
-
 	/** default logger. */
 	private static SimLogger logger = SimLogger.getLogger(MonitorWindow.class.getName());
 
@@ -102,7 +53,6 @@ public class MonitorWindow extends ContentPanel
 	private static final int WIDTH = 1366;
 	private static final int HEIGHT = 640;
 
-	private static final String ALL = "All";
 	public static final String NAME = "monitor";
 	public static final String ICON = "monitor";
     public static final String TITLE = Msg.getString("MonitorWindow.title");
@@ -140,24 +90,15 @@ public class MonitorWindow extends ContentPanel
 	private JButton buttonDetails;
 	private JButton buttonFilter;
 	
-	/** Selection Combo box */
-	private JComboBox<Object> selectionCombo;
-	
 	private JPanel statusPanel;
 
 	private Set<Settlement> currentSelection;
 
-	private UnitManager unitManager;
-
-	private EntityManagerListener umListener;
-
 	private MonitorTab activeTab;
 
-	private Map<Authority, Set<Settlement>> authorities;
-
-	private JLabel selectionDescription;
-
 	private UIContext context;
+
+	private SettlementsSelector settlementSelector;
 
 	/**
 	 * Constructor.
@@ -170,7 +111,7 @@ public class MonitorWindow extends ContentPanel
 		
 		this.context = context;
 
-		unitManager = context.getSimulation().getUnitManager();
+		var unitManager = context.getSimulation().getUnitManager();
 		
 		// Get content pane
 		JPanel mainPane = new JPanel(new BorderLayout(5, 5));
@@ -178,32 +119,19 @@ public class MonitorWindow extends ContentPanel
 		add(mainPane, BorderLayout.CENTER);
 
 		// Set up default selection
-		var choices = setupSelectionChoices();
-		Object defaultSelection = ALL;
 		String previousChoice = (uiProps != null ? uiProps.getProperty(FILTER_PROP) : null);
-		if (previousChoice != null) {
-			for(Entity s : choices) {
-				if (s.getName().equals(previousChoice)) {
-					defaultSelection = s;
-				}
-			}
-		}
 
 		// Create the settlement combo box
-        buildSelectionCombo(choices, defaultSelection);
+		settlementSelector = new SettlementsSelector(unitManager, previousChoice, true);
+		settlementSelector.setToolTipText(Msg.getString("SettlementWindow.tooltip.selectSettlement"));
 
 		// Create top pane
 		JPanel topPane = new JPanel(new FlowLayout());
 		topPane.add(new JLabel("Settlement Filter:"));
-		topPane.add(selectionCombo);
-		selectionDescription = new JLabel("");
-		topPane.add(selectionDescription);
+		topPane.add(settlementSelector);
 
 		mainPane.add(topPane, BorderLayout.NORTH);
 		
-		// Update the selection description
-		applySelection(defaultSelection);
-
 		// Create tabbed pane for the table
 		tabsSection = new JTabbedPane(StyleManager.getTabPlacement(), JTabbedPane.SCROLL_TAB_LAYOUT);
 		
@@ -233,7 +161,11 @@ public class MonitorWindow extends ContentPanel
 		setMinimumSize(new Dimension(640, 256));
 		
 		// Lastly activate the default tab
+		currentSelection = settlementSelector.getSelectedSettlements();
 		selectNewTab(getSelectedTab());
+
+		// List for changes in the settlement selection
+		settlementSelector.setSelectionListener("selectionChanged", e -> changeSelection());
 	}
 
 	/**
@@ -342,154 +274,11 @@ public class MonitorWindow extends ContentPanel
 	}
 
 	/**
-	 * Sets up a list of settlements and associated authorities.
-	 *
-	 * @return Map of authority to settlements
+	 * Reacts to a change in the settlement selection. 
 	 */
-	private List<Entity> setupSelectionChoices() {
-
-		Collection<Settlement> settlements;
-		if (GameManager.getGameMode() == GameMode.COMMAND) {
-			settlements = unitManager.getCommanderSettlements();
-		}
-		else { 
-			settlements = unitManager.getSettlements();
-		}
-		List<Entity> choices = new ArrayList<>(settlements);
-		
-		// Create the Authority maps
-		authorities = new HashMap<>();
-		for (var s : settlements) {
-			var ra = s.getReportingAuthority();
-			authorities.computeIfAbsent(ra, k -> new HashSet<>()).add(s);
-		}	
-
-		choices.addAll(authorities.keySet());
-
-		return choices;
-	}
-
-	/**
-	 * Builds the settlement combo box that uses the settlements and reporting authorities.
-	 * 
-	 * @param choices
-	 * @param selected
-	 */
-	private void buildSelectionCombo(List<Entity> choices, Object selected) {
-		List<Object> converted = new ArrayList<>(choices); // List is a pain
-
-		SortedComboBoxModel<Object> model = new SortedComboBoxModel<>(converted, new SelectionComparator());
-		model.addElement(ALL);
-		model.setSelectedItem(selected);
-		selectionCombo = new JComboBox<>(model);
-		selectionCombo.setOpaque(false);
-		selectionCombo.setToolTipText(Msg.getString("SettlementWindow.tooltip.selectSettlement")); //$NON-NLS-1$
-		selectionCombo.setPreferredSize(new Dimension(200, 25));
-	
-		// Add renderer
-		selectionCombo.setRenderer(new SelectionComboRenderer());
-		
-		// Set the item listener only after the setup is done
-		selectionCombo.addItemListener(this::changeSelection);
-
-		// Listen for new Settlements
-		umListener = new EntityManagerListener() {
-			@Override
-			public void entityAdded(Entity newEntity) {
-				addNewSettlement(newEntity);
-			}
-
-			@Override
-			public void entityRemoved(Entity removedEntity) {
-				if (removedEntity instanceof Settlement s) {
-					// Update authorities tracking
-					var ra = s.getReportingAuthority();
-					var remainingSettlements = authorities.get(ra);
-					if (remainingSettlements != null) {
-						remainingSettlements.remove(s);
-					}
-					// Force rebuild of the selection list
-					var choices = setupSelectionChoices();
-					Object currentSelection = selectionCombo.getSelectedItem();
-					buildSelectionCombo(choices, currentSelection);
-					updateTab();
-				}
-			}
-		};
-		unitManager.addEntityManagerListener(UnitType.SETTLEMENT, umListener);
-
-	}
-
-	/**
-	 * Adds new settlement to the selection and updates the Reporting Authority.
-	 * 
-	 * @param entity
-	 */
-	private void addNewSettlement(Entity entity) {
-		if (entity instanceof Settlement s) {
-			SortedComboBoxModel<Object> ms = (SortedComboBoxModel<Object>) selectionCombo.getModel();
-			ms.addElement(s);
-
-			var ra = s.getReportingAuthority();
-			if (!authorities.containsKey(ra)) {
-				authorities.put(ra, new HashSet<>());
-				ms.addElement(ra);
-			}
-			authorities.get(ra).add(s);
-
-			// Force a refresh in case new Settlement should be displayed
-			updateTab();
-		}
-	}
-
-	/**
-	 * Reacts to a change in the Combo selection. 
-	 * 
-	 * @param event
-	 */
-	private void changeSelection(ItemEvent event) {
-		applySelection(event.getItem());
+	private void changeSelection() {
+		currentSelection = settlementSelector.getSelectedSettlements();
 		updateTab();
-	}
-	
-	/**
-	 * Updates the internal selection status based on a new item.
-	 * 
-	 * @param item
-	 */
-	private void applySelection(Object item) {
-		String newDescription = "";
-		Set<Settlement> newSelection = null;
-
-		switch (item) {
-			case Settlement s -> {
-				newSelection = Set.of(s);
-			}
-			case Authority a -> {
-				newSelection = authorities.get(a);
-				if (newSelection != null) {
-					newDescription = newSelection.stream()
-										.map(Settlement::getName)
-										.sorted()
-										.collect(Collectors.joining(", ", "(", ")"));
-				}
-			}
-			case String str -> {
-				if (!str.equals(ALL)) {
-					// Should always be ALL
-					return;
-				}
-				newSelection = new HashSet<>(unitManager.getSettlements());
-			}
-			default -> {
-				// Unknown type
-				return;
-			}
-		}
-
-		// Change to the selection, must be read only as it is shared
-		currentSelection = Collections.unmodifiableSet(newSelection);
-		selectionDescription.setText(newDescription);
 	}
 
 	/**
@@ -498,11 +287,7 @@ public class MonitorWindow extends ContentPanel
 	 * @param isOpaque
 	 */
 	private void setSettlementBox(boolean isOpaque) {
-		// Set the box opaque
-		selectionCombo.setOpaque(isOpaque);
-		selectionCombo.setEnabled(!isOpaque);
-		selectionCombo.setVisible(!isOpaque);
-		selectionDescription.setVisible(!isOpaque);
+		settlementSelector.setVisible(!isOpaque);
 	}
 
 	/**
@@ -721,7 +506,7 @@ public class MonitorWindow extends ContentPanel
 	@Override
 	public Properties getUIProps() {
 		Properties result = new Properties();
-		Object e = selectionCombo.getSelectedItem();
+		Object e = settlementSelector.getSelectedItem();
 		if (e instanceof Entity ent) {
 			result.setProperty(FILTER_PROP, ent.getName());
 		}
@@ -731,58 +516,13 @@ public class MonitorWindow extends ContentPanel
 		return result;
 	}
 	
-	private class SelectionComboRenderer extends JLabel implements
-        ListCellRenderer<Object> {
-
-		public SelectionComboRenderer() {
-
-			setOpaque(true);
-			setVerticalAlignment(CENTER);
-
-		}
-
-		@Override
-		public Component getListCellRendererComponent(
-				JList<? extends Object> list,
-				Object value, int index, boolean isSelected,
-				boolean cellHasFocus) {
-
-			// Center horizontally
-			setHorizontalAlignment(CENTER); 
-			
-			this.setFont(list.getFont());
-
-			if (isSelected) {
-				setBackground(list.getSelectionBackground());
-				setForeground(list.getSelectionForeground());
-			} else {
-				setBackground(list.getBackground());
-				setForeground(list.getForeground());
-			}
-
-			
-			if (value instanceof Settlement s) {
-				this.setText(s.getName());
-			}
-			else if (value instanceof Authority a) {
-				var children = authorities.get(a);
-				this.setText(a.getName() + " (" + (children != null ? children.size() : 0) + ")");
-			}
-			else if (value instanceof String s) {
-				this.setText(s);
-            }
-			
-			return this;
-		}
-	}
-
 	/**
 	 * Prepares tool window for deletion.
 	 * Remove listeners and references to allow for garbage collection.
 	 */
 	@Override
 	public void destroy() {
-		unitManager.removeEntityManagerListener(UnitType.SETTLEMENT, umListener);
+		settlementSelector.unregister();
 
 		// Remove listeners for the active tab; should already be present but just in case
 		MonitorModel activeModel = (activeTab != null) ? activeTab.getModel() : null;

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/SettlementsSelector.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/SettlementsSelector.java
@@ -57,8 +57,8 @@ public class SettlementsSelector extends JPanel {
     /**
      * Constructor.
      * @param unitMgr Unit manager to get settlements and listen for changes.
+     * @param selected The name of the initially selected settlement or authority, or null for no selection.
      * @param showDescription Whether to show the description label.
-     * @param initialSelected The initially selected item, which can be a Settlement, Authority, or null (for no selection).
      */
     public SettlementsSelector(UnitManager unitMgr, String selected, boolean showDescription) {
         super();
@@ -92,21 +92,20 @@ public class SettlementsSelector extends JPanel {
     private void buildUI(List<Entity> choices, String selectedName, boolean showDescription) {
 		SortedComboBoxModel<Object> model = new SortedComboBoxModel<>(choices, new SelectionComparator());
 		model.addElement(ALL);
-        if (selectedName != null) {
-            if (selectedName.equals(ALL)) {
-                model.setSelectedItem(ALL);
-            }
-            else {
-                // Search for a matching name
-                var selected = choices.stream()
-                                    .filter(e -> e.getName().equals(selectedName))
-                                    .findFirst()
-                                    .orElse(null);
-                if (selected != null) {                   
-                    model.setSelectedItem(selected);
-                }
-            }
-        }
+
+		Object selectedItem = ALL;
+        if ((selectedName != null) && !selectedName.equals(ALL)) {
+			// Search for a matching name
+			var found = choices.stream()
+								.filter(e -> e.getName().equals(selectedName))
+								.findFirst()
+								.orElse(null);
+			if (found != null) {                   
+				selectedItem = found;
+			}
+		}
+
+		model.setSelectedItem(selectedItem);
 		selectionCombo = new JComboBox<>(model);
 		selectionCombo.setOpaque(false);
 	
@@ -143,7 +142,7 @@ public class SettlementsSelector extends JPanel {
 										.collect(Collectors.joining(", ", "(", ")"));
 	        }
 			case String str when str.equals(ALL) ->
-                    newSelection = new HashSet<>(unitMgr.getSettlements());
+                    newSelection = new HashSet<>(getAllSettlements());
 			default -> Collections.emptySet();   // Should never happen
 		}
 
@@ -197,11 +196,24 @@ public class SettlementsSelector extends JPanel {
         return selection;
     }
 
-
+	/**
+	 * Add a listener that gets notified when the selection changes.
+	 * @param actionCommand The action command to be used in the ActionEvent.
+	 * @param listener The listener to be notified.
+	 */
     public void setSelectionListener(String actionCommand, ActionListener listener) {
         this.selectionListener = listener;
         this.actionCommand = actionCommand;
     }
+
+	/**
+	 * Get all valid settlements based on the current game mode.
+	 * @return
+	 */
+	private Collection<Settlement> getAllSettlements() {
+		return (GameManager.getGameMode() == GameMode.COMMAND) ?
+			unitMgr.getCommanderSettlements() : unitMgr.getSettlements();
+	}
 
     /**
 	 * Sets up a list of settlements and associated authorities.
@@ -210,13 +222,8 @@ public class SettlementsSelector extends JPanel {
 	 */
 	private List<Entity> setupSelectionChoices() {
 
-		Collection<Settlement> settlements;
-		if (GameManager.getGameMode() == GameMode.COMMAND) {
-			settlements = unitMgr.getCommanderSettlements();
-		}
-		else { 
-			settlements = unitMgr.getSettlements();
-		}
+		Collection<Settlement> settlements = getAllSettlements();
+
 		List<Entity> choices = new ArrayList<>(settlements);
 		
 		// Create the Authority maps
@@ -312,7 +319,7 @@ public class SettlementsSelector extends JPanel {
 	}
 
     /**
-     * Unregistoer this component from any listeners
+     * Unregister this component from any listeners
      */
     public void unregister() {
         unitMgr.removeEntityManagerListener(UnitType.SETTLEMENT, umListener);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/SettlementsSelector.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/SettlementsSelector.java
@@ -1,0 +1,320 @@
+/*
+ * Mars Simulation Project
+ * SettlementsSelector.java
+ * @date 2026-04-30
+ * @author Barry Evans
+ */
+package com.mars_sim.ui.swing.utils;
+
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.ListCellRenderer;
+
+import com.mars_sim.core.Entity;
+import com.mars_sim.core.EntityManagerListener;
+import com.mars_sim.core.GameManager;
+import com.mars_sim.core.GameManager.GameMode;
+import com.mars_sim.core.UnitManager;
+import com.mars_sim.core.UnitType;
+import com.mars_sim.core.authority.Authority;
+import com.mars_sim.core.structure.Settlement;
+
+/**
+ * This is a component that allows the user to select a settlement, authority, or all settlements.
+ * It displays the selected item and provides a way to get the corresponding set of settlements for the current selection.
+ * It also listens for new settlements being added and updates the selection options accordingly.
+ */
+public class SettlementsSelector extends JPanel {
+    private static final String ALL = "All";
+
+    private UnitManager unitMgr;
+    private EntityManagerListener umListener;
+
+    private Map<Authority, Set<Settlement>> authorities;
+    private JComboBox<Object> selectionCombo;
+    private JLabel selectionDescription;
+    private Set<Settlement> selection;
+
+    private ActionListener selectionListener;
+    private String actionCommand;
+
+    /**
+     * Constructor.
+     * @param unitMgr Unit manager to get settlements and listen for changes.
+     * @param showDescription Whether to show the description label.
+     * @param initialSelected The initially selected item, which can be a Settlement, Authority, or null (for no selection).
+     */
+    public SettlementsSelector(UnitManager unitMgr, String selected, boolean showDescription) {
+        super();
+
+        this.unitMgr = unitMgr;
+
+        var choices = setupSelectionChoices();
+        
+        buildUI(choices, selected, showDescription);
+
+        // 	// Listen for new Settlements
+		umListener = new EntityManagerListener() {
+			@Override
+			public void entityAdded(Entity newEntity) {
+				if (newEntity instanceof Settlement s) {
+					addNewSettlement(s);
+				}
+			}
+
+			@Override
+			public void entityRemoved(Entity removedEntity) {
+				// Settlements are never removed
+			}
+		};
+		unitMgr.addEntityManagerListener(UnitType.SETTLEMENT, umListener);
+
+        // Setup initial selection
+        changeSelection(selectionCombo.getSelectedItem());
+    }
+
+    private void buildUI(List<Entity> choices, String selectedName, boolean showDescription) {
+		SortedComboBoxModel<Object> model = new SortedComboBoxModel<>(choices, new SelectionComparator());
+		model.addElement(ALL);
+        if (selectedName != null) {
+            if (selectedName.equals(ALL)) {
+                model.setSelectedItem(ALL);
+            }
+            else {
+                // Search for a matching name
+                var selected = choices.stream()
+                                    .filter(e -> e.getName().equals(selectedName))
+                                    .findFirst()
+                                    .orElse(null);
+                if (selected != null) {                   
+                    model.setSelectedItem(selected);
+                }
+            }
+        }
+		selectionCombo = new JComboBox<>(model);
+		selectionCombo.setOpaque(false);
+	
+		// Add renderer
+		selectionCombo.setRenderer(new SelectionComboRenderer());
+		
+		// Set the item listener only after the setup is done
+		selectionCombo.addItemListener(e -> changeSelection(e.getItem()));
+
+        add(selectionCombo);
+
+		if (showDescription) {
+        	selectionDescription = new JLabel("");
+			add(selectionDescription);
+		}
+    }
+
+    /**
+	 * Reacts to a change in the Combo selection. 
+	 * 
+	 * @param selectedObject The newly selected object.
+	 */
+	private void changeSelection(Object selectedObject) {
+        String description = "";
+
+		Set<Settlement> newSelection = null;
+        switch (selectedObject) {
+			case Settlement s -> newSelection = Set.of(s);
+			case Authority a -> {
+                newSelection = authorities.get(a);
+				description = newSelection.stream()
+										.map(Settlement::getName)
+										.sorted()
+										.collect(Collectors.joining(", ", "(", ")"));
+	        }
+			case String str when str.equals(ALL) ->
+                    newSelection = new HashSet<>(unitMgr.getSettlements());
+			default -> Collections.emptySet();   // Should never happen
+		}
+
+        if (newSelection != null) {
+            // Update the selection 
+            selection = newSelection;
+			if (selectionDescription != null) {
+            	selectionDescription.setText(description);
+			}
+
+            if (selectionListener != null) {
+                selectionListener.actionPerformed(new ActionEvent(this, ActionEvent.ACTION_PERFORMED, actionCommand));
+            }
+        }
+    }
+
+    /**
+     * A new Settlement has been added.
+     * @param s New settlement.
+     */
+    private void addNewSettlement(Settlement s) {
+        SortedComboBoxModel<Object> ms = (SortedComboBoxModel<Object>) selectionCombo.getModel();
+        ms.addElement(s);
+
+        var ra = s.getReportingAuthority();
+        authorities.computeIfAbsent(ra, k -> {
+            ms.addElement(ra);
+            return new HashSet<>();
+        });
+        authorities.get(ra).add(s);
+
+        // If the parent authority is selected, then simulate a change selection to update the selection set
+        if (selectionCombo.getSelectedItem() instanceof Authority a && a.equals(ra)) {
+            changeSelection(a);
+        }
+    }
+
+    /**
+     * Get the actual selected item.
+     * @return The selected item, which can be a Settlement, Authority, or String (for "All").
+     */
+    public Object getSelectedItem() {
+        return selectionCombo.getSelectedItem();
+    }
+
+    /**
+     * Get the set of settlements corresponding to the current selection. This will be a single settlement if a settlement is selected, all settlements under an authority if an authority is selected, or all settlements if "All" is selected.
+     * @return The set of settlements corresponding to the current selection.
+     */
+    public Set<Settlement> getSelectedSettlements() {
+        return selection;
+    }
+
+
+    public void setSelectionListener(String actionCommand, ActionListener listener) {
+        this.selectionListener = listener;
+        this.actionCommand = actionCommand;
+    }
+
+    /**
+	 * Sets up a list of settlements and associated authorities.
+	 *
+	 * @return Map of authority to settlements
+	 */
+	private List<Entity> setupSelectionChoices() {
+
+		Collection<Settlement> settlements;
+		if (GameManager.getGameMode() == GameMode.COMMAND) {
+			settlements = unitMgr.getCommanderSettlements();
+		}
+		else { 
+			settlements = unitMgr.getSettlements();
+		}
+		List<Entity> choices = new ArrayList<>(settlements);
+		
+		// Create the Authority maps
+		authorities = new HashMap<>();
+		for (var s : settlements) {
+			var ra = s.getReportingAuthority();
+			authorities.computeIfAbsent(ra, k -> new HashSet<>()).add(s);
+		}	
+
+		choices.addAll(authorities.keySet());
+
+		return choices;
+	}
+
+    /**
+	 * This is a comparator that sorts in the following order:
+	 * 1) String
+	 * 2) Authority
+	 * 3) Settlement
+	 */
+	private static class SelectionComparator implements Comparator<Object> {
+
+		@Override
+		public int compare(Object o1, Object o2) {
+			// String are always first
+			if (o1 instanceof String) {
+				return -1;
+			}
+			else if (o2 instanceof String) {
+				return 1;
+			}
+			if ((o1 instanceof Settlement) && (o2 instanceof Authority)) {
+				return 1;
+			}
+			else if ((o1 instanceof Authority) && (o2 instanceof Settlement)) {
+				return -1;
+			}
+			else if ((o1 instanceof Entity e1) && (o2 instanceof Entity e2)) {
+				return e1.getName().compareTo(e2.getName());
+			}
+
+			// Should never get here
+			return 0;
+		}
+	}
+
+    /**
+     * Renders items in the selection combo box, showing settlement names and authority names with settlement counts.
+     */
+    private class SelectionComboRenderer extends JLabel implements
+        ListCellRenderer<Object> {
+
+		public SelectionComboRenderer() {
+
+			setOpaque(true);
+			setVerticalAlignment(CENTER);
+
+		}
+
+		@Override
+		public Component getListCellRendererComponent(
+				JList<? extends Object> list,
+				Object value, int index, boolean isSelected,
+				boolean cellHasFocus) {
+
+			// Center horizontally
+			setHorizontalAlignment(CENTER); 
+			
+			this.setFont(list.getFont());
+
+			if (isSelected) {
+				setBackground(list.getSelectionBackground());
+				setForeground(list.getSelectionForeground());
+			} else {
+				setBackground(list.getBackground());
+				setForeground(list.getForeground());
+			}
+
+			
+			if (value instanceof Settlement s) {
+				this.setText(s.getName());
+			}
+			else if (value instanceof Authority a) {
+				var children = authorities.get(a);
+				this.setText(a.getName() + " (" + (children != null ? children.size() : 0) + ")");
+			}
+			else if (value instanceof String s) {
+				this.setText(s);
+            }
+			
+			return this;
+		}
+	}
+
+    /**
+     * Unregistoer this component from any listeners
+     */
+    public void unregister() {
+        unitMgr.removeEntityManagerListener(UnitType.SETTLEMENT, umListener);
+    }
+}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/SortedComboBoxModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/SortedComboBoxModel.java
@@ -28,7 +28,7 @@ public class SortedComboBoxModel<E> extends AbstractListModel<E>
     private Comparator<E> comparator;
     private Object selectedObject;
 
-    public SortedComboBoxModel(Collection<E> initialList, Comparator<E> comparator) {
+    public SortedComboBoxModel(Collection<? extends E> initialList, Comparator<E> comparator) {
         this.comparator = comparator;
         if (!initialList.isEmpty()) {
             this.choices.addAll(initialList);


### PR DESCRIPTION
Changes:
- Extract Authority/Settlement selector in MonitorWindow to SettlementsSelector
- SettlementsSelector allows use to select either Settlement or Authority but presents a list of SettlementsSelector
- Update MonitorWindow to use seperate selector
- Add a SettlementsSelector to the EventViewer toolbar, but redesign
- EventViewer filters on Settlement as well as Category
- Add a Toggle All option to the category filter

close #1918