### PR TITLE
feat: Standardise identification of resource type

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/BinType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/BinType.java
@@ -6,7 +6,7 @@
  */
 package com.mars_sim.core.equipment;
 
-import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.ResourceType;
 
 
 /**
@@ -21,8 +21,6 @@ public enum BinType {
 	;
 	
 	private String name;	
-
-	private static final int FIRST_BIN_RESOURCE_ID = ResourceUtil.FIRST_BIN_RESOURCE_ID;
 		
 	/** hidden constructor. */
 	private BinType(String name) {
@@ -48,7 +46,7 @@ public enum BinType {
 		if (name != null) {
 	    	for (BinType e : BinType.values()) {
 	    		if (name.equalsIgnoreCase(e.name)) {
-	    			return e.ordinal() + FIRST_BIN_RESOURCE_ID;
+	    			return e.ordinal() + ResourceType.FIRST_BIN_RESOURCE_ID;
 	    		}
 	    	}
 		}
@@ -62,7 +60,7 @@ public enum BinType {
 	 * @return {@link BinType}
 	 */
 	public static BinType convertID2Type(int typeID) {
-		return BinType.values()[typeID - FIRST_BIN_RESOURCE_ID];
+		return BinType.values()[typeID - ResourceType.FIRST_BIN_RESOURCE_ID];
 	}
 
 	/**
@@ -90,6 +88,6 @@ public enum BinType {
 	 * @return
 	 */
 	public static int getResourceID(BinType type) {
-		return type.ordinal() + FIRST_BIN_RESOURCE_ID;
+		return type.ordinal() + ResourceType.FIRST_BIN_RESOURCE_ID;
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentType.java
@@ -6,7 +6,7 @@
  */
 package com.mars_sim.core.equipment;
 
-import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.ResourceType;
 import com.mars_sim.core.tool.Msg;
 
 
@@ -23,8 +23,6 @@ public enum EquipmentType {
 	THERMAL_BOTTLE, WHEELBARROW;
 	
 	private String name;	
-
-	private static final int FIRST_EQUIPMENT_RESOURCE_ID = ResourceUtil.FIRST_EQUIPMENT_RESOURCE_ID;
 		
 	/** hidden constructor. */
 	private EquipmentType() {
@@ -45,7 +43,7 @@ public enum EquipmentType {
 		if (name != null) {
 	    	for (EquipmentType e : EquipmentType.values()) {
 	    		if (name.equalsIgnoreCase(e.name)) {
-	    			return e.ordinal() + FIRST_EQUIPMENT_RESOURCE_ID;
+	    			return e.ordinal() + ResourceType.FIRST_EQUIPMENT_RESOURCE_ID;
 	    		}
 	    	}
 		}
@@ -59,7 +57,7 @@ public enum EquipmentType {
 	 * @return {@link EquipmentType}
 	 */
 	public static EquipmentType convertID2Type(int typeID) {
-		return EquipmentType.values()[typeID - FIRST_EQUIPMENT_RESOURCE_ID];
+		return EquipmentType.values()[typeID - ResourceType.FIRST_EQUIPMENT_RESOURCE_ID];
 	}
 
 	/**
@@ -87,6 +85,6 @@ public enum EquipmentType {
 	 * @return
 	 */
 	public static int getResourceID(EquipmentType type) {
-		return type.ordinal() + FIRST_EQUIPMENT_RESOURCE_ID;
+		return type.ordinal() + ResourceType.FIRST_EQUIPMENT_RESOURCE_ID;
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/AbstractVehicleMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/AbstractVehicleMission.java
@@ -42,6 +42,7 @@ import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.project.Stage;
 import com.mars_sim.core.resource.ItemResourceUtil;
 import com.mars_sim.core.resource.MaintenanceScope;
+import com.mars_sim.core.resource.ResourceType;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.robot.Robot;
@@ -1140,50 +1141,51 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 			int id = entry.getKey();
 			Object value = entry.getValue();
 
-			if (id < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
+			switch(ResourceType.getType(id)) {
+				case ResourceType.AMOUNT_RESOURCE: {
+					double amount = (Double) value;
+					double amountStored = vehicle.getSpecificAmountResourceStored(id);
 
-				double amount = (Double) value;
-				double amountStored = vehicle.getSpecificAmountResourceStored(id);
-
-				// Check inside vehicle
-				if (VehicleType.isRover(vehicle.getVehicleType())) {
-					Rover rover = (Rover) vehicle;
-					// Check people's possession
-					for (Person person: rover.getCrew()) {
-						amountStored += person.getSpecificAmountResourceStored(id);
+					// Check inside vehicle
+					if (VehicleType.isRover(vehicle.getVehicleType())) {
+						Rover rover = (Rover) vehicle;
+						// Check people's possession
+						for (Person person: rover.getCrew()) {
+							amountStored += person.getSpecificAmountResourceStored(id);
+						}
+						// Check vehicle's equipment
+						for (Equipment equipment: rover.getContainerSet()) {
+							amountStored += equipment.getSpecificAmountResourceStored(id);
+						}
 					}
-					// Check vehicle's equipment
-					for (Equipment equipment: rover.getContainerSet()) {
-						amountStored += equipment.getSpecificAmountResourceStored(id);
+					
+					if (amountStored < amount) {
+						String newLog = "Not enough "
+								+ ResourceUtil.findAmountResourceName(id) + " to continue with "
+								+ getName() + " - Required: " + Math.round(amount * 100D) / 100D + " kg - Vehicle stored: "
+								+ Math.round(amountStored * 100D) / 100D + " kg.";
+						logger.log(vehicle, Level.WARNING, 10_000, newLog);
+						return id;
 					}
-				}
+					} break;
 				
-				if (amountStored < amount) {
-					String newLog = "Not enough "
-							+ ResourceUtil.findAmountResourceName(id) + " to continue with "
-							+ getName() + " - Required: " + Math.round(amount * 100D) / 100D + " kg - Vehicle stored: "
-							+ Math.round(amountStored * 100D) / 100D + " kg.";
-					logger.log(vehicle, Level.WARNING, 10_000, newLog);
-					return id;
-				}
+				case ResourceType.ITEM_RESOURCE: {
+					int num = (Integer) value;
+					int numStored = vehicle.getItemResourceStored(id);
+
+					if (numStored < num) {
+						String newLog = "Not enough "
+								+ ItemResourceUtil.findItemResource(id).getName() + " to continue with "
+								+ getName() + " - Required: " + num + " - Vehicle stored: " + numStored + ".";
+						logger.log(vehicle, Level.WARNING, 10_000,  newLog);
+						return id;
+					}
+					} break;
+
+				default:
+					logger.warning(vehicle, "Phase: " + getPhase() + ": unable to process the resource '"
+								+ GoodsUtil.getGood(id) + "'.");
 			}
-
-			else if (id < ResourceUtil.FIRST_VEHICLE_RESOURCE_ID) {
-				int num = (Integer) value;
-				int numStored = vehicle.getItemResourceStored(id);
-
-				if (numStored < num) {
-					String newLog = "Not enough "
-							+ ItemResourceUtil.findItemResource(id).getName() + " to continue with "
-							+ getName() + " - Required: " + num + " - Vehicle stored: " + numStored + ".";
-					logger.log(vehicle, Level.WARNING, 10_000,  newLog);
-					return id;
-				}
-			}
-
-			else
-				logger.warning(vehicle, "Phase: " + getPhase() + ": unable to process the resource '"
-						+ GoodsUtil.getGood(id) + "'.");
 		}
 		return -1;
 	}
@@ -1378,7 +1380,7 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 		while (i.hasNext()) {
 			Integer id = i.next();
 			// Check if it's an amount resource that can be stored inside
-			if (id < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
+			if (ResourceType.getType(id) == ResourceType.AMOUNT_RESOURCE) {
 				double amount = (double) optionalResources.get(id);
 
 				// Obtain a container for storing the amount resource

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/RescueSalvageVehicle.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/RescueSalvageVehicle.java
@@ -21,7 +21,7 @@ import com.mars_sim.core.mission.objectives.RescueVehicleObjective;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.job.util.JobType;
 import com.mars_sim.core.person.ai.task.util.Worker;
-import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.ResourceType;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.tool.Msg;
 import com.mars_sim.core.vehicle.Crewable;
@@ -424,24 +424,31 @@ public class RescueSalvageVehicle extends RoverMission {
 
 			for (var needed : rescueResources.entrySet()) {
 				var id = needed.getKey();
-				if (id < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
-					double amount = (Double) needed.getValue();
-					if (useBuffer) {
-						amount *= RESCUE_RESOURCE_BUFFER;
-					}
-					if (result.containsKey(id)) {
-						amount += (Double) result.get(id);
-					}
+				switch(ResourceType.getType(id)) {
+					case ResourceType.AMOUNT_RESOURCE: {
+						double amount = (Double) needed.getValue();
+						if (useBuffer) {
+							amount *= RESCUE_RESOURCE_BUFFER;
+						}
+						if (result.containsKey(id)) {
+							amount += (Double) result.get(id);
+						}
 
-					result.put(id, amount);
-					
-				}  // Check if these resources are Parts
-				else if (id < ResourceUtil.FIRST_VEHICLE_RESOURCE_ID) {
-					int num = (Integer) needed.getValue();
-					if (result.containsKey(id)) {
-						num += (Integer) result.get(id);
-					}
-					result.put(id, num);
+						result.put(id, amount);
+						
+					} break;
+
+					// Check if these resources are Parts
+					case ResourceType.ITEM_RESOURCE: {
+						int num = (Integer) needed.getValue();
+						if (result.containsKey(id)) {
+							num += (Integer) result.get(id);
+						}
+						result.put(id, num);
+					} break;
+
+					default: // Do nothing
+						break;
 				}
 			}
 		}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/resource/ItemResourceUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/resource/ItemResourceUtil.java
@@ -24,10 +24,8 @@ public class ItemResourceUtil {
 	
 	/** default logger. */
 	private static SimLogger logger = SimLogger.getLogger(ItemResourceUtil.class.getName());
-
-	private static final int FIRST_ITEM_RESOURCE_ID = ResourceUtil.FIRST_ITEM_RESOURCE_ID;
 	
-	public static final int AIRLEAK_PATCH_ID = FIRST_ITEM_RESOURCE_ID;
+	public static final int AIRLEAK_PATCH_ID = ResourceType.FIRST_ITEM_RESOURCE_ID;
 	public static final int BATTERY_MODULE_ID = AIRLEAK_PATCH_ID + 1;
 	
 	public static final int FIRE_EXTINGUISHER_ID = BATTERY_MODULE_ID + 1;
@@ -96,7 +94,7 @@ public class ItemResourceUtil {
 		fixedItemResources.put("methanol fuel cell stack", METHANOL_FUEL_CELL_STACK_ID);
 		
 		// This check will only fail if a new resource has not been added correctly
-		int expectedSize = FIRST_FREE_ITEM_RESOURCE_ID - FIRST_ITEM_RESOURCE_ID;
+		int expectedSize = FIRST_FREE_ITEM_RESOURCE_ID - ResourceType.FIRST_ITEM_RESOURCE_ID;
 		if (fixedItemResources.size() != expectedSize) {
 			throw new IllegalStateException("The number of fixed item resources is not correct. Expected: " 
 					+ expectedSize + ", Actual: " + fixedItemResources.size());

--- a/mars-sim-core/src/main/java/com/mars_sim/core/resource/ResourceType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/resource/ResourceType.java
@@ -1,0 +1,49 @@
+/*
+ * Mars Simulation Project
+ * ResourceIdentifier.java
+ * @date 2026-05-03
+ * @author Barry Evans
+ */
+package com.mars_sim.core.resource;
+
+/**
+ * This class provides the logic to infer the type of resource based on the resource ID.
+ * It also defines the ranges of resource IDs for each type of resource.
+ */
+public class ResourceType {
+
+    // Types of resources
+    public static final int AMOUNT_RESOURCE = 0;
+    public static final int ITEM_RESOURCE = 1;
+    public static final int VEHICLE_RESOURCE = 2;
+    public static final int EQUIPMENT_RESOURCE = 3;
+    public static final int ROBOT_RESOURCE = 4;
+    public static final int BIN_RESOURCE = 5;
+
+
+    private static final int TYPE_BIT = 11; // Gives 2048 per range
+
+    // First identifer of the appropriate type. This is used to determine the range of resource IDs for each type.
+	public static final int FIRST_AMOUNT_RESOURCE_ID = (AMOUNT_RESOURCE << TYPE_BIT) + 1;  // Start at 1 to avoid using 0 as a valid resource ID
+	public static final int FIRST_ITEM_RESOURCE_ID = ITEM_RESOURCE << TYPE_BIT;
+	public static final int FIRST_VEHICLE_RESOURCE_ID = VEHICLE_RESOURCE << TYPE_BIT;
+	public static final int FIRST_EQUIPMENT_RESOURCE_ID = EQUIPMENT_RESOURCE << TYPE_BIT;
+	public static final int FIRST_ROBOT_RESOURCE_ID = ROBOT_RESOURCE << TYPE_BIT;
+	public static final int FIRST_BIN_RESOURCE_ID = BIN_RESOURCE << TYPE_BIT;
+
+    private ResourceType() {
+        // Private constructor to prevent instantiation
+    }
+    
+    /** 
+     * Gets the type of resource based on the resource ID.
+      * 
+      * @param resourceID the resource ID
+      * @return the type of resource
+    */
+    public static int getType(int resourceID) {
+        return resourceID >> TYPE_BIT;
+    }
+
+
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/resource/ResourceType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/resource/ResourceType.java
@@ -1,6 +1,6 @@
 /*
  * Mars Simulation Project
- * ResourceIdentifier.java
+ * ResourceType.java
  * @date 2026-05-03
  * @author Barry Evans
  */

--- a/mars-sim-core/src/main/java/com/mars_sim/core/resource/ResourceUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/resource/ResourceUtil.java
@@ -18,17 +18,12 @@ import com.mars_sim.core.food.Food;
 import com.mars_sim.core.food.FoodUtil;
 import com.mars_sim.core.goods.GoodType;
 
+/**
+ * Helper class for Amount Resources.
+ */
 public class ResourceUtil {
 
-	
-	public static final int FIRST_AMOUNT_RESOURCE_ID = 200;
-	public static final int FIRST_ITEM_RESOURCE_ID = 500;
-	public static final int FIRST_VEHICLE_RESOURCE_ID = 1000;
-	public static final int FIRST_EQUIPMENT_RESOURCE_ID = 1010;
-	public static final int FIRST_ROBOT_RESOURCE_ID = 1020;
-	public static final int FIRST_BIN_RESOURCE_ID = 1040;
-
-	public static final int WATER_ID = FIRST_AMOUNT_RESOURCE_ID;
+	public static final int WATER_ID = ResourceType.FIRST_AMOUNT_RESOURCE_ID;
 	public static final int FOOD_ID = WATER_ID + 1;
 
 	public static final int OXYGEN_ID = FOOD_ID + 1;
@@ -276,7 +271,7 @@ public class ResourceUtil {
 		fixedResources.put("water", WATER_ID);
 
 		// This check will only fail if a new resource has not been added correctly
-		int expectedSize = FIRST_FREE_AMOUNT_RESOURCE_ID - FIRST_AMOUNT_RESOURCE_ID;
+		int expectedSize = FIRST_FREE_AMOUNT_RESOURCE_ID - ResourceType.FIRST_AMOUNT_RESOURCE_ID;
 		if (fixedResources.size() != expectedSize) {
 			throw new IllegalStateException("The number of fixed resources is not correct. Expected: " 
 					+ expectedSize + ", Actual: " + fixedResources.size());

--- a/mars-sim-core/src/main/java/com/mars_sim/core/resource/SuppliesManifest.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/resource/SuppliesManifest.java
@@ -35,7 +35,7 @@ public class SuppliesManifest {
         this.mandatoryItem = new HashMap<>();
         for(var m : mandatoryResources.entrySet())  {
             int resourceId = m.getKey();
-            if (resourceId < ResourceUtil.FIRST_ITEM_RESOURCE_ID)
+            if (ResourceType.getType(resourceId) == ResourceType.AMOUNT_RESOURCE)
                 mandatoryAmount.put(resourceId, m.getValue().doubleValue());
             else
                 mandatoryItem.put(resourceId, m.getValue().intValue());
@@ -45,12 +45,11 @@ public class SuppliesManifest {
         this.optionalItem = new HashMap<>();
         for(var m : optionalResources.entrySet())  {
             int resourceId = m.getKey();
-            if (resourceId < ResourceUtil.FIRST_ITEM_RESOURCE_ID)
+            if (ResourceType.getType(resourceId) == ResourceType.AMOUNT_RESOURCE)
                 optionalAmount.put(resourceId, m.getValue().doubleValue());
             else
                 optionalItem.put(resourceId, m.getValue().intValue());
         }
-
 
         this.mandatoryEqm = mandatoryEqm;
         this.optionalEqm = optionalEqm;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/robot/RobotType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/robot/RobotType.java
@@ -6,7 +6,7 @@
  */
 package com.mars_sim.core.robot;
 
-import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.ResourceType;
 import com.mars_sim.core.tool.Msg;
 
 public enum RobotType {
@@ -43,7 +43,7 @@ public enum RobotType {
 	 * @return
 	 */
 	public static int getResourceID(RobotType type) {
-		return type.ordinal() + ResourceUtil.FIRST_ROBOT_RESOURCE_ID;
+		return type.ordinal() + ResourceType.FIRST_ROBOT_RESOURCE_ID;
 	}
 	
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/VehicleType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/VehicleType.java
@@ -7,7 +7,7 @@
  */
 package com.mars_sim.core.vehicle;
 
-import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.ResourceType;
 import com.mars_sim.core.tool.Msg;
 
 public enum VehicleType {
@@ -68,7 +68,7 @@ public enum VehicleType {
 	 * @return
 	 */
 	public static VehicleType convertID2Type(int id) {
-		return VehicleType.values()[id - ResourceUtil.FIRST_VEHICLE_RESOURCE_ID];
+		return VehicleType.values()[id - ResourceType.FIRST_VEHICLE_RESOURCE_ID];
 	}
 	
 	/**
@@ -78,7 +78,7 @@ public enum VehicleType {
 	 * @return
 	 */
 	public static int getVehicleID(VehicleType type) {
-		return ResourceUtil.FIRST_VEHICLE_RESOURCE_ID + type.ordinal();
+		return ResourceType.FIRST_VEHICLE_RESOURCE_ID + type.ordinal();
 	}
 	
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/LoadVehicleGarage.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/LoadVehicleGarage.java
@@ -23,6 +23,7 @@ import com.mars_sim.core.person.ai.task.util.TaskPhase;
 import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.person.ai.task.util.ExperienceImpact.PhysicalEffort;
 import com.mars_sim.core.resource.ItemResourceUtil;
+import com.mars_sim.core.resource.ResourceType;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.tool.Msg;
@@ -189,7 +190,7 @@ public class LoadVehicleGarage extends Task {
 		// Check if there are enough resources at the settlement.
 		for (Entry<Integer, Number> required : resources.entrySet()) {
 			int resource = required.getKey();
-			if (resource < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
+			if (ResourceType.getType(resource) == ResourceType.AMOUNT_RESOURCE) {
 
 				double stored = settlement.getAllAmountResourceStored(resource);
 				double needed = required.getValue().doubleValue();
@@ -205,7 +206,7 @@ public class LoadVehicleGarage extends Task {
 				}
 			}
 
-			else if (resource >= ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
+			else if (ResourceType.getType(resource) == ResourceType.ITEM_RESOURCE) {
 				int needed = required.getValue().intValue();
 				int settlementNeed = getRemainingSettlementNum(settlement, vehicleCrewNum, resource);
 				int numLoaded = vehicle.getItemResourceStored(resource);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/equipment/BinTypeTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/equipment/BinTypeTest.java
@@ -1,0 +1,16 @@
+package com.mars_sim.core.equipment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class BinTypeTest {
+    @ParameterizedTest
+    @EnumSource(BinType.class)
+    void testGetName(BinType type) {
+        int calcId = BinType.getResourceID(type);
+        var calcType = BinType.convertID2Type(calcId);
+        assertEquals(type, calcType, "Conversion of " + type);
+    }
+}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/equipment/EquipmentTypeTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/equipment/EquipmentTypeTest.java
@@ -1,0 +1,16 @@
+package com.mars_sim.core.equipment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class EquipmentTypeTest {
+    @ParameterizedTest
+    @EnumSource(EquipmentType.class)
+    void testGetName(EquipmentType type) {
+        int calcId = EquipmentType.getResourceID(type);
+        var calcType = EquipmentType.convertID2Type(calcId);
+        assertEquals(type, calcType, "Conversion of " + type);
+    }
+}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/resource/ResourceTypeTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/resource/ResourceTypeTest.java
@@ -1,0 +1,26 @@
+package com.mars_sim.core.resource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ResourceTypeTest {
+    @Test
+    void testGetType() {
+        // Test that the correct type is returned for each resource ID
+        assertEquals(ResourceType.AMOUNT_RESOURCE, ResourceType.getType(ResourceType.FIRST_AMOUNT_RESOURCE_ID));
+        assertEquals(ResourceType.ITEM_RESOURCE, ResourceType.getType(ResourceType.FIRST_ITEM_RESOURCE_ID));
+        assertEquals(ResourceType.VEHICLE_RESOURCE, ResourceType.getType(ResourceType.FIRST_VEHICLE_RESOURCE_ID));
+        assertEquals(ResourceType.EQUIPMENT_RESOURCE, ResourceType.getType(ResourceType.FIRST_EQUIPMENT_RESOURCE_ID));
+        assertEquals(ResourceType.ROBOT_RESOURCE, ResourceType.getType(ResourceType.FIRST_ROBOT_RESOURCE_ID));
+        assertEquals(ResourceType.BIN_RESOURCE, ResourceType.getType(ResourceType.FIRST_BIN_RESOURCE_ID));
+    
+        // Test that the correct type is returned for each resource ID
+        assertEquals(ResourceType.AMOUNT_RESOURCE, ResourceType.getType(ResourceType.FIRST_AMOUNT_RESOURCE_ID+1));
+        assertEquals(ResourceType.ITEM_RESOURCE, ResourceType.getType(ResourceType.FIRST_ITEM_RESOURCE_ID+1));
+        assertEquals(ResourceType.VEHICLE_RESOURCE, ResourceType.getType(ResourceType.FIRST_VEHICLE_RESOURCE_ID+1));
+        assertEquals(ResourceType.EQUIPMENT_RESOURCE, ResourceType.getType(ResourceType.FIRST_EQUIPMENT_RESOURCE_ID+1));
+        assertEquals(ResourceType.ROBOT_RESOURCE, ResourceType.getType(ResourceType.FIRST_ROBOT_RESOURCE_ID+1));
+        assertEquals(ResourceType.BIN_RESOURCE, ResourceType.getType(ResourceType.FIRST_BIN_RESOURCE_ID+1));
+    }
+}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/robot/RobotTypeTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/robot/RobotTypeTest.java
@@ -1,0 +1,19 @@
+package com.mars_sim.core.robot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.mars_sim.core.equipment.EquipmentType;
+
+class RobotTypeTest {
+    @ParameterizedTest
+    @EnumSource(EquipmentType.class)
+    void testGetName(EquipmentType type) {
+        int calcId = EquipmentType.getResourceID(type);
+        var calcType = EquipmentType.convertID2Type(calcId);
+        assertEquals(type, calcType, "Conversion of " + type);
+    }
+}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/robot/RobotTypeTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/robot/RobotTypeTest.java
@@ -2,18 +2,16 @@ package com.mars_sim.core.robot;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import com.mars_sim.core.equipment.EquipmentType;
+import com.mars_sim.core.resource.ResourceType;
 
 class RobotTypeTest {
     @ParameterizedTest
-    @EnumSource(EquipmentType.class)
-    void testGetName(EquipmentType type) {
-        int calcId = EquipmentType.getResourceID(type);
-        var calcType = EquipmentType.convertID2Type(calcId);
-        assertEquals(type, calcType, "Conversion of " + type);
+    @EnumSource(RobotType.class)
+    void testGetName(RobotType type) {
+        int calcId = RobotType.getResourceID(type);
+        assertEquals(ResourceType.ROBOT_RESOURCE, ResourceType.getType(calcId), "Conversion of " + type);
     }
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/VehicleTypeTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/VehicleTypeTest.java
@@ -1,0 +1,33 @@
+package com.mars_sim.core.vehicle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class VehicleTypeTest {
+    @ParameterizedTest
+    @EnumSource(VehicleType.class)
+    void testGetName(VehicleType type) {
+        int calcId = VehicleType.getVehicleID(type);
+        var calcType = VehicleType.convertID2Type(calcId);
+        assertEquals(type, calcType, "Conversion of " + type);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = VehicleType.class, names = {"DELIVERY_DRONE", "CARGO_DRONE", "PASSENGER_DRONE"})
+    void testDrone(VehicleType type) {
+        assertTrue(VehicleType.isDrone(type), "Is Drone " + type);
+        assertFalse(VehicleType.isRover(type), "Is not Rover " + type);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = VehicleType.class, names = {"EXPLORER_ROVER", "TRANSPORT_ROVER", "CARGO_ROVER"})
+    void testVehicle(VehicleType type) {
+        assertFalse(VehicleType.isDrone(type), "Is Not Drone " + type);
+        assertTrue(VehicleType.isRover(type), "Is Rover " + type);
+    }
+
+}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadControllerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/LoadControllerTest.java
@@ -27,6 +27,7 @@ import com.mars_sim.core.person.NationSpecConfig;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.NaturalAttributeType;
 import com.mars_sim.core.resource.ItemResourceUtil;
+import com.mars_sim.core.resource.ResourceType;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.resource.SuppliesManifest;
 import com.mars_sim.core.structure.MockSettlement;
@@ -368,7 +369,7 @@ public class LoadControllerTest {
 		checkVehicleInventory(vehicle, manifest);
 
 		double optionalLoaded;
-		if (missingId < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
+		if (ResourceType.getType(missingId) == ResourceType.AMOUNT_RESOURCE) {
 			optionalLoaded = vehicle.getSpecificAmountResourceStored(missingId);
 		}
 		else {
@@ -456,7 +457,7 @@ public class LoadControllerTest {
 		requiredResourcesMap.putAll(manifest.getAmounts(false));
 		for (Entry<Integer, Double> resource : requiredResourcesMap.entrySet()) {
 			int key = resource.getKey();
-			if (key < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
+			if (ResourceType.getType(key) == ResourceType.AMOUNT_RESOURCE) {
 				String resourceName = ResourceUtil.findAmountResourceName(key);
 
 				double stored = source.getSpecificAmountResourceStored(key);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/main/MarsProject.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/main/MarsProject.java
@@ -60,8 +60,6 @@ public class MarsProject {
 	private boolean useDockingUI = false;
 	private boolean useAudio = true;
 
-	private Simulation sim;
-
 	private String simFile;
 
 
@@ -78,6 +76,7 @@ public class MarsProject {
 	 * @param args
 	 */
 	public void parseArgs(String[] args) {
+  Simulation sim;
 				
 		SimulationBuilder builder = new SimulationBuilder();
 		
@@ -338,11 +337,11 @@ public class MarsProject {
 	 */
 	private void usage(String message, Options options) {
         // New non-deprecated HelpFormatter (Commons CLI 1.10+)
-        final HelpFormatter fmt = HelpFormatter.builder().get();
+        final HelpFormatter fmt = HelpFormatter.builder().setShowSince(false).get();
         final String header = "\n" + message + "\n";
         final String footer = "";
         try {
-            fmt.printHelp("mars-sim-ui [options]", header, options, footer, true);
+            fmt.printHelp("mars-sim-ui", header, options, footer, true);
         } catch (IOException ioe) {
             // Fallback if printing help fails
             logger.severe(message);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/FoodTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/FoodTableModel.java
@@ -12,7 +12,7 @@ import com.mars_sim.core.food.Food;
 import com.mars_sim.core.food.FoodUtil;
 import com.mars_sim.core.goods.Good;
 import com.mars_sim.core.goods.GoodsUtil;
-import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.ResourceType;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.tool.Msg;
 import com.mars_sim.ui.swing.components.ColumnSpec;
@@ -144,7 +144,7 @@ class FoodTableModel extends CategoryTableModel<Food> {
     private Object getTotalMass(Settlement settlement, Food food) {
     	int id = food.getID(); 
     	
-    	if (id < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
+    	if (ResourceType.getType(id) == ResourceType.AMOUNT_RESOURCE) {
       		// For Amount Resource
     		return settlement.getSpecificAmountResourceStored(id);
     	}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTableModel.java
@@ -19,7 +19,7 @@ import com.mars_sim.core.goods.GoodsUtil;
 import com.mars_sim.core.goods.MarketManager;
 import com.mars_sim.core.resource.ItemResourceUtil;
 import com.mars_sim.core.resource.Part;
-import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.ResourceType;
 import com.mars_sim.core.robot.Robot;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.tool.Msg;
@@ -217,7 +217,7 @@ class TradeTableModel extends CategoryTableModel<Good> {
 	 */
     private Object getRepair(Settlement settlement, Good good) {
 
-    	if (good.getID() < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
+    	if (ResourceType.getType(good.getID()) != ResourceType.ITEM_RESOURCE) {
     		return null;
     	}
     	
@@ -249,33 +249,21 @@ class TradeTableModel extends CategoryTableModel<Good> {
 	 * @return
 	 */
     private Object getQuantity(Settlement settlement, int id) {
-
-    	if (id < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
-    		return null;
-    	}
-    	else if (id < ResourceUtil.FIRST_VEHICLE_RESOURCE_ID) {
-    		return settlement.getItemResourceStored(id);
-    	}
-    	else if (id < ResourceUtil.FIRST_EQUIPMENT_RESOURCE_ID) {
-    		// For Vehicle
-    		return settlement.findNumVehiclesOfType(VehicleType.convertID2Type(id));
-    	}
-    	else if (id < ResourceUtil.FIRST_ROBOT_RESOURCE_ID) {
-    		// For EVA suits 
-    		EquipmentType type = EquipmentType.convertID2Type(id);
-    		if (type == EquipmentType.EVA_SUIT)
-    			return settlement.getNumEVASuit();
-    		// For Equipment 
-    		return settlement.findNumContainersOfType(type);
-    	}
-    	else if (id < ResourceUtil.FIRST_BIN_RESOURCE_ID) {
-    		// For Robots 
-    		return settlement.getNumBots();
-    	}
-    	else {
-    		// For Bins 
-    		return settlement.findNumBinsOfType(BinType.convertID2Type(id));
-    	}
+		switch(ResourceType.getType(id)) {
+			case ResourceType.AMOUNT_RESOURCE: return null;
+			case ResourceType.ITEM_RESOURCE: return settlement.getItemResourceStored(id);
+			case ResourceType.VEHICLE_RESOURCE: return settlement.findNumVehiclesOfType(VehicleType.convertID2Type(id));
+			case ResourceType.EQUIPMENT_RESOURCE: {
+				// For Equipment
+				EquipmentType type = EquipmentType.convertID2Type(id);
+				if (type == EquipmentType.EVA_SUIT)
+					return settlement.getNumEVASuit();
+				return settlement.findNumContainersOfType(type);
+			}
+			case ResourceType.ROBOT_RESOURCE: return settlement.getNumBots();
+			case ResourceType.BIN_RESOURCE: return settlement.findNumBinsOfType(BinType.convertID2Type(id));
+			default: return null;
+		}
     }
 
 	/**
@@ -287,46 +275,48 @@ class TradeTableModel extends CategoryTableModel<Good> {
 	 */
     private Object getTotalMass(Settlement settlement, Good good) {
     	int id = good.getID(); 
-    	
-    	if (id < ResourceUtil.FIRST_ITEM_RESOURCE_ID) {
-      		// For Amount Resource
-    		return Math.round(settlement.getSpecificAmountResourceStored(id) * 100.0)/100.0;
-    	}
-    	else if (id < ResourceUtil.FIRST_VEHICLE_RESOURCE_ID) {
-    		// For Item Resource
-    		Part p = ItemResourceUtil.findItemResource(id);
-    		if (p != null) {
-    			return settlement.getItemResourceStored(id) * p.getMassPerItem();
+    	switch(ResourceType.getType(id)) {
+			case ResourceType.AMOUNT_RESOURCE: {
+      			// For Amount Resource
+    			return Math.round(settlement.getSpecificAmountResourceStored(id) * 100.0)/100.0;
     		}
-    		return 0.0;
-    	}
-    	else if (id < ResourceUtil.FIRST_EQUIPMENT_RESOURCE_ID) {
-    		// For Vehicle
-    		VehicleType vehicleType = VehicleType.convertID2Type(id);
-    		if (settlement.getAVehicle(vehicleType) == null)
-    			return 0.0;
-    		
-    		return settlement.findNumVehiclesOfType(vehicleType) * CollectionUtils.getVehicleTypeBaseMass(vehicleType); 
-    	}
-    	else if (id < ResourceUtil.FIRST_ROBOT_RESOURCE_ID) {
-    		// For Equipment   		
-    		EquipmentType type = EquipmentType.convertID2Type(id);
+			case ResourceType.ITEM_RESOURCE: {
+				// For Item Resource
+				Part p = ItemResourceUtil.findItemResource(id);
+				if (p != null) {
+					return settlement.getItemResourceStored(id) * p.getMassPerItem();
+				}
+				return 0.0;
+			}
+			case ResourceType.VEHICLE_RESOURCE: {
+				// For Vehicle
+				VehicleType vehicleType = VehicleType.convertID2Type(id);
+				if (settlement.getAVehicle(vehicleType) == null)
+					return 0.0;
+				
+    			return settlement.findNumVehiclesOfType(vehicleType) * CollectionUtils.getVehicleTypeBaseMass(vehicleType); 
+}
+			case ResourceType.EQUIPMENT_RESOURCE: {
+				// For Equipment   		
+				EquipmentType type = EquipmentType.convertID2Type(id);
 
-    		if (type == EquipmentType.EVA_SUIT)
-    			return settlement.getNumEVASuit() * EquipmentFactory.getEquipmentMass(type);
-    		
-    		return settlement.findNumContainersOfType(type) * EquipmentFactory.getEquipmentMass(type);		
-    	}
-    	else if (id < ResourceUtil.FIRST_BIN_RESOURCE_ID) {
-    		// For Robots   
-    		// Future: will need to account for individual robot mass
-    		return settlement.getNumBots() * Robot.EMPTY_MASS;
-    	}    	
-    	else {
-    		// For Bins   		
-    		BinType type = BinType.convertID2Type(id);
-    		return settlement.findNumBinsOfType(type) * BinFactory.getBinMass(type);	
-    	}
+				if (type == EquipmentType.EVA_SUIT)
+					return settlement.getNumEVASuit() * EquipmentFactory.getEquipmentMass(type);
+				
+				return settlement.findNumContainersOfType(type) * EquipmentFactory.getEquipmentMass(type);		
+			}
+			case ResourceType.ROBOT_RESOURCE: {
+				// For Robots   
+				// Future: will need to account for individual robot mass
+				return settlement.getNumBots() * Robot.EMPTY_MASS;
+			}    	
+			case ResourceType.BIN_RESOURCE: {
+				// For Bins   		
+				BinType type = BinType.convertID2Type(id);
+				return settlement.findNumBinsOfType(type) * BinFactory.getBinMass(type);	
+			}
+			default: return null;
+		}
     }
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/VehicleTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/VehicleTableModel.java
@@ -314,7 +314,7 @@ public class VehicleTableModel extends EntityMonitorModel<Vehicle> {
 					result = value;
 				break;
 				
-			case ROCK_SAMPLES : ;
+			case ROCK_SAMPLES :
 				value = vehicle.getSpecificAmountResourceStored(ResourceUtil.ROCK_SAMPLES_ID);
 				if (value == 0.0)
 					result = null;
@@ -379,7 +379,7 @@ public class VehicleTableModel extends EntityMonitorModel<Vehicle> {
 			else if (target instanceof Integer item) {
 				resourceId = item;
 				if (ResourceType.getType(resourceId) != ResourceType.AMOUNT_RESOURCE)
-					// if it's an item resource, quit
+					// if resource is not an amount then quit
 					return;
 			}
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/VehicleTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/VehicleTableModel.java
@@ -29,6 +29,7 @@ import com.mars_sim.core.person.ai.mission.MissionManagerListener;
 import com.mars_sim.core.person.ai.mission.NavPoint;
 import com.mars_sim.core.person.ai.mission.VehicleMission;
 import com.mars_sim.core.resource.AmountResource;
+import com.mars_sim.core.resource.ResourceType;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.tool.Msg;
@@ -377,7 +378,7 @@ public class VehicleTableModel extends EntityMonitorModel<Vehicle> {
 			}
 			else if (target instanceof Integer item) {
 				resourceId = item;
-				if (resourceId >= ResourceUtil.FIRST_ITEM_RESOURCE_ID)
+				if (ResourceType.getType(resourceId) != ResourceType.AMOUNT_RESOURCE)
 					// if it's an item resource, quit
 					return;
 			}


### PR DESCRIPTION
Changes:
- Create a new helper class ResourceType = ResourceType uses a bit pattern to identifier type and defines ranges for each type
- ResourceType provides method to extract the resource type from a resource int identifier
- First resource Ids removed from ResourceUtil
- Old users of First ID pattern converted to use ResourceType predicates
- Where possible if/else chains are replaced by switch using ResourceType.getType method
- Remove type id ranges from ResourceUtil and update all callers

close #1920