### PR TITLE
feat:  MetaMission controls thresholds for Mission creation

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/MissionCreateCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/MissionCreateCommand.java
@@ -31,9 +31,11 @@ public class MissionCreateCommand extends AbstractSettlementCommand {
 	@Override
 	protected boolean execute(Conversation context, String input, Settlement settlement) {
 
+		var cntl = settlement.getMissionControl();
+
 		// Get the user to select the Mission
 		List<MetaMission> automissions = MetaMissionUtil.getMetaMissions().stream()
-						.filter(m -> settlement.isMissionEnable(m.getType()))
+						.filter(m -> cntl.isMissionEnable(m.getType()))
 						.toList();
 		
 		// Add the none auto missions

--- a/mars-sim-core/src/main/java/com/mars_sim/core/goods/CommerceUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/goods/CommerceUtil.java
@@ -19,7 +19,6 @@ import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.person.PhysicalCondition;
 import com.mars_sim.core.person.ai.mission.MissionType;
-import com.mars_sim.core.person.ai.mission.Trade;
 import com.mars_sim.core.person.ai.mission.meta.TradeMeta;
 import com.mars_sim.core.resource.AmountResource;
 import com.mars_sim.core.resource.ResourceUtil;
@@ -93,7 +92,7 @@ public final class CommerceUtil {
 										Vehicle delivery) {
 		double possibleRange = delivery.getEstimatedRange() * .8D;
 
-		if (!startingSettlement.equals(tradingSettlement) && tradingSettlement.isMissionEnable(commerceType)) {
+		if (!startingSettlement.equals(tradingSettlement) && tradingSettlement.getMissionControl().isMissionEnable(commerceType)) {
 
 			boolean hasCurrentCommerce = hasCurrentCommerceMission(startingSettlement, tradingSettlement);
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/AbstractMetaMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/AbstractMetaMission.java
@@ -49,12 +49,16 @@ public abstract class AbstractMetaMission implements MetaMission {
 	private Set<JobType> preferredWorkerJob;
 	private Set<RobotType> preferredRobots = Collections.emptySet();  // Optional so empty by default
 	private Set<VehicleType> preferredVehicle = Collections.emptySet();  // Optional so empty by default
+	private int popRatio = 0;
+	private int popThreshold;
 	
 	/**
 	 * Creates a new Mission meta instance.
 	 * 
-	 * @param type 
+	 * @param type Type of mission
+	 * @param capacity Default maximum capacity for this mission type
 	 * @param preferredLeaderJob Jobs that a leader should have; null means no preference
+	 * @param preferredWorkerJob Jobs that a worker should have; null means no preference
 	 */
 	protected AbstractMetaMission(MissionType type, int capacity, Set<JobType> preferredLeaderJob, Set<JobType> preferredWorkerJob) {
 		super();
@@ -64,6 +68,10 @@ public abstract class AbstractMetaMission implements MetaMission {
 		this.name = type.getName();
 		this.capacity = capacity;
 		this.minimum = 2;
+
+		// These are defaults
+		this.popThreshold = capacity + 2;
+		this.popRatio = capacity + 4;
 	}
 
 	/**
@@ -166,6 +174,34 @@ public abstract class AbstractMetaMission implements MetaMission {
 	@Override
 	public RatingScore getProbability(Person person) {
 		return RatingScore.ZERO_RATING;
+	}
+
+	/**
+	 * Once over the threshold how many further concurrrent missiosn are allowed per number of citizens.
+	 * @param popRatio Number of citizens per additional mission.
+	 */
+	protected void setPopulationRatio(int popRatio) {
+		this.popRatio = popRatio;
+	}
+
+	/**
+	 * Define the minimum number of citizens before this misstion can be created.
+	 * @param popThreshold Lowest citizen size.
+	 */
+	protected void setPopulationThreshold(int popThreshold) {
+		this.popThreshold = popThreshold;
+	}
+
+	/**
+	 * This calculates the maximum number of missions. The algorithm check the citizens is above the population threshold.
+	 * If it is then the number of missions is 1 plus the number of citizens above the threshold divided by the population ratio.
+	 */
+	@Override
+	public int getMaxMissions(int numCitizens) {
+		if (numCitizens >= popThreshold) {
+			return 1 + (int) Math.floor((numCitizens - popThreshold) / (double)popRatio);
+		}
+		return 0;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/AbstractMetaMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/AbstractMetaMission.java
@@ -195,7 +195,7 @@ public abstract class AbstractMetaMission implements MetaMission {
 	}
 
 	/**
-	 * Once over the threshold how many further concurrrent missiosn are allowed per number of citizens.
+	 * Once over the threshold how many further concurrent missions are allowed per number of citizens.
 	 * @param popRatio Number of citizens per additional mission.
 	 */
 	protected void setPopulationRatio(int popRatio) {
@@ -203,7 +203,7 @@ public abstract class AbstractMetaMission implements MetaMission {
 	}
 
 	/**
-	 * Define the minimum number of citizens before this misstion can be created.
+	 * Define the minimum number of citizens before this mission can be created.
 	 * @param popThreshold Lowest citizen size.
 	 */
 	protected void setPopulationThreshold(int popThreshold) {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/AbstractMetaMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/AbstractMetaMission.java
@@ -51,6 +51,7 @@ public abstract class AbstractMetaMission implements MetaMission {
 	private Set<VehicleType> preferredVehicle = Collections.emptySet();  // Optional so empty by default
 	private int popRatio = 0;
 	private int popThreshold;
+	private int solThreshold = 0;
 	
 	/**
 	 * Creates a new Mission meta instance.
@@ -153,6 +154,23 @@ public abstract class AbstractMetaMission implements MetaMission {
 		return preferredWorkerJob;
 	}
 	
+	/**
+	 * Sets the minimum sol threshold for this mission. This is the minimum sol that must be reached before this mission can be created.
+	 * @param solThreshold Minimum sol threshold
+	 */
+	protected void setSolThreshold(int solThreshold) {
+		this.solThreshold = solThreshold;
+	}
+
+	/**
+	 * Gets the minimum sol threshold for this mission. This is the minimum sol that must be reached before this mission can be created.
+	 * @return Minimum sol threshold
+	 */
+	@Override
+	public int getSolThreshold() {
+		return solThreshold;
+	}
+
 	/** 
 	 * Gets the default capacity for a mission of this type.
 	 */
@@ -281,15 +299,6 @@ public abstract class AbstractMetaMission implements MetaMission {
 		return result;
 	}
 
-	/**
-	 * Is the time suitable for this mission. This may check the Mission sol in the clock or the time of day.
-	 * @param minimumSol Minimum sol for the mission to be suitable.
-	 * @return true if suitable; false otherwise.
-	 */
-	protected boolean isTimeSuitable(int minimumSol) {
-		return masterClock.getMarsTime().getMissionSol() >= minimumSol;
-	}
-	
     public static void initializeInstances(MasterClock mc) {
 		masterClock = mc;
     }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MetaMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MetaMission.java
@@ -85,4 +85,11 @@ public interface MetaMission {
 	 * @param settlement the settlement to search for vehicles.
 	 */
 	Vehicle selectVehicle(Settlement settlement);
+
+	/**
+	 * Get the maximum number of missions of this type that can be supported by a settlement based on its population.
+	 * @param numCitizens The number of citizens in the settlement
+	 * @return The maximum number of missions of this type that can be supported by the settlement
+	 */
+    int getMaxMissions(int numCitizens);
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MetaMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MetaMission.java
@@ -92,4 +92,10 @@ public interface MetaMission {
 	 * @return The maximum number of missions of this type that can be supported by the settlement
 	 */
     int getMaxMissions(int numCitizens);
+
+	/**
+	 * Get the minimum sol threshold for this mission. This is the minimum sol that must be reached before this mission can be created.
+	 * @return minimum sol threshold
+	 */
+    int getSolThreshold();
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionControl.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionControl.java
@@ -70,8 +70,10 @@ public class MissionControl implements ScheduledEventHandler {
 		this.owner = settlement;
         missionScores.add(minimumPassingScore);
 
+		owner.getPreferences().putValue(MissionLimitParameters.MISSION_CHECK_SOL, true);
+
         // Get time of next sol and schedule refresh; compensates for time zone
-        MarsTime startOfNextSol = Simulation.instance().getMasterClock().getMarsTime();
+        MarsTime startOfNextSol = getMarsTime();
 		startOfNextSol = startOfNextSol.advanceToNextMSol(settlement.getTimeZone().getMSolOffset());
         settlement.getFutureManager().addEvent(startOfNextSol, this);
     }
@@ -85,7 +87,7 @@ public class MissionControl implements ScheduledEventHandler {
 	 * @return Naming convention to apply
 	 */
 	public synchronized MissionNaming generateNames(MissionType type) {
-		int missionSol = Simulation.instance().getMasterClock().getMarsTime().getMissionSol();
+		int missionSol = getMarsTime().getMissionSol();
 
 		String sortieString = missionSol + "-" + id;
 
@@ -294,9 +296,9 @@ public class MissionControl implements ScheduledEventHandler {
 
 		var activeMissionsByType = getActiveMissions().stream()
 				.collect(Collectors.groupingBy(Mission::getMissionType, Collectors.counting()));
-
+		var checkSol = paramMgr.getBooleanValue(MissionLimitParameters.MISSION_CHECK_SOL, true);
 		for (MetaMission metaMission : MetaMissionUtil.getMetaMissions()) {
-			if (canAcceptMission(metaMission, paramMgr, activeMissionsByType)) {
+			if (canAcceptMission(metaMission, paramMgr, checkSol, activeMissionsByType)) {
 				var score = scoreMission(metaMission, leader, paramMgr);
 				if (score != null) {
 					potentials.add(score);
@@ -307,17 +309,28 @@ public class MissionControl implements ScheduledEventHandler {
 	}
 
 	/**
-	 * Checks if a mission can be accepted based on the maximum number of active missions of that type allowed by the settlement preferences.
+	 * Checks if a mission can be accepted based on the maximum number of active missions of that type allowed
+	 * by the settlement preferences. Also it check the sol threshold.
 	 * @param metaMission The mission type to check
 	 * @param paramMgr The parameter manager containing the settlement preferences
+	 * @param checkSol Whether to check the sol threshold for the mission
 	 * @param activeMissionsByType A map of active missions grouped by their type
 	 * @return true if the mission can be accepted, false otherwise
 	 */
-	private boolean canAcceptMission(MetaMission metaMission, ParameterManager paramMgr, Map<MissionType, Long> activeMissionsByType) {
+	private boolean canAcceptMission(MetaMission metaMission, ParameterManager paramMgr,
+					boolean checkSol, Map<MissionType, Long> activeMissionsByType) {
+		if (checkSol && getMarsTime().getMissionSol() < metaMission.getSolThreshold()) {
+			return false;
+		}
+		
 		int maxMissions = paramMgr.getIntValue(MissionLimitParameters.INSTANCE.getKey(metaMission.getType()),
 											Integer.MAX_VALUE);
 		int activeMissions = activeMissionsByType.getOrDefault(metaMission.getType(), 0L).intValue();
 		return activeMissions < maxMissions;
+	}
+
+	private MarsTime getMarsTime() {
+		return Simulation.instance().getMasterClock().getMarsTime();
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionControl.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionControl.java
@@ -346,4 +346,45 @@ public class MissionControl implements ScheduledEventHandler {
 	public void finishMission(boolean successful) {
 		metrics.recordValue(successful ? "Successful" : "Aborted", 1D, owner);
 	}
+
+	/**
+	 * Enables or disable a mission type.
+	 *  
+	 * @param mission
+	 * @param disable
+	 */
+	public void setMissionDisable(MissionType mission, boolean disable) {
+		owner.getPreferences().putValue(MissionWeightParameters.INSTANCE.getKey(mission), (disable ? 0D : 1D));
+	}
+	
+	/**
+	 * Checks if the mission is enabled.
+	 *
+	 * @param mission the type of the mission calling this method
+	 * @return probability value
+	 */
+	public boolean isMissionEnable(MissionType mission) {
+		return owner.getPreferences().getIntValue(MissionLimitParameters.INSTANCE.getKey(mission), 0) > 0;
+	}
+
+	/**
+	 * Population has changed in the settlement, so the mission control may need to update max. missions.
+	 */
+    public void populationChanged() {
+		var numCitizens = owner.getNumCitizens();
+		var preferences = owner.getPreferences();
+
+		for(var metaMission : MetaMissionUtil.getMetaMissions()) {
+			MissionType type = metaMission.getType();
+			var maxMissions = metaMission.getMaxMissions(numCitizens);
+
+			if (maxMissions > 0) {
+				preferences.putValue(MissionLimitParameters.INSTANCE.getKey(type), maxMissions);
+			}
+		}
+
+		// Set total mission limit
+		int optimalMissions = Math.max(1, (numCitizens/5));
+		preferences.putValue(MissionLimitParameters.TOTAL_MISSIONS, optimalMissions);
+    }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/MissionLimitParameters.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/MissionLimitParameters.java
@@ -21,6 +21,9 @@ public class MissionLimitParameters extends ParameterEnumCategory<MissionType> {
     public static final ParameterKey TOTAL_MISSIONS =
                     INSTANCE.addParameter("total", "Total Missions", ParameterValueType.INTEGER);
 
+    public static final ParameterKey MISSION_CHECK_SOL = INSTANCE.addParameter(
+                        "mission_sol","Mission start check Sol", ParameterValueType.BOOLEAN);
+
     private MissionLimitParameters() {
         super("MISSION_LIMIT", ParameterValueType.INTEGER, MissionType.class);     
     }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/CollectIceMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/CollectIceMeta.java
@@ -39,6 +39,7 @@ public class CollectIceMeta extends AbstractMetaMission {
 		super(MissionType.COLLECT_ICE, 4, PREFERRED_LEADER_JOBS, PREFERRED_WORKER_JOBS);
 
 		setPreferredVehicle(VehicleType.ROVER_TYPES);
+		setPopulationRatio(5);
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/CollectIceMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/CollectIceMeta.java
@@ -33,13 +33,14 @@ public class CollectIceMeta extends AbstractMetaMission {
 	private static final int VALUE = 750;
 
 	/** Starting sol for this mission to commence. */
-	public static final int MIN_STARTING_SOL = 3;
+	private static final int MIN_STARTING_SOL = 3;
 	
 	CollectIceMeta() {
 		super(MissionType.COLLECT_ICE, 4, PREFERRED_LEADER_JOBS, PREFERRED_WORKER_JOBS);
 
 		setPreferredVehicle(VehicleType.ROVER_TYPES);
 		setPopulationRatio(5);
+		setSolThreshold(MIN_STARTING_SOL);
 	}
 
 	@Override
@@ -50,56 +51,53 @@ public class CollectIceMeta extends AbstractMetaMission {
 	@Override
 	public RatingScore getProbability(Person person) {
 
-		RatingScore missionProbability = RatingScore.ZERO_RATING;
-    	if (!isTimeSuitable(MIN_STARTING_SOL)) {
+    	if (!person.isInSettlement()) {
     		return RatingScore.ZERO_RATING;
     	}
     	
-		if (person.isInSettlement()) {
+		Settlement settlement = person.getSettlement();
 
-			Settlement settlement = person.getSettlement();
+		RoleType roleType = person.getRole().getType();
+		if (roleType.isCouncil()
+				|| person.getMind().getJobType() == JobType.AREOLOGIST
+				|| person.getMind().getJobType() == JobType.CHEMIST
+				|| person.getMind().getJobType() == JobType.BOTANIST
+				|| person.getMind().getJobType() == JobType.CHEF
+				|| RoleType.CHIEF_OF_MISSION_PLANNING == roleType
+				|| RoleType.CHIEF_OF_SUPPLY_RESOURCE == roleType
+				|| RoleType.MISSION_SPECIALIST == roleType
+				|| RoleType.RESOURCE_SPECIALIST == roleType
+				) {
 
-			RoleType roleType = person.getRole().getType();
-
-            if (roleType.isCouncil()
-            		|| person.getMind().getJobType() == JobType.AREOLOGIST
-        			|| person.getMind().getJobType() == JobType.CHEMIST
-        			|| person.getMind().getJobType() == JobType.BOTANIST
-        			|| person.getMind().getJobType() == JobType.CHEF
-					|| RoleType.CHIEF_OF_MISSION_PLANNING == roleType
-					|| RoleType.CHIEF_OF_SUPPLY_RESOURCE == roleType
-					|| RoleType.MISSION_SPECIALIST == roleType
-					|| RoleType.RESOURCE_SPECIALIST == roleType
- 					) {
-
-	            // Check if there are enough barrel at the settlement for collecting ice.
-            	int stored = settlement.findNumContainersOfType(EquipmentType.BARREL);
-            	int needed = CollectIce.REQUIRED_BARRELS;
-	            if (stored < needed) {
-	            	BuildingManager.injectEquipmentDemand(EquipmentType.BARREL, settlement, stored, needed);
-	            	return RatingScore.ZERO_RATING;
-	            }
-	            
-				missionProbability = new RatingScore(1);
-	    		missionProbability.addModifier(DEMAND_PROBABILITY, settlement.getIceDemandCache() / VALUE);
-
-				// Job modifier.
-	    		missionProbability.addModifier(LEADER, getLeaderSuitability(person));
-
-				// If this town has a crop farm objective, divided by bonus
-				missionProbability.addModifier(GOODS, Math.min(1,
-							settlement.getGoodsManager().getCommerceFactor(CommerceType.CROP)/2));
-
-				// if introvert, score  0 to  50 --> -2 to 0
-				// if extrovert, score 50 to 100 -->  0 to 2
-				// Reduce probability if introvert
-				int extrovert = person.getExtrovertmodifier();
-				missionProbability.addModifier(PERSON_EXTROVERT, (1 + extrovert/2.0));
-
-				missionProbability.applyRange(0D, LIMIT);
+			// Check if there are enough barrel at the settlement for collecting ice.
+			int stored = settlement.findNumContainersOfType(EquipmentType.BARREL);
+			int needed = CollectIce.REQUIRED_BARRELS;
+			if (stored < needed) {
+				BuildingManager.injectEquipmentDemand(EquipmentType.BARREL, settlement, stored, needed);
+				return RatingScore.ZERO_RATING;
 			}
+			
+			var missionProbability = new RatingScore(1);
+			missionProbability.addModifier(DEMAND_PROBABILITY, settlement.getIceDemandCache() / VALUE);
+
+			// Job modifier.
+			missionProbability.addModifier(LEADER, getLeaderSuitability(person));
+
+			// If this town has a crop farm objective, divided by bonus
+			missionProbability.addModifier(GOODS, Math.min(1,
+						settlement.getGoodsManager().getCommerceFactor(CommerceType.CROP)/2));
+
+			// if introvert, score  0 to  50 --> -2 to 0
+			// if extrovert, score 50 to 100 -->  0 to 2
+			// Reduce probability if introvert
+			int extrovert = person.getExtrovertmodifier();
+			missionProbability.addModifier(PERSON_EXTROVERT, (1 + extrovert/2.0));
+
+			missionProbability.applyRange(0D, LIMIT);
+
+			return missionProbability;
 		}
 
-		return missionProbability;
+		return RatingScore.ZERO_RATING;
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/CollectRegolithMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/CollectRegolithMeta.java
@@ -40,6 +40,7 @@ public class CollectRegolithMeta extends AbstractMetaMission {
 		super(MissionType.COLLECT_REGOLITH, 4, PREFERRED_LEADER_JOBS, PREFERRED_WORKER_JOBS);
 
 		setPreferredVehicle(VehicleType.ROVER_TYPES);
+		setPopulationRatio(5);
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/CollectRegolithMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/CollectRegolithMeta.java
@@ -34,13 +34,14 @@ public class CollectRegolithMeta extends AbstractMetaMission {
 	private static final int VALUE = 500;
 
 	/** Starting sol for this mission to commence. */
-	public static final int MIN_STARTING_SOL = 4;
+	private static final int MIN_STARTING_SOL = 4;
 
 	CollectRegolithMeta() {
 		super(MissionType.COLLECT_REGOLITH, 4, PREFERRED_LEADER_JOBS, PREFERRED_WORKER_JOBS);
 
 		setPreferredVehicle(VehicleType.ROVER_TYPES);
 		setPopulationRatio(5);
+		setSolThreshold(MIN_STARTING_SOL);
 	}
 
 	@Override
@@ -51,54 +52,51 @@ public class CollectRegolithMeta extends AbstractMetaMission {
 	@Override
 	public RatingScore getProbability(Person person) {
 
-    	if (!isTimeSuitable(MIN_STARTING_SOL)) {
+    	if (!person.isInSettlement()) {
     		return RatingScore.ZERO_RATING;
     	}
 
-    	RatingScore missionProbability = RatingScore.ZERO_RATING;
-		if (person.isInSettlement()) {
+		Settlement settlement = person.getSettlement();
 
-			Settlement settlement = person.getSettlement();
+		RoleType roleType = person.getRole().getType();
 
-			RoleType roleType = person.getRole().getType();
-
-	           if (roleType.isCouncil()
-	            		|| person.getMind().getJobType() == JobType.AREOLOGIST
-	        			|| person.getMind().getJobType() == JobType.CHEMIST
-						|| RoleType.CHIEF_OF_MISSION_PLANNING == roleType
-						|| RoleType.CHIEF_OF_SUPPLY_RESOURCE == roleType
-						|| RoleType.MISSION_SPECIALIST == roleType
-						|| RoleType.RESOURCE_SPECIALIST == roleType
-	        		   ) {
+		if (roleType.isCouncil()
+					|| person.getMind().getJobType() == JobType.AREOLOGIST
+					|| person.getMind().getJobType() == JobType.CHEMIST
+					|| RoleType.CHIEF_OF_MISSION_PLANNING == roleType
+					|| RoleType.CHIEF_OF_SUPPLY_RESOURCE == roleType
+					|| RoleType.MISSION_SPECIALIST == roleType
+					|| RoleType.RESOURCE_SPECIALIST == roleType
+					) {
 
 
-	        	// Check if there are enough large bag at the settlement for collecting regolith.
-	        	int stored = settlement.findNumContainersOfType(EquipmentType.LARGE_BAG);
-	            int needed = CollectRegolith.REQUIRED_LARGE_BAGS;
-		        if (stored < needed) {
-	        	   BuildingManager.injectEquipmentDemand(EquipmentType.LARGE_BAG, settlement, stored, needed);
-	        	   return RatingScore.ZERO_RATING;
-	        	}
-		            
-	    		missionProbability = new RatingScore(1);
-	    		missionProbability.addModifier(DEMAND_PROBABILITY, settlement.getRegolithDemandCache() / VALUE);
-
-				// Job modifier.
-	    		missionProbability.addModifier(LEADER, getLeaderSuitability(person));
-
-				// If this town has a manufacturing objective, divided by bonus
-				missionProbability.addModifier(GOODS, Math.min(1,
-								settlement.getGoodsManager().getCommerceFactor(CommerceType.MANUFACTURING)/2));
-
-				// if introvert, score  0 to  50 --> -2 to 0
-				// if extrovert, score 50 to 100 -->  0 to 2
-				// Increase probability if extrovert
-				int extrovert = person.getExtrovertmodifier();
-				missionProbability.addModifier(PERSON_EXTROVERT, (1 + extrovert/2.0));
-				missionProbability.applyRange(0, LIMIT);
+			// Check if there are enough large bag at the settlement for collecting regolith.
+			int stored = settlement.findNumContainersOfType(EquipmentType.LARGE_BAG);
+			int needed = CollectRegolith.REQUIRED_LARGE_BAGS;
+			if (stored < needed) {
+				BuildingManager.injectEquipmentDemand(EquipmentType.LARGE_BAG, settlement, stored, needed);
+				return RatingScore.ZERO_RATING;
 			}
+				
+			var missionProbability = new RatingScore(1);
+			missionProbability.addModifier(DEMAND_PROBABILITY, settlement.getRegolithDemandCache() / VALUE);
+
+			// Job modifier.
+			missionProbability.addModifier(LEADER, getLeaderSuitability(person));
+
+			// If this town has a manufacturing objective, divided by bonus
+			missionProbability.addModifier(GOODS, Math.min(1,
+							settlement.getGoodsManager().getCommerceFactor(CommerceType.MANUFACTURING)/2));
+
+			// if introvert, score  0 to  50 --> -2 to 0
+			// if extrovert, score 50 to 100 -->  0 to 2
+			// Increase probability if extrovert
+			int extrovert = person.getExtrovertmodifier();
+			missionProbability.addModifier(PERSON_EXTROVERT, (1 + extrovert/2.0));
+			missionProbability.applyRange(0, LIMIT);
+			return missionProbability;
 		}
 
-		return missionProbability;
+		return RatingScore.ZERO_RATING;
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ConstructionMissionMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ConstructionMissionMeta.java
@@ -37,6 +37,8 @@ public class ConstructionMissionMeta extends AbstractMetaMission {
     ConstructionMissionMeta() {
     	super(MissionType.CONSTRUCTION, 10, LEADER_JOBS, WORKER_JOBS);
 		setMinimumMembers(3);
+		setPopulationRatio(30);
+		setPopulationThreshold(20);
     }
     
     @Override

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/DeliveryMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/DeliveryMeta.java
@@ -41,7 +41,7 @@ public class DeliveryMeta extends AbstractMetaMission {
     
     private static final int VALUE = 1;
 	/** Starting sol for this mission to commence. */
-	public static final int MIN_STARTING_SOL = 4;
+	private static final int MIN_STARTING_SOL = 4;
 	
     private static final double DIVISOR = 10;
 
@@ -53,6 +53,7 @@ public class DeliveryMeta extends AbstractMetaMission {
 		setPreferredRobots(Set.of(RobotType.DELIVERYBOT));
 		setPreferredVehicle(Set.of(VehicleType.DELIVERY_DRONE));
 		setPopulationRatio(6);
+		setSolThreshold(MIN_STARTING_SOL);
 	}
 
 	/**
@@ -76,10 +77,6 @@ public class DeliveryMeta extends AbstractMetaMission {
 		// Check if mission is possible for person based on their circumstance.
 		Settlement settlement = person.getAssociatedSettlement();
 
-    	if (!isTimeSuitable(MIN_STARTING_SOL)) {
-    		return RatingScore.ZERO_RATING;
-    	}
-		
 		RoleType roleType = person.getRole().getType();
 		if (RoleType.CHIEF_OF_SUPPLY_RESOURCE == roleType
 				|| RoleType.MISSION_SPECIALIST == roleType

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/DeliveryMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/DeliveryMeta.java
@@ -52,6 +52,7 @@ public class DeliveryMeta extends AbstractMetaMission {
 
 		setPreferredRobots(Set.of(RobotType.DELIVERYBOT));
 		setPreferredVehicle(Set.of(VehicleType.DELIVERY_DRONE));
+		setPopulationRatio(6);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMeta.java
@@ -37,7 +37,7 @@ public class ExplorationMeta extends AbstractMetaMission {
 			JobType.BOTANIST, JobType.CHEMIST, JobType.METEOROLOGIST, JobType.PILOT);	
 
 	/** Starting sol for this mission to commence. */
-	public static final int MIN_STARTING_SOL = 2;
+	private static final int MIN_STARTING_SOL = 2;
 
 	private static final double VALUE = 20D;
 
@@ -48,6 +48,7 @@ public class ExplorationMeta extends AbstractMetaMission {
 		
 		setPreferredVehicle(VehicleType.ROVER_TYPES);
 		setPopulationRatio(5);
+		setSolThreshold(MIN_STARTING_SOL);
 	}
 
 	
@@ -67,9 +68,6 @@ public class ExplorationMeta extends AbstractMetaMission {
 	@Override
 	public RatingScore getProbability(Person person) {
 
-    	if (!isTimeSuitable(MIN_STARTING_SOL)) {
-    		return RatingScore.ZERO_RATING;
-    	}
     	RatingScore missionProbability = RatingScore.ZERO_RATING;
 		Settlement settlement = person.getAssociatedSettlement();
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMeta.java
@@ -47,6 +47,7 @@ public class ExplorationMeta extends AbstractMetaMission {
 					PREFERRED_WORKER_JOBS);
 		
 		setPreferredVehicle(VehicleType.ROVER_TYPES);
+		setPopulationRatio(5);
 	}
 
 	

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/FieldStudyMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/FieldStudyMeta.java
@@ -47,6 +47,7 @@ public class FieldStudyMeta extends AbstractMetaMission {
 
 		setPreferredVehicle(Set.of(VehicleType.EXPLORER_ROVER));
 		setPopulationRatio(6);
+		setSolThreshold(2);
 	}
 
 	/**
@@ -61,8 +62,6 @@ public class FieldStudyMeta extends AbstractMetaMission {
 
 		// Check if mission is possible for person based on their circumstance.
 		Settlement settlement = person.getAssociatedSettlement();
-		
-		if (!isTimeSuitable(2)) return RatingScore.ZERO_RATING;
 		
 		RoleType roleType = person.getRole().getType();
 		JobType jobType = person.getMind().getJobType();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/FieldStudyMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/FieldStudyMeta.java
@@ -46,6 +46,7 @@ public class FieldStudyMeta extends AbstractMetaMission {
 		this.scienceType = scienceType;
 
 		setPreferredVehicle(Set.of(VehicleType.EXPLORER_ROVER));
+		setPopulationRatio(6);
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/MiningMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/MiningMeta.java
@@ -44,6 +44,7 @@ public class MiningMeta extends AbstractMetaMission {
     	super(MissionType.MINING, 6, PREFERRED_LEADER_JOBS, PREFERRED_WORKER_JOBS);
 
 		setPreferredVehicle(Set.of(VehicleType.CARGO_ROVER, VehicleType.EXPLORER_ROVER));
+		setPopulationRatio(8);
     }
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/MiningMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/MiningMeta.java
@@ -36,7 +36,7 @@ public class MiningMeta extends AbstractMetaMission {
 	private static final Set<JobType> PREFERRED_WORKER_JOBS = Set.of(JobType.AREOLOGIST, JobType.ASTRONOMER, JobType.PILOT);
 
 	/** Starting sol for this mission to commence. */
-	public static final int MIN_STARTING_SOL = 4;
+	private static final int MIN_STARTING_SOL = 4;
 	/** The multiplier factor. */
 	private static final double FACTOR = 5.0;
 	
@@ -45,6 +45,7 @@ public class MiningMeta extends AbstractMetaMission {
 
 		setPreferredVehicle(Set.of(VehicleType.CARGO_ROVER, VehicleType.EXPLORER_ROVER));
 		setPopulationRatio(8);
+		setSolThreshold(MIN_STARTING_SOL);
     }
 
 	/**
@@ -63,87 +64,83 @@ public class MiningMeta extends AbstractMetaMission {
     @Override
     public RatingScore getProbability(Person person) {
 
-    	if (!isTimeSuitable(MIN_STARTING_SOL)) {
+    	if (!person.isInSettlement()) {
     		return RatingScore.ZERO_RATING;
     	}
     	
 		RatingScore missionProbability = RatingScore.ZERO_RATING;
 
-        if (person.isInSettlement()) {
+		Settlement settlement = person.getSettlement();
+		
+		RoleType roleType = person.getRole().getType();
 
-        	Settlement settlement = person.getSettlement();
-    		
-            RoleType roleType = person.getRole().getType();
+		if (roleType.isCouncil()
+				|| RoleType.CHIEF_OF_SCIENCE == roleType
+				|| RoleType.CHIEF_OF_MISSION_PLANNING == roleType
+				|| RoleType.CHIEF_OF_SUPPLY_RESOURCE == roleType
+				|| RoleType.SCIENCE_SPECIALIST == roleType
+				|| RoleType.MISSION_SPECIALIST == roleType
+				|| RoleType.RESOURCE_SPECIALIST == roleType
+				) {
 
-            if (roleType.isCouncil()
-					|| RoleType.CHIEF_OF_SCIENCE == roleType
- 					|| RoleType.CHIEF_OF_MISSION_PLANNING == roleType
- 					|| RoleType.CHIEF_OF_SUPPLY_RESOURCE == roleType
- 		 			|| RoleType.SCIENCE_SPECIALIST == roleType
- 		 			|| RoleType.MISSION_SPECIALIST == roleType
- 					|| RoleType.RESOURCE_SPECIALIST == roleType
- 					) {
+			// Check if available light utility vehicles.
+			//boolean reservableLUV =
+			if (!Mining.isLUVAvailable(settlement))
+				return RatingScore.ZERO_RATING;
 
-	            // Check if available light utility vehicles.
-	            //boolean reservableLUV =
-	            if (!Mining.isLUVAvailable(settlement))
-	            	return RatingScore.ZERO_RATING;
-
-	            // Check if LUV attachment parts available.            
-	            if (!Mining.areAvailableAttachmentParts(settlement)) {
-	            	if (!settlement.getItemResourceIDs().contains(ItemResourceUtil.PNEUMATIC_DRILL_ID)) {
-	            		BuildingManager.injectPartDemand(ItemResourceUtil.findItemResource(ItemResourceUtil.PNEUMATIC_DRILL_ID),
-	            				settlement, 1);
-	    			}
-	    			if (!settlement.getItemResourceIDs().contains(ItemResourceUtil.BACKHOE_ID)) {
-	    				BuildingManager.injectPartDemand(ItemResourceUtil.findItemResource(ItemResourceUtil.BACKHOE_ID),
-	            				settlement, 1);
-	    			}
-    	
-	            	return RatingScore.ZERO_RATING;
-	            }
-
-	            // Check if there are enough bags at the settlement for collecting minerals.
-	        	int stored = settlement.findNumContainersOfType(EquipmentType.LARGE_BAG);
-	            int needed = Mining.NUMBER_OF_LARGE_BAGS;
-		        if (stored < needed) {
-	            	BuildingManager.injectEquipmentDemand(EquipmentType.LARGE_BAG, settlement, stored, needed);
-	            	return RatingScore.ZERO_RATING;
-	            }
-	            
-				missionProbability = new RatingScore(1D);
-	
-				// Get available rover.
-				var rover = (Rover)selectVehicle(settlement);
-
-				if (rover != null) {
-					// Find best mining site.
-					missionProbability.addModifier("miningmaturity",
-										Mining.getMatureMiningSitesTotalScore(rover, settlement) * FACTOR);
+			// Check if LUV attachment parts available.            
+			if (!Mining.areAvailableAttachmentParts(settlement)) {
+				if (!settlement.getItemResourceIDs().contains(ItemResourceUtil.PNEUMATIC_DRILL_ID)) {
+					BuildingManager.injectPartDemand(ItemResourceUtil.findItemResource(ItemResourceUtil.PNEUMATIC_DRILL_ID),
+							settlement, 1);
 				}
+				if (!settlement.getItemResourceIDs().contains(ItemResourceUtil.BACKHOE_ID)) {
+					BuildingManager.injectPartDemand(ItemResourceUtil.findItemResource(ItemResourceUtil.BACKHOE_ID),
+							settlement, 1);
+				}
+	
+				return RatingScore.ZERO_RATING;
+			}
 
-	            // Crowding modifier
-	            int crowding = settlement.getIndoorPeopleCount()
-	                    - settlement.getPopulationCapacity();
-	            if (crowding > 0) {
-	                missionProbability.addModifier(OVER_CROWDING, (crowding + 1));
-	            }
+			// Check if there are enough bags at the settlement for collecting minerals.
+			int stored = settlement.findNumContainersOfType(EquipmentType.LARGE_BAG);
+			int needed = Mining.NUMBER_OF_LARGE_BAGS;
+			if (stored < needed) {
+				BuildingManager.injectEquipmentDemand(EquipmentType.LARGE_BAG, settlement, stored, needed);
+				return RatingScore.ZERO_RATING;
+			}
+			
+			missionProbability = new RatingScore(1D);
 
-	            // Job modifier.
-				missionProbability.addModifier(LEADER, getLeaderSuitability(person));
-				missionProbability = applyCommerceAverage(missionProbability, settlement, CommerceType.TOURISM,
-													CommerceType.RESEARCH);
+			// Get available rover.
+			var rover = (Rover)selectVehicle(settlement);
+			if (rover != null) {
+				// Find best mining site.
+				missionProbability.addModifier("miningmaturity",
+									Mining.getMatureMiningSitesTotalScore(rover, settlement) * FACTOR);
+			}
+
+			// Crowding modifier
+			int crowding = settlement.getIndoorPeopleCount()
+					- settlement.getPopulationCapacity();
+			if (crowding > 0) {
+				missionProbability.addModifier(OVER_CROWDING, (crowding + 1));
+			}
+
+			// Job modifier.
+			missionProbability.addModifier(LEADER, getLeaderSuitability(person));
+			missionProbability = applyCommerceAverage(missionProbability, settlement, CommerceType.TOURISM,
+												CommerceType.RESEARCH);
 
 
-				// if introvert, score  0 to  50 --> -2 to 0
-				// if extrovert, score 50 to 100 -->  0 to 2
-				// Reduce probability if introvert
-				int extrovert = person.getExtrovertmodifier();
-				missionProbability.addModifier(PERSON_EXTROVERT, (1 + extrovert/2.0));
+			// if introvert, score  0 to  50 --> -2 to 0
+			// if extrovert, score 50 to 100 -->  0 to 2
+			// Reduce probability if introvert
+			int extrovert = person.getExtrovertmodifier();
+			missionProbability.addModifier(PERSON_EXTROVERT, (1 + extrovert/2.0));
 
-				missionProbability.applyRange(0, LIMIT);
- 			}
-        }
+			missionProbability.applyRange(0, LIMIT);
+		}
 
         return missionProbability;
     }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/TradeMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/TradeMeta.java
@@ -35,7 +35,7 @@ public class TradeMeta extends AbstractMetaMission {
 	private static final Set<JobType> WORKER_JOBS = Set.of(JobType.PILOT);
 
 	/** Starting sol for this mission to commence. */
-	public static final int MIN_STARTING_SOL = 4;
+	private static final int MIN_STARTING_SOL = 4;
 
 	public static final int MAX_MEMBERS = 3;
 
@@ -44,6 +44,7 @@ public class TradeMeta extends AbstractMetaMission {
 
 		setPreferredVehicle(Set.of(VehicleType.CARGO_ROVER));
 		setPopulationRatio(10);
+		setSolThreshold(MIN_STARTING_SOL);
 	}
 
 	/**
@@ -61,11 +62,6 @@ public class TradeMeta extends AbstractMetaMission {
 
 	@Override
 	public RatingScore getProbability(Person person) {
-
-    	if (!isTimeSuitable(MIN_STARTING_SOL)) {
-    		return RatingScore.ZERO_RATING;
-    	}
-
 		RatingScore missionProbability = RatingScore.ZERO_RATING;
 		Settlement settlement = person.getAssociatedSettlement();
 		// Check if person is in a settlement.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/TradeMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/TradeMeta.java
@@ -43,9 +43,9 @@ public class TradeMeta extends AbstractMetaMission {
 		super(MissionType.TRADE, MAX_MEMBERS, LEADER_JOBS, WORKER_JOBS);
 
 		setPreferredVehicle(Set.of(VehicleType.CARGO_ROVER));
+		setPopulationRatio(10);
 	}
 
-	
 	/**
 	 * Get the Vehicle comparator that is based on largest cargo
 	 */

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/TravelToSettlementMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/TravelToSettlementMeta.java
@@ -42,6 +42,7 @@ public class TravelToSettlementMeta extends AbstractMetaMission {
         setPreferredVehicle(Set.of(VehicleType.TRANSPORT_ROVER, VehicleType.EXPLORER_ROVER));
         setPopulationRatio(20);
         setPopulationThreshold(20);
+        setSolThreshold(EARLIEST_SOL_TRAVEL);
     }
     
 	/**
@@ -60,10 +61,6 @@ public class TravelToSettlementMeta extends AbstractMetaMission {
     @Override
     public RatingScore getProbability(Person person) {
 
-    	if (!isTimeSuitable(EARLIEST_SOL_TRAVEL)) {
-    		return RatingScore.ZERO_RATING;
-    	}
-    	
         RatingScore missionProbability = RatingScore.ZERO_RATING;
         if (person.isInSettlement()) {
             // Check if mission is possible for person based on their

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/TravelToSettlementMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/TravelToSettlementMeta.java
@@ -39,7 +39,9 @@ public class TravelToSettlementMeta extends AbstractMetaMission {
 	public TravelToSettlementMeta() {
     	super(MissionType.TRAVEL_TO_SETTLEMENT, 8, LEADER_JOBS, WORKER_JOBS);
 
-        setPreferredVehicle(VehicleType.ROVER_TYPES);
+        setPreferredVehicle(Set.of(VehicleType.TRANSPORT_ROVER, VehicleType.EXPLORER_ROVER));
+        setPopulationRatio(20);
+        setPopulationThreshold(20);
     }
     
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -77,9 +77,6 @@ import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.PhysicalCondition;
 import com.mars_sim.core.person.ai.job.util.JobType;
 import com.mars_sim.core.person.ai.job.util.JobUtil;
-import com.mars_sim.core.person.ai.mission.MissionLimitParameters;
-import com.mars_sim.core.person.ai.mission.MissionType;
-import com.mars_sim.core.person.ai.mission.MissionWeightParameters;
 import com.mars_sim.core.person.ai.role.RoleType;
 import com.mars_sim.core.person.ai.shift.ShiftManager;
 import com.mars_sim.core.person.ai.shift.ShiftPattern;
@@ -130,7 +127,6 @@ public class Settlement extends Unit implements Temporal,
 	/**
 	 * Shared preference key for Mission limits
 	 */
-	private static final int MAX_NUM_SOLS = 3;
 	private static final int RESOURCE_UPDATE_FREQ = 30;
 	private static final int RESOURCE_SAMPLING_FREQ = 50; // in msols
 	private static final int RESOURCE_STAT_SOLS = 12;
@@ -486,8 +482,6 @@ public class Settlement extends Unit implements Temporal,
 		
 		preferences.resetValues(sponsor.getPreferences());
 
-		// Do mission limits; all have a limit of 1 first
-		preferences.putValue(MissionLimitParameters.INSTANCE.getKey(MissionType.CONSTRUCTION), 1);
 		// Call weather to add this location
 		weather.addLocation(location);
 		// Construct the Exploration Manager.
@@ -1861,21 +1855,7 @@ public class Settlement extends Unit implements Temporal,
 			// Update the population factor
 			popFactor = Math.max(1, Math.log(Math.sqrt(numCitizens)));
 
-			// Update mission limit dependent upon population
-			setMissionLimit(MissionType.MINING, 0, 8);
-			setMissionLimit(MissionType.COLLECT_ICE, 1, 5);
-			setMissionLimit(MissionType.COLLECT_REGOLITH, 1, 5);
-			setMissionLimit(MissionType.EXPLORATION, 1, 5);
-			setMissionLimit(MissionType.AREOLOGY, 1, 6);
-			setMissionLimit(MissionType.BIOLOGY, 1, 6);
-			setMissionLimit(MissionType.METEOROLOGY, 1, 6);
-			setMissionLimit(MissionType.TRADE, 0, 10);
-			setMissionLimit(MissionType.TRAVEL_TO_SETTLEMENT, 0, 20);
-			setMissionLimit(MissionType.DELIVERY, 0, 6);
-
-			// Set total mission limit
-			int optimalMissions = Math.max(1, (numCitizens/5));
-			preferences.putValue(MissionLimitParameters.TOTAL_MISSIONS, optimalMissions);
+			missionControl.populationChanged();
 
 			// EVA capacity
 			int evaCapacity = (int)Math.ceil(numCitizens * EVA_PERCENTAGE);
@@ -1887,18 +1867,6 @@ public class Settlement extends Unit implements Temporal,
 			return true;
 		}
 		return false;
-	}
-
-	/**
-	 * Calculates the mission limit parameter based on the population and person ratio.
-	 * 
-	 * @param type Type of Mission to control
-	 * @param minMissions Minimum number of missions
-	 * @param personRatio Ratio of person to mission
-	 */
-	private void setMissionLimit(MissionType type, int minMissions, int personRatio) {
-		int optimalMissions = Math.max(minMissions, (numCitizens/personRatio));
-		preferences.putValue(MissionLimitParameters.INSTANCE.getKey(type), optimalMissions);
 	}
 
 	/**
@@ -2872,32 +2840,12 @@ public class Settlement extends Unit implements Temporal,
 		return waterConsumption.getAveragePerSol();
 	}
 
-	/**
-	 * Enables or disable a mission type.
-	 *  
-	 * @param mission
-	 * @param disable
-	 */
-	public void setMissionDisable(MissionType mission, boolean disable) {
-		preferences.putValue(MissionWeightParameters.INSTANCE.getKey(mission), (disable ? 0D : 1D));
-	}
-
 	public void setAllowTradeMissionFromASettlement(Settlement settlement, boolean allowed) {
 		allowTradeMissionSettlements.put(settlement.getIdentifier(), allowed);
 	}
 
 	public boolean isAllowedTradeMission(Settlement settlement) {
 		return allowTradeMissionSettlements.getOrDefault(settlement.getIdentifier(), Boolean.TRUE);
-	}
-
-	/**
-	 * Checks if the mission is enabled.
-	 *
-	 * @param mission the type of the mission calling this method
-	 * @return probability value
-	 */
-	public boolean isMissionEnable(MissionType mission) {
-		return preferences.getIntValue(MissionLimitParameters.INSTANCE.getKey(mission), 0) > 0;
 	}
 
 	/**

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mission/MetaMissionTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mission/MetaMissionTest.java
@@ -1,5 +1,6 @@
 package com.mars_sim.core.mission;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
@@ -47,4 +48,34 @@ class MetaMissionTest extends MarsSimUnitTest {
 
         assertTrue(slScore > lScore, "Leader suitability score for super leader should be higher than leader");
     }
+
+    @Test
+    @DisplayName("Test max missions increase with population growth")
+    void testMaxMissionsByPopulationGrowth() {
+        int populationThreshold = 4;
+        int populationRatio = 3;
+        var settlement = buildSettlement("test");
+
+        var meta = new MockMetaMission(2, 3, Set.of(JobType.TRADER), Set.of(JobType.PILOT),
+                        populationRatio, populationThreshold);
+
+        int personCounter = 1;
+        while (settlement.getNumCitizens() < (populationThreshold + 1)) {
+            buildPerson("citizen-" + personCounter++, settlement);
+        }
+
+        int citizens = settlement.getNumCitizens();
+        assertTrue(citizens > populationThreshold, "Settlement population should be over the threshold");
+        assertEquals(1, meta.getMaxMissions(citizens),
+                        "One Person over threshold should allow one concurrent missions");
+
+        for (int expectedMissions = 2; expectedMissions <= 3; expectedMissions++) {
+            for (int i = 0; i < populationRatio; i++) {
+                buildPerson("citizen-" + personCounter++, settlement);
+            }
+            assertEquals(expectedMissions, meta.getMaxMissions(settlement.getNumCitizens()),
+                            "Max missions should increase after each additional population ratio block");
+        }
+    }
+
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mission/MissionControlTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mission/MissionControlTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.mars_sim.core.TestEntityListener;
@@ -19,11 +20,14 @@ import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.map.location.LocalPosition;
 import com.mars_sim.core.person.ai.job.util.JobType;
 import com.mars_sim.core.person.ai.mission.CollectIce;
+import com.mars_sim.core.person.ai.mission.MissionLimitParameters;
 import com.mars_sim.core.person.ai.mission.MissionPlanning;
 import com.mars_sim.core.person.ai.mission.MissionType;
 import com.mars_sim.core.person.ai.mission.PlanType;
+import com.mars_sim.core.person.ai.mission.meta.MetaMissionUtil;
 import com.mars_sim.core.person.ai.role.RoleType;
 import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.test.MarsSimUnitTest;
 
 class MissionControlTest extends MarsSimUnitTest{
@@ -185,18 +189,43 @@ class MissionControlTest extends MarsSimUnitTest{
         clock.setMarsTime(clock.getMarsTime().addTime(4000));
 
         var mission = missionControl.getNewMission(leader);
-        assertNull(mission, "Mission should be created");
+        assertNull(mission, "Mission should not be created");
 
         var tm = leader.getMind().getTaskManager();
         assertTrue(tm.getMissionProbCache().isEmpty(), "Mission probability cache should be empty after mission creation");
         assertNull(tm.getSelectedMission(), "Selected mission should be set after mission creation");
     }
 
+    @DisplayName("Test ice collection mission can be created when mission is disabled")
     @Test
-    void testIceMissionCreated() {
-        var settlement = buildSettlement("Test", true, 5);
-        var missionControl = new MissionControl(settlement);
+    void testIceMissionDisabled() {
+        var settlement = buildIcePreRequisites();
         var leader = buildPerson("Leader", settlement, RoleType.MISSION_SPECIALIST, JobType.PILOT);
+    
+        // Advance 4 sols into the simulation
+        var clock = getSim().getMasterClock();
+        clock.setMarsTime(clock.getMarsTime().addTime(4000));
+        
+        // Disable ice collection mission
+        var missionControl = new MissionControl(settlement);
+        missionControl.setMissionDisable(MissionType.COLLECT_ICE, true);
+        var mission = missionControl.getNewMission(leader);
+        assertNull(mission, "No ice mission possible");
+
+        // Enable ice collection mission
+        missionControl.setMissionDisable(MissionType.COLLECT_ICE, false);
+        mission = missionControl.getNewMission(leader);
+        assertNotNull(mission, "Mission should be created");
+        assertEquals(MissionType.COLLECT_ICE, mission.getMissionType(), "Mission type created");
+
+        var tm = leader.getMind().getTaskManager();
+        assertEquals(1, tm.getMissionProbCache().size(), "Mission probability cache should be empty after mission creation");
+        assertEquals(MissionType.COLLECT_ICE, tm.getSelectedMission().getMeta().getType(), "Selected mission should be set after mission creation");
+    }
+
+    
+    private Settlement buildIcePreRequisites() {
+        var settlement = buildSettlement("Test", true, 5);
 
         // Add workers
         for(var p = 0; p < 4; p++) {
@@ -219,19 +248,28 @@ class MissionControlTest extends MarsSimUnitTest{
                                                 ResourceUtil.FOOD_ID, 100D,
                                                 r.getFuelTypeID(), 100D,
                                                 ResourceUtil.WATER_ID, 100D);
-        loadSettlementAmounts(settlement, resources);
-
-        // Advance 4 sols into the simulation
-        var clock = getSim().getMasterClock();
-        clock.setMarsTime(clock.getMarsTime().addTime(4000));
+        loadSettlementAmounts(settlement, resources);  
         
-        // Disable ice collection mission
-        missionControl.setMissionDisable(MissionType.COLLECT_ICE, true);
+        return settlement;
+    }
+
+    @DisplayName("Test ice collection mission can be created when mission sol is advance")
+    @Test
+    void testIceMissionSolBased() {
+        var settlement = buildIcePreRequisites();
+        var leader = buildPerson("Leader", settlement, RoleType.MISSION_SPECIALIST, JobType.PILOT);
+    
+        // Test on the first sol and should fail
+        var missionControl = new MissionControl(settlement);
         var mission = missionControl.getNewMission(leader);
-        assertNull(mission, "No ice mission possible");
+        assertNull(mission, "Mission should not be created");
+
+        // Advance sol pass threshold
+        var meta = MetaMissionUtil.getMetaMission(MissionType.COLLECT_ICE);
+        var clock = getSim().getMasterClock();
+        clock.setMarsTime(clock.getMarsTime().addTime(meta.getSolThreshold() * 1000D));
 
         // Enable ice collection mission
-        missionControl.setMissionDisable(MissionType.COLLECT_ICE, false);
         mission = missionControl.getNewMission(leader);
         assertNotNull(mission, "Mission should be created");
         assertEquals(MissionType.COLLECT_ICE, mission.getMissionType(), "Mission type created");
@@ -239,6 +277,26 @@ class MissionControlTest extends MarsSimUnitTest{
         var tm = leader.getMind().getTaskManager();
         assertEquals(1, tm.getMissionProbCache().size(), "Mission probability cache should be empty after mission creation");
         assertEquals(MissionType.COLLECT_ICE, tm.getSelectedMission().getMeta().getType(), "Selected mission should be set after mission creation");
+    }
+
+    @DisplayName("Test ice collection mission can be created when sol check is disabled")
+    @Test
+    void testIceMissionNoSolCheck() {
+        var settlement = buildIcePreRequisites();
+        var leader = buildPerson("Leader", settlement, RoleType.MISSION_SPECIALIST, JobType.PILOT);
+    
+        // Test on the first sol and should fail
+        var missionControl = new MissionControl(settlement);
+        var mission = missionControl.getNewMission(leader);
+        assertNull(mission, "Mission should not be created");
+
+        // Disable sol check for ice collection mission
+        settlement.getPreferences().putValue(MissionLimitParameters.MISSION_CHECK_SOL, false);
+
+        // Enable ice collection mission
+        mission = missionControl.getNewMission(leader);
+        assertNotNull(mission, "Mission should be created");
+        assertEquals(MissionType.COLLECT_ICE, mission.getMissionType(), "Mission type created");
     }
 }
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mission/MissionControlTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mission/MissionControlTest.java
@@ -226,12 +226,12 @@ class MissionControlTest extends MarsSimUnitTest{
         clock.setMarsTime(clock.getMarsTime().addTime(4000));
         
         // Disable ice collection mission
-        settlement.setMissionDisable(MissionType.COLLECT_ICE, true);
+        missionControl.setMissionDisable(MissionType.COLLECT_ICE, true);
         var mission = missionControl.getNewMission(leader);
         assertNull(mission, "No ice mission possible");
 
         // Enable ice collection mission
-        settlement.setMissionDisable(MissionType.COLLECT_ICE, false);
+        missionControl.setMissionDisable(MissionType.COLLECT_ICE, false);
         mission = missionControl.getNewMission(leader);
         assertNotNull(mission, "Mission should be created");
         assertEquals(MissionType.COLLECT_ICE, mission.getMissionType(), "Mission type created");

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mission/MockMetaMission.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mission/MockMetaMission.java
@@ -14,6 +14,13 @@ class MockMetaMission extends AbstractMetaMission {
         setMinimumMembers(minMembers);
     }
 
+    MockMetaMission(int minMembers, int maxMembers, Set<JobType> leaderJobs, Set<JobType> workerJobs,
+                    int populationRatio, int populationThreshold) {
+        this(minMembers, maxMembers, leaderJobs, workerJobs);
+        setPopulationRatio(populationRatio);
+        setPopulationThreshold(populationThreshold);
+    }
+
     @Override
     public Mission constructInstance(Person person, boolean needsReview) {
         return null;

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/commander/CommanderWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/commander/CommanderWindow.java
@@ -1286,7 +1286,7 @@ public class CommanderWindow extends ContentPanel {
 		r1 = new JRadioButton(CANNOT_INITIATE);
 
 		// Set up initial conditions
-		if (settlement.isMissionEnable(MissionType.TRADE)) {
+		if (settlement.getMissionControl().isMissionEnable(MissionType.TRADE)) {
 			r0.setSelected(true);
 			r1.setSelected(false);
 		}
@@ -1387,10 +1387,10 @@ public class CommanderWindow extends ContentPanel {
 
 	        if (button == r0) {
 				logger.config("r0 selected");
-	        	settlement.setMissionDisable(MissionType.TRADE, false);
+	        	settlement.getMissionControl().setMissionDisable(MissionType.TRADE, false);
 	        } else if (button == r1) {
 	        	logger.config("r1 selected");
-	        	settlement.setMissionDisable(MissionType.TRADE, true);
+	        	settlement.getMissionControl().setMissionDisable(MissionType.TRADE, true);
 	        } else if (button == r2) {
 	        	logger.config("r2 selected");
 		        disableAllCheckedSettlement();


### PR DESCRIPTION
This PR moves the control of any Preferences relating to Missions under the Mission Control class. 
In particular a new Preference is added that allows the user to disable the Sol threshold for creating missions. This is useful for testing o running an accelerated simulation.

To support this, MetaMission now holds the minimum sol threshold for each mission as a explicit property. It is no longer embedded in the probability calculations. The new property is used by the mission control when searching for new missions.

The meta mission is also responsible for calculating how many concurrent missions a population count can support via the getMaxMissions method. This uses a combination of a population threshold, min people before mission can be created, and a population ratio, govern additional missions.

This is part of #1986
