### PR TITLE
feat(ui): Use the Base model pattern in Wizards

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/EntityEventType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/EntityEventType.java
@@ -58,9 +58,6 @@ public class EntityEventType {
 
 	// For Cooking and PreparingDessert
 	public static final String FOOD_EVENT = "food event";
-	
-	// For work shift change
-	public static final String SHIFT_EVENT = "shift event";
 
 	// For Mind
 	public static final String JOB_EVENT = "job event";

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentType.java
@@ -37,7 +37,7 @@ public enum EquipmentType implements Named {
 	}
 
 	/**
-	 * Get the unique resoruce id for this EwquipmentType.
+	 * Get the unique resource id for this EquipmentType.
 	 * The resource id is used to reference the EquipmentType in the Inventory.
 	 */
 	public int getResourceID() {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentType.java
@@ -37,6 +37,14 @@ public enum EquipmentType implements Named {
 	}
 
 	/**
+	 * Get the unique resoruce id for this EwquipmentType.
+	 * The resource id is used to reference the EquipmentType in the Inventory.
+	 */
+	public int getResourceID() {
+		return this.ordinal() + ResourceType.FIRST_EQUIPMENT_RESOURCE_ID;
+	}
+
+	/**
 	 * Obtains the type id (not the ordinal id) of the equipment.
 	 * 
 	 * @param name
@@ -88,6 +96,6 @@ public enum EquipmentType implements Named {
 	 * @return
 	 */
 	public static int getResourceID(EquipmentType type) {
-		return type.ordinal() + ResourceType.FIRST_EQUIPMENT_RESOURCE_ID;
+		return type.getResourceID();
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
@@ -693,7 +693,7 @@ public class Person extends AbstractMobileUnit implements Worker, Temporal, Unit
 		if (value) {
 			// Set work shift to OFF
 			if (shiftSlot != null)
-				shiftSlot.getShift().leaveShift();
+				shiftSlot.resignShift();
 	
 			// Relinquish his role
 			var roleType = role.getType();
@@ -724,7 +724,7 @@ public class Person extends AbstractMobileUnit implements Worker, Temporal, Unit
 		
 		// Set work shift to OFF
 		if (shiftSlot != null)
-			shiftSlot.getShift().leaveShift();
+			shiftSlot.resignShift();
 
 		// Relinquish his role
 		var roleType = role.getType();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/shift/Shift.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/shift/Shift.java
@@ -7,6 +7,9 @@
 package com.mars_sim.core.person.ai.shift;
 
 
+import java.util.HashSet;
+import java.util.Set;
+
 import com.mars_sim.core.events.ScheduledEventHandler;
 import com.mars_sim.core.time.MarsTime;
 
@@ -22,7 +25,7 @@ public class Shift implements ScheduledEventHandler {
     private String name;
     private boolean onDuty = false;
     private int targetPercentage;
-    private int members = 0;
+    private Set<ShiftSlot> members = new HashSet<>();
 
     /**
      * Creates an active Shift defined by a shared specification.
@@ -86,21 +89,21 @@ public class Shift implements ScheduledEventHandler {
     }
 
     public int getSlotNumber() {
-        return members;
+        return members.size();
     }
     
     /**
      * Increases how many shots have been allocated to the shift.
      */
-    void joinShift() {
-        members++;
+    void joinShift(ShiftSlot slot) {
+        members.add(slot);
     }
 
     /**
      * Leaves the shift.
      */
-    public void leaveShift() {
-        members--;
+    public void leaveShift(ShiftSlot slot) {
+        members.remove(slot);
     }
 
     /**
@@ -131,6 +134,9 @@ public class Shift implements ScheduledEventHandler {
     public int execute(MarsTime now) {
         // Flip the on duty flag
         onDuty = !onDuty;
+
+        // Tell members
+        members.forEach(slot -> slot.shiftChange());
 
         int duration = 0;
         if (onDuty) {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/shift/ShiftSlot.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/shift/ShiftSlot.java
@@ -73,7 +73,7 @@ public class ShiftSlot implements ScheduledEventHandler {
       	}
       	
         else {
-        	shift.joinShift();
+        	shift.joinShift(this);
         }
     }
 
@@ -112,6 +112,8 @@ public class ShiftSlot implements ScheduledEventHandler {
     	
         boolean origOnCall = onCall;
         onCall = newOnCall;
+        worker.fireUnitUpdate(SHIFT_EVENT);
+
         return origOnCall;
     }
 
@@ -122,6 +124,8 @@ public class ShiftSlot implements ScheduledEventHandler {
      */
     public void setOnLeave(int duration) {
         onLeave = true;
+        worker.fireUnitUpdate(SHIFT_EVENT);
+
 
         // Scheduled end of leave
         worker.getAssociatedSettlement().getFutureManager().addEvent(duration, this);
@@ -159,9 +163,9 @@ public class ShiftSlot implements ScheduledEventHandler {
      	if (isGuest)
     		return;
     	
-        shift.leaveShift();
+        shift.leaveShift(this);
         shift = newShift;
-        shift.joinShift();
+        shift.joinShift(this);
 
         worker.fireUnitUpdate(SHIFT_EVENT);
     }
@@ -179,6 +183,7 @@ public class ShiftSlot implements ScheduledEventHandler {
     @Override
     public int execute(MarsTime now) {
         onLeave = false;
+        worker.fireUnitUpdate(SHIFT_EVENT);
         return 0;
     }
 
@@ -189,5 +194,21 @@ public class ShiftSlot implements ScheduledEventHandler {
      */
     public String getStatusDescription() {
         return shift.getName() + SEPARATOR + getStatus().getName();
+    }
+
+    /**
+     * The shift has changed. If direct on shift, i.e. not on call or leave then fire an event.
+     */
+    void shiftChange() {
+        if (!onCall && !onLeave) {
+            worker.fireUnitUpdate(SHIFT_EVENT);
+        }
+    }
+
+    /**
+     * Resigns from the current shift and do not join another.
+     */
+    public void resignShift() {
+        shift.leaveShift(this);
     }
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/structure/ShiftManagerTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/structure/ShiftManagerTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import com.mars_sim.core.test.MarsSimUnitTest;
+import com.mars_sim.core.TestEntityListener;
 import com.mars_sim.core.events.ScheduledEventManager;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.shift.Shift;
@@ -31,7 +32,7 @@ import com.mars_sim.core.time.MarsTime;
 /**
  * Test the internals of the ShiftMansger
  */
-public class ShiftManagerTest extends MarsSimUnitTest {
+class ShiftManagerTest extends MarsSimUnitTest {
 
 	private ShiftManager buildManager(Settlement owner, int [] endTimes, int [] allocations) {
         List<ShiftSpec> specs = new ArrayList<>();
@@ -181,11 +182,13 @@ public class ShiftManagerTest extends MarsSimUnitTest {
      * Checks that the OnDuty override flag works.
      */
     @Test
-    public void testOnCal() {
+    void testOnCal() {
         Settlement settlement = buildSettlement("mock");
         ScheduledEventManager futures = settlement.getFutureManager();
 
         Person worker = buildPerson("OnCall Worker", settlement);
+        var listener = new TestEntityListener(ShiftSlot.SHIFT_EVENT);
+        worker.addEntityListener(listener);
 
         int [] endTimes = {500, 1000};
         int [] allocations = {40, 20};
@@ -197,18 +200,23 @@ public class ShiftManagerTest extends MarsSimUnitTest {
 
         // Shift on duty standard
         testWorkStatus(futures, slot, shiftEnd, "Standard worker", WorkStatus.ON_DUTY, WorkStatus.OFF_DUTY);
+        assertEquals(2, listener.getEventsReceived(), "Events when person comes on/off shift");
 
         // Check OnCall
         slot.setOnCall(true);
+        assertEquals(3, listener.getEventsReceived(), "OnCall event fired");
         testWorkStatus(futures, slot, shiftEnd, "On-Call worker", WorkStatus.ON_CALL, WorkStatus.ON_CALL);
 
         // Check OnLeave & OnCall. On Call takes precedence
         slot.setOnLeave(1000);
+        assertEquals(4, listener.getEventsReceived(), "OnLeave event fired");
         testWorkStatus(futures, slot, shiftEnd, "On-Call & On-Leave worker", WorkStatus.ON_CALL, WorkStatus.ON_CALL);
 
         // Check OnLeave 
         slot.setOnCall(false);
+        assertEquals(5, listener.getEventsReceived(), "Off OnCall event fired");
         testWorkStatus(futures, slot, shiftEnd, "On-Leave worker", WorkStatus.ON_LEAVE, WorkStatus.ON_LEAVE);
+        assertEquals(5, listener.getEventsReceived(), "Still on leave so no events");
     }
 
     /**

--- a/mars-sim-tools/src/main/resources/help/version_history.html
+++ b/mars-sim-tools/src/main/resources/help/version_history.html
@@ -13,17 +13,30 @@
 
   <H4>A. CORE ENGINE IMPROVEMENTS :</H4>
   <OL>
-    <LI></LI>	
+    <LI>Metric manager provides a consistent and centralised means to record large volumes of metrics from the simulation.</LI>
+    <LI>Mission creation and management improvements. Meta Missions define the parameters of the associated missions.</LI>
+    <LI>Mission control logic is now localised to the parent Settlement instead of being global.</LI>
+    <LI>Person & Robot absolute values, e.g. health, energy, now have a levels system overlaid. This supports internationalisation and significantly reduces the volume of events.</LI>
+    <LI>Upgrade to JDK25.</LI>
+    <LI>Refactor the Colony classes and move configurations to a dedicated XML file.</LI>
+    <LI>Provide a single means to identify the type of a Resource ID.</LI>
+    <LI>Make Rating an interface to promote safe/unmodified sharing.</LI>
+    <LI>The type and number of Robots is defined in the Supplies Manifest instead of explicitly in the ResupplyMission. This provides a consistent approach.</LI>
   </OL>
     
   <H4>B. UI IMPROVEMENT :</H4>
   <OL>
-    <LI></LI>
+    <LI>Displaying of collection of Entities is now based on a common table pattern that dynamically update.</LI>
+    <LI>In the Settlement map, hatches are rendered differently according to the material of the 2 adjacent buildings.</LI>
+    <LI>Metric viewer now available in the UI.</LI>
+    <LI>Beta: Add desktop notification for Events when the main window is in closed state.</LI>
+    <LI>Improve filtering on the Event Viewer.</LI>
   </OL>  
   
   <H4>C. FIXES :</H4>
   <OL>
-    <LI></LI>
+    <LI>Fix Food table in Monitor Window not dynamically updating.</LI>
+    <LI>Fix race condition when EntityPanel can fail if an EntityEvent is delivered during the construction.</LI>
   </OL>
 <br>
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/BotsPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/BotsPanel.java
@@ -6,14 +6,11 @@
  */
 package com.mars_sim.ui.swing.tool.missionwizard;
 
-import java.util.Comparator;
 import java.util.List;
 
-import com.mars_sim.core.person.ai.mission.Mission;
 import com.mars_sim.core.robot.Robot;
-import com.mars_sim.core.tool.Msg;
-import com.mars_sim.ui.swing.components.ColumnSpec;
-import com.mars_sim.ui.swing.utils.wizard.AbstractWizardItemModel;
+import com.mars_sim.ui.swing.utils.model.BaseRobotModel;
+import com.mars_sim.ui.swing.utils.wizard.WizardItemModel;
 import com.mars_sim.ui.swing.utils.wizard.WizardItemStep;
 
 /**
@@ -57,56 +54,39 @@ class BotsPanel extends WizardItemStep<MissionDataBean, Robot>
 	/**
 	 * Table model for people.
 	 */
-	private static class RobotTableModel extends AbstractWizardItemModel<Robot> {
+	private static class RobotTableModel extends BaseRobotModel
+				implements WizardItemModel<Robot> {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
 
-		private static final List<ColumnSpec> COLUMNS = List.of(
-				new ColumnSpec(Msg.getString("entity.name"), String.class),
-				new ColumnSpec(Msg.getString("robot.type"), String.class),
-				new ColumnSpec(Msg.getString("mission.singular"), String.class),
-				new ColumnSpec(Msg.getString("robot.performance"), Double.class, ColumnSpec.STYLE_PERCENTAGE)
-		);
-
 		/** Constructor. */
 		private RobotTableModel(MissionDataBean state) {
-			super(COLUMNS);
+			super(NAME, TYPE, MISSION, PERFORMANCE);
 
-			List<Robot> robots = state.getStartingSettlement().getAllAssociatedRobots().stream()
-					.sorted(Comparator.comparing(Robot::getName))
-					.toList();
-			setItems(robots);
+			var robots = state.getStartingSettlement().getAllAssociatedRobots();
+			setEntities(robots);
+			enableListeners(true);
+		}
+
+		@Override
+		public Robot getItem(int row) {
+			return (Robot) getAssociatedEntity(row);
 		}
 
 		/**
 		 * Failure is if the Person is already assigned to a mission.
 		 */
 		@Override
-		protected String isFailureCell(Robot item, int column) {
-			return (column == 3 && item.getBotMind().getMission() != null) ? MissionCreate.ALREADY_ON_MISSION : null;
-		}
-
-		/**
-		 * Gets the value for the cell at columnIndex and rowIndex.
-		 * 
-		 * @param item the item.
-		 * @param column the column index.
-		 * @return Rendered values
-		 */
-		@Override
-		protected Object getItemValue(Robot item, int column) {
-			return switch (column) {
-				case 0 -> item.getName();
-				case 1 -> item.getRobotType().getName();
-				case 2 -> {
-					Mission mission = item.getBotMind().getMission();
-					if (mission != null) yield mission.getName();
-					else yield null;
+		public String isFailureCell(int row, int column) {
+			var colSpec = getColumnSpec(column);
+			if (colSpec.equals(MISSION.column())) {
+				var item = getItem(row);
+				if (item.getMission() != null) {
+					return MissionCreate.ALREADY_ON_MISSION;
 				}
-				case 3 -> item.getPerformanceRating() * 100D;
-				default -> null;
-			}; 
+			}
+			return null;
 		}
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/ConstructionPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/ConstructionPanel.java
@@ -7,13 +7,11 @@
 
 package com.mars_sim.ui.swing.tool.missionwizard;
 
-import java.util.Comparator;
 import java.util.List;
 
 import com.mars_sim.core.building.construction.ConstructionSite;
-import com.mars_sim.core.tool.Msg;
-import com.mars_sim.ui.swing.components.ColumnSpec;
-import com.mars_sim.ui.swing.utils.wizard.AbstractWizardItemModel;
+import com.mars_sim.ui.swing.utils.model.BaseConstructionSiteModel;
+import com.mars_sim.ui.swing.utils.wizard.WizardItemModel;
 import com.mars_sim.ui.swing.utils.wizard.WizardItemStep;
 /**
  * A wizard panel for selecting settlers.
@@ -55,58 +53,39 @@ class ConstructionPanel extends WizardItemStep<MissionDataBean, ConstructionSite
 	/**
 	 * Table model for sites.
 	 */
-	private static class SiteTableModel extends AbstractWizardItemModel<ConstructionSite> {
+	private static class SiteTableModel extends BaseConstructionSiteModel
+				implements WizardItemModel<ConstructionSite> {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
 
-		private static final List<ColumnSpec> COLUMNS = List.of(
-				new ColumnSpec(Msg.getString("entity.name"), String.class),
-				new ColumnSpec(Msg.getString("building.singular"), String.class),
-				new ColumnSpec(Msg.getString("constructionsite.stage"), String.class),
-				new ColumnSpec(Msg.getString("mission.singular"), String.class)
-		);
-
 		/** Constructor. */
 		private SiteTableModel(MissionDataBean state) {
-			super(COLUMNS);
+			super(NAME, BUILDING, STAGE, MISSION);
 
-			List<ConstructionSite> people = state.getStartingSettlement().getConstructionManager().getConstructionSites().stream()
-					.sorted(Comparator.comparing(ConstructionSite::getName))
-					.toList();
-			setItems(people);
+			List<ConstructionSite> people = state.getStartingSettlement().getConstructionManager().getConstructionSites();
+			setEntities(people);
+			enableListeners(true);
+		}
+
+		@Override
+		public ConstructionSite getItem(int row) {
+			return (ConstructionSite) getAssociatedEntity(row);
 		}
 
 		/**
 		 * Failure is if the Person is already assigned to a mission.
 		 */
 		@Override
-		protected String isFailureCell(ConstructionSite item, int column) {
-			return switch (column) {
-				case 3 -> item.getWorkOnSite() != null ? MissionCreate.ALREADY_ON_MISSION : null;
-				default -> null;
-			};
-		}
-
-		/**
-		 * Gets the value for the cell at columnIndex and rowIndex.
-		 * 
-		 * @param item the item.
-		 * @param column the column index.
-		 * @return Rendered values
-		 */
-		@Override
-		protected Object getItemValue(ConstructionSite item, int column) {
-			return switch (column) {
-				case 0 -> item.getName();
-				case 1 -> item.getBuildingName();
-				case 2 -> item.getDescription();
-				case 3 -> {
-					var onSite = item.getWorkOnSite();
-					yield onSite != null ? onSite.getName() : null;
+		public String isFailureCell(int row, int column) {
+			var colSpec = getColumnSpec(column);
+			if (colSpec.equals(MISSION.column())) {
+				var item = getItem(row);
+				if (item.getWorkOnSite() != null) {
+					return MissionCreate.ALREADY_ON_MISSION;
 				}
-				default -> null;
-			}; 
+			}
+			return null;
 		}
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/DestinationSettlementPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/DestinationSettlementPanel.java
@@ -53,7 +53,7 @@ class DestinationSettlementPanel extends WizardItemStep<MissionDataBean,Settleme
 	}
 	
 	/**
-	 * A table model for settlements base on tehBaseSettlementModel.
+	 * A table model for settlements based on the BaseSettlementModel.
 	 */
     private static class SettlementTableModel extends BaseSettlementModel
 				implements WizardItemModel<Settlement> {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/DestinationSettlementPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/DestinationSettlementPanel.java
@@ -7,15 +7,14 @@
 
 package com.mars_sim.ui.swing.tool.missionwizard;
 
-import java.util.Comparator;
 import java.util.List;
 
 import com.mars_sim.core.Simulation;
 import com.mars_sim.core.structure.Settlement;
-import com.mars_sim.core.tool.Msg;
 import com.mars_sim.core.vehicle.Vehicle;
 import com.mars_sim.ui.swing.components.ColumnSpec;
-import com.mars_sim.ui.swing.utils.wizard.AbstractWizardItemModel;
+import com.mars_sim.ui.swing.utils.model.BaseSettlementModel;
+import com.mars_sim.ui.swing.utils.wizard.WizardItemModel;
 import com.mars_sim.ui.swing.utils.wizard.WizardItemStep;
 
 /**
@@ -54,53 +53,54 @@ class DestinationSettlementPanel extends WizardItemStep<MissionDataBean,Settleme
 	}
 	
 	/**
-	 * A table model for settlements.
+	 * A table model for settlements base on tehBaseSettlementModel.
 	 */
-    private static class SettlementTableModel extends AbstractWizardItemModel<Settlement> {
+    private static class SettlementTableModel extends BaseSettlementModel
+				implements WizardItemModel<Settlement> {
     	
     	/** default serial id. */
     	private static final long serialVersionUID = 1L;
-		private static final List<ColumnSpec> COLUMNS = List.of(
-				new ColumnSpec(Msg.getString("entity.name"), String.class),
-				new ColumnSpec("Distance (km)", Double.class, ColumnSpec.STYLE_DIGIT1),
-				new ColumnSpec(Msg.getString("settlement.population"), Integer.class),
-				new ColumnSpec("Pop. Capacity", Integer.class)
-		);
+
+		private static final int RANGE_VAL = 1001;
+		private static final EntityColumnSpec RANGE = new EntityColumnSpec(new ColumnSpec(RANGE_VAL, "Distance (km)", Double.class, ColumnSpec.STYLE_DIGIT1), null);
+		private static final int CAP_VAL = 1002;
+		private static final EntityColumnSpec POP_CAPACITY = new EntityColumnSpec(new ColumnSpec(CAP_VAL, "Pop. Capacity", Integer.class), null);
+
 		private MissionDataBean state;
 
     	/**
     	 * hidden constructor.
     	 */
     	private SettlementTableModel(MissionDataBean state) {
-    		super(COLUMNS);
+    		super(NAME, RANGE, POPULATION, POP_CAPACITY);
 
 			var baseSettlement = state.getStartingSettlement();
 			this.state = state;
 
 			var options = Simulation.instance().getUnitManager().getSettlements().stream()
 					.filter(s -> !s.equals(baseSettlement))
-					.sorted(Comparator.comparing(Settlement::getName))
 					.toList();
-			setItems(options);
+			setEntities(options);
+
+			enableListeners(true);
     	}
     	
 
 		@Override
-		protected Object getItemValue(Settlement settlement, int column) {
-			return switch(column) {
-				case 0 -> settlement.getName();
-				case 1 -> state.getStartingSettlement().getCoordinates().getDistance(settlement.getCoordinates());
-				case 2 -> settlement.getIndoorPeopleCount();
-				case 3 -> settlement.getPopulationCapacity();
-				default -> null;
+		protected Object getEntityValue(Settlement settlement, int columnVal) {
+			return switch(columnVal) {
+				case RANGE_VAL -> state.getStartingSettlement().getCoordinates().getDistance(settlement.getCoordinates());
+				case CAP_VAL -> settlement.getPopulationCapacity();
+				default -> super.getEntityValue(settlement, columnVal);
 			};
         }
     	
-
 		@Override
-		protected String isFailureCell(Settlement settlement, int column) {    		
-    		if (column == 1) {
+		public String isFailureCell(int row, int column) {
+			var colSpec = getColumnSpec(column);
+			if (colSpec.equals(RANGE.column())) {		
 				Settlement startingSettlement = state.getStartingSettlement();
+				var settlement = getItem(row);
 				double distance = startingSettlement.getCoordinates().getDistance(settlement.getCoordinates());
 				Vehicle v = state.getRover();
 				if (v == null) {
@@ -112,5 +112,10 @@ class DestinationSettlementPanel extends WizardItemStep<MissionDataBean,Settleme
     		
     		return null;
     	}
+
+		@Override
+		public Settlement getItem(int row) {
+			return (Settlement)getAssociatedEntity(row);
+		}
     }
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/DronePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/DronePanel.java
@@ -7,16 +7,13 @@
 
 package com.mars_sim.ui.swing.tool.missionwizard;
 
-import java.util.Comparator;
 import java.util.List;
 
 import com.mars_sim.core.person.ai.mission.Mission;
-import com.mars_sim.core.person.ai.mission.MissionType;
-import com.mars_sim.core.tool.Msg;
 import com.mars_sim.core.vehicle.Drone;
 import com.mars_sim.core.vehicle.StatusType;
-import com.mars_sim.ui.swing.components.ColumnSpec;
-import com.mars_sim.ui.swing.utils.wizard.AbstractWizardItemModel;
+import com.mars_sim.ui.swing.utils.model.BaseVehicleModel;
+import com.mars_sim.ui.swing.utils.wizard.WizardItemModel;
 import com.mars_sim.ui.swing.utils.wizard.WizardItemStep;
 import com.mars_sim.ui.swing.utils.wizard.WizardPane;
 
@@ -58,85 +55,52 @@ class DronePanel extends WizardItemStep<MissionDataBean, Drone> {
 	/**
 	 * A table model for vehicles.
 	 */
-	private static class DroneTableModel extends AbstractWizardItemModel<Drone> {
+	private static class DroneTableModel extends BaseVehicleModel implements WizardItemModel<Drone> {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
-		private static final List<ColumnSpec> COLUMNS = List.of(
-				new ColumnSpec(Msg.getString("entity.name"), String.class),
-				new ColumnSpec(Msg.getString("vehicle.type"), String.class),
-				new ColumnSpec(Msg.getString("vehicle.range"), Double.class, ColumnSpec.STYLE_DIGIT1),
-				new ColumnSpec("Capacity", Double.class, ColumnSpec.STYLE_DIGIT1),
-				new ColumnSpec(Msg.getString("vehicle.status"), String.class),
-				new ColumnSpec("Reserved", Boolean.class),
-				new ColumnSpec(Msg.getString("mission.singular"), String.class)
-		);
-				
-		private MissionDataBean state;
 
 		/**
 		 * Constructor
 		 */
 		private DroneTableModel(MissionDataBean state) {
-			super(COLUMNS);
-			this.state = state;
+			super(NAME, TYPE, EST_RANGE, CARGO_CAPACITY, STATUS, RESERVED, MISSION);
 		
 			var startingSettlement = state.getStartingSettlement();
 			var r = startingSettlement.getParkedGaragedDrones().stream()
 					.filter(Drone.class::isInstance)
-					.map(Drone.class::cast)
-					.sorted(Comparator.comparing(Drone::getName))
 					.toList();
-			setItems(r);
+			setEntities(r);
+			enableListeners(true);
 		}
 
-		/**	
-		 * Returns the value for the table cell.
-		 * @param vehicle the vehicle.
-		 * @param column the table column.
-		 * @return the cell value.
-		 */
 		@Override
-		protected Object getItemValue(Drone vehicle, int column) {
-			return switch(column) {
-				case 0 -> vehicle.getName();
-				case 1 -> vehicle.getVehicleSpec().getName();
-				case 2 -> vehicle.getEstimatedRange();
-				case 3 -> vehicle.getCargoCapacity();
-				case 4 -> vehicle.printStatusTypes();
-				case 5 -> vehicle.isReserved();
-				case 6 -> {
-					Mission mission = vehicle.getMission();
-					yield (mission != null ? mission.getName() : null);
-				}
-				default -> null;
-			};
+		public Drone getItem(int row) {
+			return (Drone)getAssociatedEntity(row);
 		}
 
 		/**
 		 * Check for failure cells.
 		 */
 		@Override
-		protected String isFailureCell(Drone vehicle, int column) {
-			String result = null;
+		public String isFailureCell(int row, int column) {
+			var colSpec = getColumnSpec(column);
+			var vehicle = (Drone)getAssociatedEntity(row);
 
-			if (column == 5) {
+			if (colSpec.equals(RESERVED.column())) {
 				return (vehicle.isReserved() ? "Reserved" : null);
-			} else if (column == 4) {
+			}
+			else if (colSpec.equals(STATUS.column())) {
 				if ((vehicle.getPrimaryStatus() != StatusType.PARKED) 
 						&& (vehicle.getPrimaryStatus() != StatusType.GARAGED))
 					return MissionCreate.VEHICLE_WRONG_STATUS;
-
-				// Allow rescue/salvage mission to use vehicle undergoing maintenance.
-				if (MissionType.RESCUE_SALVAGE_VEHICLE == state.getMissionType()) {
-                    result = vehicle.haveStatusType(StatusType.MAINTENANCE) ? "Vehicle is undergoing maintenance" : null;
-					}
-			} else if (column == 6) {
+			}
+			else if (colSpec.equals(MISSION.column())) {
 				Mission mission = vehicle.getMission();
 				return (mission != null) ? MissionCreate.ALREADY_ON_MISSION : null;
 			}
 
-			return result;
+			return null;
 		}
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/LightUtilityVehiclePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/LightUtilityVehiclePanel.java
@@ -9,11 +9,11 @@ package com.mars_sim.ui.swing.tool.missionwizard;
 
 import java.util.List;
 
-import com.mars_sim.core.tool.Msg;
+import com.mars_sim.core.person.ai.mission.Mission;
 import com.mars_sim.core.vehicle.LightUtilityVehicle;
 import com.mars_sim.core.vehicle.StatusType;
-import com.mars_sim.ui.swing.components.ColumnSpec;
-import com.mars_sim.ui.swing.utils.wizard.AbstractWizardItemModel;
+import com.mars_sim.ui.swing.utils.model.BaseVehicleModel;
+import com.mars_sim.ui.swing.utils.wizard.WizardItemModel;
 import com.mars_sim.ui.swing.utils.wizard.WizardItemStep;
 
 /**
@@ -52,55 +52,45 @@ class LightUtilityVehiclePanel extends WizardItemStep<MissionDataBean,LightUtili
 	/**
 	 * A table model for vehicles.
 	 */
-	private static class VehicleTableModel extends AbstractWizardItemModel<LightUtilityVehicle> {
+	private static class VehicleTableModel extends BaseVehicleModel
+			implements WizardItemModel<LightUtilityVehicle> {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
-		private static final List<ColumnSpec> COLUMNS = List.of(
-				new ColumnSpec(Msg.getString("entity.name"), String.class),
-				new ColumnSpec(Msg.getString("vehicle.status"), String.class),
-				new ColumnSpec(Msg.getString("mission.singular"), String.class)
-		);
 
 		/** hidden Constructor. */
 		private VehicleTableModel(MissionDataBean state) {
-			super(COLUMNS);
+			super(NAME, STATUS, MISSION);
 
 			var l = state.getStartingSettlement().getParkedGaragedVehicles().stream()
 						.filter(LightUtilityVehicle.class::isInstance)
 						.map(LightUtilityVehicle.class::cast)
 						.toList();
-			setItems(l);
-		}
-
-
-		@Override
-		protected Object getItemValue(LightUtilityVehicle vehicle, int column) {
-			return switch(column) {
-				case 0 -> vehicle.getName();
-				case 1 -> vehicle.printStatusTypes();
-				case 2 -> {
-							var m = vehicle.getMission();
-							yield (m != null ? m.getName() : "");
-				}
-				default -> null;
-			};
+			setEntities(l);
+			enableListeners(true);
 		}
 
 		@Override
-		protected String isFailureCell(LightUtilityVehicle vehicle, int column) {
-			String result = null;
+		public LightUtilityVehicle getItem(int row) {
+			return (LightUtilityVehicle) getAssociatedEntity(row);
+		}
 
-			if (column == 1) {
-				result = ((vehicle.getPrimaryStatus() != StatusType.PARKED)
-							&& (vehicle.getPrimaryStatus() != StatusType.GARAGED))
-						? MissionCreate.VEHICLE_WRONG_STATUS : null;
+		@Override
+		public String isFailureCell(int row, int column) {
+			var colSpec = getColumnSpec(column);
+			var vehicle = getItem(row);
+
+			if (colSpec.equals(STATUS.column())) {
+				if ((vehicle.getPrimaryStatus() != StatusType.PARKED) 
+						&& (vehicle.getPrimaryStatus() != StatusType.GARAGED))
+					return MissionCreate.VEHICLE_WRONG_STATUS;
 			}
-			else if (column == 2) {
-				result = (vehicle.getMission() != null) ? MissionCreate.ALREADY_ON_MISSION: null;
+			else if (colSpec.equals(MISSION.column())) {
+				Mission mission = vehicle.getMission();
+				return (mission != null) ? MissionCreate.ALREADY_ON_MISSION : null;
 			}
 
-			return result;
+			return null;
 		}
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/MembersPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/MembersPanel.java
@@ -12,10 +12,9 @@ import java.util.List;
 
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.mission.Delivery;
-import com.mars_sim.core.person.ai.mission.Mission;
-import com.mars_sim.core.tool.Msg;
 import com.mars_sim.ui.swing.components.ColumnSpec;
-import com.mars_sim.ui.swing.utils.wizard.AbstractWizardItemModel;
+import com.mars_sim.ui.swing.utils.model.BasePersonModel;
+import com.mars_sim.ui.swing.utils.wizard.WizardItemModel;
 import com.mars_sim.ui.swing.utils.wizard.WizardItemStep;
 /**
  * A wizard panel for selecting settlers.
@@ -34,7 +33,7 @@ class MembersPanel extends WizardItemStep<MissionDataBean, Person>
 	 */
 	public MembersPanel(MissionCreate wizard, MissionDataBean state) {
 		// Use WizardPanel constructor
-		super(ID, wizard, new PeopleTableModel(state), 2,
+		super(ID, wizard, new MembersTableModel(state), 2,
 				getCapacity(state));
 
 	}
@@ -43,8 +42,7 @@ class MembersPanel extends WizardItemStep<MissionDataBean, Person>
 	 * Update 
 	 */
 	@Override
-	protected void updateState(MissionDataBean state, List<Person> selection) {
-				
+	protected void updateState(MissionDataBean state, List<Person> selection) {				
 		state.setPersonMembers(selection);
 	}
 
@@ -70,63 +68,38 @@ class MembersPanel extends WizardItemStep<MissionDataBean, Person>
 		};
 	}
 
-	/**
-	 * Table model for people.
-	 */
-	private static class PeopleTableModel extends AbstractWizardItemModel<Person> {
+	private static class MembersTableModel extends BasePersonModel implements WizardItemModel<Person> {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
 
-		private static final List<ColumnSpec> COLUMNS = List.of(
-				new ColumnSpec(Msg.getString("entity.name"), String.class),
-				new ColumnSpec(Msg.getString("person.job"), String.class),
-				new ColumnSpec(Msg.getString("person.shift"), String.class),
-				new ColumnSpec(Msg.getString("mission.singular"), String.class),
-				new ColumnSpec(Msg.getString("person.performance"), Double.class, ColumnSpec.STYLE_PERCENTAGE),
-				new ColumnSpec(Msg.getString("person.health"), String.class)
-		);
-
 		/** Constructor. */
-		private PeopleTableModel(MissionDataBean state) {
-			super(COLUMNS);
+		private MembersTableModel(MissionDataBean state) {
+			super(NAME, JOB, SHIFT, MISSION, PERFORMANCE, HEALTH);
 
 			List<Person> people = state.getStartingSettlement().getIndoorPeople().stream()
 					.sorted(Comparator.comparing(Person::getName))
 					.toList();
-			setItems(people);
+			setEntities(people);
+
+			enableListeners(true);
 		}
 
-		/**
-		 * Failure is if the Person is already assigned to a mission.
-		 */
 		@Override
-		protected String isFailureCell(Person item, int column) {
-			return ((column == 3 && item.getMind().getMission() != null) ? MissionCreate.ALREADY_ON_MISSION : null);
+		public Person getItem(int row) {
+			return (Person)getAssociatedEntity(row);
 		}
 
-		/**
-		 * Gets the value for the cell at columnIndex and rowIndex.
-		 * 
-		 * @param item the item.
-		 * @param column the column index.
-		 * @return Rendered values
-		 */
 		@Override
-		protected Object getItemValue(Person item, int column) {
-			return switch (column) {
-				case 0 -> item.getName();
-				case 1 -> item.getMind().getJobType().getName();
-				case 2 -> item.getShiftSlot().getStatusDescription();
-				case 3 -> {
-					Mission mission = item.getMind().getMission();
-					if (mission != null) yield mission.getName();
-					else yield null;
+		public String isFailureCell(int row, int column) {
+			ColumnSpec columnSpec = getColumnSpec(column);
+			if (columnSpec.equals(MISSION.column())) {
+				Person person = getItem(row);
+				if (person.getMind().getMission() != null) {
+					return MissionCreate.ALREADY_ON_MISSION;
 				}
-				case 4 -> item.getPerformanceRating() * 100D;
-				case 5 -> item.getPhysicalCondition().getStatus();
-				default -> null;
-			}; 
-		}
+			}
+			return null;
+		}	
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/RescueVehiclePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/RescueVehiclePanel.java
@@ -7,17 +7,15 @@
 
 package com.mars_sim.ui.swing.tool.missionwizard;
 
-import java.util.Comparator;
 import java.util.List;
 
 import com.mars_sim.core.Simulation;
 import com.mars_sim.core.person.ai.mission.RescueSalvageVehicle;
 import com.mars_sim.core.resource.ResourceUtil;
-import com.mars_sim.core.tool.Msg;
-import com.mars_sim.core.vehicle.Rover;
 import com.mars_sim.core.vehicle.Vehicle;
 import com.mars_sim.ui.swing.components.ColumnSpec;
-import com.mars_sim.ui.swing.utils.wizard.AbstractWizardItemModel;
+import com.mars_sim.ui.swing.utils.model.BaseVehicleModel;
+import com.mars_sim.ui.swing.utils.wizard.WizardItemModel;
 import com.mars_sim.ui.swing.utils.wizard.WizardItemStep;
 import com.mars_sim.ui.swing.utils.wizard.WizardPane;
 
@@ -60,28 +58,28 @@ class RescueVehiclePanel extends WizardItemStep<MissionDataBean, Vehicle> {
 	/**
 	 * A table model for vehicles.
 	 */
-	private static class VehicleTableModel extends AbstractWizardItemModel<Vehicle> {
+	private static class VehicleTableModel extends BaseVehicleModel
+			implements WizardItemModel<Vehicle> {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
-		private static final List<ColumnSpec> COLUMNS = List.of(
-				new ColumnSpec(Msg.getString("entity.name"), String.class),
-				new ColumnSpec("Distance", Double.class, ColumnSpec.STYLE_DIGIT1),
-				new ColumnSpec("Crew", Integer.class),
-				new ColumnSpec(Msg.getString("vehicle.status"), String.class),
-				new ColumnSpec("Oxygen", Double.class, ColumnSpec.STYLE_DIGIT1),
-				new ColumnSpec("Water", Double.class, ColumnSpec.STYLE_DIGIT1),
-				new ColumnSpec("Food", Double.class, ColumnSpec.STYLE_DIGIT1),
-				new ColumnSpec("Rescuing Rover", String.class)
-		);
-				
+
+		private static final int RANGE_VAL = 101;
+		private static final EntityColumnSpec RANGE = new EntityColumnSpec(new ColumnSpec(RANGE_VAL, "Distance", Double.class,
+									ColumnSpec.STYLE_DIGIT1), null);
+		private static final int RESCUE_VAL = 102;
+		private static final EntityColumnSpec RESCUE = new EntityColumnSpec(new ColumnSpec(RESCUE_VAL, "Rescuing Rover",
+									String.class), null);
+
 		private MissionDataBean state;
 
 		/**
 		 * Constructor
 		 */
 		private VehicleTableModel(MissionDataBean state) {
-			super(COLUMNS);
+			super(NAME, RANGE, ONBOARD, STATUS, RESCUE);
+
+			addResourceColumns(List.of(ResourceUtil.OXYGEN_ID, ResourceUtil.WATER_ID, ResourceUtil.FOOD_ID));
 			this.state = state;
 		
 			// Bit mess but calling is rare
@@ -89,38 +87,32 @@ class RescueVehiclePanel extends WizardItemStep<MissionDataBean, Vehicle> {
 
 			var r = unitMgr.getVehicles().stream()
 					.filter(Vehicle::isBeaconOn)
-					.sorted(Comparator.comparing(Vehicle::getName))
 					.toList();
 
-			setItems(r);
+			setEntities(r);
+			enableListeners(true);
+		}
+
+		@Override
+		public Vehicle getItem(int row) {
+			return (Vehicle) getAssociatedEntity(row);
 		}
 
 		/**	
 		 * Returns the value for the table cell.
 		 * @param vehicle the vehicle.
-		 * @param column the table column.
+		 * @param column the column value.
 		 * @return the cell value.
 		 */
 		@Override
-		protected Object getItemValue(Vehicle vehicle, int column) {
+		protected Object getEntityValue(Vehicle vehicle, int column) {
 			return switch(column) {
-				case 0 -> vehicle.getName();
-				case 1 -> state.getStartingSettlement().getCoordinates().getDistance(vehicle.getCoordinates());
-				case 2 -> {
-					if (vehicle instanceof Rover r)
-						yield r.getCrewNum();
-					else
-						yield 0;
-				} 
-				case 3 -> vehicle.printStatusTypes();
-				case 4 -> vehicle.getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID);
-				case 5 -> vehicle.getSpecificAmountResourceStored(ResourceUtil.WATER_ID);
-				case 6 -> vehicle.getSpecificAmountResourceStored(ResourceUtil.FOOD_ID);
-				case 7 -> { 
+				case RANGE_VAL -> state.getStartingSettlement().getCoordinates().getDistance(vehicle.getCoordinates());
+				case RESCUE_VAL -> {
 					var helper = RescueSalvageVehicle.getRescueingVehicle(vehicle);
 					yield helper != null ? helper.getName() : "";
 				}
-				default -> null;
+				default -> super.getEntityValue(vehicle, column);
 			};
 		}	
 
@@ -128,16 +120,18 @@ class RescueVehiclePanel extends WizardItemStep<MissionDataBean, Vehicle> {
 		 * Check for failure cells.
 		 */
 		@Override
-		protected String isFailureCell(Vehicle vehicle, int column) {
-			return switch(column) {
-				case 7 -> RescueSalvageVehicle.getRescueingVehicle(vehicle) != null ? "Already being rescued" : null;
-				case 1 -> {
-    				var distance = state.getStartingSettlement().getCoordinates().getDistance(vehicle.getCoordinates())
-							* 2.2D; // Round trip distance
-    				yield (distance > state.getRover().getRange()) ? MissionCreate.VEHICLE_OUT_OF_RANGE : null;
-				}
-				default -> null;
-			};
+		public String isFailureCell(int row, int column) {
+			var colSpec = getColumnSpec(column);
+			var vehicle = getItem(row);
+			if (colSpec.equals(RANGE.column())) {
+				var distance = state.getStartingSettlement().getCoordinates().getDistance(vehicle.getCoordinates())
+						* 2.2D; // Round trip distance
+				return (distance > state.getRover().getRange()) ? MissionCreate.VEHICLE_OUT_OF_RANGE : null;
+			}
+			else if (colSpec.equals(RESCUE.column())) {
+				return RescueSalvageVehicle.getRescueingVehicle(vehicle) != null ? "Already being rescued" : null;
+			}
+			return null;
 		}
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/RoverPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/RoverPanel.java
@@ -7,15 +7,13 @@
 
 package com.mars_sim.ui.swing.tool.missionwizard;
 
-import java.util.Comparator;
 import java.util.List;
 
 import com.mars_sim.core.person.ai.mission.Mission;
-import com.mars_sim.core.tool.Msg;
 import com.mars_sim.core.vehicle.Rover;
 import com.mars_sim.core.vehicle.StatusType;
-import com.mars_sim.ui.swing.components.ColumnSpec;
-import com.mars_sim.ui.swing.utils.wizard.AbstractWizardItemModel;
+import com.mars_sim.ui.swing.utils.model.BaseVehicleModel;
+import com.mars_sim.ui.swing.utils.wizard.WizardItemModel;
 import com.mars_sim.ui.swing.utils.wizard.WizardItemStep;
 import com.mars_sim.ui.swing.utils.wizard.WizardPane;
 
@@ -58,79 +56,53 @@ class RoverPanel extends WizardItemStep<MissionDataBean, Rover> {
 	/**
 	 * A table model for vehicles.
 	 */
-	private static class VehicleTableModel extends AbstractWizardItemModel<Rover> {
+	private static class VehicleTableModel extends BaseVehicleModel
+		implements WizardItemModel<Rover> {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
-		private static final List<ColumnSpec> COLUMNS = List.of(
-				new ColumnSpec(Msg.getString("entity.name"), String.class),
-				new ColumnSpec(Msg.getString("vehicle.type"), String.class),
-				new ColumnSpec(Msg.getString("vehicle.range"), Double.class, ColumnSpec.STYLE_INTEGER),
-				new ColumnSpec("Capacity", Double.class, ColumnSpec.STYLE_INTEGER),
-				new ColumnSpec(Msg.getString("vehicle.status"), String.class),
-				new ColumnSpec("Reserved", Boolean.class),
-				new ColumnSpec(Msg.getString("mission.singular"), String.class),
-				new ColumnSpec("Crew", Integer.class),
-				new ColumnSpec("Has Lab", Boolean.class),
-				new ColumnSpec("Has Sickbay", Boolean.class)
-		);
-				
+	
 		/**
 		 * Constructor
 		 */
 		private VehicleTableModel(MissionDataBean state) {
-			super(COLUMNS);
+			super(NAME, TYPE, EST_RANGE, CARGO_CAPACITY, STATUS, RESERVED, MISSION,
+					CREW_CAPACITY, HAS_LAB);
 		
 			var startingSettlement = state.getStartingSettlement();
 			var r = startingSettlement.getParkedGaragedVehicles().stream()
 					.filter(Rover.class::isInstance)
-					.map(Rover.class::cast)
-					.sorted(Comparator.comparing(Rover::getName))
 					.toList();
-			setItems(r);
+			setEntities(r);
+			enableListeners(true);
 		}
 
-		/**	
-		 * Returns the value for the table cell.
-		 * @param vehicle the vehicle.
-		 * @param column the table column.
-		 * @return the cell value.
-		 */
 		@Override
-		protected Object getItemValue(Rover vehicle, int column) {
-			return switch(column) {
-				case 0 -> vehicle.getName();
-				case 1 -> vehicle.getVehicleSpec().getName();
-				case 2 -> vehicle.getEstimatedRange();
-				case 3 -> vehicle.getCargoCapacity();
-				case 4 -> vehicle.printStatusTypes();
-				case 5 -> vehicle.isReserved();
-				case 6 -> {
-					Mission mission = vehicle.getMission();
-					if (mission != null)
-						yield mission.getName();
-					else
-						yield "None";
-				}
-				case 7 -> vehicle.getCrewCapacity();
-				case 8 -> vehicle.hasLab();
-				case 9 -> vehicle.hasSickBay();
-				default -> null;
-			};
+		public Rover getItem(int row) {
+			return (Rover) getAssociatedEntity(row);
 		}
 
 		/**
 		 * Check for failure cells.
 		 */
 		@Override
-		protected String isFailureCell(Rover vehicle, int column) {
-			return switch(column) {
-				case 5 -> vehicle.isReserved() ? "Reserved" : null;
-				case 4 -> (vehicle.getPrimaryStatus() != StatusType.PARKED) 
-						&& (vehicle.getPrimaryStatus() != StatusType.GARAGED) ? MissionCreate.VEHICLE_WRONG_STATUS : null;
-				case 6 -> vehicle.getMission() != null ? MissionCreate.ALREADY_ON_MISSION : null;
-				default -> null;
-			};
+		public String isFailureCell(int row, int column) {
+			var colSpec = getColumnSpec(column);
+			var vehicle = getItem(row);
+
+			if (colSpec.equals(RESERVED.column())) {
+				return (vehicle.isReserved() ? "Reserved" : null);
+			}
+			else if (colSpec.equals(STATUS.column())) {
+				if ((vehicle.getPrimaryStatus() != StatusType.PARKED) 
+						&& (vehicle.getPrimaryStatus() != StatusType.GARAGED))
+					return MissionCreate.VEHICLE_WRONG_STATUS;
+			}
+			else if (colSpec.equals(MISSION.column())) {
+				Mission mission = vehicle.getMission();
+				return (mission != null) ? MissionCreate.ALREADY_ON_MISSION : null;
+			}
+			return null;
 		}
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/SciencePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/SciencePanel.java
@@ -6,7 +6,6 @@
  */
 package com.mars_sim.ui.swing.tool.missionwizard;
 
-import java.util.Comparator;
 import java.util.List;
 
 import com.mars_sim.core.Simulation;
@@ -14,9 +13,8 @@ import com.mars_sim.core.science.ScienceType;
 import com.mars_sim.core.science.ScientificStudy;
 import com.mars_sim.core.science.ScientificStudyManager;
 import com.mars_sim.core.science.StudyStatus;
-import com.mars_sim.core.tool.Msg;
-import com.mars_sim.ui.swing.components.ColumnSpec;
-import com.mars_sim.ui.swing.utils.wizard.AbstractWizardItemModel;
+import com.mars_sim.ui.swing.utils.model.BaseScienceStudyModel;
+import com.mars_sim.ui.swing.utils.wizard.WizardItemModel;
 import com.mars_sim.ui.swing.utils.wizard.WizardItemStep;
 
 /**
@@ -52,18 +50,14 @@ class SciencePanel extends WizardItemStep<MissionDataBean,ScientificStudy> {
     /**
 	 * A table model for scientific studies.
 	 */
-	private static class StudyTableModel extends AbstractWizardItemModel<ScientificStudy> {
+	private static class StudyTableModel extends BaseScienceStudyModel
+                implements WizardItemModel<ScientificStudy> {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
-        private static final List<ColumnSpec> COLUMNS = List.of(
-				new ColumnSpec(Msg.getString("entity.name"), String.class),
-				new ColumnSpec(Msg.getString("scientificstudy.phase"), String.class),
-				new ColumnSpec(Msg.getString("scientificstudy.collaborator.plural"), Integer.class)
-		);
 
 		private StudyTableModel(MissionDataBean state) {
-            super(COLUMNS);
+            super(NAME, PHASE, SCIENCE);
 
             ScientificStudyManager manager = Simulation.instance().getScientificStudyManager();
             var studyScience = switch(state.getMissionType()) {
@@ -76,28 +70,25 @@ class SciencePanel extends WizardItemStep<MissionDataBean,ScientificStudy> {
             // Hide suitable studies for the starting settlement, and sort by name.
             var studies = manager.getAllStudies(state.getStartingSettlement()).stream()
                 .filter(s -> s.getScience() == studyScience)
-                .sorted(Comparator.comparing(ScientificStudy::getName))
                 .toList();
-            setItems(studies);
+            setEntities(studies);
+            enableListeners(true);
 		}
 
         @Override
-        protected String isFailureCell(ScientificStudy item, int column) {
-            return switch(column) {
-                case 1 -> item.getPhase() != StudyStatus.RESEARCH_PHASE ? "Study is not in research phase" : null;
-                case 2 -> item.getCollaborativeResearchers().isEmpty() ? "No researchers assigned to study" : null;
-                default -> null;
-            };
+        public ScientificStudy getItem(int row) {
+            return (ScientificStudy)getAssociatedEntity(row);
         }
 
         @Override
-        protected Object getItemValue(ScientificStudy item, int column) {
-            return switch(column) {
-                case 0 -> item.getName();
-                case 1 -> item.getPhase().getName();
-                case 2 -> item.getCollaborativeResearchers().size();
-                default -> null;
-            };
+        public String isFailureCell(int row, int column) {
+            var columnVal = getColumnSpec(column);
+            if (columnVal.equals(PHASE.column())) {
+                var item = getItem(row);
+                return (item.getPhase() != StudyStatus.RESEARCH_PHASE) ? "Study is not in research phase" : null;
+            }
+
+            return null;
         }
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/SciencePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/SciencePanel.java
@@ -20,7 +20,7 @@ import com.mars_sim.ui.swing.utils.wizard.WizardItemStep;
 /**
  * A wizard panel for selecting the scientific study for a science mission.
  * All studies that are at the starting settlement and match the science type are shown.
- * Only studies in the research phase with assigned researchers can be selected.
+ * Only studies in the research phase can be selected.
  */
 class SciencePanel extends WizardItemStep<MissionDataBean,ScientificStudy> {
     

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/SettlementTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/SettlementTableModel.java
@@ -32,7 +32,8 @@ public class SettlementTableModel extends BaseSettlementModel implements Monitor
 	 * simulation.
 	 */
 	public SettlementTableModel() {
-		super(RESOURCES, NAME, POPULATION, PARKED, MISSION, POWER_GEN, POWER_LOAD, ENERGY_STORED);
+		super(NAME, POPULATION, PARKED, MISSION, POWER_GEN, POWER_LOAD, ENERGY_STORED);
+		addResourceColumns(RESOURCES);
 	}
 
 	@Override

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/VehicleTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/VehicleTableModel.java
@@ -31,8 +31,9 @@ public class VehicleTableModel extends BaseVehicleModel implements MonitorModel 
 													ResourceUtil.WATER_ID, ResourceUtil.FOOD_ID);
 	
 	public VehicleTableModel() {
-		super(RESOURCES, NAME, TYPE, SETTLEMENT, LOCATION, DESTINATION, DESTDIST, MISSION, DRIVER,
+		super(NAME, TYPE, SETTLEMENT, LOCATION, DESTINATION, DESTDIST, MISSION, DRIVER,
 				STATUS, BEACON, RESERVED, SPEED, MALFUNCTION, BATTERY, FUEL);
+		addResourceColumns(RESOURCES);
 	}
 
 	@Override

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/transportable/ResupplySettlementStep.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/transportable/ResupplySettlementStep.java
@@ -7,15 +7,13 @@
 
 package com.mars_sim.ui.swing.tool.transportable;
 
-import java.util.Comparator;
 import java.util.List;
 
 import com.mars_sim.core.Simulation;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.structure.Settlement;
-import com.mars_sim.core.tool.Msg;
-import com.mars_sim.ui.swing.components.ColumnSpec;
-import com.mars_sim.ui.swing.utils.wizard.AbstractWizardItemModel;
+import com.mars_sim.ui.swing.utils.model.BaseSettlementModel;
+import com.mars_sim.ui.swing.utils.wizard.WizardItemModel;
 import com.mars_sim.ui.swing.utils.wizard.WizardItemStep;
 import com.mars_sim.ui.swing.utils.wizard.WizardPane;
 
@@ -48,57 +46,36 @@ class ResupplySettlementStep extends WizardItemStep<TransportState, Settlement> 
 	protected void updateState(TransportState state, List<Settlement> sel) {
 		state.setLandingSettlement(sel.get(0));
 	}
-
-	// Base column for all settlement models.
-	private static final ColumnSpec NAME = new ColumnSpec(0, Msg.getString("entity.name"), String.class, ColumnSpec.STYLE_DEFAULT);
-	private static final ColumnSpec POP = new ColumnSpec(1, Msg.getString("settlement.population"), Integer.class, ColumnSpec.STYLE_DEFAULT);
-	private static final ColumnSpec ROVERS = new ColumnSpec(2, Msg.getString("rover.plural"), Integer.class, ColumnSpec.STYLE_DEFAULT);
-	private static final ColumnSpec OXYGEN = new ColumnSpec(3, "Oxygen", Double.class, ColumnSpec.STYLE_DIGIT1);
-	private static final ColumnSpec WATER = new ColumnSpec(4, "Water", Double.class, ColumnSpec.STYLE_DIGIT1);		
-	private static final ColumnSpec FOOD = new ColumnSpec(5, "Food", Double.class, ColumnSpec.STYLE_DIGIT1);
-	private static final ColumnSpec METHANE = new ColumnSpec(6, "Methane", Double.class, ColumnSpec.STYLE_DIGIT1);
-	private static final ColumnSpec METHANOL = new ColumnSpec(7, "Methanol", Double.class, ColumnSpec.STYLE_DIGIT1);
-
-	private static final List<ColumnSpec> BASE_COLS = List.of(NAME, POP, ROVERS, OXYGEN, WATER, FOOD, METHANE, METHANOL);
-
 	
 	/**
 	 * A table model for settlements.
 	 */
-	private static class SettlementTableModel extends AbstractWizardItemModel<Settlement> {
+	private static class SettlementTableModel extends BaseSettlementModel
+								implements WizardItemModel<Settlement> {
 
 		/**
 		 * Constructor.
 		 */
 		private SettlementTableModel() {
-			super(BASE_COLS);
+			super(NAME, POPULATION);
+
+			addResourceColumns(List.of(ResourceUtil.OXYGEN_ID, ResourceUtil.WATER_ID, ResourceUtil.FOOD_ID,
+							ResourceUtil.METHANE_ID, ResourceUtil.METHANOL_ID));		
 
 			// Add all settlements to table sorted by name.
-			var settlements = Simulation.instance().getUnitManager().getSettlements().stream()
-				.sorted(Comparator.comparing(Settlement::getName)).toList();
-			setItems(settlements);
+			var settlements = Simulation.instance().getUnitManager().getSettlements();
+			setEntities(settlements);
+			enableListeners(true);
 		}
 
-		/**
-		 * Returns the value for the cell at columnIndex and rowIndex.
-		 * @param item the item whose value is to be queried
-		 * @param column the column whose value is to be queried
-		 * @return the value Object at the specified cell
-		 */
 		@Override
-		protected Object getItemValue(Settlement settlement, int column) {
-			var spec = getColumnSpec(column);
-			return switch(spec.id()) {
-				case 0 -> settlement.getName();
-				case 1 -> settlement.getIndoorPeopleCount();
-				case 2 -> settlement.findNumParkedRovers();
-				case 3 -> settlement.getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID);
-				case 4 -> settlement.getSpecificAmountResourceStored(ResourceUtil.WATER_ID);
-				case 5 -> settlement.getSpecificAmountResourceStored(ResourceUtil.FOOD_ID);
-				case 6 -> settlement.getSpecificAmountResourceStored(ResourceUtil.METHANE_ID);
-				case 7 -> settlement.getSpecificAmountResourceStored(ResourceUtil.METHANOL_ID);
-				default -> null;
-			};
+		public Settlement getItem(int row) {
+			return (Settlement) getAssociatedEntity(row);
+		}
+
+		@Override
+		public String isFailureCell(int row, int column) {
+			return null;
 		}
 	}
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/AbstractEntityModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/AbstractEntityModel.java
@@ -7,13 +7,13 @@
 package com.mars_sim.ui.swing.utils.model;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.swing.table.AbstractTableModel;
 
@@ -39,7 +39,7 @@ public abstract class AbstractEntityModel<T extends MonitorableEntity> extends A
     public record EntityColumnSpec(ColumnSpec column, Set<String> eventTypes) {}
 
 	private List<T> entities = new ArrayList<>();
-    private ColumnSpec[] columns;
+    private List<ColumnSpec> columns = new ArrayList<>();
     private Map<String, List<Integer>> monitoredEvents = new HashMap<>();
 
     /**
@@ -47,27 +47,34 @@ public abstract class AbstractEntityModel<T extends MonitorableEntity> extends A
      * @param columns Columns to render
      */
     protected AbstractEntityModel(EntityColumnSpec[] columns) {
-        Set<Integer> valIds = new HashSet<>();
+        addColumns(columns);
+    }
+
+    /**
+     * Add columns to the model. The column spec and associated event types are provided in the EntityColumnSpec array.
+     * @param newColumns Array of new columns to add.
+     */
+    protected void addColumns(EntityColumnSpec[] newColumns) {
+        // Load exisitng value ids
+        var existingIds = columns.stream().map(ColumnSpec::id).collect(Collectors.toSet());
+        Set<Integer> valIds = new HashSet<>(existingIds);
 
         // Create the event map by extracting the event types against the index of the EntityColumnSpec
-        int idx = 0;
-        for (EntityColumnSpec ecs : columns) {
+        for (EntityColumnSpec ecs : newColumns) {
             if (ecs.eventTypes() != null) {
                 for (String eventType : ecs.eventTypes()) {
-                    monitoredEvents.computeIfAbsent(eventType, k -> new ArrayList<>()).add(idx);
+                    monitoredEvents.computeIfAbsent(eventType, k -> new ArrayList<>()).add(columns.size());
                 }
             }
-            idx++;
+            columns.add(ecs.column());
             
             valIds.add(ecs.column().id());
         }
 
         // Check all columns have unique Ids
-        if (valIds.size() != columns.length) {
+        if (valIds.size() != columns.size()) {
             throw new IllegalArgumentException("Column Ids must be unique");
         }
-
-        this.columns = Arrays.stream(columns).map(EntityColumnSpec::column).toArray(ColumnSpec[]::new);
     }
 
     /**
@@ -163,16 +170,17 @@ public abstract class AbstractEntityModel<T extends MonitorableEntity> extends A
 
     @Override
     public int getColumnCount() {
-        return columns.length;
+        return columns.size();
     }
 
     @Override
     public Class<?> getColumnClass(int columnIndex) {
-        return columns[columnIndex].type();    }
+        return columns.get(columnIndex).type();
+    }
 
     @Override
     public String getColumnName(int columnIndex) {
-        return columns[columnIndex].name();
+        return columns.get(columnIndex).name();
     }
 
     @Override
@@ -182,7 +190,7 @@ public abstract class AbstractEntityModel<T extends MonitorableEntity> extends A
 
     @Override
     public ColumnSpec getColumnSpec(int modelIndex) {
-        return columns[modelIndex];
+        return columns.get(modelIndex);
     }
 
     /**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/BaseConstructionSiteModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/BaseConstructionSiteModel.java
@@ -1,0 +1,60 @@
+/*
+ * Mars Simulation Project
+ * BaseConstructionSiteModel.java
+ * @date 2026-07-10
+ * @author Barry Evans
+ */
+package com.mars_sim.ui.swing.utils.model;
+
+import com.mars_sim.core.tool.Msg;
+import com.mars_sim.ui.swing.components.ColumnSpec;
+
+import java.util.Set;
+
+import com.mars_sim.core.building.construction.ConstructionSite;
+
+/**
+ * This is a model for ConstructionSite entities. It provides a number of predefined available columns.
+ * The subclass defines which columns are to be rendered.
+ */
+public class BaseConstructionSiteModel extends AbstractEntityModel<ConstructionSite> {
+
+    private static final int NAME_VAL = 0;
+    private static final int BUILDING_VAL = 1;
+    private static final int MISSION_VAL = 2;
+    private static final int STAGE_VAL = 3;
+
+    // Basic fixed properties of a ConstructionSite
+    protected static final EntityColumnSpec NAME = new EntityColumnSpec(
+                    new ColumnSpec(NAME_VAL, Msg.getString("entity.name"), String.class), null);
+    protected static final EntityColumnSpec BUILDING = new EntityColumnSpec(
+                    new ColumnSpec(BUILDING_VAL, Msg.getString("building.singular"), String.class), null);
+    protected static final EntityColumnSpec MISSION = new EntityColumnSpec(
+                    new ColumnSpec(MISSION_VAL, Msg.getString("mission.singular"), String.class), 
+                            Set.of(ConstructionSite.START_CONSTRUCTION_SITE_EVENT, ConstructionSite.END_CONSTRUCTION_SITE_EVENT));
+    protected static final EntityColumnSpec STAGE = new EntityColumnSpec(
+                    new ColumnSpec(STAGE_VAL, Msg.getString("constructionstage.singular"), String.class),
+                            Set.of(ConstructionSite.ADD_CONSTRUCTION_STAGE_EVENT));
+
+    /**
+     * Create a generic ConstructionSite model with the specified columns.
+     * @param columns Columns to show.
+     */
+    public BaseConstructionSiteModel(EntityColumnSpec... columns) {
+        super(columns);
+    }
+
+    @Override
+    protected Object getEntityValue(ConstructionSite entity, int valueIndex) {
+        return switch (valueIndex) {
+            case NAME_VAL -> entity.getName();
+            case BUILDING_VAL -> entity.getBuildingName();
+            case MISSION_VAL -> {
+                var onSite = entity.getWorkOnSite();
+                yield onSite != null ? onSite.getName() : null;
+            }
+            case STAGE_VAL -> entity.getDescription();
+            default -> null;
+        };
+    }
+}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/BasePersonModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/BasePersonModel.java
@@ -70,7 +70,7 @@ public abstract class BasePersonModel extends AbstractEntityModel<Person> {
 	protected static final EntityColumnSpec JOB = new EntityColumnSpec(new ColumnSpec(JOB_VAL, Msg.getString("person.job"), String.class),
                                                 Set.of(EntityEventType.JOB_EVENT));
 	protected static final EntityColumnSpec SHIFT = new EntityColumnSpec(new ColumnSpec(SHIFT_VAL, Msg.getString("person.shift"), String.class),
-                                                Set.of(EntityEventType.SHIFT_EVENT));
+                                                Set.of(ShiftSlot.SHIFT_EVENT));
       
     /**
      * Create a generic person model with the specified columns.

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/BaseRobotModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/BaseRobotModel.java
@@ -38,6 +38,7 @@ public abstract class BaseRobotModel extends AbstractEntityModel<Robot> {
     protected static final EntityColumnSpec NAME = BaseWorkerModel.NAME;
     protected static final EntityColumnSpec TASK = BaseWorkerModel.TASK;
     protected static final EntityColumnSpec SETTLEMENT = BaseWorkerModel.SETTLEMENT;
+    protected static final EntityColumnSpec MISSION = BaseWorkerModel.MISSION;
     protected static final EntityColumnSpec TYPE = new EntityColumnSpec(new ColumnSpec(TYPE_VAL, Msg.getString("robot.type"),
                                                         String.class), null);
     protected static final EntityColumnSpec LOCATION = new EntityColumnSpec(new ColumnSpec(LOCATION_VAL, Msg.getString("entity.coordinates"),

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/BaseSettlementModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/BaseSettlementModel.java
@@ -6,6 +6,7 @@
  */
 package com.mars_sim.ui.swing.utils.model;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -50,18 +51,24 @@ public abstract class BaseSettlementModel extends AbstractEntityModel<Settlement
                                 Set.of(PowerGrid.STORED_ENERGY_EVENT));
 
     // Resource columns
-    private List<Integer> resources;
+    private List<Integer> resources = new ArrayList<>();
 
     /**
      * Creates a generic building model with the specified columns.
      * 
-     * @param resources The list of monitored resource IDs.
      * @param columns Columns to show.
      */
-    protected BaseSettlementModel(List<Integer> resources, EntityColumnSpec... columns) {
-        super(ResourceColumnHelper.getColumns(resources, columns));
+    protected BaseSettlementModel(EntityColumnSpec... columns) {
+        super(columns);
+    }
 
-        this.resources = resources;
+    /**
+     * Add resource columns to the model. The resource columns are created for the specified list of resource IDs.
+     * @param resources Resource IDs to add
+     */
+    protected void addResourceColumns(List<Integer> resources) {
+        addColumns(InventoryColumnHelper.getResourceColumn(resources));
+        this.resources.addAll(resources);
     }
 
     /**
@@ -73,7 +80,7 @@ public abstract class BaseSettlementModel extends AbstractEntityModel<Settlement
     @Override
     public void entityUpdate(EntityEvent event) {
         if (event.getType().equals(EntityEventType.INVENTORY_RESOURCE_EVENT)) {
-            event = ResourceColumnHelper.convertResourceToEvent(event, resources);
+            event = InventoryColumnHelper.convertResourceToEvent(event, resources);
             if (event == null) {
                 // Not a monitored resource
                 return;
@@ -101,8 +108,7 @@ public abstract class BaseSettlementModel extends AbstractEntityModel<Settlement
             case POWER_GEN_VAL -> entity.getPowerGrid().getGeneratedPower();
             case POWER_LOAD_VAL -> entity.getPowerGrid().getPowerLoad();
             case ENERGY_STORED_VAL -> entity.getPowerGrid().displayStoredEnergy();
-            default -> (valueIndex >= ResourceColumnHelper.RESOURCE_VAL) ?
-                        entity.getSpecificAmountResourceStored(valueIndex - ResourceColumnHelper.RESOURCE_VAL) : null;
+            default -> InventoryColumnHelper.getValue(entity, valueIndex);
         };
     }
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/BaseVehicleModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/BaseVehicleModel.java
@@ -6,7 +6,7 @@
  */
 package com.mars_sim.ui.swing.utils.model;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,26 +81,24 @@ public abstract class BaseVehicleModel extends AbstractEntityModel<Vehicle> {
     protected static final EntityColumnSpec FUEL = new EntityColumnSpec(new ColumnSpec(FUEL_VAL, "Fuel %", Double.class, ColumnSpec.STYLE_INTEGER), null);
     
     private Map<Vehicle, VehicleMission> vehicleToMission = new HashMap<>();
-    private List<Integer> resources = Collections.emptyList();
+    private List<Integer> resources = new ArrayList<>();
 
     /**
      * Create a generic vehicle model with the specified columns.
-     * @param resources List of resource IDs to create columns for.
-     * @param columns Columns to show.
-     */
-    protected BaseVehicleModel(List<Integer> resources,EntityColumnSpec... columns) {
-        super(ResourceColumnHelper.getColumns(resources, columns));
-        this.resources = resources;
-    }
-
-    /**
-     * Create a generic vehicle model with the specified columns and no resources
      * @param columns Columns to show.
      */
     protected BaseVehicleModel(EntityColumnSpec... columns) {
         super(columns);
     }
 
+    /**
+     * Add resource columns to the model. The resource columns are created for the specified list of resource IDs.
+     * @param resources Resource IDs to add
+     */
+    protected void addResourceColumns(List<Integer> resources) {
+        addColumns(InventoryColumnHelper.getResourceColumn(resources));
+        this.resources.addAll(resources);
+    }
 
     /**
      * Attachs listener to an associated Mission.
@@ -156,7 +154,7 @@ public abstract class BaseVehicleModel extends AbstractEntityModel<Vehicle> {
             }
         }
         else if (event.getType().equals(EntityEventType.INVENTORY_RESOURCE_EVENT)) {
-            event = ResourceColumnHelper.convertResourceToEvent(event, resources);
+            event = InventoryColumnHelper.convertResourceToEvent(event, resources);
             if (event == null) {
                 // Not a monitored resource
                 return;
@@ -229,9 +227,8 @@ public abstract class BaseVehicleModel extends AbstractEntityModel<Vehicle> {
 			}
 
             // Check for a resource column
-            default -> (valueIndex >= ResourceColumnHelper.RESOURCE_VAL) ?
-                        entity.getSpecificAmountResourceStored(valueIndex - ResourceColumnHelper.RESOURCE_VAL) : null;
-            };
+            default -> InventoryColumnHelper.getValue(entity, valueIndex);
+        };
     }
 
     @Override

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/BaseVehicleModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/BaseVehicleModel.java
@@ -22,6 +22,8 @@ import com.mars_sim.core.person.ai.mission.VehicleMission;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.tool.Msg;
 import com.mars_sim.core.unit.MobileUnit;
+import com.mars_sim.core.vehicle.Crewable;
+import com.mars_sim.core.vehicle.Rover;
 import com.mars_sim.core.vehicle.Vehicle;
 import com.mars_sim.ui.swing.StyleManager;
 import com.mars_sim.ui.swing.components.ColumnSpec;
@@ -52,6 +54,11 @@ public abstract class BaseVehicleModel extends AbstractEntityModel<Vehicle> {
     private static final int MALFUNCTION_VAL = 13;
     private static final int BATTERY_VAL = 14;
     private static final int FUEL_VAL = 15;
+    private static final int ONBOARD_VAL = 16;
+    private static final int EST_RANGE_VAL = 17;
+    private static final int CARGO_CAP_VAL = 18;
+    private static final int CREW_CAP_VAL = 19;
+    private static final int HASLAB_VAL = 20;
 
     // Basic fixed properties of a Vehicle
     protected static final EntityColumnSpec NAME = new EntityColumnSpec(new ColumnSpec(NAME_VAL, Msg.getString("entity.name"), String.class), null);
@@ -79,7 +86,12 @@ public abstract class BaseVehicleModel extends AbstractEntityModel<Vehicle> {
                             String.class), Set.of(MalfunctionManager.MALFUNCTION_EVENT));
     protected static final EntityColumnSpec BATTERY = new EntityColumnSpec(new ColumnSpec(BATTERY_VAL, "Battery", String.class), null);
     protected static final EntityColumnSpec FUEL = new EntityColumnSpec(new ColumnSpec(FUEL_VAL, "Fuel %", Double.class, ColumnSpec.STYLE_INTEGER), null);
-    
+    protected static final EntityColumnSpec ONBOARD = new EntityColumnSpec(new ColumnSpec(ONBOARD_VAL, "Onboard", Integer.class), null);
+    protected static final EntityColumnSpec EST_RANGE = new EntityColumnSpec(new ColumnSpec(EST_RANGE_VAL, Msg.getString("vehicle.range"), Double.class, ColumnSpec.STYLE_DIGIT1), null);
+    protected static final EntityColumnSpec CARGO_CAPACITY = new EntityColumnSpec(new ColumnSpec(CARGO_CAP_VAL, "Capacity", Double.class, ColumnSpec.STYLE_DIGIT1), null);
+    protected static final EntityColumnSpec CREW_CAPACITY = new EntityColumnSpec(new ColumnSpec(CREW_CAP_VAL, "Crew", Integer.class), null);
+    protected static final EntityColumnSpec HAS_LAB = new EntityColumnSpec(new ColumnSpec(HASLAB_VAL, "Has Lab", Boolean.class), null);
+
     private Map<Vehicle, VehicleMission> vehicleToMission = new HashMap<>();
     private List<Integer> resources = new ArrayList<>();
 
@@ -185,6 +197,26 @@ public abstract class BaseVehicleModel extends AbstractEntityModel<Vehicle> {
             case DRIVER_VAL -> (entity.getOperator() != null ? entity.getOperator().getName() : null);
 			case BATTERY_VAL -> entity.getController().getBattery().getBatteryStatus().getName();
 			case FUEL_VAL -> entity.getFuelPercent();
+            case EST_RANGE_VAL -> entity.getEstimatedRange();
+            case CARGO_CAP_VAL -> entity.getCargoCapacity();
+            case HASLAB_VAL -> {
+                if (entity instanceof Rover r)
+                    yield r.hasLab();
+                else
+                    yield false;
+            }
+            case CREW_CAP_VAL -> {
+                if (entity instanceof Crewable r)
+                    yield r.getCrewCapacity();
+                else
+                    yield 0;
+                }
+            case ONBOARD_VAL -> {
+					if (entity instanceof Crewable r)
+						yield r.getCrewNum();
+					else
+						yield 0;
+				}
 
             case LOCATION_VAL -> {
 				if (entity.getMission() instanceof AbstractVehicleMission vm) {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/InventoryColumnHelper.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/model/InventoryColumnHelper.java
@@ -1,6 +1,6 @@
 /*
  * Mars Simulation Project
- * ResourceColumnHelper.java
+ * InventoryColumnHelper.java
  * @date 2026-06-27
  * @author Barry Evans
  */
@@ -10,45 +10,51 @@ import java.util.List;
 import java.util.Set;
 
 import com.mars_sim.core.EntityEvent;
+import com.mars_sim.core.equipment.EquipmentOwner;
+import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.resource.AmountResource;
-import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.resource.ItemResource;
+import com.mars_sim.core.resource.ResourceType;
 import com.mars_sim.ui.swing.components.ColumnSpec;
 import com.mars_sim.ui.swing.utils.model.AbstractEntityModel.EntityColumnSpec;
 
 /**
- * A utility class to help with the creation of resource columns for a table model based onthe resource ids.
+ * A utility class to help with the creation of columns for a table model based on the resource ids.
+ * It supports AmountResource, ItemResource e.g. parts, Containers & EquipmentType.
  * It provides methods to create an array of EntityColumnSpec for the specified resources and columns,
  * and to convert an inbound event that references a change to an Inventory into a pseudo event that references the resource column.
  * 
  */
-public class ResourceColumnHelper {
+public class InventoryColumnHelper {
     private static final String RES_PREFIX = "res:";
 
     // Base value for resource columns. The actual column index is RESOURCE_VAL + resourceID
-    static final int RESOURCE_VAL = 1000;
+    static final int AMOUNT_VAL = 1000;
+    private static final Set<Integer> SUPPORTED_TYPES = Set.of(ResourceType.AMOUNT_RESOURCE, ResourceType.ITEM_RESOURCE,
+                                                                ResourceType.EQUIPMENT_RESOURCE);
 
-    private ResourceColumnHelper() {
+    private InventoryColumnHelper() {
         /* This utility class should not be instantiated */
     }
 
     /**
-     * Create an array of EntityColumnSpec for the specified resources and columns.
-     * Note this could be resued elsewhere.
+     * Create an array of EntityColumnSpec for the specified Resources.
      * @param resources Set of resource IDs to create columns for.
-     * @param columns Array of named columns.
-     * @return Array of EntityColumnSpec including both existing and resource columns.  
+     * @return Array of EntityColumnSpec covering the resource columns.  
      */
-    static EntityColumnSpec[] getColumns(List<Integer> resources, EntityColumnSpec[] columns) {
-        EntityColumnSpec[] resourceColumns = new EntityColumnSpec[resources.size() + columns.length];
-    
-        // Named columns first
-        System.arraycopy(columns, 0, resourceColumns, 0, columns.length);
+    static EntityColumnSpec[] getResourceColumn(List<Integer> resources) {
+        EntityColumnSpec[] resourceColumns = new EntityColumnSpec[resources.size()];
     
         // Then add the resource columns with the pseudo event type for each resource
-        int idx = columns.length;
+        int idx = 0;
         for(var resourceID : resources) {
-            var name =ResourceUtil.findAmountResourceName(resourceID);
-            var resColumn = new EntityColumnSpec(new ColumnSpec(RESOURCE_VAL + resourceID, name, Double.class, ColumnSpec.STYLE_INTEGER),
+            // Check supported resource type
+            if (!SUPPORTED_TYPES.contains(ResourceType.getType(resourceID))) {
+                throw new IllegalArgumentException("Unsupported resource type for resource ID: " + resourceID);
+            }
+
+            var name = ResourceType.getName(resourceID);
+            var resColumn = new EntityColumnSpec(new ColumnSpec(AMOUNT_VAL + resourceID, name, Double.class, ColumnSpec.STYLE_INTEGER),
                                 Set.of(RES_PREFIX + resourceID));
             resourceColumns[idx++] = resColumn;
         }
@@ -66,6 +72,7 @@ public class ResourceColumnHelper {
         var target = event.getTarget();
         int resourceID = switch (target) {
             case AmountResource ar -> ar.getID();
+            case ItemResource ir -> ir.getID();
             case Integer i -> i;
             default -> -1;
         };
@@ -77,5 +84,19 @@ public class ResourceColumnHelper {
             return null;
         }
         return new EntityEvent(event.getSource(), pseudoEventType, event.getTarget());
+    }
+
+
+    public static Object getValue(EquipmentOwner owner, int columnIndex) {
+        if (columnIndex >= AMOUNT_VAL) {
+            int resourceID = columnIndex - AMOUNT_VAL;
+            return switch (ResourceType.getType(resourceID)) {
+                case ResourceType.AMOUNT_RESOURCE -> owner.getSpecificAmountResourceStored(resourceID);
+                case ResourceType.ITEM_RESOURCE -> owner.getItemResourceStored(resourceID);
+                case ResourceType.EQUIPMENT_RESOURCE -> owner.findNumContainersOfType(EquipmentType.convertID2Type(resourceID));
+                default -> null;
+            };
+        }
+        return null;
     }
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/wizard/AbstractWizardItemModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/wizard/AbstractWizardItemModel.java
@@ -183,26 +183,6 @@ public abstract class AbstractWizardItemModel<T> extends AbstractTableModel
 	 * @return Rendered values
 	 */
 	protected abstract Object getItemValue(T item, int column);
-	
-	/**
-	 * Checks if row contains a failure cell.
-	 * 
-	 * @param row the row index.
-	 * @return true if row has failure cell.
-	 */
-	@Override
-	public boolean isFailureItem(int row) {
-		T item = items.get(row);
-		for (int x = 0; x < getColumnCount(); x++) {
-			String failure = isFailureCell(item, x);
-
-			// Stop on first failure
-			if (failure != null) {
-				return true;
-			}
-		}
-		return false;
-	}
 
 	/**
 	 * Checks if the cell at the specified row and column is in a failure state.

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/wizard/WizardItemModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/wizard/WizardItemModel.java
@@ -7,20 +7,14 @@
 package com.mars_sim.ui.swing.utils.wizard;
 
 import com.mars_sim.ui.swing.components.EnhancedTableModel;
+import com.mars_sim.ui.swing.utils.StatefulComponent;
 
 /**
  * This represents a model that is used to select items in the WizardItemStep class.
  * It is a standard table model but supports the concept of failure of cells that do not match a criteria.
  */
  
-public interface WizardItemModel<T> extends EnhancedTableModel {
-
-    /**
-     * Checks if the item at the given row has any failure cells. This checks all columns in the row
-     * @param row Index of the item to check.
-     * @return true if the item has any failure cells, false otherwise.
-     */
-    boolean isFailureItem(int row);
+public interface WizardItemModel<T> extends EnhancedTableModel, StatefulComponent {
 
     /**
      * Get the item at the given row in the model. Note this is the model row, not the view row.
@@ -28,11 +22,6 @@ public interface WizardItemModel<T> extends EnhancedTableModel {
      * @return the item at the given row, or null if none.
      */
     T getItem(int row);
-
-    /**
-     * Releases any resources held by the model.
-     */
-    void release();
 
     /**
      * Checks if the cell at the given row and column has a failure.

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/wizard/WizardItemStep.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/wizard/WizardItemStep.java
@@ -422,7 +422,6 @@ public abstract class WizardItemStep<S,I> extends WizardStep<S> {
 		@Override
 		public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
 			// Should never be called as cells are not editable
-			throw new UnsupportedOperationException("Unimplemented method 'setValueAt'");
 		}
 
 		@Override
@@ -438,9 +437,12 @@ public abstract class WizardItemStep<S,I> extends WizardStep<S> {
 		@Override
 		public void tableChanged(TableModelEvent e) {
 			// Have to remap the event to be from this model
-			var mappedE = new TableModelEvent(this, e.getFirstRow(), e.getLastRow(), e.getColumn()+1, e.getType());
+			if (e.getColumn() != TableModelEvent.ALL_COLUMNS) {
+				e = new TableModelEvent(this, e.getFirstRow(), e.getLastRow(), e.getColumn() + 1, e.getType());
+			}
+
 			for (TableModelListener l : listeners) {
-				l.tableChanged(mappedE);
+				l.tableChanged(e);
 			}
 		}
 	}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/wizard/WizardItemStep.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/wizard/WizardItemStep.java
@@ -14,7 +14,9 @@ import java.awt.Dimension;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -28,7 +30,8 @@ import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.border.Border;
 import javax.swing.event.ListSelectionEvent;
-import javax.swing.table.AbstractTableModel;
+import javax.swing.event.TableModelEvent;
+import javax.swing.event.TableModelListener;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellRenderer;
 
@@ -227,12 +230,31 @@ public abstract class WizardItemStep<S,I> extends WizardStep<S> {
 	 */
 	private List<I> getValidedSelection() {
 		var selectedUnits = new ArrayList<I>();
-		for (var rowModel : orderedSelection) {
-			if (!model.isFailureItem(rowModel)) {
-				selectedUnits.add(model.getItem(rowModel));
+		for (var rowSelected : orderedSelection) {
+			if (!isFailureItem(model, rowSelected)) {
+				selectedUnits.add(model.getItem(rowSelected));
 			}
 		}
 		return selectedUnits;
+	}
+
+	/**
+	 * Checks if row contains a failure cell.
+	 * 
+	 * @param model the item model.
+	 * @param row the row index.
+	 * @return true if row has failure cell.
+	 */
+	private boolean isFailureItem(WizardItemModel<I> model, int row) {
+		for (int x = 0; x < model.getColumnCount(); x++) {
+			String failure = model.isFailureCell(row, x);
+
+			// Stop on first failure
+			if (failure != null) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -272,6 +294,7 @@ public abstract class WizardItemStep<S,I> extends WizardStep<S> {
 	private static class FailureCellDecorator<I> implements TableCellRenderer {
 
 		private static final Border RED_BORDER = BorderFactory.createLineBorder(Color.RED, 2);
+		private static final Border NO_BORDER = BorderFactory.createEmptyBorder(2, 2, 2, 2);
 
 		// Private data members.
 		private WizardItemModel<I> model;
@@ -303,7 +326,7 @@ public abstract class WizardItemStep<S,I> extends WizardStep<S> {
 			if (model.isFailureCell(rowModel, column) != null)
 				l.setBorder(RED_BORDER);
 			else
-				l.setBorder(null);
+				l.setBorder(NO_BORDER);
 
 			return l;
 		}
@@ -312,12 +335,14 @@ public abstract class WizardItemStep<S,I> extends WizardStep<S> {
 	/**
 	 * This is a proxy model that adds a selection column.
 	 */
-	private class SelectionColumnModel<T> extends AbstractTableModel implements WizardItemModel<T> {
+	private class SelectionColumnModel<T> implements TableModelListener, WizardItemModel<T> {
 		private static final ColumnSpec SELECTION_COL = new ColumnSpec("#", Integer.class);
 		private WizardItemModel<T> model;
+		private Set<TableModelListener> listeners = new HashSet<>();
 
 		private SelectionColumnModel(WizardItemModel<T> model) {
 			this.model = model;
+			model.addTableModelListener(this);
 		}
 
 		@Override
@@ -335,9 +360,8 @@ public abstract class WizardItemStep<S,I> extends WizardStep<S> {
 			if (columnIndex == 0) {
 				var selectedIdx = orderedSelection.indexOf(rowIndex);
 				return selectedIdx >= 0 ? selectedIdx + 1 : null;
-			} else {
-				return model.getValueAt(rowIndex, columnIndex - 1);
 			}
+			return model.getValueAt(rowIndex, columnIndex - 1);
 		}
 
 		@Override
@@ -346,17 +370,11 @@ public abstract class WizardItemStep<S,I> extends WizardStep<S> {
 		}
 
 		@Override
-		public boolean isFailureItem(int rowIndex) {
-			return model.isFailureItem(rowIndex);
-		}
-
-		@Override
 		public String isFailureCell(int rowIndex, int columnIndex) {
 			if (columnIndex == 0) {
 				return null;
-			} else {
-				return model.isFailureCell(rowIndex, columnIndex - 1);
 			}
+			return model.isFailureCell(rowIndex, columnIndex - 1);
 		}
 
 		@Override
@@ -368,9 +386,8 @@ public abstract class WizardItemStep<S,I> extends WizardStep<S> {
 		public ColumnSpec getColumnSpec(int modelIndex) {
 			if (modelIndex == 0) {
 				return SELECTION_COL;
-			} else {
-				return model.getColumnSpec(modelIndex - 1);
 			}
+			return model.getColumnSpec(modelIndex - 1);
 		}
 
 		@Override
@@ -385,17 +402,45 @@ public abstract class WizardItemStep<S,I> extends WizardStep<S> {
 		public String getColumnName(int columnIndex) {
 			if (columnIndex == 0) {
 				return SELECTION_COL.name();
-			} else {
-				return model.getColumnName(columnIndex - 1);
 			}
+			return model.getColumnName(columnIndex - 1);
 		}
 
 		@Override
 		public Class<?> getColumnClass(int columnIndex) {
 			if (columnIndex == 0) {
 				return SELECTION_COL.type();
-			} else {
-				return model.getColumnClass(columnIndex - 1);
+			}
+			return model.getColumnClass(columnIndex - 1);
+		}
+
+		@Override
+		public boolean isCellEditable(int rowIndex, int columnIndex) {
+			return false;
+		}
+
+		@Override
+		public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
+			// Should never be called as cells are not editable
+			throw new UnsupportedOperationException("Unimplemented method 'setValueAt'");
+		}
+
+		@Override
+		public void addTableModelListener(TableModelListener l) {
+			listeners.add(l);
+		}
+
+		@Override
+		public void removeTableModelListener(TableModelListener l) {
+			listeners.remove(l);
+		}
+
+		@Override
+		public void tableChanged(TableModelEvent e) {
+			// Have to remap the event to be from this model
+			var mappedE = new TableModelEvent(this, e.getFirstRow(), e.getLastRow(), e.getColumn()+1, e.getType());
+			for (TableModelListener l : listeners) {
+				l.tableChanged(mappedE);
 			}
 		}
 	}


### PR DESCRIPTION
This reuses the Base model pattern to replace the custom table where possible in the Wizards, Mission & Transport.

To support this the Base models now have a generic `InventoryColumnHelper` that can map any Resource id into a table column that will dynamically updated as the resources change. This is used in the Vehicle & Settlement base model.

The majority of WizardItemModel are now implement by the appropriate Base model providing a consistent and dynamically updating table.

close: #1970