### PR TITLE
feat: Use Mertic to record Mission stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 **/target/
 .classpath
 .project
-.settings/
+**/.settings/
 .idea
 .prefs
 /mars-sim.iml

--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/MissionPlanCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/MissionPlanCommand.java
@@ -7,12 +7,12 @@
 
 package com.mars_sim.console.chat.simcommand.settlement;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.mars_sim.console.chat.ChatCommand;
 import com.mars_sim.console.chat.Conversation;
 import com.mars_sim.console.chat.simcommand.StructuredResponse;
-import com.mars_sim.core.person.ai.mission.PlanType;
 import com.mars_sim.core.structure.Settlement;
 
 /**
@@ -43,7 +43,7 @@ public class MissionPlanCommand extends AbstractSettlementCommand {
 		context.println(prompt2);
 		int newObj = context.getIntInput("Select an option ");
 		int max = 0;
-		boolean totals = false;
+		Map<String, Double> totals = null;
 		int today = context.getSim().getMasterClock().getMarsTime().getMissionSol();
 
 		switch (newObj) {
@@ -60,28 +60,28 @@ public class MissionPlanCommand extends AbstractSettlementCommand {
 			break;
 		
 		case 4:			
-			totals = true;
+			totals = new HashMap<>();
 			max = 3;
 			break;
 			
 		case 5:
 			max = 7;
-			totals = true;
+			totals = new HashMap<>();
 			break;
 			
 		case 6:
 			max = 14;
-			totals = true;
+			totals = new HashMap<>();
 			break;
 			
 		case 7:
 			max = 28;
-			totals = true;
+			totals = new HashMap<>();
 			break;
 			
 		case 8:
 			max = today;
-			totals = true;
+			totals = new HashMap<>();
 			break;
 			
 		default:
@@ -91,43 +91,35 @@ public class MissionPlanCommand extends AbstractSettlementCommand {
 
 		StructuredResponse response = new StructuredResponse();
 
-		response.appendHeading("On Sol " + today + ", the " + (totals ? "combined " : "")
-								+ "data for the last " + max + " sols shows");
+		response.appendHeading("On Sol " + today + ", the data for the last N sols");
 
 		Map<Integer, Map<String, Double>> plannings = settlement.getMissionControl().getHistoricalMissions();
 
-		int totalApproved = 0;
-		int totalNotApproved = 0;
 		int firstSol = today;
 		int lastSol = Math.max(0, today - max); // Don't go negative
 		for (int i = firstSol; i > lastSol; i--) {
-			Map<String, Double> plans = plannings.get(i);
-			if (plans != null) {
-				int approved = (int) plans.getOrDefault(PlanType.APPROVED.name(), 0D).doubleValue();
-				int notApproved = (int) plans.getOrDefault(PlanType.NOT_APPROVED.name(), 0D).doubleValue();
-	
-				if (totals) {
-					totalApproved += approved;
-					totalNotApproved += notApproved;
-				}
-				else {
-					response.appendText("Stats for sol " + i);
-					response.appendLabelledDigit("# of plans approved", approved);
-					response.appendLabelledDigit("# of plans not approved", notApproved);
+			response.appendText("Stats for sol " + i);
+
+			var sol = plannings.get(i);
+			outputStats(response, sol);
+
+			if (totals != null) {
+				for(var p : sol.entrySet()) {
+					totals.merge(p.getKey(), p.getValue(), Double::sum);
 				}
 			}
-			else {
-	        	context.println("No plans reviewed.");
-	        	return false;
-	        }
 		}
 		
-		if (totals) {
-			response.appendLabelledDigit("# of plans approved", totalApproved);
-			response.appendLabelledDigit("# of plans not approved", totalNotApproved);
+		if (totals != null) {
+			response.appendText("Stats for total:");
+			outputStats(response, totals);
 		}
 		
 		context.println(response.getOutput());
 		return true;
+	}
+
+	private static void outputStats(StructuredResponse response, Map<String, Double> stats) {
+		stats.entrySet().forEach(p -> response.appendLabelledDigit(p.getKey(), p.getValue().intValue()));
 	}
 }

--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/MissionPlanCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/MissionPlanCommand.java
@@ -98,15 +98,18 @@ public class MissionPlanCommand extends AbstractSettlementCommand {
 		int firstSol = today;
 		int lastSol = Math.max(0, today - max); // Don't go negative
 		for (int i = firstSol; i > lastSol; i--) {
-			response.appendText("Stats for sol " + i);
-
 			var sol = plannings.get(i);
-			outputStats(response, sol);
-
-			if (totals != null) {
-				for(var p : sol.entrySet()) {
-					totals.merge(p.getKey(), p.getValue(), Double::sum);
+			if (sol != null) {
+				response.appendText("Stats for sol " + i);
+				outputStats(response, sol);
+				if (totals != null) {
+					for(var p : sol.entrySet()) {
+						totals.merge(p.getKey(), p.getValue(), Double::sum);
+					}
 				}
+			}
+			else {
+				response.appendText("No data for sol " + i);
 			}
 		}
 		

--- a/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
@@ -58,6 +58,7 @@ import com.mars_sim.core.logging.SimuLoggingFormatter;
 import com.mars_sim.core.malfunction.MalfunctionFactory;
 import com.mars_sim.core.malfunction.MalfunctionManager;
 import com.mars_sim.core.metrics.MetricManager;
+import com.mars_sim.core.metrics.database.DatabaseMetricManager;
 import com.mars_sim.core.metrics.memory.MemoryMetricManager;
 import com.mars_sim.core.mission.MissionStep;
 import com.mars_sim.core.moon.LunarColonyManager;
@@ -409,7 +410,7 @@ public class Simulation implements ClockPulseListener, Serializable {
 
 		// Common handler for full planet events
 		scheduledEvents = new ScheduledEventManager(masterClock);
-		metricManager = new MemoryMetricManager();
+		metricManager = new DatabaseMetricManager(SimulationRuntime.getDataDir() + "/metrics/");
 
 		// Initialize serializable objects
 		malfunctionFactory = new MalfunctionFactory();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
@@ -271,7 +271,7 @@ public class Simulation implements ClockPulseListener, Serializable {
 		// Create marsClock instance
 		masterClock = new MasterClock(simulationConfig, 256);
 		scheduledEvents = new ScheduledEventManager(masterClock);
-		metricManager = new MemoryMetricManager();
+		metricManager = new MemoryMetricManager(2);
 
 		// Create lunar world instance
 		lunarWorld = new LunarWorld(); 
@@ -301,7 +301,7 @@ public class Simulation implements ClockPulseListener, Serializable {
 		// Create marsClock instance
 		masterClock = new MasterClock(simulationConfig, 256);
 		scheduledEvents = new ScheduledEventManager(masterClock);
-		metricManager = new MemoryMetricManager();
+		metricManager = new MemoryMetricManager(2);
 
 		// Set instances for logging
 		SimuLoggingFormatter.initializeInstances(masterClock);
@@ -410,7 +410,8 @@ public class Simulation implements ClockPulseListener, Serializable {
 
 		// Common handler for full planet events
 		scheduledEvents = new ScheduledEventManager(masterClock);
-		metricManager = new DatabaseMetricManager(SimulationRuntime.getDataDir() + "/metrics/");
+		//metricManager = new DatabaseMetricManager(SimulationRuntime.getDataDir() + File.separator +"metrics");
+		metricManager = new MemoryMetricManager(10);
 
 		// Initialize serializable objects
 		malfunctionFactory = new MalfunctionFactory();
@@ -1393,6 +1394,11 @@ public class Simulation implements ClockPulseListener, Serializable {
 			if (pulse.isNewSol()) {
 				// Compute reliability daily for each part
 				malfunctionFactory.computePartReliability(pulse.getMarsTime().getMissionSol());
+
+				// Flush any old metrics
+				if (metricManager instanceof MemoryMetricManager mm) {
+					mm.newSol(pulse.getMarsTime());
+				}
 			}
 
 			// Update scheduled events

--- a/mars-sim-core/src/main/java/com/mars_sim/core/metrics/MetricGroup.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/metrics/MetricGroup.java
@@ -6,6 +6,8 @@
  */
 package com.mars_sim.core.metrics;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -54,5 +56,16 @@ public class MetricGroup implements Serializable {
             }
         }
         return solBreakdown;
