### PR TITLE
docs: Add Missions to documentation generator library

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/AbstractMetaMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/AbstractMetaMission.java
@@ -165,12 +165,19 @@ public abstract class AbstractMetaMission implements MetaMission {
 		return name;
 	}
 
-	protected Set<JobType> getPreferredLeaderJob() {
+	@Override
+	public Set<JobType> getPreferredLeaderJob() {
 		return preferredLeaderJob;
 	}
 
-	protected Set<JobType> getPreferredWorkerJobs() {
+	@Override
+	public Set<JobType> getPreferredWorkerJobs() {
 		return preferredWorkerJob;
+	}
+
+	@Override
+	public Set<RobotType> getPreferredRobots() {
+		return preferredRobots;
 	}
 	
 	/**
@@ -188,6 +195,15 @@ public abstract class AbstractMetaMission implements MetaMission {
 	@Override
 	public int getSolThreshold() {
 		return solThreshold;
+	}
+
+	/**
+	 * Gets the population threshold for this mission. This is the minimum number of citizens that must be present in a settlement before this mission can be created.
+	 * @return
+	 */
+	@Override
+	public int getPopThreshold() {
+		return popThreshold;
 	}
 
 	/** 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MetaMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MetaMission.java
@@ -11,9 +11,11 @@ import java.util.Set;
 
 import com.mars_sim.core.data.RatingScore;
 import com.mars_sim.core.person.Person;
+import com.mars_sim.core.person.ai.job.util.JobType;
 import com.mars_sim.core.person.ai.mission.Mission;
 import com.mars_sim.core.person.ai.mission.MissionType;
 import com.mars_sim.core.person.ai.task.util.Worker;
+import com.mars_sim.core.robot.RobotType;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.vehicle.Vehicle;
 import com.mars_sim.core.vehicle.VehicleType;
@@ -114,6 +116,12 @@ public interface MetaMission {
 	 */
     int getSolThreshold();
 
+	/**
+	 * Gets the population threshold for this mission. This is the minimum number of citizens that must be present in a settlement before this mission can be created.
+	 * @return
+	 */
+	int getPopThreshold();
+
     /**
      * Gets the preferred vehicle types for this mission. This is optional and can be left empty.
      * By default no VehicleTypes are preferred. If a VehicleType is preferred then it will be given a higher suitability score.
@@ -121,4 +129,21 @@ public interface MetaMission {
      */
     Set<VehicleType> getPreferredVehicle();
 
+	/**
+	 * Gets the preferred leader job types for this mission.
+	 * @return Preferred leader job types
+	 */
+	Set<JobType> getPreferredLeaderJob();
+
+	/**
+	 * Gets the preferred worker job types for this mission.
+	 * @return Preferred worker job types
+	 */
+    Set<JobType> getPreferredWorkerJobs();
+
+	/**
+	 * Gets the preferred robot types for this mission. This is optional and can be left empty.
+	 * @return Preferred robot types
+	 */
+	Set<RobotType> getPreferredRobots();
 }

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/HelpContext.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/HelpContext.java
@@ -61,6 +61,7 @@ public class HelpContext {
 										CrewGenerator.TYPE_NAME,
 										CropGenerator.TYPE_NAME,
 										FoodGenerator.TYPE_NAME,
+										MissionGenerator.TYPE_NAME,
 										PartGenerator.TYPE_NAME,
 										ProcessGenerator.TYPE_NAME,
 										ResourceGenerator.TYPE_NAME,
@@ -298,6 +299,7 @@ public class HelpContext {
 			case CrewGenerator.TYPE_NAME -> new CrewGenerator(this);
 			case CropGenerator.TYPE_NAME -> new CropGenerator(this);
 			case FoodGenerator.TYPE_NAME -> new FoodGenerator(this);
+			case MissionGenerator.TYPE_NAME -> new MissionGenerator(this);
 			case MalfunctionGenerator.TYPE_NAME -> new MalfunctionGenerator(this);
 			case MealGenerator.TYPE_NAME -> new MealGenerator(this);
 			case ManifestGenerator.TYPE_NAME -> new ManifestGenerator(this);

--- a/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/MissionGenerator.java
+++ b/mars-sim-tools/src/main/java/com/mars_sim/tools/helpgenerator/MissionGenerator.java
@@ -1,0 +1,71 @@
+/*
+ * Mars Simulation Project
+ * MissionGenerator.java
+ * @date 2026-07-11
+ * @author Barry Evans
+ */
+package com.mars_sim.tools.helpgenerator;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import com.mars_sim.core.mission.MetaMission;
+import com.mars_sim.core.mission.MetaMissionRegistry;
+
+/**
+ * Generates help output for Mission Meta definitions.
+ */
+public class MissionGenerator extends TypeGenerator<MetaMission> {
+
+    public static final String TYPE_NAME = "mission";
+
+    protected MissionGenerator(HelpContext parent) {
+        super(parent, TYPE_NAME, "Mission",
+                "Definitions of mission types and their planning constraints.",
+                null);
+    }
+
+    @Override
+    protected void addEntityProperties(MetaMission mission, Map<String, Object> scope) {
+        var leaderJobs = mission.getPreferredLeaderJob().stream()
+                .map(j -> j.getName())
+                .sorted()
+                .toList();
+        scope.put("leaderJobs", leaderJobs);
+        scope.put("hasLeaderJobs", !leaderJobs.isEmpty());
+
+        var workerJobs = mission.getPreferredWorkerJobs().stream()
+                .map(j -> j.getName())
+                .sorted()
+                .toList();
+        scope.put("workerJobs", workerJobs);
+        scope.put("hasWorkerJobs", !workerJobs.isEmpty());
+
+        var preferredVehicles = mission.getPreferredVehicle().stream()
+                .map(v -> v.getName())
+                .sorted()
+                .toList();
+        scope.put("preferredVehicles", preferredVehicles);
+        scope.put("hasPreferredVehicles", !preferredVehicles.isEmpty());
+
+        var preferredRobots = mission.getPreferredRobots().stream()
+                .map(r -> r.getName())
+                .sorted()
+                .toList();
+        scope.put("preferredRobots", preferredRobots);
+        scope.put("hasPreferredRobots", !preferredRobots.isEmpty());
+    }
+
+    @Override
+    protected List<MetaMission> getEntities() {
+        return MetaMissionRegistry.getMetaMissions().stream()
+                .sorted(Comparator.comparing(MetaMission::getName))
+                .toList();
+    }
+
+    @Override
+    protected String getEntityName(MetaMission mission) {
+        return mission.getName();
+    }
+}

--- a/mars-sim-tools/src/main/resources/templates/html-help/mission-detail.mustache
+++ b/mars-sim-tools/src/main/resources/templates/html-help/mission-detail.mustache
@@ -1,0 +1,62 @@
+{{<help-layout}}
+  {{$body}}
+    <div id="characteristics">
+      <h3>Characteristics</h3>
+      <table class="characteristics">
+        <tr><td>Mission Type:</td><td>{{mission.type.name}} ({{mission.type.shortCode}})</td></tr>
+        <tr><td>Automatic:</td><td>{{mission.automatic}}</td></tr>
+        <tr><td>Minimum Members:</td><td>{{mission.minimumMembers}}</td></tr>
+        <tr><td>Default Capacity:</td><td>{{mission.defaultCapacity}}</td></tr>
+        <tr><td>Sol Threshold:</td><td>{{mission.solThreshold}}</td></tr>
+        <tr><td>Population Threshold:</td><td>{{mission.popThreshold}}</td></tr>
+      </table>
+    </div>
+
+    {{#hasLeaderJobs}}
+    <div id="leader-jobs">
+      <h3>Preferred Leader Jobs</h3>
+      <ul>
+      {{#leaderJobs}}
+        <li>{{.}}</li>
+      {{/leaderJobs}}
+      </ul>
+    </div>
+    {{/hasLeaderJobs}}
+
+    {{#hasWorkerJobs}}
+    <div id="worker-jobs">
+      <h3>Preferred Worker Jobs</h3>
+      <ul>
+      {{#workerJobs}}
+        <li>{{.}}</li>
+      {{/workerJobs}}
+      </ul>
+    </div>
+    {{/hasWorkerJobs}}
+
+    {{#hasPreferredVehicles}}
+    <div id="vehicles">
+      <h3>Preferred Vehicles</h3>
+      <ul>
+      {{#preferredVehicles}}
+        <li>{{.}}</li>
+      {{/preferredVehicles}}
+      </ul>
+    </div>
+    {{/hasPreferredVehicles}}
+
+    {{#hasPreferredRobots}}
+    <div id="robots">
+      <h3>Preferred Robots</h3>
+      <ul>
+      {{#preferredRobots}}
+        <li>{{.}}</li>
+      {{/preferredRobots}}
+      </ul>
+    </div>
+    {{/hasPreferredRobots}}
+
+    </br>
+    <a class="backlink" href="index.html">Back to Mission Meta list</a>
+  {{/body}}
+{{/help-layout}}

--- a/mars-sim-tools/src/main/resources/templates/hugo/mission-detail.mustache
+++ b/mars-sim-tools/src/main/resources/templates/hugo/mission-detail.mustache
@@ -1,0 +1,54 @@
+{{>detail-head}}
+
+## Characteristics
+
+| Attribute | Value |
+|--------:|:------|
+|Mission Type:|{{mission.type.name}} ({{mission.type.shortCode}})|
+|Automatic:|{{mission.automatic}}|
+|Minimum Members:|{{mission.minimumMembers}}|
+|Default Capacity:|{{mission.defaultCapacity}}|
+|Sol Threshold:|{{mission.solThreshold}}|
+|Population Threshold:|{{mission.popThreshold}}|
+
+## Preferred Leader Jobs
+{{#hasLeaderJobs}}
+{{#leaderJobs}}
+- {{.}}
+{{/leaderJobs}}
+{{/hasLeaderJobs}}
+{{^hasLeaderJobs}}
+None defined.
+{{/hasLeaderJobs}}
+
+## Preferred Worker Jobs
+{{#hasWorkerJobs}}
+{{#workerJobs}}
+- {{.}}
+{{/workerJobs}}
+{{/hasWorkerJobs}}
+{{^hasWorkerJobs}}
+None defined.
+{{/hasWorkerJobs}}
+
+## Preferred Vehicles
+{{#hasPreferredVehicles}}
+{{#preferredVehicles}}
+- {{.}}
+{{/preferredVehicles}}
+{{/hasPreferredVehicles}}
+{{^hasPreferredVehicles}}
+None defined.
+{{/hasPreferredVehicles}}
+
+## Preferred Robots
+{{#hasPreferredRobots}}
+{{#preferredRobots}}
+- {{.}}
+{{/preferredRobots}}
+{{/hasPreferredRobots}}
+{{^hasPreferredRobots}}
+None defined.
+{{/hasPreferredRobots}}
+
+{{>footer}}

--- a/mars-sim-tools/src/test/java/com/mars_sim/tools/helpgenerator/HelpGeneratorTest.java
+++ b/mars-sim-tools/src/test/java/com/mars_sim/tools/helpgenerator/HelpGeneratorTest.java
@@ -22,6 +22,9 @@ import org.junit.jupiter.api.Test;
 import com.mars_sim.core.SimulationConfig;
 import com.mars_sim.core.SimulationRuntime;
 import com.mars_sim.core.configuration.ScenarioConfig;
+import com.mars_sim.core.mission.MetaMission;
+import com.mars_sim.core.mission.MetaMissionRegistry;
+import com.mars_sim.core.person.ai.mission.MissionType;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.core.robot.RobotType;
 
@@ -87,6 +90,7 @@ class HelpGeneratorTest {
         assertTitledTable(content, "skills", "Skills", true);
         assertTitledTable(content, "attributes", "Attributes", true);
     }
+
 
     @Test
     void testVehicleHelp() throws IOException {
@@ -268,6 +272,24 @@ class HelpGeneratorTest {
         assertDIV(content, "missions");
         assertDIV(content, "buildings");
         assertDIV(content, "vehicles");
+    }
+
+    
+    @Test
+    void testMissionHelp() throws IOException {
+        var context = createGenerator();
+        
+        // Has both inputs and outputs
+        var spec = MetaMissionRegistry.getMetaMission(MissionType.DELIVERY);
+
+        var vg = new MissionGenerator(context);
+        var content = createDoc(vg, spec);
+
+        assertTitledTable(content, "characteristics", "Characteristics", false);
+        assertDIV(content, "robots");
+        assertDIV(content, "vehicles");
+        assertDIV(content, "worker-jobs");
+        assertDIV(content, "leader-jobs");
     }
 
     /**


### PR DESCRIPTION
Changes:
- Change MetaMission to expose controlling parameters
- Create MissionGenerator to generate mission documentation
- Create mission template for Hugo & HTML
- Add unittest for Delivery documentation

ref #1986