### PR TITLE
feat: Convert Settlement SolData over to Metrics

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/ResourceCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/ResourceCommand.java
@@ -24,7 +24,6 @@ import com.mars_sim.core.person.Person;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.resourceprocess.ResourceProcess;
 import com.mars_sim.core.structure.Settlement;
-import com.mars_sim.core.structure.WaterUseType;
 
 public class ResourceCommand extends AbstractSettlementCommand {
 	private static final String PROJECTED_DAILY_CONSUMED = "Projected daily consumed";
@@ -176,26 +175,16 @@ public class ResourceCommand extends AbstractSettlementCommand {
 		response.appendTableRow("People", Math.round(consumption * 100.0) / 100.0);
 		net = net + consumption;
 
-		// Add water usage from making meal and dessert
-		double cooking = settlement.getDailyWaterUsage(WaterUseType.PREP_MEAL)
-					+ settlement.getDailyWaterUsage(WaterUseType.PREP_DESSERT);
-		response.appendTableRow("Cooking", Math.round(cooking * 100.0) / 100.0);
-		net = net + cooking;
-
-		// Prints living usage
-		List<Building> quarters = settlement.getBuildingManager()
-				.getBuildings(FunctionType.LIVING_ACCOMMODATION);
-		double livingUsage = quarters.stream()
-					.mapToDouble(b -> b.getLivingAccommodation().getDailyAverageWaterUsage())
-					.sum();		
-		response.appendTableRow("Accommodation", Math.round(livingUsage * 100.0) / 100.0);
-		net = net + livingUsage;
-
-		// Prints cleaning usage
-		double cleaning = settlement.getDailyWaterUsage(WaterUseType.CLEAN_MEAL)
-					+ settlement.getDailyWaterUsage(WaterUseType.CLEAN_DESSERT);
-		response.appendTableRow("Cleaning", Math.round(cleaning * 100.0) / 100.0);
-		net = net + cleaning;
+		// Get water usage.
+		var waterUsage = settlement.getDailyWaterUsage();
+		for(var entry: waterUsage.entrySet()) {
+			String type = entry.getKey();
+			double amount = entry.getValue();
+			if (amount > 0) {
+				response.appendTableRow(type, Math.round(amount * 100.0) / 100.0);
+				net = net + amount;
+			}
+		}
 
 		// Prints output from resource processing
 		double output = 0;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
@@ -410,8 +410,7 @@ public class Simulation implements ClockPulseListener, Serializable {
 
 		// Common handler for full planet events
 		scheduledEvents = new ScheduledEventManager(masterClock);
-		//metricManager = new DatabaseMetricManager(SimulationRuntime.getDataDir() + File.separator +"metrics");
-		metricManager = new MemoryMetricManager(10);
+		metricManager = new MemoryMetricManager(20);
 
 		// Initialize serializable objects
 		malfunctionFactory = new MalfunctionFactory();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/metrics/MetricGroup.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/metrics/MetricGroup.java
@@ -59,6 +59,20 @@ public class MetricGroup implements Serializable {
     }
 
     /**
+     * Get the average value per sol for each Measure. This uses the Average calculator to get the average for each sol.
+     * @return Map keys on measure name
+     */
+    public Map<String, Double> getAveragePerSol() {
+        Map<String, Double> averagePerSol = new HashMap<>();
+        for(Metric metric : metrics.values()) {
+            var results = metric.applyBySol(0, sol -> new Total());
+            double totalAverage = results.values().stream().mapToDouble(Total::getSum).average().orElse(0.0);
+            averagePerSol.put(metric.getKey().measure(), totalAverage);
+        }
+        return averagePerSol;
+    }
+    
+    /**
      * Custom deserialization logic to reinitialize the transient metrics map after deserialization.
      * @param ois
      * @throws ClassNotFoundException

--- a/mars-sim-core/src/main/java/com/mars_sim/core/metrics/memory/MemoryMetricManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/metrics/memory/MemoryMetricManager.java
@@ -29,10 +29,12 @@ public class MemoryMetricManager extends MetricManager {
 
     // 1 double & 1 memory reference at 8 bytes each plus 1 reference in Metric
     private static final int MEMORY_PER_DATA = 24;
+    private static final int MAX_MEMORY_PERC = 2; // 2% of max memory
 
     private Map<MetricKey, MemoryMetric> metrics;
-    private int maxSol = 1;
-    private int totalDataPoints = 0;
+    private int maxSol = 1; // Maximum number of sols to retain in memory for each metric
+    private int maxPoints;
+    private int earliestSol = 1; // The earliest sol that is currently being tracked
 
     /**
      * Creates a new MemoryMetricManager with the specified maximum number of sols to retain.
@@ -40,8 +42,27 @@ public class MemoryMetricManager extends MetricManager {
      */
     public MemoryMetricManager(int maxSol) {
         super();
-        metrics = new HashMap<>();
+        this.metrics = new HashMap<>();
         this.maxSol = maxSol;
+        var maxMem = (Runtime.getRuntime().maxMemory() * MAX_MEMORY_PERC) / 100.0;
+        this.maxPoints = (int) (maxMem / MEMORY_PER_DATA);
+
+        logger.info("MemoryMetricManager initialized with maxSol: " + maxSol + ", maxPoints: " + maxPoints);
+    }
+
+    /**
+     * Ovveride the default maxPoints to a new value.
+     * @param maxPoints The new maximum number of data points to retain in memory.
+     */
+    void setMaxPoints(int maxPoints) {
+        this.maxPoints = maxPoints;
+    }
+
+    /**
+     * Get the maximum number of data points to retain in memory.
+     */
+    public int getMaxPoints() {
+        return maxPoints;
     }
 
     /**
@@ -63,16 +84,33 @@ public class MemoryMetricManager extends MetricManager {
      * @param time Current mars time.
      */
     public void newSol(MarsTime time) {
-        var earliestSol = time.getMissionSol() - maxSol + 1;
-        if (earliestSol>= 1) {
+        int newDataPointCount = metrics.values().stream().mapToInt(Metric::getSize).sum();
+
+        // Check if the total sols has past the limit
+        var newEarliest = time.getMissionSol() - maxSol + 1;
+        if (newEarliest <= earliestSol) {
+            // No sol limit so check memory usage and remove old sols if necessary
+            if (newDataPointCount > maxPoints) {
+                logger.info("Memory usage exceeded limit. Current data points: " + newDataPointCount + ", max allowed: " + maxPoints);
+                newEarliest = earliestSol + 1; // Remove the new earliest one sol forward
+            }
+        }
+        else {
+            logger.info("Sol limit exceeded. Earliest allowed sol: " + newEarliest + ", max sols: " + maxSol);
+        }
+
+        // Remove old sols from all metrics if the earliest sol is greater than or equal to 1
+        if (newEarliest > earliestSol) {
+            earliestSol = newEarliest;
+
             metrics.values().forEach(mm -> mm.removeOldSols(earliestSol));
+
+            // Update the total data points after removing old sols
+            newDataPointCount = metrics.values().stream().mapToInt(Metric::getSize).sum();
         }  
         
-        int newDataPointCount = metrics.values().stream().mapToInt(Metric::getSize).sum();
-        logger.info("Total data points in memory: " + newDataPointCount + ", previous: " + totalDataPoints
-                + " (estimated memory usage: " + (newDataPointCount * MEMORY_PER_DATA)/1024D + " KB)");  
-    
-        totalDataPoints = newDataPointCount;
+        logger.info("Total data points: " + newDataPointCount + ", max: " + maxPoints
+                + ", earliest sol held: " + earliestSol);
     }
 
     @Override

--- a/mars-sim-core/src/main/java/com/mars_sim/core/resource/ResourceType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/resource/ResourceType.java
@@ -6,6 +6,11 @@
  */
 package com.mars_sim.core.resource;
 
+import com.mars_sim.core.equipment.BinType;
+import com.mars_sim.core.equipment.EquipmentType;
+import com.mars_sim.core.robot.RobotType;
+import com.mars_sim.core.vehicle.VehicleType;
+
 /**
  * This class provides the logic to infer the type of resource based on the resource ID.
  * It also defines the ranges of resource IDs for each type of resource.
@@ -45,5 +50,23 @@ public class ResourceType {
         return resourceID >> TYPE_BIT;
     }
 
-
+    /**
+     * Gets the name of the resource based on the resource ID.
+     * This is an uber coordinator method that will call the appropriate method to get the name of the resource based on its type.
+     * 
+     * @param resourceID the resource ID
+     * @return the name of the resource
+     */
+    public static String getName(int resourceID) {
+        int type = getType(resourceID);
+        return switch (type) {
+            case AMOUNT_RESOURCE -> ResourceUtil.findAmountResourceName(resourceID);
+            case ITEM_RESOURCE -> ItemResourceUtil.findItemResourceName(resourceID);
+            case VEHICLE_RESOURCE -> VehicleType.convertID2Type(resourceID).getName();
+            case EQUIPMENT_RESOURCE -> EquipmentType.convertID2Type(resourceID).getName();
+            case ROBOT_RESOURCE -> RobotType.convertID2Type(resourceID).getName();
+            case BIN_RESOURCE -> BinType.convertID2Type(resourceID).getName();
+            default -> "Resource:" + resourceID;
+        };
+    }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/robot/RobotType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/robot/RobotType.java
@@ -38,12 +38,15 @@ public enum RobotType {
 
 	/**
 	 * Convert an robot type to the associated resourceID.
-	 * Note : Needs revisiting. Equipment should be referenced by the RobotType enum.
-	 * 
-	 * @return
 	 */
 	public static int getResourceID(RobotType type) {
 		return type.ordinal() + ResourceType.FIRST_ROBOT_RESOURCE_ID;
 	}
-	
+
+	/**
+	 * Obtains the enum type of the robot with its type id.
+	 */
+	public static RobotType convertID2Type(int resourceId) {
+		return RobotType.values()[resourceId - ResourceType.FIRST_ROBOT_RESOURCE_ID];
+	}	
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -90,6 +90,7 @@ import com.mars_sim.core.person.ai.task.util.SettlementTaskManager;
 import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.person.health.RadiationExposure;
 import com.mars_sim.core.process.CompletedProcess;
+import com.mars_sim.core.resource.ResourceType;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.robot.Robot;
 import com.mars_sim.core.science.ScienceType;
@@ -2845,7 +2846,8 @@ public class Settlement extends Unit implements Temporal,
 	 * @param millisols the labor time
 	 */
 	public void addOutput(int resource, double amount, double millisols) {
-		dailyResourceOutput.recordValue(ResourceUtil.findAmountResourceName(resource), amount, this);
+		// This is not optimal and needs a better way to record Measures as not only String
+		dailyResourceOutput.recordValue(ResourceType.getName(resource), amount, this);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -41,7 +41,6 @@ import com.mars_sim.core.building.utility.heating.ThermalSystem;
 import com.mars_sim.core.building.utility.power.PowerGrid;
 import com.mars_sim.core.data.History;
 import com.mars_sim.core.data.Range;
-import com.mars_sim.core.data.SolMetricDataLogger;
 import com.mars_sim.core.data.UnitSet;
 import com.mars_sim.core.environment.DustStorm;
 import com.mars_sim.core.environment.SurfaceFeatures;
@@ -68,6 +67,8 @@ import com.mars_sim.core.manufacture.ManufacturingManager;
 import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.map.location.LocalPosition;
 import com.mars_sim.core.map.location.SurfacePOI;
+import com.mars_sim.core.metrics.MetricCategory;
+import com.mars_sim.core.metrics.MetricGroup;
 import com.mars_sim.core.mineral.RandomMineralFactory;
 import com.mars_sim.core.mission.MissionControl;
 import com.mars_sim.core.parameter.ParameterManager;
@@ -306,12 +307,13 @@ public class Settlement extends Unit implements Temporal,
 	/** The settlement objective type instance. */
 	private ObjectiveType objectiveType = ObjectiveType.BUILDERS_HAVEN;
 
-	/** The settlement's water consumption in kitchen when preparing/cleaning meal and dessert. */
-	private SolMetricDataLogger<WaterUseType> waterConsumption = new SolMetricDataLogger<>(MAX_NUM_SOLS);
-	/** The settlement's daily output (resources produced). */
-	private SolMetricDataLogger<Integer> dailyResourceOutput = new SolMetricDataLogger<>(MAX_NUM_SOLS);
-	/** The settlement's daily labor hours output. */
-	private SolMetricDataLogger<Integer> dailyLaborTime = new SolMetricDataLogger<>(MAX_NUM_SOLS);
+	/**
+	 * Metrics for the settlement.
+	 */
+	private static final MetricCategory WATER_CATEGORY = new MetricCategory("Water Usage");
+	private MetricGroup waterConsumption = new MetricGroup(WATER_CATEGORY);
+	private static final MetricCategory PRODUCED_CATEGORY = new MetricCategory("Resource Produced");
+	private MetricGroup dailyResourceOutput = new MetricGroup(PRODUCED_CATEGORY);
 	
 	/** The settlement's achievement in scientific fields. */
 	private EnumMap<ScienceType, Double> scientificAchievement;
@@ -326,9 +328,6 @@ public class Settlement extends Unit implements Temporal,
 	private Map<Integer, Double> resourcesCollected = new HashMap<>();
 	/** The settlement's resource statistics. */
 	private Map<Integer, Map<Integer, Map<Integer, Double>>> resourceStat = new HashMap<>();
-	
-	/** The last 20 mission scores */
-	private List<Double> missionScores;
 
 	/** The set of available pressurized/pressurizing airlocks. */
 	private Set<Building> pressurizedAirlocks = new UnitSet<>();
@@ -2845,11 +2844,8 @@ public class Settlement extends Unit implements Temporal,
 	 * @param amount the amount or quantity produced
 	 * @param millisols the labor time
 	 */
-	public void addOutput(Integer resource, double amount, double millisols) {
-
-		// Record the amount of resource produced
-		dailyResourceOutput.increaseDataPoint(resource, amount);
-		dailyLaborTime.increaseDataPoint(resource, millisols);
+	public void addOutput(int resource, double amount, double millisols) {
+		dailyResourceOutput.recordValue(ResourceUtil.findAmountResourceName(resource), amount, this);
 	}
 
 	/**
@@ -2859,18 +2855,17 @@ public class Settlement extends Unit implements Temporal,
 	 * @param amount
 	 */
 	public void addWaterConsumption(WaterUseType type, double amount) {
-		waterConsumption.increaseDataPoint(type, amount);
+		waterConsumption.recordValue(type.getName(), amount, this);
 	}
 
 	/**
 	 * Gets the daily average water usage of the last x sols Not: most weight on
 	 * yesterday's usage. Least weight on usage from x sols ago.
 	 *
-	 * @param type
-	 * @return
+	 * @return Map keys on water usage
 	 */
-	public double getDailyWaterUsage(WaterUseType type) {
-		return waterConsumption.getDailyAverage(type);
+	public Map<String, Double> getDailyWaterUsage() {
+		return waterConsumption.getAveragePerSol();
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/WaterUseType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/WaterUseType.java
@@ -7,9 +7,24 @@
 
 package com.mars_sim.core.structure;
 
-public enum WaterUseType {
+
+import com.mars_sim.core.Named;
+import com.mars_sim.core.tool.Msg;
+
+public enum WaterUseType implements Named {
 	PREP_MEAL,
 	PREP_DESSERT,
 	CLEAN_MEAL,
 	CLEAN_DESSERT;
+
+	private String name;
+
+	private WaterUseType() {
+		this.name = Msg.getStringOptional("WaterUseType", name());
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/MicroInventoryTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/MicroInventoryTest.java
@@ -109,49 +109,30 @@ class MicroInventoryTest {
 		int resource = ResourceUtil.CO2_ID;
 		inv.setSpecificCapacity(resource, CAPACITY_AMOUNT);
 		
-		double excess = inv.storeAmountResource(resource, CAPACITY_AMOUNT);
-		System.out.println("excess: " + excess);
+		inv.storeAmountResource(resource, CAPACITY_AMOUNT);
 		
 		double shortfall = inv.retrieveAmountResource(resource, CAPACITY_AMOUNT/2);
-		System.out.println("shortfall: " + shortfall);
-		
 		assertEquals(0D, shortfall, "Shortfall on 1st retrieve");
 		
 		double stored = inv.getSpecificAmountResourceStored(resource);
-		System.out.println("stored: " + stored);
 		
 		assertEquals(CAPACITY_AMOUNT/2, stored, "Stored on 1st retrieve");
 		assertEquals(CAPACITY_AMOUNT/2, inv.getRemainingSpecificCapacity(resource), "Remaining after 1st retrieve");
 		
-		double mass = inv.getStoredMass();
-		System.out.println("mass: " + mass);
-		
+		double mass = inv.getStoredMass();		
 		assertEquals(CAPACITY_AMOUNT/2, mass, "Total mass after 1st retrieve");
 
-		shortfall = inv.retrieveAmountResource(resource, CAPACITY_AMOUNT/2);
-		System.out.println("shortfall: " + shortfall);
-		
+		shortfall = inv.retrieveAmountResource(resource, CAPACITY_AMOUNT/2);		
 		assertEquals(0D, shortfall, "Shortfall on 2nd retrieve");
 		
-		stored = inv.getSpecificAmountResourceStored(resource);
-		System.out.println("stored: " + stored);
-		
+		stored = inv.getSpecificAmountResourceStored(resource);		
 		assertEquals(0D, stored, "Stored on 2nd retrieve");
 		
-		double cap = inv.getRemainingSpecificCapacity(resource);
-		System.out.println("cap: " + cap);
-		
+		double cap = inv.getRemainingSpecificCapacity(resource);		
 		assertEquals(CAPACITY_AMOUNT, cap, "Remaining after 2nd retrieve");
-		
-		double totalSpecificStored = inv.getTotalSpecificAmountResourceStored();
-		System.out.println("totalSpecificStored: " + totalSpecificStored);
-		
-		double totalStockStored = inv.getTotalStockAmountResourceStored();
-		System.out.println("totalStockStored: " + totalStockStored);
 		
 		inv.printStoredMass();
 		mass = inv.getStoredMass();
-		System.out.println("mass: " + mass);
 		
 		assertEquals(0D, mass, "Total mass after 2nd retrieve");
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/TestContainment.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/TestContainment.java
@@ -182,7 +182,7 @@ class TestContainment extends MarsSimUnitTest {
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
 	@Test
-	public void testPersonInGarage() {
+	void testPersonInGarage() {
 		var person = buildPerson("Worker One", settlement);
 
 		assertInsideSettlement("Initial person", person, settlement);
@@ -196,7 +196,7 @@ class TestContainment extends MarsSimUnitTest {
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
 	@Test
-	public void testVehicleInGarage() {
+	void testVehicleInGarage() {
 		Vehicle vehicle = buildRover(settlement, "Garage Rover", new LocalPosition(1,1), EXPLORER_ROVER);
         
 		// Since garage has been built at constructor, once the vehicle is built, 
@@ -216,7 +216,7 @@ class TestContainment extends MarsSimUnitTest {
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
 	@Test
-	public void testVehicleNearSettlement() {
+	void testVehicleNearSettlement() {
 		Vehicle vehicle = buildRover(settlement, "Near Rover", new LocalPosition(1,1), EXPLORER_ROVER);
 		
 		// Vehicle leaves garage
@@ -227,9 +227,7 @@ class TestContainment extends MarsSimUnitTest {
 		// Since garage has been built at constructor, once the vehicle is built, 
 		// it goes into a garage automatically 
 		
-		boolean isInGarage = vehicle.isInGarage();
-		System.out.println("In testVehicleNearSettlement(), isInGarage: " + isInGarage);
-		
+		boolean isInGarage = vehicle.isInGarage();		
 		assertVehicleGaraged("Vehicle in garage", vehicle, settlement);
 		
 		LocationStateType state = LocationStateType.SETTLEMENT_VICINITY;
@@ -243,7 +241,7 @@ class TestContainment extends MarsSimUnitTest {
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
 	@Test
-	public void testVehicleOnSurface() {
+	void testVehicleOnSurface() {
 		Vehicle vehicle = buildRover(settlement, "Garage Rover", new LocalPosition(1,1), EXPLORER_ROVER);
 
 		assertTrue(vehicle.transfer(getSurface()),
@@ -256,7 +254,7 @@ class TestContainment extends MarsSimUnitTest {
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
 	@Test
-	public void testBagOnSurface() {
+	void testBagOnSurface() {
 
 		Equipment bag = EquipmentFactory.createEquipment(EquipmentType.BAG, settlement);
 		
@@ -274,7 +272,7 @@ class TestContainment extends MarsSimUnitTest {
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
 	@Test
-	public void testBagOnVehicle() {
+	void testBagOnVehicle() {
 
 		Equipment bag = EquipmentFactory.createEquipment(EquipmentType.BAG, settlement);
 		
@@ -301,7 +299,7 @@ class TestContainment extends MarsSimUnitTest {
 	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
 	 */
 	@Test
-	public void testPersonOnVehicle() {
+	void testPersonOnVehicle() {
 
 		Person person = buildPerson("Test Person", settlement);
 		
@@ -342,33 +340,4 @@ class TestContainment extends MarsSimUnitTest {
 		
 		assertInsideSettlement("After return", person, settlement);
 	}
-
-	
-	/*
-	 * Test method for 'com.mars_sim.simulation.person.ai.task.LoadVehicle.isFullyLoaded()'
-	 */
-//	public void testEVAOnPerson() {
-//		Person person = new Person("Worker Two", settlement);
-//		person.initialize(); // TODO This is bad. Why do we have to call a 2nd method after the constructor ???
-//        unitManager.addUnit(person);
-//
-//        person.transfer(settlement,  surface);
-//
-//		EVASuit suit = new EVASuit("EVA Suit", settlement);
-//		unitManager.addUnit(suit);
-//		assertTrue("transfer suit to Person", suit.transfer(settlement, person));
-//
-//		assertEquals("Location state type", LocationStateType.ON_PERSON_OR_ROBOT, suit.getLocationStateType());
-//		assertNull("Settlement", suit.getSettlement());
-//		
-//		assertFalse("InSettlement", suit.isInSettlement());
-//		assertFalse("IsInside", suit.isInside());
-//		assertFalse("IsOutside", suit.isOutside());
-//
-//		assertFalse("isInVehicle", suit.isInVehicle());
-//		assertNull("Vehicle", suit.getVehicle());
-//		
-//		assertEquals("Container", person, suit.getContainerUnit());
-//		assertEquals("Top container", person, suit.getTopContainerUnit());
-//	}
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/function/cooking/task/CookMealMetaTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/function/cooking/task/CookMealMetaTest.java
@@ -14,9 +14,9 @@ import com.mars_sim.core.person.ai.job.util.JobType;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.time.MarsTime;
 
-public class CookMealMetaTest extends MarsSimUnitTest {
+class CookMealMetaTest extends MarsSimUnitTest {
     @Test
-    public void testMealTime() {
+    void testMealTime() {
         var s = buildSettlement("mock");
      
         buildKitchen(s.getBuildingManager());
@@ -41,7 +41,7 @@ public class CookMealMetaTest extends MarsSimUnitTest {
     }
 
     @Test
-    public void testMultiKitchen() {
+    void testMultiKitchen() {
         var s = buildSettlement("mock");
      
         var b1 = buildKitchen(s.getBuildingManager());
@@ -61,7 +61,7 @@ public class CookMealMetaTest extends MarsSimUnitTest {
     }
 
     @Test
-    public void testCooks() {
+    void testCooks() {
         var s = buildSettlement("mock");
      
         var b = buildKitchen(s.getBuildingManager());
@@ -82,11 +82,7 @@ public class CookMealMetaTest extends MarsSimUnitTest {
         p1.getTaskManager().replaceTask(new CookMeal(p1, k));
         results = mt.getSettlementTasks(s);
         task = results.get(0);
-        
-        String taskName = p1.getTaskManager().getTaskDescription(false);
-        System.out.println(p1 + " " + taskName);
-        int numCooks = k.getNumCooks();
-        System.out.println(p1 + " at " + p1.getBuildingLocation() + " (numCooks: " + numCooks + ")");
+
         assertEquals(k.getCookCapacity() - 1, task.getDemand(), "Meal task demand after 1 chef");
 
         var p2 = buildPerson("Chef", s, JobType.CHEF, b, FunctionType.COOKING);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/building/function/farming/CropTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/building/function/farming/CropTest.java
@@ -14,7 +14,7 @@ import com.mars_sim.core.map.location.LocalPosition;
 import com.mars_sim.core.robot.RobotType;
 import com.mars_sim.core.time.MarsTime;
 
-public class CropTest extends MarsSimUnitTest{
+class CropTest extends MarsSimUnitTest {
     
 	public Building buildGreenhouse(BuildingManager buildingManager) {
 		return buildFunction(buildingManager, "Large Greenhouse", BuildingCategory.FARMING,
@@ -22,17 +22,17 @@ public class CropTest extends MarsSimUnitTest{
 	}
 
     @Test
-    public void testGrowingWhiteMustard() {
+    void testGrowingWhiteMustard() {
         testCropGrowth("White Mustard");  // Select a crop with a short growing cycle
     }
 
     @Test
-    public void testGrowingSpringOnion() {
+    void testGrowingSpringOnion() {
         testCropGrowth("Spring Onion");  // Select a crop with a short growing cycle
     }
     
     @Test
-    public void testGrowingGreenBellPepper() {
+    void testGrowingGreenBellPepper() {
         testCropGrowth("Green Bell Pepper");  // Select a crop with a short growing cycle
     }
 
@@ -94,7 +94,6 @@ public class CropTest extends MarsSimUnitTest{
         
         double cropCache = crop.getCropCache();
         
-        // assertTrue((harvested.value()/harvested.max()) > 0.5D, cropName + " crop harvested over 10%");
         assertEquals(cropCache + s.getSpecificAmountResourceStored(spec.getCropID()), harvested.value(), 0.01, cropName + " stored");
    
         return crop;

--- a/mars-sim-core/src/test/java/com/mars_sim/core/manufacture/WorkshopProcessTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/manufacture/WorkshopProcessTest.java
@@ -15,11 +15,11 @@ import com.mars_sim.core.process.ProcessItem;
 import com.mars_sim.core.resource.ItemType;
 import com.mars_sim.core.structure.Settlement;
 
-public class WorkshopProcessTest extends MarsSimUnitTest {
+class WorkshopProcessTest extends MarsSimUnitTest {
     private static final String FURNACE_PROCESS = "Cast aluminum ingot";
 
     @Test
-    public void testManuProcessFailed() {
+    void testManuProcessFailed() {
         ManufactureProcessInfo processInfo = getConfig().getManufactureConfiguration().getManufactureProcessList().stream()
                             .filter(p -> p.getName().equals(FURNACE_PROCESS))
                             .findAny().get();
@@ -46,11 +46,11 @@ public class WorkshopProcessTest extends MarsSimUnitTest {
     }
 
     @Test
-    public void testManuProcess() {
+    void testManuProcess() {
         ManufactureProcessInfo processInfo = getConfig().getManufactureConfiguration().getManufactureProcessList().stream()
                             .filter(p -> p.getName().equals(FURNACE_PROCESS))
                             .findAny().get();
-        assertTrue(processInfo.getProcessTimeRequired() > 0, "Process has prcoess time");
+        assertTrue(processInfo.getProcessTimeRequired() > 0, "Process has process time");
         
         var s = buildSettlement("Test", true);
         var b = ManufacturingManagerTest.buildWorkshop(getContext(), s.getBuildingManager());
@@ -78,7 +78,7 @@ public class WorkshopProcessTest extends MarsSimUnitTest {
     }
 
     @Test
-    public void testSalvProcess() {
+    void testSalvProcess() {
         SalvageProcessInfo processInfo = getConfig().getManufactureConfiguration().getSalvageInfoList().stream()
                             .filter(p -> p.getName().equals(SalvageProcessInfo.NAME_PREFIX + "gas canister"))
                             .findAny().get();

--- a/mars-sim-core/src/test/java/com/mars_sim/core/map/location/CoordinatesFormatTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/map/location/CoordinatesFormatTest.java
@@ -119,7 +119,6 @@ class CoordinatesFormatTest {
         // Do North & West
         for(var v : values) {
             var s = CoordinatesFormat.DIGIT_FORMAT.format(v[0]);
-            System.out.println("Parsing: " + s);
             var c = CoordinatesFormat.DIGIT_FORMAT.parse(s).doubleValue();
             assertEquals(c, v[0], 0.001);
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/metrics/memory/MemoryMetricManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/metrics/memory/MemoryMetricManagerTest.java
@@ -47,4 +47,31 @@ class MemoryMetricManagerTest extends MetricManagerTest {
         assertEquals(MAX_SOL, m.getSize(), "Metric size after removing old sols");
         
     }
+
+    @Test
+    @DisplayName("newSol should remove datapoints from metrics")
+    void testRemoveDataPoints() {
+        var manager = new MemoryMetricManager(100); // Must be large sols
+
+        var maxPoints = 3;
+        manager.setMaxPoints(maxPoints);
+        assertEquals(maxPoints, manager.getMaxPoints(), "Max points should be set correctly");
+
+        var s = buildSettlement("Test");
+        var m = manager.getMetric(new MetricKey(s, TEMP_CAT, "Average"));
+
+        // Add data points for sols 0 to MAX_SOL+1
+        var clock = getSim().getMasterClock();
+        var marsTime = clock.getMarsTime();
+        for (int sol = 0; sol <= maxPoints; sol++) {
+            m.recordValue(1D);
+
+            marsTime = marsTime.addTime(1000D);
+            clock.setMarsTime(marsTime);
+        }
+        assertEquals(maxPoints + 1, m.getSize(), "Metric size before newSol");
+    
+        manager.newSol(marsTime);
+        assertEquals(maxPoints, m.getSize(), "Metric size after newSol");
+    }   
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/LoadPersonTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/LoadPersonTest.java
@@ -7,6 +7,7 @@
 
 package com.mars_sim.core.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -23,14 +24,14 @@ import com.mars_sim.core.structure.Settlement;
 /**
  * Tests the ability of a person to carry resources.
  */
-public class LoadPersonTest extends MarsSimUnitTest {
+class LoadPersonTest extends MarsSimUnitTest {
 
 	private Settlement settlement = null;
 	private String name = "Jim Loader";
 	private Person person;
 
 	@BeforeEach
-    public void setUpPerson() {
+    void setUpPerson() {
 		settlement = buildSettlement("mock");
 		
 		person = buildPerson(name, settlement);
@@ -44,41 +45,32 @@ public class LoadPersonTest extends MarsSimUnitTest {
 	 * Test if a person can carry resources.
 	 */
 	@Test
-	public void testCarrying() throws Exception {
-		double capacity = Math.round(person.getCarryingCapacity() * 10D)/10D;
-		System.out.println(person + " has a carrying capacity of " + capacity + " kg.");
-		
-		double weight = Math.round(person.getMass() * 10D)/10D;
-		System.out.println(person + " weighs " + weight + " kg.");
+	void testCarrying() {
+		double capacity = Math.round(person.getCarryingCapacity() * 10D)/10D;		
 		
 		assertTrue(capacity > 0, person + " has no carrying capacity.");
 		
 		double amount = 1D;
-		
-		double cap = person.getSpecificCapacity(ResourceUtil.FOOD_ID);
-		System.out.println(person + " has a capacity of " + cap + " kg for food.");
-		
+				
 		double remain0 = person.getRemainingSpecificCapacity(ResourceUtil.FOOD_ID);
-		System.out.println("1. " + person + " has a remaining capacity of " + remain0 + " kg for food.");
-		assertTrue(remain0 == 1.0, "Incorrect remaining capacity.");
+		assertEquals(1.0, remain0, "Incorrect remaining capacity.");
 		
 		double excess = person.storeAmountResource(ResourceUtil.FOOD_ID, amount);	
 		
 		double remain1 = person.getRemainingSpecificCapacity(ResourceUtil.FOOD_ID);
-		System.out.println("2. " + person + " has a remaining capacity of " + remain1 + " kg for food.");
-		assertTrue(remain1 == 0.0, "Incorrect remaining capacity.");
+		assertEquals(0.0, remain1, "Incorrect remaining capacity.");
 		
-		assertTrue(excess == 0.0, "Can't carry " + amount + " kg of food.");
+		assertEquals(0.0, excess, "Can't carry " + amount + " kg of food.");
 		
 		double missing = person.retrieveAmountResource(ResourceUtil.FOOD_ID, amount);
-		assertTrue(missing == 0.0, "Can't retrieve food.");
+		assertEquals(0.0, missing, "Can't retrieve food.");
 	}
 	
 	/*
 	 * Test if a person can transfer equipment.
 	 */
 	@Test
-	public void testTransferEquipment() {
+	void testTransferEquipment() {
 		Equipment bag = EquipmentFactory.createEquipment(EquipmentType.BAG, settlement);
 
 		boolean canTransfer = bag.transfer(person);
@@ -91,7 +83,7 @@ public class LoadPersonTest extends MarsSimUnitTest {
 	 * Test if a person can be assigned a thermal bottle.
 	 */
 	@Test
-	public void testAssignThermalBottle() {
+	void testAssignThermalBottle() {
 		Equipment bottle = EquipmentFactory.createEquipment(EquipmentType.THERMAL_BOTTLE, settlement);
 
 		person.assignThermalBottle();
@@ -100,6 +92,5 @@ public class LoadPersonTest extends MarsSimUnitTest {
 		
 		assertTrue(hasIt, bottle + " cannot be transferred from " + settlement 
 				+ " to " + person.getName() + ".");
-	}
-	
+	}	
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/test/MarsSimUnitTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/test/MarsSimUnitTest.java
@@ -57,6 +57,7 @@ public abstract class MarsSimUnitTest {
 
     @BeforeEach
     public void init() {
+		SimulationRuntime.initialiseLogging();
     	SimulationRuntime.enableFileLogging(null);
     	
         // Initialize the MarsSimContextImpl for each test

--- a/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/UnloadVehicleEVATest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/UnloadVehicleEVATest.java
@@ -18,12 +18,12 @@ import com.mars_sim.core.resource.ItemResourceUtil;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.vehicle.StatusType;
 
-public class UnloadVehicleEVATest extends MarsSimUnitTest {
+class UnloadVehicleEVATest extends MarsSimUnitTest {
     private static final int ITEM_AMOUNT = 10;
     private static final double RESOURCE_AMOUNT = 10;
 
     @Test
-    public void testCreateTask() {
+    void testCreateTask() {
         var s = buildSettlement("Vehicle base");
 
         // Load the vehicle
@@ -34,7 +34,6 @@ public class UnloadVehicleEVATest extends MarsSimUnitTest {
         
         double mass = v.getStoredMass();
         // 10 + 10 + .5 * 10 = 25.0
-        System.out.println("vehicle stored mass: " + mass);
         
         assertGreaterThan("Initial stored mass", 0D, mass);
 
@@ -51,35 +50,24 @@ public class UnloadVehicleEVATest extends MarsSimUnitTest {
         EVAOperationTest.executeEVAWalk(getContext(), eva, task);
 
         double storedO2Settlement0 = s.getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID);
-//        System.out.println("storedO2Settlement0: " + storedO2Settlement0);
-        
-//        double storedO2Person = p.getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID);
-//        System.out.println("storedO2Person: " + storedO2Person);
-        
-//        double storedO2Vehicle = v.getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID);
-//        System.out.println("storedO2Vehicle: " + storedO2Vehicle);
         
         // Do maintenance and advance to return
         executeTaskUntilPhase(p, task, 3000);
         
         mass = v.getStoredMass();
-        System.out.println("vehicle stored mass: " + mass);
         
         assertEquals(0D, mass, "Final stored mass");
         assertFalse(v.haveStatusType(StatusType.UNLOADING), "Vehicle has UNLOADING");
 
         double storedO2Settlement1 = s.getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID);
-        System.out.println("storedO2Settlement1: " + storedO2Settlement1); 
         
         assertLessThan("Oxygen unloaded", storedO2Settlement0 + RESOURCE_AMOUNT, storedO2Settlement1);
         
         double storedFood = s.getSpecificAmountResourceStored(ResourceUtil.FOOD_ID);
-        System.out.println("storedFood: " + storedFood);
         
         assertEquals(RESOURCE_AMOUNT, storedFood, "Food unloaded");
         
         int storedGarment = s.getItemResourceStored(ItemResourceUtil.GARMENT_ID);
-        System.out.println("storedGarment: " + storedGarment);
         
         assertEquals(ITEM_AMOUNT, storedGarment, "Garments unloaded");
 
@@ -89,7 +77,7 @@ public class UnloadVehicleEVATest extends MarsSimUnitTest {
     }
 
     @Test
-    public void testMetaTask() {
+    void testMetaTask() {
         var s = buildSettlement("Vehicle base", true);
 
         var v = buildRover(s, "rover1", new LocalPosition(10, 10), EXPLORER_ROVER);

--- a/mars-sim-core/src/test/resources/logging.properties
+++ b/mars-sim-core/src/test/resources/logging.properties
@@ -1,0 +1,10 @@
+# Test logging configuration for mars-sim-core unit tests
+# Keep normal INFO logging by default, but suppress chatty mars-sim package INFO logs.
+
+handlers= java.util.logging.ConsoleHandler
+
+.level= INFO
+com.mars_sim.level= WARNING
+
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter

--- a/mars-sim-tools/src/test/java/com/mars_sim/tools/helpgenerator/HelpGeneratorTest.java
+++ b/mars-sim-tools/src/test/java/com/mars_sim/tools/helpgenerator/HelpGeneratorTest.java
@@ -16,9 +16,11 @@ import org.apache.commons.io.FileUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.mars_sim.core.SimulationConfig;
+import com.mars_sim.core.SimulationRuntime;
 import com.mars_sim.core.configuration.ScenarioConfig;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.robot.RobotType;
@@ -29,6 +31,11 @@ class HelpGeneratorTest {
 	
     private SimulationConfig simconfig;
     
+    @BeforeAll
+    static void setup() {
+        SimulationRuntime.initialiseLogging();
+    }
+
     private HelpContext createGenerator() {
         simconfig = SimulationConfig.loadConfig();
 

--- a/mars-sim-tools/src/test/java/com/mars_sim/tools/helpgenerator/HelpLibraryTest.java
+++ b/mars-sim-tools/src/test/java/com/mars_sim/tools/helpgenerator/HelpLibraryTest.java
@@ -9,12 +9,18 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.mars_sim.core.SimulationConfig;
+import com.mars_sim.core.SimulationRuntime;
 
 class HelpLibraryTest {
-
+    @BeforeAll
+    static void setup() {
+        SimulationRuntime.initialiseLogging();
+    }
+    
     @Test
     void testCreateLibrary() throws IOException {
 		// Load config files

--- a/mars-sim-tools/src/test/resources/logging.properties
+++ b/mars-sim-tools/src/test/resources/logging.properties
@@ -1,0 +1,10 @@
+# Test logging configuration for mars-sim-core unit tests
+# Keep normal INFO logging by default, but suppress chatty mars-sim package INFO logs.
+
+handlers= java.util.logging.ConsoleHandler
+
+.level= INFO
+com.mars_sim.level= WARNING
+
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/metrics/MetricChartViewer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/metrics/MetricChartViewer.java
@@ -10,6 +10,8 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -28,6 +30,7 @@ import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
 import com.mars_sim.core.Entity;
 import com.mars_sim.core.metrics.Metric;
 import com.mars_sim.core.metrics.MetricCategory;
+import com.mars_sim.core.metrics.MetricKey;
 import com.mars_sim.core.metrics.MetricManager;
 import com.mars_sim.core.metrics.MetricManagerListener;
 import com.mars_sim.core.time.ClockPulse;
@@ -49,17 +52,20 @@ public class MetricChartViewer extends ContentPanel
     public static final String ICON = "metrics";
 
     private static final String SELECT_PROMPT = "-- Select --";
+    private static final String ALL_MEASURES = "ALL";  // Token value for all measures
     
     private transient MetricManager metricManager;
     private JTabbedPane tabbedPane;
     private JComboBox<Entity> entityComboBox;
     private JComboBox<MetricCategory> categoryComboBox;
     private JComboBox<String> measureComboBox;
-    private JButton newButton;
+    private JButton showMetric;
     private JButton removeButton;
     private JButton addButton;
     private JCheckBox cummulative;
     private JCheckBox shapes;
+    private JButton showCategory;
+    private Map<MetricKey, MetricDataset> categoryToDataset = new HashMap<>();
         
     /**
      * Creates a new MetricChartViewer component with the specified MetricManager.
@@ -94,7 +100,8 @@ public class MetricChartViewer extends ContentPanel
         add(tabbedPane, BorderLayout.CENTER);
                         
         // Initially disable buttons
-        newButton.setEnabled(false);
+        showMetric.setEnabled(false);
+        showCategory.setEnabled(false);
         updateButtonState();
 
         // Set preferred size
@@ -129,10 +136,12 @@ public class MetricChartViewer extends ContentPanel
          
         JPanel controlPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 4, 2));
 
-        newButton = new JButton("New Chart");
-        newButton.addActionListener(e -> addNewChart());
+        showMetric = new JButton("Show Metric");
+        showMetric.addActionListener(e -> showMetricNewChart());
+        showCategory = new JButton("Show Category");
+        showCategory.addActionListener(e -> showCategoryNewChart());
         addButton = new JButton("Add To Chart");
-        addButton.addActionListener(e -> addToChart());
+        addButton.addActionListener(e -> addMeasureToChart());
         removeButton = new JButton("Remove Chart");
         removeButton.addActionListener(e -> removeSelectedChart());
 
@@ -161,8 +170,9 @@ public class MetricChartViewer extends ContentPanel
         });
 
         // Add buttons
-        controlPanel.add(newButton);
+        controlPanel.add(showMetric);
         controlPanel.add(addButton);
+        controlPanel.add(showCategory);
         controlPanel.add(removeButton);
         controlPanel.add(cummulative);
         controlPanel.add(shapes);
@@ -187,6 +197,7 @@ public class MetricChartViewer extends ContentPanel
     private void populateMeasureComboBox() {
         measureComboBox.removeAllItems();
 
+        boolean enableNewChartButtons = false;
         if (entityComboBox.getSelectedIndex() > 0 && categoryComboBox.getSelectedIndex() > 0) {
             var measures = metricManager.getMeasures(
                                 (Entity) entityComboBox.getSelectedItem(),
@@ -196,11 +207,11 @@ public class MetricChartViewer extends ContentPanel
                 measureComboBox.addItem(m);
             }
             measureComboBox.setSelectedIndex(0);
-            newButton.setEnabled(true);
+            enableNewChartButtons = true;
         }
-        else {
-            newButton.setEnabled(false);
-        }
+
+        showCategory.setEnabled(enableNewChartButtons);
+        showMetric.setEnabled(enableNewChartButtons);
     }
     
     private void categorySelected() {
@@ -299,11 +310,11 @@ public class MetricChartViewer extends ContentPanel
         }
         return null;
     }
-        
+
     /**
      * Adds the selected metric to the currently selected chart tab.
      */
-    private void addToChart() {
+    private void addMeasureToChart() {
         int selectedIndex = tabbedPane.getSelectedIndex();
         var data = getSelectedMetric();
         if (data != null && (selectedIndex >= 0)) {
@@ -321,49 +332,93 @@ public class MetricChartViewer extends ContentPanel
     }
 
     /**
-     * Adds a new chart tab based on the current dropdown selections.
+     * Show a new chart for the selected Metric
      */
-    private void addNewChart() {
-
+    private void showMetricNewChart() {
         var data = getSelectedMetric();
         if (data != null) {
             // Create the chart
             var dataset = new MetricDataset();
             dataset.setCumulative(cummulative.isSelected());
-            if (!dataset.addMetric(data)) {
-                // Metric already present, do not add duplicate chart
-                return;
-            }
+            dataset.addMetric(data);
 
-            JFreeChart chart = createMetricChart(dataset);
-            
-            // Create chart panel
-            ChartPanel chartPanel = new ChartPanel(chart);
-            chartPanel.setPreferredSize(new Dimension(600, 400));
-            chartPanel.setMouseWheelEnabled(true);
-            
-            // Add to tabbed pane
-            tabbedPane.addTab(dataset.getTitle(), chartPanel);
-            
-            // Select the new tab
-            tabbedPane.setSelectedIndex(tabbedPane.getTabCount() - 1);
-            
-            // Update button states
-            updateButtonState();
-            
+            buildNewChart(dataset);
+           
             // Reset selections to encourage creating different charts
             measureComboBox.setSelectedIndex(0); // Reset to "-- Select --"
         }
     }
+        
+    /**
+     * Show a new chart for the selected Category
+     */
+    private void showCategoryNewChart() {
+        var entityObj = (Entity)entityComboBox.getSelectedItem();
+        var category = (MetricCategory) categoryComboBox.getSelectedItem();
+        
+        // Make the category is selected and there are measures
+        if (entityObj == null || category == null || measureComboBox.getModel().getSize() == 0) {
+            return;
+        }
+
+        // Create the dataset
+        var dataset = new MetricDataset();
+        dataset.setCumulative(cummulative.isSelected());
+
+        // add all known measures
+        for(var m : metricManager.getMeasures(entityObj, category)) {
+            // Find selected Metrix
+            var metric = metricManager.getMetric(entityObj, category, m);
+            dataset.addMetric(metric);
+        }
+
+        buildNewChart(dataset);
+
+        // Add to map so new Measure are auto added
+        categoryToDataset.put(new MetricKey(entityObj, category, ALL_MEASURES), dataset);
+    }
     
+    private void buildNewChart(MetricDataset dataset) {
+        JFreeChart chart = createMetricChart(dataset);
+        
+        // Create chart panel
+        ChartPanel chartPanel = new ChartPanel(chart);
+        chartPanel.setPreferredSize(new Dimension(600, 400));
+        chartPanel.setMouseWheelEnabled(true);
+        
+        // Add to tabbed pane
+        tabbedPane.addTab(dataset.getTitle(), chartPanel);
+        
+        // Select the new tab
+        tabbedPane.setSelectedIndex(tabbedPane.getTabCount() - 1);
+        
+        // Update button states
+        updateButtonState();     
+    }
+
     /**
      * Removes the currently selected chart tab.
      */
     private void removeSelectedChart() {
         int selectedIndex = tabbedPane.getSelectedIndex();
         if (selectedIndex >= 0) {
+            var selection = tabbedPane.getTabComponentAt(selectedIndex);
             tabbedPane.removeTabAt(selectedIndex);
             updateButtonState();
+
+            // Remove from categoryToDataset map if it was a category chart
+            ChartPanel chartPanel = (ChartPanel) selection;
+            JFreeChart chart = chartPanel.getChart();
+            XYPlot plot = chart.getXYPlot();
+            var dataset = (MetricDataset) plot.getDataset();
+
+            // Check if the dataset is in the map and remove it
+            for(var entry : categoryToDataset.entrySet()) {
+                if (entry.getValue() == dataset) {
+                    categoryToDataset.remove(entry.getKey());
+                    break;
+                }
+            }
         }
     }
     
@@ -417,9 +472,20 @@ public class MetricChartViewer extends ContentPanel
         dataset.refresh();
 	}
 
+    /**
+     * New metric added so update the dropdowns to include it.
+     * Also check if the new Metric belongs to an existing Chart
+     */
     @Override
     public void newMetric(Metric m) {
         populateCategoryComboBox();
         populateEntityComboBox();
+
+        // Check if the new metric belongs to an existing chart for the same category
+        var pseudoKey = new MetricKey(m.getKey().asset(), m.getKey().category(), ALL_MEASURES);
+        var dataset = categoryToDataset.get(pseudoKey);
+        if (dataset != null) {
+            dataset.addMetric(m);
+        }
     }
 }

--- a/mars-sim-ui/src/test/java/com/mars_sim/ui/swing/tool/metrics/MetricDatasetTest.java
+++ b/mars-sim-ui/src/test/java/com/mars_sim/ui/swing/tool/metrics/MetricDatasetTest.java
@@ -8,6 +8,7 @@ package com.mars_sim.ui.swing.tool.metrics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import com.mars_sim.core.Entity;
 import com.mars_sim.core.EntityIdentifier;
 import com.mars_sim.core.Simulation;
 import com.mars_sim.core.SimulationConfig;
+import com.mars_sim.core.SimulationRuntime;
 import com.mars_sim.core.metrics.Metric;
 import com.mars_sim.core.metrics.MetricCategory;
 import com.mars_sim.core.metrics.MetricManager;
@@ -64,9 +66,14 @@ class MetricDatasetTest {
     private MarsTime startTime;
     private MetricManager manager;
 
+    @BeforeAll
+    static void ghlobalSetup() {
+        SimulationRuntime.initialiseLogging();
+        SimulationConfig.loadConfig();
+    }
+
     @BeforeEach
     void setup() {
-        SimulationConfig.loadConfig();
         var sim = Simulation.instance();
         sim.testRun();
         var clock = sim.getMasterClock();

--- a/mars-sim-ui/src/test/java/com/mars_sim/ui/swing/tool/settlement/TestSVGMapUtil.java
+++ b/mars-sim-ui/src/test/java/com/mars_sim/ui/swing/tool/settlement/TestSVGMapUtil.java
@@ -7,10 +7,11 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.batik.gvt.GraphicsNode;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.mars_sim.core.SimulationConfig;
+import com.mars_sim.core.SimulationRuntime;
 import com.mars_sim.core.building.construction.ConstructionConfig;
 import com.mars_sim.core.building.construction.ConstructionStageInfo;
 import com.mars_sim.core.resource.Part;
@@ -23,11 +24,12 @@ import com.mars_sim.ui.swing.tool.svg.SVGMapUtil;
  */
 class TestSVGMapUtil {
 
-    private SimulationConfig config;
+    private static SimulationConfig config;
 
-    @BeforeEach
-    void setUp() {
-    	config = SimulationConfig.loadConfig();
+    @BeforeAll
+    static void setup() {
+        SimulationRuntime.initialiseLogging();
+        config = SimulationConfig.loadConfig();
     }
 
     /**

--- a/mars-sim-ui/src/test/resources/logging.properties
+++ b/mars-sim-ui/src/test/resources/logging.properties
@@ -1,0 +1,10 @@
+# Test logging configuration for mars-sim-core unit tests
+# Keep normal INFO logging by default, but suppress chatty mars-sim package INFO logs.
+
+handlers= java.util.logging.ConsoleHandler
+
+.level= INFO
+com.mars_sim.level= WARNING
+
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter


### PR DESCRIPTION
This PR converts some Settlement SolData instance to use Metrics:
- Water usage
- Resource produced

It also improves the Metric Viewer behaviour to be more optimal for Categories with a lot of Measures.
The Memory Metric manager has an additional strategy for purging data points. It uses the max heap memory and assumes 1% can be used for data points. If the data point total reaches the threshold it will purge the oldest sol. This allows a long sol duratino to be used safe that it can not consume excessive memory.

In addition the UnitTest excessive logging is resolved.

close #1962