+    }
+
+    /**
+     * Custom deserialization logic to reinitialize the transient metrics map after deserialization.
+     * @param ois
+     * @throws ClassNotFoundException
+     * @throws IOException
+     */
+    private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
+        ois.defaultReadObject();
+        this.metrics = new HashMap<>();
     }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/metrics/MetricGroup.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/metrics/MetricGroup.java
@@ -1,0 +1,58 @@
+/*
+ * Mars Simulation Project
+ * MetricGroup.java
+ * @date 2026-05-20
+ * @author Barry Evans
+ */
+package com.mars_sim.core.metrics;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.mars_sim.core.Entity;
+import com.mars_sim.core.Simulation;
+
+/** 
+ * This class represents a group of metrics for a specific category.
+ * It allows recording values for different measures and provides a breakdown of totals by sol.
+ */
+public class MetricGroup implements Serializable {
+    private MetricCategory category;
+    private transient Map<String, Metric> metrics = new HashMap<>();
+
+    public MetricGroup(MetricCategory category) {
+        this.category = category;
+    }
+
+    /**
+     * Records a value for a specific measure and owner entity. If the metric for the measure does not exist, it is created.
+     * @param measure The measure name for the metric.
+     * @param value The value to record for the metric.
+     * @param owner The entity that owns the metric if a new one is required.
+     */
+    public void recordValue(String measure, double value, Entity owner) {
+        // Get cached or find a real metric for this measure
+        var found = metrics.computeIfAbsent(measure, k ->
+                    Simulation.instance().getMetricManager().getMetric(owner, category, measure));
+        found.recordValue(value);
+    }
+
+    /**
+     * Get the totals for each sol, broken down by measure. This is useful for reporting and analysis.
+     * It uses the Total calculator to get the totals for each sol.
+     * @return Map keys on mission sol
+     */
+    public Map<Integer, Map<String, Double>> getSolBreakdown() {
+        Map<Integer, Map<String, Double>> solBreakdown = new HashMap<>();
+        for(Metric metric : metrics.values()) {
+            var results = metric.applyBySol(0, sol -> new Total());
+            for(var entry: results.entrySet()) {
+                int sol = entry.getKey();
+                double value = entry.getValue().getSum();
+                solBreakdown.computeIfAbsent(sol, k -> new HashMap<>()).put(metric.getKey().measure(), value);
+            }
+        }
+        return solBreakdown;
+    }
+}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/metrics/database/DatabaseMetricConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/metrics/database/DatabaseMetricConfig.java
@@ -6,7 +6,7 @@
  */
 package com.mars_sim.core.metrics.database;
 
