### PR TITLE
Upgrade to JDK 25

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 21
+          java-version: 25
           
       - name: Build with Maven
         run: mvn -B package -DskipTests=true --file pom.xml 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: 21
+        java-version: 25
         distribution: 'temurin'
         cache: 'maven'
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: 21
+        java-version: 25
         distribution: 'temurin'
         cache: 'maven'    
     - name: Build with Maven

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
       - name: Cache SonarQube packages
         uses: actions/cache@v4
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 	<inceptionYear>2009</inceptionYear>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>		
+		<maven.compiler.source>25</maven.compiler.source>
+		<maven.compiler.target>25</maven.compiler.target>		
 		<sonar.java.source>21</sonar.java.source>
 
 		<timestamp>${maven.build.timestamp}</timestamp>


### PR DESCRIPTION
Resolves #1956.

Upgrades the build from Java 21 to Java 25 (via OpenRewrite `UpgradeBuildToJava25` / `UpgradePluginsForJava25`):
- `maven.compiler.source`/`target` 21 → 25
- JDK 21 → 25 in the four GitHub Actions workflows

Verified locally: `mvn verify` is green under Temurin 25 — all 721 previously-passing tests still pass (no test lost).

*Prepared with the open-source [bump-java-version](https://github.com/vasiliy-mikhailov/bump-java-version-skill) skill.*
