### PR TITLE
fix: Prevent EVA continuing when mission aborted

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/AbstractVehicleMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/AbstractVehicleMission.java
@@ -1116,67 +1116,6 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 	}
 
 	/**
-	 * Determines the emergency destination settlement for the mission if one is
-	 * reachable, otherwise sets the emergency beacon and ends the mission.
-	 * 
-	 * @param reason
-	 */
-	protected final void determineEmergencyDestination(MissionStatus reason) {
-		Settlement oldHome = getStartingSettlement();
-
-		// Determine closest settlement.
-		boolean requestHelp = false;
-		Settlement newDestination = MissionUtil.findClosestSettlement(getCurrentMissionLocation());
-		
-		if (newDestination != null) {
-			double newDistance = getCurrentMissionLocation().getDistance(newDestination.getCoordinates());
-			int id = 0;
-
-			if (vehicle instanceof GroundVehicle v) {
-				
-				id = hasEnoughResources(getResourcesNeededForTrip(false, newDistance));
-
-				// Check if enough resources to get to settlement.
-				if (id == -1D) {
-					// Nothing is lacking
-					logger.info(v, "Reported no lacking of resources. Turning toward " + newDestination.getName() +
-							". New distance: " + Math.round(newDistance * 1000.0)/1000.0);
-				}
-				
-				else {
-					// Supposedly lacking in resources to go to this new destination. Turn on beacon
-					// Note: but it may suffice since the amount of resource needed is just an estimate and each person
-					//       can ration food and water			
-					requestHelp = true;
-					
-					// Question, should it starting driving toward the settlement as close as possible
-					//           or wait for rescue ?
-					
-					logger.info(v, "Possibly lacking resources. Turning toward " + newDestination.getName() +
-							". New distance: " + Math.round(newDistance * 1000.0)/1000.0);
-				}	
-				
-				travelDirectToSettlement(newDestination);
-				
-				// Creating emergency destination mission event for going to a new settlement.
-				if (!newDestination.equals(oldHome)) {
-					registerHistoricalEvent(newDestination, HistoricalEventType.MISSION_EMERGENCY_DESTINATION, reason.getName());
-				}
-			}
-			// Note: for Drone mission, Will need to alert the player differently if it runs out of fuel
-		}
-		else {
-			requestHelp = true;
-		}
-
-		// Need help
-		if (requestHelp) {
-			abortPhase();
-			getHelp(reason);
-		}
-	}
-
-	/**
 	 * Sets the vehicle's emergency beacon on or off.
 	 *
 	 * @param member   the mission member performing the mission.
@@ -1196,20 +1135,6 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 
 		vehicle.setEmergencyBeacon(beaconOn);
 
-	}
-
-	/**
-	 * Gets to the nearest settlement and end collection phase if necessary.
-	 */
-	public void goToNearestSettlement() {
-		Settlement nearestSettlement = MissionUtil.findClosestSettlement(getCurrentMissionLocation());
-		if (nearestSettlement != null) {
-			clearRemainingNavpoints();
-			addNavpoint(nearestSettlement);
-			// Note: Not sure if they should become citizens of another settlement
-			updateTravelDestination();
-			abortPhase();
-		}
 	}
 
 	/**
@@ -1490,13 +1415,12 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 		int index = getNextNavpointIndex();
 
 		// REmove all points that are after the current point
-		for (int x = navPoints.size()-1; x >= index; x--) {
+		for (int x = navPoints.size()-1; x > index; x--) {
 			navPoints.remove(x);
 		}
 		
 		// Note: how to compensate the shifted index upon removal of this navPoint
 		fireMissionUpdate(NAVPOINTS_EVENT);
-
 	}
 
 	/**
@@ -1699,7 +1623,10 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 			
 			// If mission is still at home then leave the vehicle
 			if (getStage() != Stage.PREPARATION) {
-				determineEmergencyDestination(status);
+				addMissionStatus(status);
+
+				// What to do with status ?
+				travelDirectToSettlement(startingSettlement);
 			}
 			else {
 				// Already at home

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/EVAMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/EVAMission.java
@@ -169,9 +169,6 @@ abstract class EVAMission extends RoverMission {
 		if (evaPhase.equals(getPhase())) {
 
 			logger.info(getRover(), "EVA ended due to external trigger.");
-
-			// set activeEVA to false
-			activeEVA = false;
 			
 			endEVATasks();
 		}
@@ -192,6 +189,8 @@ abstract class EVAMission extends RoverMission {
 				}
 			}
 		}
+
+		activeEVA = false;
 	}
     
 	/**
@@ -201,37 +200,37 @@ abstract class EVAMission extends RoverMission {
 	 * @throws MissionException if problem performing phase.
 	 */
 	private void evaPhase(Worker member) {
+		if (!activeEVA) 
+			return;
+
+		// Check if crew has been at site for more than one sol.
+		double timeDiff = getPhaseTimeElapse();
+		if (timeDiff > getEstimatedTimeAtEVASite(false)) {
+			logger.info(getVehicle(), 10_000L, "Ran out of EVA site time.");
+			addMissionLog("No More EVA Site Time", member.getName());
+			activeEVA = false;
+		}
+
+
+		// Anyone in the crew or a single person at the home settlement has a dangerous
+		// illness, end phase.
+		if (activeEVA && hasEmergency()) {
+			logger.info(getVehicle(), 10_000L, "A medical emergency was reported during the EVA phase of the mission.");
+			addMissionLog("Medical Emergency", member.getName());
+			activeEVA = false;
+		}
+
+		// Check if enough resources for remaining trip. false = not using margin.
+		if (activeEVA && !hasEnoughResourcesForRemainingMission()) {
+			logger.info(getVehicle(), 10_000L, "Not enough resources was reported during the EVA phase of the mission.");
+			addMissionLog("Not Enough Resources", member.getName());
+			activeEVA = false;
+		}
 		
+		// All good so far, perform the EVA
 		if (activeEVA) {
-			// Check if crew has been at site for more than one sol.
-			double timeDiff = getPhaseTimeElapse();
-			if (timeDiff > getEstimatedTimeAtEVASite(false)) {
-				logger.info(getVehicle(), 10_000L, "Ran out of EVA site time.");
-				addMissionLog("No More EVA Site Time", member.getName());
-				activeEVA = false;
-			}
-
-
-			// Anyone in the crew or a single person at the home settlement has a dangerous
-			// illness, end phase.
-			if (activeEVA && hasEmergency()) {
-				logger.info(getVehicle(), 10_000L, "A medical emergency was reported during the EVA phase of the mission.");
-				addMissionLog("Medical Emergency", member.getName());
-				activeEVA = false;
-			}
-
-			// Check if enough resources for remaining trip. false = not using margin.
-			if (activeEVA && !hasEnoughResourcesForRemainingMission()) {
-				logger.info(getVehicle(), 10_000L, "Not enough resources was reported during the EVA phase of the mission.");
-				addMissionLog("Not Enough Resources", member.getName());
-				activeEVA = false;
-			}
-			
-			// All good so far, perform the EVA
-			if (activeEVA) {
-				// performEVA will check if rover capacity is full
-				activeEVA = performEVA((Person) member);
-			}
+			// performEVA will check if rover capacity is full
+			activeEVA = performEVA((Person) member);
 		}
 
 		// An EVA-ending event was triggered. End EVA phase.

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/MembersPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/MembersPanel.java
@@ -74,7 +74,7 @@ class MembersPanel extends WizardItemStep<MissionDataBean, Person>
 
 		/** Constructor. */
 		private MembersTableModel(MissionDataBean state) {
-			super(NAME, JOB, SHIFT, MISSION, PERFORMANCE, HEALTH);
+			super(NAME, JOB, SHIFT, MISSION, INSIDE, PERFORMANCE, HEALTH);
 
 			List<Person> people = state.getStartingSettlement().getIndoorPeople().stream()
 					.sorted(Comparator.comparing(Person::getName))

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 		<maven.compiler.source>25</maven.compiler.source>
 		<maven.compiler.target>25</maven.compiler.target>		
 		<sonar.java.source>25</sonar.java.source>
+		<sonar.coverage.inclusions>mars-sim-core/**/*.java</sonar.coverage.inclusions>
 
 		<timestamp>${maven.build.timestamp}</timestamp>
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>


### PR DESCRIPTION
This is not guaranteed to fix tbhe problem but aims to gracefully handle the situation when an EVA is aborted.

Changes:
- In EVAMission stop new EVAs once EVA is cancelled
- When aborting return direct to the home settlement

ref #2022