-import java.util.UUID;
+import java.io.File;
 
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
@@ -62,7 +62,7 @@ public class DatabaseMetricConfig {
         // DB_CLOSE_DELAY=-1 keeps the named in-memory database alive until close() is called.
         DriverManagerDataSource ds = new DriverManagerDataSource(
             "jdbc:h2:" +
-            (path != null ? path + "/marssim-metrics" : "mem:marssim") + ";DB_CLOSE_DELAY=-1");
+            (path != null ? path + File.separator + "marssim-metrics" : "mem:marssim"));
         this.jdbcTemplate = new JdbcTemplate(ds);
         initializeSchema();
     }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/metrics/memory/MemoryMetric.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/metrics/memory/MemoryMetric.java
@@ -109,4 +109,27 @@ public class MemoryMetric extends Metric {
         }
         return null;
     }
+
+    /**
+     * Remove all sol data that is earlier that the specified sol.
+     * @param earliestSol Earliest sol to he held.
+     */
+    void removeOldSols(int earliestSol) {
+        // Avoid scanning the metric if going to alter
+        for(int s = firstSol; s < earliestSol; s++) {
+            var removed = solSeries.remove(s);
+            size -= (removed != null) ? removed.size() : 0;
+        }
+        // Recalculate firstSol and lastSol
+        firstSol = Integer.MAX_VALUE;
+        lastSol = Integer.MIN_VALUE;
+        for(int s : solSeries.keySet()) {
+            if (s < firstSol) {
+                firstSol = s;
+            }
+            if (s > lastSol) {
+                lastSol = s;
+            }
+        }
+    }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/metrics/memory/MemoryMetricManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/metrics/memory/MemoryMetricManager.java
@@ -12,35 +12,67 @@ import java.util.Map;
 import java.util.Set;
 
 import com.mars_sim.core.Entity;
+import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.metrics.Metric;
 import com.mars_sim.core.metrics.MetricCategory;
 import com.mars_sim.core.metrics.MetricKey;
 import com.mars_sim.core.metrics.MetricManager;
