### PR TITLE
fix(ui): Stop NPE during MonitorWindow construction

### DIFF
--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorWindow.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/MonitorWindow.java
@@ -98,6 +98,7 @@ public class MonitorWindow extends ContentPanel
 	private MonitorTab activeTab;
 
 	private UIContext context;
+	private boolean listenersActive = false;  // Must be false until window fully constructed
 
 	private SettlementsSelector settlementSelector;
 
@@ -167,6 +168,10 @@ public class MonitorWindow extends ContentPanel
 
 		// List for changes in the settlement selection
 		settlementSelector.setSelectionListener("selectionChanged", e -> changeSelection());
+
+		// Now that the window is fully constructed, activate the listeners
+		getSelectedTab().getModel().enableListeners(true);
+		listenersActive = true;
 	}
 
 	/**
@@ -363,7 +368,7 @@ public class MonitorWindow extends ContentPanel
 			previousModel.removeTableModelListener(this);
 		}
 		if (activiateListeners) {
-			tabTableModel.enableListeners(true);
+			tabTableModel.enableListeners(listenersActive);
 		}
 
 		// Listener for row changes


### PR DESCRIPTION
The problem is random but appears to be a result of an EntityEvent arriving during the contructor which break the sorting.

The answer is to defer the activation of the listeners until after the window is fully constructed.