### PR TITLE
fix: Add more defensive coding to handle concurrency problems

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/Simulation.java
@@ -83,6 +83,7 @@ import com.mars_sim.core.time.ClockPulseListener;
 import com.mars_sim.core.time.CompressedClockListener;
 import com.mars_sim.core.time.MasterClock;
 import com.mars_sim.core.time.SystemDateTime;
+import com.mars_sim.core.time.Temporal;
 import com.mars_sim.core.tool.CheckSerializedSize;
 import com.mars_sim.core.tool.Msg;
 import com.mars_sim.core.vehicle.Rover;
@@ -1385,9 +1386,9 @@ public class Simulation implements ClockPulseListener, Serializable {
 			DataLogger.changeTime(pulse.getMasterClock().getMarsTime());
 			
 			// Always update environment first			
-			orbitInfo.timePassing(pulse);
-			weather.timePassing(pulse);
-			surfaceFeatures.timePassing(pulse);
+			executePulseSafely("Orbit", pulse, orbitInfo);
+			executePulseSafely("Weather", pulse, weather);
+			executePulseSafely("Surface Features", pulse, surfaceFeatures);
 
 			if (pulse.isNewSol()) {
 				// Compute reliability daily for each part
@@ -1400,12 +1401,12 @@ public class Simulation implements ClockPulseListener, Serializable {
 			}
 
 			// Update scheduled events
-			scheduledEvents.timePassing(pulse);
+			executePulseSafely("Scheduled Events", pulse, scheduledEvents);
 
 			// Lastly cascade the pulse to the Entity managers
-			lunarColonyManager.timePassing(pulse);
-			unitManager.timePassing(pulse);			
-			marketManager.timePassing(pulse);
+			executePulseSafely("Lunar Colony Manager", pulse, lunarColonyManager);
+			executePulseSafely("Unit Manager", pulse, unitManager);			
+			executePulseSafely("Market Manager", pulse, marketManager);
 			
 			// Pending save
 			if (savePending != null) {
@@ -1413,6 +1414,20 @@ public class Simulation implements ClockPulseListener, Serializable {
 				saveCallback = null;
 				savePending = null;
 			}
+		}
+	}
+
+	/**
+	 * This executes the clock pulse on a target object and catches any exceptions that may occur during the execution.
+	 * @param context Context for any error messages
+	 * @param pulse Pulse to action
+	 * @param target Temporal object to action
+	 */
+	private void executePulseSafely(String context, ClockPulse pulse, Temporal target) {
+		try {
+			target.timePassing(pulse);
+		} catch (Exception e) {
+			logger.log(Level.SEVERE, context + ": Error during clock pulse: " + e.getMessage(), e);
 		}
 	}
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/components/RetryRowSorter.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/components/RetryRowSorter.java
@@ -23,7 +23,7 @@ public class RetryRowSorter<T extends TableModel> extends TableRowSorter<T> {
 
     public RetryRowSorter(T model) {
         super(model);
-        setSortsOnUpdates(true);
+        setSortsOnUpdates(false);
     }
 
     /**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/components/RetryRowSorter.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/components/RetryRowSorter.java
@@ -42,4 +42,23 @@ public class RetryRowSorter<T extends TableModel> extends TableRowSorter<T> {
             }
         }
     }
+
+    
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IndexOutOfBoundsException {@inheritDoc}
+     */
+    @Override
+    public void rowsUpdated(int firstRow, int endRow) {
+        for(int i = 0; i < RETRY_COUNT; i++) {
+            try {
+                super.rowsUpdated(firstRow, endRow);
+                return; // Success, exit the method
+            } catch (RuntimeException e) {
+                // Log the exception or handle it as needed
+                logger.warning("RetryRowSorter: Exception occurred while updating rows. " + e.getMessage());
+            }
+        }
+    }
 }

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/SettlementsSelector.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/SettlementsSelector.java
@@ -168,10 +168,10 @@ public class SettlementsSelector extends JPanel
 
         // If the parent authority is selected, then simulate a change selection to update the selection set
         if (selectionCombo.getSelectedItem() instanceof Authority a && a.equals(ra)) {
-            changeSelection(a);
+            SwingHelper.runInEDT(() -> changeSelection(a));
         }
 		else if (selectionCombo.getSelectedItem() instanceof String str && str.equals(ALL)) {
-			changeSelection(ALL);
+			SwingHelper.runInEDT(() -> changeSelection(ALL));
 		}
     }
 


### PR DESCRIPTION
Changes:
- RetryRowSorter now applies the catch/retry pattern when a resort is triggered via a table event
- Disable auto resorting on an table event change
- SettlementSelector uses the AWT Event thread to change the selection. This avoids the Unit Threads updating the UI
- Simulation class uses the try/catch pattern when applying the pulse to top level temporals; This reduces the blast radius of failures