### PR TITLE
feat(ui): Add Notifications message to desktop

### DIFF
--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/ContentManager.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/ContentManager.java
@@ -6,56 +6,153 @@
  */
 package com.mars_sim.ui.swing;
 
+import java.awt.Taskbar;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
 import javax.swing.JFrame;
+import javax.swing.WindowConstants;
 
+import com.formdev.flatlaf.util.SystemInfo;
+import com.mars_sim.core.Simulation;
 import com.mars_sim.ui.swing.UIConfig.WindowSpec;
 import com.mars_sim.ui.swing.sound.AudioPlayer;
+import com.mars_sim.ui.swing.utils.SaveDialog;
+
 
 /**
- * This represents the content manager for the main window. It provides methods to get the properties of all UI elements and the details of all content windows currently open on the desktop.
+ * This represents the content manager for the main window. It provides methods to get the properties of all UI elements.
  * This is used to save the UI configuration.
- * It provides an interface to the shared main UI components, such as the Mars Terminal and the content windows and UIConfig.
  */
-public interface ContentManager {
+public abstract class ContentManager {
+
+    private static final String AUDIO_PROPS = "audio";
+    private static final String STYLE_PROPS = "style";
+
+    private UIConfig config;
+    private AudioPlayer audio = null;
+    private JFrame mainFrame;
+    private Simulation sim;
+
+    protected ContentManager(Simulation sim, UIConfig config, boolean useAudio) {
+        this.config = config;
+        this.sim = sim;
+
+        // Set up the look and feel library to be used
+		StyleManager.setUIProps(config.getPropSet(STYLE_PROPS));
+		
+		// Start audio if enabled
+		if (useAudio) {
+            Properties props = config.getPropSet(AUDIO_PROPS);
+            audio = new AudioPlayer(props);
+		}
+			
+        mainFrame = new JFrame("Mars Simulation");
+		mainFrame.setResizable(true);
+        mainFrame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        mainFrame.addWindowListener(new WindowAdapter() {
+			@Override
+			public void windowClosing(WindowEvent event) {
+				// Save simulation and UI configuration when window is closed.
+				SaveDialog.createEndSimulation(sim, ContentManager.this);
+			}
+		});
+
+        // Setup icons
+		if (SystemInfo.isMacOS) {
+			Taskbar taskbar = Taskbar.getTaskbar();
+			taskbar.setIconImage(StyleManager.getIconImage());
+			
+			// Move the menu bar out of the main window to the top of the screen
+			System.setProperty( "apple.laf.useScreenMenuBar", "true" );
+		}
+		else {
+			mainFrame.setIconImage(StyleManager.getIconImage());
+		}
+    }
+
+	/**
+	 * Sets up the screen config used from last saved session.
+	 */
+	protected boolean loadSavedScreen() {
+		// Display screen at a certain location
+		var location = config.getMainWindowLocation();
+		if (location == null) {
+			return false;
+		}
+		mainFrame.setLocation(config.getMainWindowLocation());
+
+		// For the Main Window	
+		var selectedSize = config.getMainWindowDimension();
+		if (selectedSize != null) {
+			// Set frame size
+			mainFrame.setSize(selectedSize);
+		}
+
+		return true;
+	}
 
     /**
-     * Get the properties of all UI elements. This is used to save the UI configuration.
-     * @return A map of UI element names to their properties.
-     */
-    Map<String, Properties> getUIProps();
+	 * Gets the UI property sets of the application. Each set has a name. 
+	 * @return A map of UI property sets.
+	 */
+	public Map<String, Properties> getUIProps() {
+        Map<String, Properties> result = new HashMap<>();
+
+        if (audio != null) {
+            result.put(AUDIO_PROPS, audio.getUIProps());
+        }
+
+        result.put(STYLE_PROPS, StyleManager.getUIProps());
+        return result;
+    }
 
     /**
 	 * Get the details of all content windows currently open on the desktop. This is used to save the UI configuration.
 	 * @return
 	 */
-	List<WindowSpec> getContentSpecs();
+	public abstract List<WindowSpec> getContentSpecs();
+    
+    /**
+     * Get the UI configuration for the main window.
+     * @return UI configuration.
+     */
+    public UIConfig getConfig() {
+        return config;
+    }
+    
+    /**
+     * Get the top-level frame of the main window.
+     * @return Top level main frame.
+     */
+    public JFrame getTopFrame() {
+        return mainFrame;
+    }
 
     /**
-     * Get the UIConfig for this UI. This is used to save the UI configuration.
-     * @return
+     * Get the Simulation instance.
+     * @return The Simulation instance.
      */
-    UIConfig getConfig();
-
-
-    /**
-     * Get the top-level frame of the main window. This is used to save the UI configuration.
-     * @return Top lewvel main frame.
-     */
-    JFrame getTopFrame();
+    public Simulation getSimulation() {
+        return sim;
+    }
 
     /**
-     * Shutdown the UI. This is used to save the UI configuration and close all UI elements.
-     * It is a method of no return.
+     * Shutdown the UI. The subclass should implement this method to perform any necessary cleanup when the application is closed..
      */
-    void shutdown();
+    public void shutdown() {
+        mainFrame.dispose();
+    }
 
     /**
-     * Get the AudioPlayer instance. 
-     * @return The AudioPlayer instance.
+     * Get the AudioPlayer instance. This could be null if audio is not enabled.
+      * @return The AudioPlayer instance, or null if audio is not enabled.
      */
-    AudioPlayer getAudio();
+    public AudioPlayer getAudio() {
+        return audio;
+    }
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/ContentManager.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/ContentManager.java
@@ -55,7 +55,7 @@ public abstract class ContentManager {
 			
         mainFrame = new JFrame("Mars Simulation");
 		mainFrame.setResizable(true);
-        mainFrame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        mainFrame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         mainFrame.addWindowListener(new WindowAdapter() {
 			@Override
 			public void windowClosing(WindowEvent event) {
@@ -76,7 +76,7 @@ public abstract class ContentManager {
 			mainFrame.setIconImage(StyleManager.getIconImage());
 		}
 
-        // Activiate notification manager
+        // Activate notification manager
         this.noticeMgr = new NotificationManager(sim, mainFrame, config.getPropSet(NOTIFICATION_PROPS));
     }
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/ContentManager.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/ContentManager.java
@@ -32,11 +32,13 @@ public abstract class ContentManager {
 
     private static final String AUDIO_PROPS = "audio";
     private static final String STYLE_PROPS = "style";
+    private static final String NOTIFICATION_PROPS = "notification";
 
     private UIConfig config;
     private AudioPlayer audio = null;
     private JFrame mainFrame;
     private Simulation sim;
+    private NotificationManager noticeMgr;
 
     protected ContentManager(Simulation sim, UIConfig config, boolean useAudio) {
         this.config = config;
@@ -73,6 +75,9 @@ public abstract class ContentManager {
 		else {
 			mainFrame.setIconImage(StyleManager.getIconImage());
 		}
+
+        // Activiate notification manager
+        this.noticeMgr = new NotificationManager(sim, mainFrame, config.getPropSet(NOTIFICATION_PROPS));
     }
 
 	/**
@@ -103,11 +108,15 @@ public abstract class ContentManager {
 	public Map<String, Properties> getUIProps() {
         Map<String, Properties> result = new HashMap<>();
 
+        result.put(STYLE_PROPS, StyleManager.getUIProps());
+
         if (audio != null) {
             result.put(AUDIO_PROPS, audio.getUIProps());
         }
 
-        result.put(STYLE_PROPS, StyleManager.getUIProps());
+        if (noticeMgr != null) {
+            result.put(NOTIFICATION_PROPS, noticeMgr.getUIProps());
+        }
         return result;
     }
 
@@ -139,6 +148,13 @@ public abstract class ContentManager {
      */
     public Simulation getSimulation() {
         return sim;
+    }
+
+    /**
+     * Get the notification manager instance.
+     */
+    public NotificationManager getNotifications() {
+        return noticeMgr;   
     }
 
     /**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/MainMenuBar.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/MainMenuBar.java
@@ -214,8 +214,14 @@ public class MainMenuBar extends JMenuBar implements ActionListener {
 		
 		if (audioPlayer != null) {
 			var audio = createToolMenuItem(AudioControl.TITLE, AudioControl.ICON, null,
-					e -> {AudioControl.showPopup(audioPlayer);});
+					e -> AudioControl.showPopup(audioPlayer));
 			settingsMenu.add(audio);
+		}
+
+		// Notification control
+		var notificationManager = manager.getNotifications();
+		if (notificationManager != null) {
+			settingsMenu.add(notificationManager.getSettingsMenu());
 		}
 
 		// Add window system options

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/NotificationManager.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/NotificationManager.java
@@ -1,0 +1,230 @@
+/*
+ * Mars Simulation Project
+ * NotificationManager.java
+ * @date 2026-05-04
+ * @author Barry Evans
+ */
+package com.mars_sim.ui.swing;
+
+import java.awt.AWTException;
+import java.awt.Frame;
+import java.awt.SystemTray;
+import java.awt.TrayIcon;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import javax.swing.ButtonGroup;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.JRadioButtonMenuItem;
+import javax.swing.SwingUtilities;
+import javax.swing.event.MenuEvent;
+import javax.swing.event.MenuListener;
+
+import com.mars_sim.core.Simulation;
+import com.mars_sim.core.SimulationRuntime;
+import com.mars_sim.core.events.HistoricalEvent;
+import com.mars_sim.core.events.HistoricalEventListener;
+import com.mars_sim.core.logging.SimLogger;
+
+/**
+ * This class provides the ability to publish notifications onto the desktop of the user.
+ * It listens for historical events and shows a notification when a new event is added to the simulation. It also provides a menu for the user to control when notifications are shown.
+ * Notifications are shown using the system tray if it is supported by the operating system.
+ * If the system tray is not supported, notifications will be disabled and a warning will be logged.
+ */
+public class NotificationManager implements HistoricalEventListener {
+
+    private static final String NOTIFICATION_CONTROL = "notificationControl";
+	private static final SimLogger logger = SimLogger.getLogger(NotificationManager.class.getName());
+
+    enum NotificationControl {
+        NEVER, ALWAYS, WHEN_CLOSED
+    }
+
+    private NotificationControl notificationControl = NotificationControl.WHEN_CLOSED; // Default value
+    private TrayIcon trayIcon;
+    private JFrame mainFrame;
+
+    public NotificationManager(Simulation sim, JFrame mainframe, Properties uiProps) {
+        this.mainFrame = mainframe;
+
+        // Build systray
+        if (SystemTray.isSupported()) {
+            // Initialize system tray notifications here
+            SystemTray tray = SystemTray.getSystemTray();
+
+            trayIcon = new TrayIcon(StyleManager.getIconImage(), SimulationRuntime.SHORT_TITLE);
+            trayIcon.setImageAutoSize(true);
+            try {
+                tray.add(trayIcon);
+                createTrayIconMenu();
+            } catch (AWTException e) {
+                logger.severe("Failed to add tray icon", e);
+                trayIcon = null; // Disable tray icon if it fails to initialize
+            }
+        }
+        else {
+            logger.warning("System tray not supported. Notifications will be disabled.");
+        }
+
+        // Restore notification control setting from properties, defaulting to existing value if not set or invalid
+        String controlValue = uiProps.getProperty(NOTIFICATION_CONTROL, notificationControl.name());
+        try {   
+            this.notificationControl = NotificationControl.valueOf(controlValue);
+        } catch (IllegalArgumentException e) {
+            logger.warning("Invalid notification control value in properties: " + controlValue);
+        }
+
+        // Listen for changes in the notification control setting
+        sim.getEventManager().addListener(this);
+    }
+
+    private List<JMenuItem> buildSettingsMenu() {
+        List<JMenuItem>  menuItems = new ArrayList<>();
+        ButtonGroup group = new ButtonGroup();
+        // Create radio button menu items for each notification control option
+        for (NotificationControl control : NotificationControl.values()) {
+            JRadioButtonMenuItem menuItem = new JRadioButtonMenuItem(getDisplayName(control));
+            menuItem.setSelected(control == notificationControl);
+            menuItem.addActionListener(new NotificationControlActionListener(control));
+            group.add(menuItem);
+            menuItems.add(menuItem);
+        }
+
+        return menuItems;
+    }
+
+    public JMenu getSettingsMenu() {
+        JMenu settingsMenu = new JMenu("Notification Settings");
+        settingsMenu.addMenuListener(new MenuListener() {
+            @Override
+            public void menuSelected(MenuEvent me) {
+                JMenu menuSource = (JMenu) me.getSource();
+		        menuSource.removeAll();//
+				for (JMenuItem item : buildSettingsMenu()) {
+                    menuSource.add(item);
+                }
+            }
+
+            @Override
+            public void menuDeselected(MenuEvent me) {
+				// Nothing to do
+            }
+
+            @Override
+            public void menuCanceled(MenuEvent me) {
+				// Nothing to do
+            }
+        });
+        return settingsMenu;
+     }
+
+    /**
+     * Creates and configures the popup menu for the tray icon.
+     */
+    private void createTrayIconMenu() {
+
+        // Add mouse listener to show popup menu on right-click
+        trayIcon.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                if (e.isPopupTrigger()) {
+                    showPopupMenu(e);
+                }
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                if (e.isPopupTrigger()) {
+                    showPopupMenu(e);
+                }
+            }
+
+            private void showPopupMenu(MouseEvent e) {
+                var popupMenu = new JPopupMenu();
+                for (JMenuItem menuItem : buildSettingsMenu()) {
+                    popupMenu.add(menuItem);
+                }
+                popupMenu.setLocation(e.getX(), e.getY());
+                popupMenu.setInvoker(popupMenu);
+                popupMenu.setVisible(true);
+            }
+        });
+    }
+
+    /**
+     * Returns a user-friendly display name for the notification control option.
+     * @param control The notification control option
+     * @return User-friendly display name
+     */
+    private static String getDisplayName(NotificationControl control) {
+        return switch (control) {
+            case NEVER -> "Never show notifications";
+            case ALWAYS -> "Always show notifications";
+            case WHEN_CLOSED -> "Show notifications when window is closed";
+            default -> control.name();  
+        };
+    }
+
+    /**
+     * Action listener for notification control menu items.
+     */
+    private class NotificationControlActionListener implements ActionListener {
+        private final NotificationControl control;
+
+        public NotificationControlActionListener(NotificationControl control) {
+            this.control = control;
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            notificationControl = control;
+            logger.info("Notification control changed to: " + control);
+        }
+    }
+
+    /**
+     * Show a notification message. It will only be shown if the visibility criteria is meet. 
+     * @param title The title of the notification.
+     * @param message The message content of the notification.
+     * @param isWarning Whether the notification is a warning.
+     */    
+    public void showNotification(String title, String message, boolean isWarning) {
+        TrayIcon.MessageType messageType = isWarning ? TrayIcon.MessageType.WARNING : TrayIcon.MessageType.INFO;
+
+        // Check if we can show a notification based on the control setting and main frame visibility
+        if (trayIcon != null && (notificationControl == NotificationControl.ALWAYS
+                    || (notificationControl == NotificationControl.WHEN_CLOSED
+                            && (mainFrame != null) && (mainFrame.getState() == Frame.ICONIFIED)))) {
+            SwingUtilities.invokeLater(() -> trayIcon.displayMessage(title, message, messageType));
+        }
+    }
+
+    /**
+     * Get the notification-related UI properties to be saved in the configuration.
+     * @return Settings to contol notifications.
+     */
+    public Properties getUIProps() {
+        Properties props = new Properties();
+        props.setProperty(NOTIFICATION_CONTROL, notificationControl.name());
+        return props;
+    }
+
+    /**
+     * A historical event has occured so potentially show a notification about it.
+     * @param event The historical event that has been added to the simulation.
+     */
+    @Override
+    public void eventAdded(HistoricalEvent event) {
+        String message = event.getType().getName() + ": " + event.getSource().getName();
+        showNotification("Event Added", message, false);
+    }
+}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/NotificationManager.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/NotificationManager.java
@@ -46,10 +46,10 @@ public class NotificationManager implements HistoricalEventListener {
 	private static final SimLogger logger = SimLogger.getLogger(NotificationManager.class.getName());
 
     enum NotificationControl {
-        NEVER, ALWAYS, WHEN_CLOSED
+        NEVER, ALWAYS, WHEN_MINIMISED
     }
 
-    private NotificationControl notificationControl = NotificationControl.WHEN_CLOSED; // Default value
+    private NotificationControl notificationControl = NotificationControl.WHEN_MINIMISED; // Default value
     private TrayIcon trayIcon;
     private JFrame mainFrame;
 
@@ -167,9 +167,9 @@ public class NotificationManager implements HistoricalEventListener {
      */
     private static String getDisplayName(NotificationControl control) {
         return switch (control) {
-            case NEVER -> "Never show notifications";
-            case ALWAYS -> "Always show notifications";
-            case WHEN_CLOSED -> "Show notifications when window is closed";
+            case NEVER -> "Never show";
+            case ALWAYS -> "Always show";
+            case WHEN_MINIMISED -> "Only Show when minimised";
             default -> control.name();  
         };
     }
@@ -202,7 +202,7 @@ public class NotificationManager implements HistoricalEventListener {
 
         // Check if we can show a notification based on the control setting and main frame visibility
         if (trayIcon != null && (notificationControl == NotificationControl.ALWAYS
-                    || (notificationControl == NotificationControl.WHEN_CLOSED
+                    || (notificationControl == NotificationControl.WHEN_MINIMISED
                             && (mainFrame != null) && (mainFrame.getState() == Frame.ICONIFIED)))) {
             SwingUtilities.invokeLater(() -> trayIcon.displayMessage(title, message, messageType));
         }
@@ -210,7 +210,7 @@ public class NotificationManager implements HistoricalEventListener {
 
     /**
      * Get the notification-related UI properties to be saved in the configuration.
-     * @return Settings to contol notifications.
+     * @return Settings to control notifications.
      */
     public Properties getUIProps() {
         Properties props = new Properties();

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/StyleManager.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/StyleManager.java
@@ -13,7 +13,6 @@ import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -293,12 +292,11 @@ public class StyleManager {
 	}
 
     /**
-     * Gets the styles used.
-     * 
+     * Get the properties configurable style parameters.
      * @return
      */
-    public static Map<String, Properties> getStyles() {
-        return styles;
+    public static Properties getUIProps() {
+        return styles.get(LAF_STYLE);
     }
 
     /**
@@ -306,14 +304,8 @@ public class StyleManager {
      * 
      * @param newStyles
      */
-    public static void setStyles(Map<String,Properties> newStyles) {
-        // MErge the incoming styles with the ones used internally
-        for(Entry<String, Properties> usedStyle : styles.entrySet()) {
-            Properties overrides = newStyles.get(usedStyle.getKey());
-            if (overrides != null) {
-                usedStyle.getValue().putAll(overrides);
-            }
-        }
+    public static void setUIProps(Properties newStyles) {
+        styles.get(LAF_STYLE).putAll(newStyles);
 
         // Load LAF to use styles
         setLAF(getLAF());

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/ToolToolBar.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/ToolToolBar.java
@@ -95,12 +95,11 @@ public class ToolToolBar extends JToolBar implements ActionListener {
 	 * 
 	 * @param manager the content manager for the main window, used to access shared UI components and save the UI configuration on exit.
 	 * @param context the UIContext for this toolbar, used to access the simulation and open tool windows.
-	 * @param audioPlayer the AudioPlayer for the simulation, used to control audio settings.
 	 */
-	public ToolToolBar(ContentManager manager, UIContext context, AudioPlayer audioPlayer) {
+	public ToolToolBar(ContentManager manager, UIContext context) {
 
 		// Initialize data members
-		this.audioPlayer = audioPlayer;
+		this.audioPlayer = manager.getAudio();
 		this.context = context;
 		this.manager = manager;
 		masterClock = context.getSimulation().getMasterClock();

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/UIConfig.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/UIConfig.java
@@ -57,7 +57,6 @@ public class UIConfig {
 	/** Internal window types. */
 	public static final String TOOL = "tool";
 	public static final String UNIT = "unit";
-	public static final String AUDIO_PROPS = "audio";
 
 	private static final String FILE_NAME = "ui_settings.xml";
 	
@@ -231,19 +230,12 @@ public class UIConfig {
 
 		// Output the extra properties
 		Map<String, Properties> extraProps = new HashMap<>();
-		extraProps.putAll(StyleManager.getStyles());
 		extraProps.putAll(mainWindow.getUIProps());
 
 		Element propsElement = new Element(PROP_SETS);
 		uiElement.addContent(propsElement);
 		for (Entry<String,Properties> entry : extraProps.entrySet()) {
 			outputProperties(propsElement, entry.getKey(), entry.getValue());
-		}
-	
-		// Output the audio properties
-		var audio = mainWindow.getAudio();
-		if (audio != null) {
-			outputProperties(propsElement, UIConfig.AUDIO_PROPS, audio.getUIProps());
 		}
 
 		saveDocumentToXMLFile(outputDoc, new File(SimulationRuntime.getSaveDir(), FILE_NAME));
@@ -389,15 +381,6 @@ public class UIConfig {
 	 */
 	public WindowSpec getInternalWindowDetails(String windowName) {
 		return loadedSpecs.get(windowName);
-	}
-
-	/**
-	 * Gets the property sets defined in the config.
-	 * 
-	 * @return
-	 */
-	public Map<String, Properties> getPropSets() {
-		return propSets;
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/SimulationConfigEditor.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/configeditor/SimulationConfigEditor.java
@@ -193,7 +193,7 @@ public class SimulationConfigEditor {
 		// Preload the config to set up the preferred LAF
 		UIConfig configs = new UIConfig();
 		configs.parseFile();
-		StyleManager.setStyles(configs.getPropSets());
+		StyleManager.setUIProps(configs.getPropSet("style"));
 
 		hasError = false;
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/desktop/MainWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/desktop/MainWindow.java
@@ -10,14 +10,9 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.Frame;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
-import java.awt.Taskbar;
 import java.awt.Toolkit;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -25,17 +20,13 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.swing.BorderFactory;
-import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JToolBar;
 import javax.swing.SwingConstants;
-import javax.swing.WindowConstants;
 
-import com.formdev.flatlaf.util.SystemInfo;
 import com.mars_sim.core.GameManager;
 import com.mars_sim.core.Simulation;
-import com.mars_sim.core.SimulationRuntime;
 import com.mars_sim.core.time.ClockListener;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.ClockPulseListener;
@@ -43,7 +34,6 @@ import com.mars_sim.core.time.CompressedClockListener;
 import com.mars_sim.core.time.MasterClock;
 import com.mars_sim.ui.swing.ContentManager;
 import com.mars_sim.ui.swing.MarsPanelBorder;
-import com.mars_sim.ui.swing.StyleManager;
 import com.mars_sim.ui.swing.ToolToolBar;
 import com.mars_sim.ui.swing.UIConfig;
 import com.mars_sim.ui.swing.UIConfig.WindowSpec;
@@ -52,7 +42,6 @@ import com.mars_sim.ui.swing.entitywindow.EntityToolBar;
 import com.mars_sim.ui.swing.sound.AudioPlayer;
 import com.mars_sim.ui.swing.tool.JStatusBar;
 import com.mars_sim.ui.swing.tool.guide.GuideWindow;
-import com.mars_sim.ui.swing.utils.SaveDialog;
 import com.mars_sim.ui.swing.utils.SpeedControl;
 import com.mars_sim.ui.swing.utils.SwingHelper;
 
@@ -60,10 +49,7 @@ import com.mars_sim.ui.swing.utils.SwingHelper;
  * The MainWindow class is the primary UI frame for the project. It contains the
  * main desktop pane window are, status bar and tool bars.
  */
-public class MainWindow
-		extends JComponent implements ClockListener, ClockPulseListener, ContentManager {
-
-	private static final long serialVersionUID = 1L;
+public class MainWindow extends ContentManager implements ClockListener, ClockPulseListener {
 
 	private static final Logger logger = Logger.getLogger(MainWindow.class.getName());
 
@@ -74,11 +60,6 @@ public class MainWindow
 	private static final String MAIN_PROPS = "main-window";
 
 	private static final String EXTERNAL_BROWSER = "use-external";
-		
-	/** The main window frame. */
-	private JFrame frame;
-
-	private transient UIConfig uiconfigs;
 
 	// Data members
 	private boolean isIconified = false;
@@ -92,15 +73,11 @@ public class MainWindow
 
 	private Dimension selectedSize;
 	
-	private Simulation sim;
-
 	private JMemoryMeter memoryBar;
 
 	private boolean useExternalBrowser;
 
 	private ClockPulseListener clockHandler;
-
-	private AudioPlayer soundPlayer;
 
 	private SpeedControl speedControls;
 
@@ -111,17 +88,14 @@ public class MainWindow
 	 * @param config UI configuration to use for the window.
 	 * @param audio Audio player for the window.
 	 */
-	public MainWindow(Simulation sim, UIConfig config, AudioPlayer audio) {
-		this.sim = sim;
+	public MainWindow(Simulation sim, UIConfig config, boolean useAudio) {
+		super(sim, config, useAudio);
 
 		logger.config("Starting as " + GameManager.getGameMode());
 
 		// Set Apache Batik library system property so that it doesn't output:
 		// "Graphics2D from BufferedImage lacks BUFFERED_IMAGE hint" in system err.
 		System.setProperty("org.apache.batik.warn_destination", "false");
-
-		this.uiconfigs = config;
-		this.soundPlayer = audio;
 
 		GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
 		GraphicsDevice[] gd = ge.getScreenDevices();
@@ -145,22 +119,22 @@ public class MainWindow
 		int screenHeight = graphicsDevice.getDisplayMode().getHeight();
 
 		// Set up the frame
-		frame = new JFrame();
-		frame.setResizable(true);
+		var frame = getTopFrame();
 		frame.setMinimumSize(new Dimension(640, 640));
 
 		// Set the UI configuration
-		boolean useDefault = uiconfigs.useUIDefault();
+		boolean useDefault = getConfig().useUIDefault();
 
-		if (useDefault || !setUpSavedScreen()) {
+		if (useDefault || !loadSavedScreen()) {
 			logger.config("Will calculate screen size for default display instead.");
-			setUpDefaultScreen(graphicsDevice, screenWidth, screenHeight, useDefault);
+			setUpDefaultScreen(frame, graphicsDevice, screenWidth, screenHeight, useDefault);
 		}
 		
+		var soundPlayer = getAudio();
+
 		// Set up MainDesktopPane
 		desktop = new MainDesktopPane(this, sim, soundPlayer);
-		
-		init(soundPlayer, sim.getMasterClock());
+		init(frame, soundPlayer, sim.getMasterClock());
 
 		// Show frame
 		frame.setVisible(true);
@@ -170,48 +144,26 @@ public class MainWindow
 	}
 
 	/**
-	 * Sets up the screen config used from last saved session.
-	 */
-	private boolean setUpSavedScreen() {
-		// Display screen at a certain location
-		var location = uiconfigs.getMainWindowLocation();
-		if (location == null) {
-			return false;
-		}
-		frame.setLocation(uiconfigs.getMainWindowLocation());
-
-		// For the Main Window	
-		selectedSize = uiconfigs.getMainWindowDimension();
-		if (selectedSize != null) {
-			// Set frame size
-			frame.setSize(selectedSize);
-			logger.config("Last saved window dimension: " + SwingHelper.toString(selectedSize));
-		}
-
-		return true;
-	}
-
-	/**
 	 * Sets up the default screen config.
-	 * 
+	 * @param frame 
 	 * @param gd
 	 * @param screenWidth
 	 * @param screenHeight
 	 * @param useDefaults
 	 */
-	private void setUpDefaultScreen(GraphicsDevice gd, int screenWidth, int screenHeight, boolean useDefaults) {
+	private void setUpDefaultScreen(JFrame frame, GraphicsDevice gd, int screenWidth, int screenHeight, boolean useDefaults) {
 		int initY;
 		int initX;
 		
 		// Set main window frame size
-		selectedSize = calculatedScreenSize(gd, screenWidth, screenHeight, useDefaults, uiconfigs.getMainWindowDimension());
+		selectedSize = calculatedScreenSize(gd, screenWidth, screenHeight, useDefaults, getConfig().getMainWindowDimension());
 
 		frame.setSize(selectedSize);
 
 		logger.config("Default main window dimension: " + SwingHelper.toString(selectedSize));
 
-		initX = (int)(screenWidth - selectedSize.width) / 2;
-		initY = (int)(screenHeight - selectedSize.height) / 2;
+		initX = (screenWidth - selectedSize.width) / 2;
+		initY = (screenHeight - selectedSize.height) / 2;
 		frame.setLocation(initX, initY);
 
 		logger.config("Use default configuration to set main window's frame to the center of the screen.");
@@ -289,41 +241,9 @@ public class MainWindow
 	 * Initializes UI elements for the frame
 	 * @param audio The audio player to use but maybe null if audio is not initialized
 	 * @param masterClock Main clock
+	 * @param frame 
 	 */
-	private void init(AudioPlayer audio, MasterClock masterClock) {
-	
-		frame.addWindowListener(new WindowAdapter() {
-			@Override
-			public void windowClosing(WindowEvent event) {
-				// Save simulation and UI configuration when window is closed.
-				SaveDialog.createEndSimulation(sim, MainWindow.this);
-			}
-		});
-
-		frame.addWindowStateListener(e -> {
-			int state = e.getNewState();
-			isIconified = (state == Frame.ICONIFIED);
-			if (state == Frame.MAXIMIZED_HORIZ
-					|| state == Frame.MAXIMIZED_VERT)
-				logger.log(Level.CONFIG, "MainWindow set to maximum.");
-			repaint();
-		});
-	
-		frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-
-		changeTitle(false);
-
-		if (SystemInfo.isMacOS) {
-			final Taskbar taskbar = Taskbar.getTaskbar();
-			taskbar.setIconImage(StyleManager.getIconImage());
-			
-			// Move the menu bar out of the main window to the top of the screen
-			System.setProperty( "apple.laf.useScreenMenuBar", "true" );
-		}
-		else {
-			frame.setIconImage(StyleManager.getIconImage());
-		}
-		
+	private void init(JFrame frame, AudioPlayer audio, MasterClock masterClock) {
 
 		// Set up the main pane
 		JPanel mainPane = new JPanel(new BorderLayout());
@@ -361,7 +281,7 @@ public class MainWindow
 		toolbarPane.add(floatingSpeedBar, BorderLayout.WEST);
 	
      	// Prepare tool toolbar
-     	toolToolbar = new ToolToolBar(this, desktop, audio);
+     	toolToolbar = new ToolToolBar(this, desktop);
      	toolToolbar.requestFocusInWindow();
      	// Add toolToolbar to toolbarPane
      	toolbarPane.add(toolToolbar, BorderLayout.CENTER);
@@ -380,7 +300,7 @@ public class MainWindow
 		bottomPane.add(unitToolbar, BorderLayout.CENTER);
 
 		// set the visibility of tool and unit bars from preferences
-		Properties props = uiconfigs.getPropSet(MAIN_PROPS);
+		Properties props = getConfig().getPropSet(MAIN_PROPS);
 		unitToolbar.setVisible(UIConfig.extractBoolean(props, SHOW_UNIT_BAR, false));
 		toolToolbar.setVisible(UIConfig.extractBoolean(props, SHOW_TOOL_BAR, true));
 		useExternalBrowser = UIConfig.extractBoolean(props, EXTERNAL_BROWSER, false);
@@ -411,38 +331,20 @@ public class MainWindow
 		// Listen for clock changes
 		masterClock.addClockListener(this);
 	}
-	
-	/**
-	 * Get the window's frame.
-	 *
-	 * @return the frame.
-	 */
-	@Override
-	public JFrame getTopFrame() {
-		return frame;
-	}
 
 	/**
 	 * Close the main frame and unregister any listeners or active components.
 	 */
 	@Override
 	public void shutdown() {
-		frame.dispose();
+		super.shutdown();
 
-		var masterClock = sim.getMasterClock();
+		var masterClock = getSimulation().getMasterClock();
 		masterClock.removeClockPulseListener(clockHandler);
 		masterClock.removeClockListener(this);
 
 		speedControls.unregister();
 		desktop.destroy();
-	}
-
-	/**
-	 * Get the assigned audio player.
-	 */
-	@Override
-	public AudioPlayer getAudio() {
-		return soundPlayer;
 	}
 
 	/**
@@ -464,34 +366,11 @@ public class MainWindow
 	}
 
 	/**
-	 * Changes the title.
-	 * 
-	 * @param isPaused
-	 */
-	private void changeTitle(boolean isPaused) {
-		String suffix = switch (GameManager.getGameMode()) {
-			case COMMAND -> "Command Mode";
-			case SANDBOX -> "Sandbox Mode";
-			case SPONSOR -> "Sponsor Mode";
-			case SOCIETY ->  "Society Mode";	
-		};
-		frame.setTitle(SimulationRuntime.SHORT_TITLE + "  -  " + suffix + (isPaused ? "  -  [ P A U S E ]" : ""));
-	}
-
-	/**
-	 * Gets the UIConfig for this UI.
-	 */
-	@Override
-	public UIConfig getConfig() {
-		return uiconfigs;
-	}
-
-	/**
 	 * Gets the UI properties of the application.
 	 */
 	@Override
 	public Map<String, Properties> getUIProps() {
-		Map<String, Properties> result = new HashMap<>();
+		Map<String, Properties> result = super.getUIProps();
 
 		// Local details
 		Properties desktopProps = new Properties();
@@ -523,7 +402,7 @@ public class MainWindow
 	 */
 	@Override
 	public void pauseChange(boolean isPaused) {
-		changeTitle(isPaused);
+		// No need to do anything here since the MasterClock is controlling the pause status
 	}
 
 	@Override
@@ -556,7 +435,7 @@ public class MainWindow
 	 * @param helpPage
 	 */
 	public void showHelp(String helpPage) {
-		var library = GuideWindow.getHelp(sim.getConfig());
+		var library = GuideWindow.getHelp(getSimulation().getConfig());
 
 		var  helpURI = library.getPage(helpPage);	
 		if (useExternalBrowser) {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/docking/DockingAdapter.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/docking/DockingAdapter.java
@@ -27,17 +27,19 @@ import io.github.andrewauclair.moderndocking.Dockable;
  */
 class DockingAdapter extends JPanel implements Dockable {
 
+    private DockingWindow dockingParent;
     private ContentPanel content;
     private JLabel contentLabel;
     private JLabel contentSize;
 
     /**
      * Create a new DockingAdapter to wrap the given content panel.
+     * @param parent the parent docking window, used to notify when the content panel is closed.
      * @param contentPanel Panel holding the content.
      */
-    public DockingAdapter(ContentPanel contentPanel) {
+    public DockingAdapter(DockingWindow parent, ContentPanel contentPanel) {
+        this.dockingParent = parent;
         this.content = contentPanel;
-
         setLayout(new BorderLayout());
         add(contentPanel, BorderLayout.CENTER);
 
@@ -102,12 +104,10 @@ class DockingAdapter extends JPanel implements Dockable {
     public boolean requestClose() {
 
         // Line up the close in the future, cannot deregister until after the call stack unwinds
-        var topLevelAncestor = getTopLevelAncestor();
-        if (topLevelAncestor instanceof DockingWindow window) {
-            SwingUtilities.invokeLater(() ->
-                window.closeContentPanel(this)
-            );
-        }
+        SwingUtilities.invokeLater(() ->
+            dockingParent.closeContentPanel(this)
+        );
+    
         // Return true to allow the close to proceed.
         return true;
     }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/docking/DockingWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/docking/DockingWindow.java
@@ -8,10 +8,7 @@ package com.mars_sim.ui.swing.docking;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
@@ -19,11 +16,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
-import javax.swing.WindowConstants;
 
 import com.mars_sim.core.Entity;
 import com.mars_sim.core.Simulation;
@@ -31,8 +26,8 @@ import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.ClockPulseListener;
 import com.mars_sim.core.time.CompressedClockListener;
-import com.mars_sim.ui.swing.ConfigurableWindow;
 import com.mars_sim.ui.swing.ContentManager;
+import com.mars_sim.ui.swing.ConfigurableWindow;
 import com.mars_sim.ui.swing.ContentPanel;
 import com.mars_sim.ui.swing.ContentPanel.Placement;
 import com.mars_sim.ui.swing.MainMenuBar;
@@ -44,13 +39,11 @@ import com.mars_sim.ui.swing.UIConfig.WindowSpec;
 import com.mars_sim.ui.swing.UIContext;
 import com.mars_sim.ui.swing.entitywindow.EntityContentFactory;
 import com.mars_sim.ui.swing.entitywindow.EntityContentPanel;
-import com.mars_sim.ui.swing.sound.AudioPlayer;
 import com.mars_sim.ui.swing.tool.ToolRegistry;
 import com.mars_sim.ui.swing.tool.entitybrowser.EntityBrowser;
 import com.mars_sim.ui.swing.tool.eventviewer.EventViewer;
 import com.mars_sim.ui.swing.tool.monitor.MonitorWindow;
 import com.mars_sim.ui.swing.utils.AttributePanel;
-import com.mars_sim.ui.swing.utils.SaveDialog;
 import com.mars_sim.ui.swing.utils.SpeedControl;
 
 import io.github.andrewauclair.moderndocking.Dockable;
@@ -64,8 +57,8 @@ import io.github.andrewauclair.moderndocking.ext.ui.DockingUI;
  * The main window for the Mars Simulation UI that uses a docking approach to the window layout.
  * It implements the UIContext interface to provide access to the simulation and other UI features.
  */
-public class DockingWindow extends JFrame 
-        implements ClockPulseListener, UIContext, ContentManager {
+public class DockingWindow extends ContentManager 
+        implements ClockPulseListener, UIContext {
     /**
      * A blank panel used as an anchor for docking regions.
      */
@@ -92,18 +85,13 @@ public class DockingWindow extends JFrame
 
     private static SimLogger logger = SimLogger.getLogger(DockingWindow.class.getName());
 
-    private Simulation sim;
     private Set<DockingAdapter> windows = new HashSet<>();
     private Map<Placement, Dockable> anchors = new EnumMap<>(Placement.class);
     private ToolToolBar toolToolBar;
-    private UIConfig config;
-    private AudioPlayer audio;
     private SpeedControl speed;
 
-    private DockingWindow(Simulation sim, UIConfig config, AudioPlayer audio) {
-        this.sim = sim;
-        this.config = config;
-        this.audio = audio;
+    private DockingWindow(Simulation sim, UIConfig config, boolean useAudio) {
+        super(sim, config, useAudio);
 
         // Set up the look and feel library to be used
         StyleManager.setTabPlacement(SwingConstants.TOP);
@@ -112,28 +100,29 @@ public class DockingWindow extends JFrame
         AttributePanel.setUseDynamicLayout(true);
 
         // Setup the JFrame
-        setTitle("Mars Simulation");
-        setSize(1200, 800);
-        setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        var frame = getTopFrame();
+        if (!loadSavedScreen()) {
+            frame.setSize(1200, 800);
+        }
 
         // Initialize Docking. Force tabs for single Dockerables
-        Docking.initialize(this);
+        Docking.initialize(frame);
         DockingUI.initialize();
 
-        RootDockingPanel dockingPanel = new RootDockingPanel(this);
+        RootDockingPanel dockingPanel = new RootDockingPanel(frame);
 
-        setLayout(new BorderLayout());
-        add(dockingPanel, BorderLayout.CENTER);
+        frame.setLayout(new BorderLayout());
+        frame.add(dockingPanel, BorderLayout.CENTER);
 
-        toolToolBar = new ToolToolBar(this, this, audio);
+        toolToolBar = new ToolToolBar(this, this);
         var topPanel = new JPanel(new BorderLayout());
         topPanel.add(toolToolBar, BorderLayout.CENTER);
 
         speed = new SpeedControl(sim.getMasterClock());
         topPanel.add(speed, BorderLayout.WEST);
-        add(topPanel, BorderLayout.NORTH);
+        frame.add(topPanel, BorderLayout.NORTH);
 
-        setJMenuBar(new MainMenuBar(this, this, audio));
+        frame.setJMenuBar(new MainMenuBar(this, this, getAudio()));
 
         // Add the blanks panels for docking anchors
         createBlank(Placement.CENTER);
@@ -145,23 +134,16 @@ public class DockingWindow extends JFrame
         
         // Add default tools
         openInitialTools();
-
-        addWindowListener(new WindowAdapter() {
-			@Override
-			public void windowClosing(WindowEvent event) {
-				// Save simulation and UI configuration when window is closed.
-				SaveDialog.createEndSimulation(sim, DockingWindow.this);
-			}
-		});
     }
 
     /**
      * Open initial windows based on the UIConfig. If no windows are configured, open a default set of tools.
      */
     private void openInitialTools() {
-        List<WindowSpec> startingWindows = config.getConfiguredWindows();
+        List<WindowSpec> startingWindows = getConfig().getConfiguredWindows();
 
 		if (!startingWindows.isEmpty()) {
+            var sim = getSimulation();
 			for(WindowSpec w : startingWindows) {
 				switch(w.type()) {
 					case UIConfig.TOOL:
@@ -205,7 +187,7 @@ public class DockingWindow extends JFrame
      * @param panel Content to add
      */
     private void addContentPanel(ContentPanel panel) {
-        var w = new DockingAdapter(panel);
+        var w = new DockingAdapter(this, panel);
         
         Docking.registerDockable(w);
         logger.info("Content Panel registered: " + w.getPersistentID() + " " + panel.getTitle());
@@ -219,7 +201,7 @@ public class DockingWindow extends JFrame
         else {
             // Add direct to the window in the specified region
             var region = getRegion(panel.getPlacement());
-            Docking.dock(w, this, region);
+            Docking.dock(w, getTopFrame(), region);
         }
         windows.add(w);
 
@@ -248,7 +230,7 @@ public class DockingWindow extends JFrame
     private void createBlank(Placement placement) {
         var anchor = new Anchor();
         Docking.registerDockingAnchor(anchor);
-        Docking.dock(anchor, this, getRegion(placement));
+        Docking.dock(anchor, getTopFrame(), getRegion(placement));
 
         anchors.put(placement, anchor);
     }
@@ -316,23 +298,13 @@ public class DockingWindow extends JFrame
         return toolContent;
     }
 
-    @Override
-    public Simulation getSimulation() {
-        return sim;
-    }
-
-    @Override
-    public JFrame getTopFrame() {
-        return this;
-    }
-
-    
 	/**
 	 * Plays a sound by name.
 	 * @param soundName The name of the sound to play
 	 */
 	@Override
 	public void playSound(String soundName) {
+        var audio = getAudio();
         if (audio != null) {
             audio.playSound(soundName);
         }
@@ -356,23 +328,14 @@ public class DockingWindow extends JFrame
      * Factory method to create and show a DockingWindow for the given simulation.
      * @param sim Simulation running.
      * @param config UI configuration to use for the window.
-     * @param audio Audio player for the window.
+     * @param useAudio Whether to use audio for the window.
      * @return The created DockingWindow.
      */
-    public static DockingWindow create(Simulation sim, UIConfig config, AudioPlayer audio) {
-        var dw = new DockingWindow(sim, config, audio);
+    public static DockingWindow create(Simulation sim, UIConfig config, boolean useAudio) {
+        var dw = new DockingWindow(sim, config, useAudio);
 
-        dw.setVisible(true);
+        dw.getTopFrame().setVisible(true);
         return dw;
-    }
-
-    /**
-     * Saved any ui properties specifc to the Docking windows.
-     * @return Map of property sets for the UI elements in the Docking window.
-     */
-    @Override
-    public Map<String, Properties> getUIProps() {
-		return Collections.emptyMap();
     }
 
     /**
@@ -403,23 +366,11 @@ public class DockingWindow extends JFrame
 		return results;
     }
 
-    /**
-     * Get the assigned audio player.
-     */
-    @Override
-    public AudioPlayer getAudio() {
-        return audio;
-    }
-
-    @Override
-    public UIConfig getConfig() {
-        return config;
-    }
-
     @Override
     public void shutdown() {
+        super.shutdown();
+
         // Close the window and release resources
         speed.unregister();
-        dispose();
     }
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/main/MarsProject.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/main/MarsProject.java
@@ -29,12 +29,12 @@ import com.mars_sim.core.SimulationBuilder;
 import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.SimulationRuntime;
 import com.mars_sim.core.configuration.Scenario;
+import com.mars_sim.ui.swing.ContentManager;
 import com.mars_sim.ui.swing.StyleManager;
 import com.mars_sim.ui.swing.UIConfig;
 import com.mars_sim.ui.swing.configeditor.SimulationConfigEditor;
 import com.mars_sim.ui.swing.desktop.MainWindow;
 import com.mars_sim.ui.swing.docking.DockingWindow;
-import com.mars_sim.ui.swing.sound.AudioPlayer;
 
 /**
 * MarsProject is the main class for starting mars-sim's UI mode. It creates both the
@@ -60,8 +60,6 @@ public class MarsProject {
 	private boolean useDockingUI = false;
 	private boolean useAudio = true;
 
-	private Simulation sim;
-
 	private String simFile;
 
 
@@ -78,6 +76,7 @@ public class MarsProject {
 	 * @param args
 	 */
 	public void parseArgs(String[] args) {
+  Simulation sim;
 				
 		SimulationBuilder builder = new SimulationBuilder();
 		
@@ -122,29 +121,21 @@ public class MarsProject {
 			if (!useCleanUI || askScreenConfig()) {
 				config.parseFile();
 			}
-
-			// Set up the look and feel library to be used
-			StyleManager.setStyles(config.getPropSets());
 		
-			// Start audio if enabled
-			AudioPlayer audio = null;
-			if (useAudio) {
-				Properties props = config.getPropSet(UIConfig.AUDIO_PROPS);
-				audio = new AudioPlayer(props);
-			}
-			
 			// Build main window
+			ContentManager contentMgr = null;
 			splashWindow.setStatusMessage("Starting the Main Window...");
 			if (config.useDockingUI() || useDockingUI) {
-				DockingWindow.create(sim, config, audio);
+				contentMgr = DockingWindow.create(sim, config, useAudio);
 			}
 			else {
-				new MainWindow(sim, config, audio);
+				contentMgr = new MainWindow(sim, config, useAudio);
 			}
 
 			// Switch from Splash to main window as one
 			SwingUtilities.invokeLater(splashWindow::remove);
 
+			var audio = contentMgr.getAudio();
 			if (audio != null) {
 				audio.playRandomTracks();
 			}


### PR DESCRIPTION
This PR adds the ability to display notification messages when new Historical Events arrives. This is provided by a new class  `NotificationManager` that allows the user to control when a message is displayed:

- Always
- Never
- When the simulation window is closed.

The notification control is via the Setting menu.

In support the ContentManager is upgraded to an abstract class to hold common logic both both window styles.

Cloe #1864 

