### PR TITLE
Add JavaDoc comment to SimWorld class

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/fxgl/SimWorld.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/fxgl/SimWorld.java
@@ -7,6 +7,12 @@
 
 package com.mars_sim.core.fxgl;
 
+/**
+ * Represents the simulation world for the Mars Simulation Project using FXGL.
+ *
+ * @author Manny Kung
+ * @date 2024-08-10
+ */
 public class SimWorld {
 
 }


### PR DESCRIPTION
## Problem Background
The `SimWorld` class in the Mars Simulation Project lacked a JavaDoc comment, reducing code readability and maintainability. As a public class in the `fxgl` package, proper documentation is essential for developers to understand its purpose and usage in the simulation.

## Changes
- Added a comprehensive JavaDoc comment to the `SimWorld` class, including:
  - A brief description of its role in the Mars Simulation Project using FXGL.
  - Author information (@author Manny Kung) and date (@date 2024-08-10) to track contributions and maintain consistency with project standards.

## Verification
This change is documentation-only and does not alter code functionality. Verification can be done by:
- Reviewing the updated JavaDoc in the source file `mars-sim-core/src/main/java/com/mars_sim/core/fxgl/SimWorld.java`.
- Running the project build (e.g., with `mvn compile` or IDE tools) to ensure no compilation errors are introduced.
- Confirming that the comment style aligns with existing JavaDoc conventions in the repository, such as using standard tags and formatting.