### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -9,6 +9,9 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sonarqube:
     # Only run in the canonical repository and not for Dependabot


### PR DESCRIPTION
Potential fix for [https://github.com/mars-sim/mars-sim/security/code-scanning/37](https://github.com/mars-sim/mars-sim/security/code-scanning/37)

Add an explicit `permissions` block to the workflow (or job) to enforce least privilege for `GITHUB_TOKEN`.  
Best single fix without changing behavior is to define workflow-level permissions immediately under `on:` (before `jobs:`), so all jobs inherit it unless overridden.

For this workflow, `contents: read` is the minimal and generally sufficient permission for checkout and analysis.  
Edit **`.github/workflows/sonarqube.yml`** by inserting:

```yml
permissions:
  contents: read
```

between the trigger section and `jobs:`.

No imports/methods/definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