+import com.mars_sim.core.time.MarsTime;
 
 /**
  * In-memory metric manager that creates {@link MemoryMetric} instances.
  */
 public class MemoryMetricManager extends MetricManager {
 
+    private static final SimLogger logger = SimLogger.getLogger(MemoryMetricManager.class.getName());
     private static final long serialVersionUID = 1L;
-    private Map<MetricKey, Metric> metrics;
 
-    public MemoryMetricManager() {
+    // 1 double & 1 memory reference at 8 bytes each plus 1 reference in Metric
+    private static final int MEMORY_PER_DATA = 24;
+
+    private Map<MetricKey, MemoryMetric> metrics;
+    private int maxSol = 1;
+    private int totalDataPoints = 0;
+
+    /**
+     * Creates a new MemoryMetricManager with the specified maximum number of sols to retain.
+     * @param maxSol Maximum number of sols to retain in memory for each metric.
+     */
+    public MemoryMetricManager(int maxSol) {
         super();
         metrics = new HashMap<>();
+        this.maxSol = maxSol;
     }
 
     /**
      * Reinitializes the MetricManager after deserialization.
      */
+    @Override
     public void reinit() {
         //There is a problem with dserializing the HashMap.The saved hashcode for the the same key
         // is different after deserialization, so we need to rebuild the map.
-        var newMetrics = new HashMap<MetricKey, Metric>(); 
+        var newMetrics = new HashMap<MetricKey, MemoryMetric>(); 
         for (var entry : metrics.entrySet()) {
             newMetrics.put(entry.getKey(), entry.getValue());
         }
         this.metrics = newMetrics;
+    }
+
+    /**
+     * A new sol has started so check all metrics to see if they need to be updated.
+     * @param time Current mars time.
+     */
+    public void newSol(MarsTime time) {
+        var earliestSol = time.getMissionSol() - maxSol + 1;
+        if (earliestSol>= 1) {
+            metrics.values().forEach(mm -> mm.removeOldSols(earliestSol));
+        }  
+        
+        int newDataPointCount = metrics.values().stream().mapToInt(Metric::getSize).sum();
+        logger.info("Total data points in memory: " + newDataPointCount + ", previous: " + totalDataPoints
+                + " (estimated memory usage: " + (newDataPointCount * MEMORY_PER_DATA)/1024D + " KB)");  
+    
+        totalDataPoints = newDataPointCount;
     }
 
     @Override
@@ -98,6 +130,8 @@ public class MemoryMetricManager extends MetricManager {
         if (m == null) {
             m = new MemoryMetric(key);
             metrics.put(key, m);
+
+            // Must update metric before notifying listeners
             notifyListeners(m);
         }
         return m;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionControl.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionControl.java
@@ -17,9 +17,10 @@ import java.util.stream.Collectors;
 import com.mars_sim.core.EntityManagerListener;
 import com.mars_sim.core.Simulation;
 import com.mars_sim.core.data.RatingLog;
-import com.mars_sim.core.data.SolMetricDataLogger;
 import com.mars_sim.core.events.ScheduledEventHandler;
 import com.mars_sim.core.logging.SimLogger;
+import com.mars_sim.core.metrics.MetricCategory;
+import com.mars_sim.core.metrics.MetricGroup;
 import com.mars_sim.core.mission.util.MissionRating;
 import com.mars_sim.core.parameter.ParameterManager;
 import com.mars_sim.core.person.Person;
@@ -57,17 +58,16 @@ public class MissionControl implements ScheduledEventHandler {
 	private double minimumPassingScore = INITIAL_MISSION_PASSING_SCORE;
     private List<Double> missionScores = new ArrayList<>();
 	private Set<Mission> allMissions = new CopyOnWriteArraySet<>();
-	private SolMetricDataLogger<String> historicalMissions;
 	private Settlement owner;
 	private int id = 1;
 	
 	private transient Set<EntityManagerListener> listeners;
+	private static final MetricCategory MISSION_CAT = new MetricCategory("Missions");
+	private MetricGroup metrics = new MetricGroup(MISSION_CAT);
 
     public MissionControl(Settlement settlement) {
 		this.owner = settlement;
         missionScores.add(minimumPassingScore);
-
-		historicalMissions = new SolMetricDataLogger<>(10);
 
         // Get time of next sol and schedule refresh; compensates for time zone
         MarsTime startOfNextSol = Simulation.instance().getMasterClock().getMarsTime();
@@ -177,7 +177,7 @@ public class MissionControl implements ScheduledEventHandler {
         double score = mp.getScore();
 		double minScore = mp.getPassingScore();   // Passing score is set when the review is started
 		PlanType state = (score > minScore ? PlanType.APPROVED : PlanType.NOT_APPROVED);
-		historicalMissions.increaseDataPoint(state.name(), 1D);
+		metrics.recordValue(state.getName(), 1D, owner);
 
 		// Updates the mission plan status
 		mp.setStatus(state);
@@ -203,7 +203,7 @@ public class MissionControl implements ScheduledEventHandler {
 	 * @return
 	 */
 	public Map<Integer, Map<String, Double>> getHistoricalMissions() {
-		return historicalMissions.getHistory();
+		return metrics.getSolBreakdown();
 	}
 
 	
@@ -213,6 +213,7 @@ public class MissionControl implements ScheduledEventHandler {
 	 */
 	public void addMission(Mission mission) {
 		allMissions.add(mission);
+		metrics.recordValue("Started", 1D, owner);
 
 		if (listeners != null) {
 			synchronized (listeners) {
@@ -366,5 +367,13 @@ public class MissionControl implements ScheduledEventHandler {
 		score.addModifier("settlement.ratio", settlementRatio);
 
 		return new MissionRating(metaMission, score);
+	}
+
+	/**
+	 * A mission has been finished and the control needs to be notified so it can update the statistics.
+	 * @param successful true if the mission was successful, false otherwise
+	 */
+	public void finishMission(boolean successful) {
+		metrics.recordValue(successful ? "Successful" : "Aborted", 1D, owner);
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionProject.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionProject.java
@@ -65,6 +65,10 @@ public abstract class MissionProject implements Mission {
                 log.addEntry("Completed");
                 status.add(ACCOMPLISHED);
             }
+
+            // Update stats
+            fireMissionUpdate(Mission.END_MISSION_EVENT, this);
+            getAssociatedSettlement().getMissionControl().finishMission(successful);
             clearDown();
         }
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/AbstractMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/AbstractMission.java
@@ -748,7 +748,9 @@ public abstract class AbstractMission implements Mission, Temporal {
 		
 		setPhase(finalPhase, listOfStatuses);
 		log.setDone();
-		done = true; 
+		done = true;
+
+		getAssociatedSettlement().getMissionControl().finishMission(!aborted);
 		
 		StringBuilder status = new StringBuilder();
 		

--- a/mars-sim-core/src/test/java/com/mars_sim/core/metrics/MetricGroupTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/metrics/MetricGroupTest.java
@@ -1,0 +1,51 @@
+package com.mars_sim.core.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.mars_sim.core.MockEntity;
+import com.mars_sim.core.test.MarsSimUnitTest;
+
+
+class MetricGroupTest extends MarsSimUnitTest {
+    @Test
+    void testGetSolBreakdown() {
+        var entity = new MockEntity("id");
+
+        var cat = new MetricCategory("Cat1");
+        var group = new MetricGroup(cat);
+
+        var measure1 = "Measure1";
+        var measure2 = "Measure2";
+
+        // Load up values in different sols
+        group.recordValue(measure1, 1D, entity);
+        group.recordValue(measure1, 1D, entity);
+        group.recordValue(measure2, 5D, entity);
+
+        var clock = getSim().getMasterClock();
+        var nextSol = clock.getMarsTime().addTime(1000);
+        clock.setMarsTime(nextSol);
+        group.recordValue(measure1, 2D, entity);
+        group.recordValue(measure2, 2D, entity);
+
+        nextSol = nextSol.addTime(1000);
+        clock.setMarsTime(nextSol);
+        group.recordValue(measure1, 20D, entity);
+
+        var histogram = group.getSolBreakdown();
+        assertEquals(3, histogram.size(), "number of sols in breakdown");
+
+        var sol1 = histogram.get(1);
+        assertEquals(2, sol1.get(measure1), "sol 1 measure 1 value");
+        assertEquals(5, sol1.get(measure2), "sol 1 measure 2 value");
+
+        var sol2 = histogram.get(2);
+        assertEquals(2, sol2.get(measure1), "sol 2 measure 1 value");
+        assertEquals(2, sol2.get(measure2), "sol 2 measure 2 value");   
+
+        var sol3 = histogram.get(3);
+        assertEquals(20, sol3.get(measure1), "sol 3 measure 1 value");
+    }
+}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/metrics/MetricManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/metrics/MetricManagerTest.java
@@ -3,7 +3,6 @@ package com.mars_sim.core.metrics;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.mars_sim.core.Entity;
-import com.mars_sim.core.metrics.database.DatabaseMetricManager;
 import com.mars_sim.core.test.MarsSimUnitTest;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -15,10 +14,9 @@ import java.util.List;
 /**
  * Unit tests for the MetricManager class.
  */
-@DisplayName("MetricManager Tests")
-class MetricManagerTest extends MarsSimUnitTest {
-    private static final MetricCategory TEMP_CAT = new MetricCategory("Temperature");
-    private static final MetricCategory PRES_CAT = new MetricCategory("Pressure");
+public abstract class MetricManagerTest extends MarsSimUnitTest {
+    protected static final MetricCategory TEMP_CAT = new MetricCategory("Temperature");
+    protected static final MetricCategory PRES_CAT = new MetricCategory("Pressure");
 
     private MetricManager manager;
 
@@ -29,12 +27,17 @@ class MetricManagerTest extends MarsSimUnitTest {
     void setUp() {
         
         // Create an in memory DatabaseMetricManager for testing
-        manager = new DatabaseMetricManager(null);
+        manager = createMetricManager();
         
         measure1 = "Average";
         measure2 = "Maximum";
     }
 
+    protected abstract MetricManager createMetricManager();
+
+    protected MetricManager getManager() {
+        return manager;
+    }
 
     @Test
     @DisplayName("Constructor should create empty MetricManager")

--- a/mars-sim-core/src/test/java/com/mars_sim/core/metrics/memory/MemoryMetricManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/metrics/memory/MemoryMetricManagerTest.java
@@ -1,0 +1,50 @@
+package com.mars_sim.core.metrics.memory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.mars_sim.core.metrics.MetricKey;
+import com.mars_sim.core.metrics.MetricManager;
+import com.mars_sim.core.metrics.MetricManagerTest;
+
+@DisplayName("MemoryMetricManager Tests")
+class MemoryMetricManagerTest extends MetricManagerTest {
+    private static final int MAX_SOL = 3;
+    
+    @Override
+    protected MetricManager createMetricManager() {
+        return new MemoryMetricManager(MAX_SOL);
+    }
+
+    @Test
+    @DisplayName("newSol should remove old sols from metrics")
+    void testNewSolRemovesOldSols() {
+        var manager = (MemoryMetricManager) getManager();
+        var s = buildSettlement("Test");
+        
+        // Add data points for sols 0 to MAX_SOL+1
+        var clock = getSim().getMasterClock();
+        var marsTime = clock.getMarsTime();
+        for (int sol = 1; sol <= MAX_SOL+1; sol++) {
+            marsTime = marsTime.addTime(1000D);
+            clock.setMarsTime(marsTime);
+
+            manager.addValue(s, TEMP_CAT, "Average", 1D);
+
+        }
+        
+        var m = manager.getMetric(new MetricKey(s, TEMP_CAT, "Average"));
+        var origRange = m.getSolRange().size();
+        assertTrue(origRange > MAX_SOL, "Original sol range should be greater than MAX_SOL");
+        assertEquals(MAX_SOL+1, m.getSize(), "Metric size original");
+
+        manager.newSol(marsTime);
+        var newRange = m.getSolRange();
+        assertEquals(MAX_SOL, newRange.size(), "Sol range should equal MAX_SOL");
+        assertEquals(MAX_SOL, m.getSize(), "Metric size after removing old sols");
+        
+    }
+}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mission/MissionControlTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mission/MissionControlTest.java
@@ -76,10 +76,10 @@ class MissionControlTest extends MarsSimUnitTest{
 
         // Check the scoring has changed
         var history = missionControl.getHistoricalMissions();
-        var numApproved = history.get(1).get(PlanType.APPROVED.name()).doubleValue();
+        var numApproved = history.get(1).get(PlanType.APPROVED.getName()).doubleValue();
         assertEquals(1D, numApproved, "Historical score should match final score");
 
-        assertNull(history.get(1).get(PlanType.NOT_APPROVED.name()), "There should be no rejected missions");
+        assertNull(history.get(1).get(PlanType.NOT_APPROVED.getName()), "There should be no rejected missions");
     }
 
    @Test
@@ -103,10 +103,10 @@ class MissionControlTest extends MarsSimUnitTest{
 
         // Check the scoring has changed
         var history = missionControl.getHistoricalMissions();
-        var numNotApproved = history.get(1).get(PlanType.NOT_APPROVED.name()).doubleValue();
+        var numNotApproved = history.get(1).get(PlanType.NOT_APPROVED.getName()).doubleValue();
         assertEquals(1D, numNotApproved, "Historical score should match final score");
 
-        assertNull(history.get(1).get(PlanType.APPROVED.name()), "There should be no approved missions");
+        assertNull(history.get(1).get(PlanType.APPROVED.getName()), "There should be no approved missions");
     }
 
     

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/metrics/MetricChartViewer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/metrics/MetricChartViewer.java
@@ -66,7 +66,7 @@ public class MetricChartViewer extends ContentPanel
      * @param metricManager The MetricManager to use for populating dropdowns and retrieving metrics
      */
     public MetricChartViewer(MetricManager metricManager) {
-        super(NAME, "Metric Chart Viewer", Placement.CENTER);
+        super(NAME, TITLE, Placement.CENTER);
 
         this.metricManager = metricManager;
 
@@ -108,7 +108,7 @@ public class MetricChartViewer extends ContentPanel
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
         panel.setBorder(SwingHelper.createLabelBorder("Chart Controls"));
         
-        JPanel keyPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 10));
+        JPanel keyPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 4, 2));
 
         // Add labels and dropdowns
         keyPanel.add(new JLabel("Entity:"));
@@ -126,7 +126,7 @@ public class MetricChartViewer extends ContentPanel
         keyPanel.add(measureComboBox);
         panel.add(keyPanel);
          
-        JPanel controlPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 10));
+        JPanel controlPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 4, 2));
 
         newButton = new JButton("New Chart");
         newButton.addActionListener(e -> addNewChart());
@@ -292,11 +292,9 @@ public class MetricChartViewer extends ContentPanel
         var measure = (String) measureComboBox.getSelectedItem();
         
         if (entityObj != null && category != null && !SELECT_PROMPT.equals(measure)) {
-            
-            Entity entity = (Entity) entityObj;
-            
+                        
             // Find selected Metrix
-            return metricManager.getMetric(entity, category, measure);
+            return metricManager.getMetric(entityObj, category, measure);
         }
         return null;
     }

--- a/mars-sim-ui/src/main/resources/icons.properties
+++ b/mars-sim-ui/src/main/resources/icons.properties
@@ -19,6 +19,7 @@ event				= /icons/monitor_tool/flag_24.png
 food				= /icons/monitor_tool/food_24.png
 lander16            = /icons/lander_hab16.png
 mars				= /icons/monitor_tool/mars_24.png
+metrics             = /icons/monitor_tool/analytics_24.png
 settlement_map		= /icons/monitor_tool/settlement_map_24.png
 task				= /icons/tabpanel/clipboard_24.png
 trade				= /icons/monitor_tool/trade_24.png

--- a/mars-sim-ui/src/test/java/com/mars_sim/ui/swing/tool/metrics/MetricDatasetTest.java
+++ b/mars-sim-ui/src/test/java/com/mars_sim/ui/swing/tool/metrics/MetricDatasetTest.java
@@ -70,7 +70,7 @@ class MetricDatasetTest {
         var sim = Simulation.instance();
         sim.testRun();
         var clock = sim.getMasterClock();
-        manager = new MemoryMetricManager();
+        manager = new MemoryMetricManager(2);
         
         // Create test entities
         testEntity1 = new LocalMockEntity("E1");


### PR DESCRIPTION
Changes:
- Added MetricGroup to record Metric Measure that share the same Category and Entity
- Add Unit test
- Completed missions notifiy parent MissionControl of the completion
- MissionControl replaces SolHistory with MetricGroup
- MissionControl record approvals, rejected, succesful, aborted and started missions
- Updated MissionPlanCommand to display MetricGroup stats
- Simulation uses MemoryMetricManager with a 10 sol limit

DatabaseMetricManager is too unstable tobe default currently

ref: #1340