### PR TITLE
Fix construction mission LUV handling

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/construction/task/ConstructBuilding.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/construction/task/ConstructBuilding.java
@@ -25,7 +25,6 @@ import com.mars_sim.core.structure.Airlock;
 import com.mars_sim.core.tool.Msg;
 import com.mars_sim.core.tool.RandomUtil;
 import com.mars_sim.core.vehicle.Crewable;
-import com.mars_sim.core.vehicle.GroundVehicle;
 import com.mars_sim.core.vehicle.LightUtilityVehicle;
 
 /**
@@ -58,7 +57,7 @@ public class ConstructBuilding extends EVAOperation {
 	private ConstructionSite site;
 	private LightUtilityVehicle luv;
 
-	private List<GroundVehicle> vehicles;
+	private List<LightUtilityVehicle> vehicles;
 
 	/**
 	 * Constructor.
@@ -103,7 +102,7 @@ public class ConstructBuilding extends EVAOperation {
 	 * @throws Exception if error constructing task.
 	 */
 	public ConstructBuilding(Person person, ConstructionStage stage, ConstructionSite site,
-			List<GroundVehicle> vehicles) {
+			List<LightUtilityVehicle> vehicles) {
 		// Use EVAOperation parent constructor.
 		super(NAME, person, RandomUtil.getRandomDouble(5D) + 100D, CONSTRUCTION);
 
@@ -243,22 +242,21 @@ public class ConstructBuilding extends EVAOperation {
 	 * @throws Exception if error obtaining construction vehicle.
 	 */
 	private void obtainVehicle() {
-		Iterator<GroundVehicle> i = vehicles.iterator();
+		Iterator<LightUtilityVehicle> i = vehicles.iterator();
 		while (i.hasNext() && (luv == null)) {
-			GroundVehicle vehicle = i.next();
+			LightUtilityVehicle vehicle = i.next();
 			if (!vehicle.getMalfunctionManager().hasMalfunction()
-				&& (vehicle instanceof LightUtilityVehicle tempLuv)
-				&& (tempLuv.getOperator() == null)) {
+				&& (vehicle.getOperator() == null)) {
 
 					// Warning: do not call addPerson directly
-//					tempLuv.addPerson(person);
+//					vehicle.addPerson(person);
 					
 					// Call transfer()
-					person.transfer(tempLuv);
+					person.transfer(vehicle);
 				
-					tempLuv.setOperator(person);
+					vehicle.setOperator(person);
 
-					luv = tempLuv;
+					luv = vehicle;
 					operatingLUV = true;
 
 					// Place light utility vehicles at random location in construction site.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/objectives/ConstructionObjective.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/objectives/ConstructionObjective.java
@@ -11,7 +11,7 @@ import java.util.List;
 import com.mars_sim.core.building.construction.ConstructionSite;
 import com.mars_sim.core.building.construction.ConstructionStage;
 import com.mars_sim.core.mission.MissionObjective;
-import com.mars_sim.core.vehicle.GroundVehicle;
+import com.mars_sim.core.vehicle.LightUtilityVehicle;
 
 /**
  * This class holds the objectives and facilities of a Construction mission.
@@ -22,11 +22,11 @@ public class ConstructionObjective implements MissionObjective {
 	private ConstructionSite site;
 	private ConstructionStage stage;
 
-	private List<GroundVehicle> constructionVehicles;
+	private List<LightUtilityVehicle> constructionVehicles;
 	private List<Integer> luvAttachmentParts;
 
     public ConstructionObjective(ConstructionSite site, ConstructionStage stage,
-            List<GroundVehicle> constructionVehicles, List<Integer> luvAttachmentParts) {
+            List<LightUtilityVehicle> constructionVehicles, List<Integer> luvAttachmentParts) {
         this.site = site;
         this.stage = stage;
         this.constructionVehicles = constructionVehicles;
@@ -46,7 +46,7 @@ public class ConstructionObjective implements MissionObjective {
         return stage;
     }
 
-    public List<GroundVehicle> getConstructionVehicles() {
+    public List<LightUtilityVehicle> getConstructionVehicles() {
         return constructionVehicles;
     }
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/ConstructionMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/ConstructionMission.java
@@ -34,7 +34,6 @@ import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.structure.SettlementParameters;
 import com.mars_sim.core.tool.RandomUtil;
 import com.mars_sim.core.vehicle.Crewable;
-import com.mars_sim.core.vehicle.GroundVehicle;
 import com.mars_sim.core.vehicle.LightUtilityVehicle;
 import com.mars_sim.core.vehicle.StatusType;
 import com.mars_sim.core.vehicle.Vehicle;
@@ -117,7 +116,7 @@ public class ConstructionMission extends AbstractMission {
 	 */
 	public ConstructionMission(Collection<Worker> members, Settlement settlement,
 			ConstructionSite choosenSite,
-			List<GroundVehicle> vehicles) {
+			List<LightUtilityVehicle> vehicles) {
 		if (choosenSite == null) {
 			throw new IllegalArgumentException("Choosen site is missing");
 		}
@@ -138,7 +137,7 @@ public class ConstructionMission extends AbstractMission {
 		createObjectives(choosenSite, vehicles);
 	}
 	
-	private void createObjectives(ConstructionSite site, List<GroundVehicle> constructionVehicles) {
+	private void createObjectives(ConstructionSite site, List<LightUtilityVehicle> constructionVehicles) {
 		var settlement = site.getAssociatedSettlement();
 		site.setWorkOnSite(this);
 
@@ -167,9 +166,9 @@ public class ConstructionMission extends AbstractMission {
 	/**
 	 * Reserves construction vehicles for the mission.
 	 */
-	private List<GroundVehicle> reserveConstructionVehicles(Settlement settlement, ConstructionStage stage) {
+	private List<LightUtilityVehicle> reserveConstructionVehicles(Settlement settlement, ConstructionStage stage) {
 		// Construct a new list of construction vehicles
-		List<GroundVehicle> constructionVehicles = new ArrayList<>();
+		List<LightUtilityVehicle> constructionVehicles = new ArrayList<>();
 		for(ConstructionVehicleType vehicleType : stage.getInfo().getVehicles()) {
 			// Only handle light utility vehicles for now.
 			if (vehicleType.getVehicleType() == VehicleType.LUV) {
@@ -208,7 +207,7 @@ public class ConstructionMission extends AbstractMission {
 	 * Retrieves LUV attachment parts from the settlement.
 	 * @return 
 	 */
-	public List<Integer> retrieveConstructionLUVParts(Settlement settlement, ConstructionStage stage, List<GroundVehicle> reserved) {
+	public List<Integer> retrieveConstructionLUVParts(Settlement settlement, ConstructionStage stage, List<LightUtilityVehicle> reserved) {
 		List<Integer> luvAttachmentParts = new ArrayList<>();
 		int vehicleIndex = 0;
 		for(var k : stage.getInfo().getVehicles()) {
@@ -449,8 +448,7 @@ public class ConstructionMission extends AbstractMission {
 	 */
 	private void showLightUtilityVehicle() {
 		var site = objective.getSite();
-		for(GroundVehicle vehicle : objective.getConstructionVehicles()) {
-			LightUtilityVehicle luv = (LightUtilityVehicle) vehicle;
+		for(LightUtilityVehicle luv : objective.getConstructionVehicles()) {
 			// Place light utility vehicles at random location in construction site.
 			LocalPosition settlementLocSite = LocalAreaUtil.getRandomLocalPos(site);
 			luv.setParkedLocation(settlementLocSite, RandomUtil.getRandomDouble(360D));
@@ -488,7 +486,7 @@ public class ConstructionMission extends AbstractMission {
 	 *
 	 * @return list of construction vehicles.
 	 */
-	public List<GroundVehicle> getConstructionVehicles() {
+	public List<LightUtilityVehicle> getConstructionVehicles() {
 		return objective.getConstructionVehicles();
 	}
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/mission/ConstructionMissionTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/mission/ConstructionMissionTest.java
@@ -1,0 +1,33 @@
+package com.mars_sim.core.person.ai.mission;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.mars_sim.core.building.construction.ConstructionSite;
+import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.core.vehicle.LightUtilityVehicle;
+
+class ConstructionMissionTest {
+
+    @Test
+    void testConstructionVehiclesAreLightUtilityVehicles() throws Exception {
+        var constructor = ConstructionMission.class.getConstructor(Collection.class, Settlement.class,
+                ConstructionSite.class, List.class);
+        assertEquals(LightUtilityVehicle.class, getListType(constructor.getGenericParameterTypes()[3]),
+                "Construction missions should only accept light utility vehicles");
+
+        var getter = ConstructionMission.class.getMethod("getConstructionVehicles");
+        assertEquals(LightUtilityVehicle.class, getListType(getter.getGenericReturnType()),
+                "Construction missions should only expose light utility vehicles");
+    }
+
+    private static Class<?> getListType(java.lang.reflect.Type type) {
+        var parameterized = (ParameterizedType) type;
+        return (Class<?>) parameterized.getActualTypeArguments()[0];
+    }
+}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/ConfirmationPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/ConfirmationPanel.java
@@ -53,7 +53,7 @@ class ConfirmationPanel extends WizardStep<MissionDataBean>  {
             attrs.addLabelledItem(Msg.getString("lightutilityvehicle.singular"), new EntityLabel(state.getLUV(), context), null);
         }
         if ((state.getConstructionVehicles() != null) && !state.getConstructionVehicles().isEmpty()) {
-            attrs.addLabelledItem(Msg.getString("lightutilityvehicle.singular"),
+            attrs.addLabelledItem(Msg.getString("lightutilityvehicle.plural"),
                     createEntityList(state.getConstructionVehicles(), context), null);
         }
 

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/ConfirmationPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/ConfirmationPanel.java
@@ -52,6 +52,10 @@ class ConfirmationPanel extends WizardStep<MissionDataBean>  {
         if (state.getLUV() != null) {
             attrs.addLabelledItem(Msg.getString("lightutilityvehicle.singular"), new EntityLabel(state.getLUV(), context), null);
         }
+        if ((state.getConstructionVehicles() != null) && !state.getConstructionVehicles().isEmpty()) {
+            attrs.addLabelledItem(Msg.getString("lightutilityvehicle.singular"),
+                    createEntityList(state.getConstructionVehicles(), context), null);
+        }
 
         // Final purpose
         if (state.getConstructionSite() != null) {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/LightUtilityVehiclePanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/LightUtilityVehiclePanel.java
@@ -10,6 +10,7 @@ package com.mars_sim.ui.swing.tool.missionwizard;
 import java.util.List;
 
 import com.mars_sim.core.person.ai.mission.Mission;
+import com.mars_sim.core.person.ai.mission.MissionType;
 import com.mars_sim.core.vehicle.LightUtilityVehicle;
 import com.mars_sim.core.vehicle.StatusType;
 import com.mars_sim.ui.swing.utils.model.BaseVehicleModel;
@@ -30,14 +31,19 @@ class LightUtilityVehiclePanel extends WizardItemStep<MissionDataBean,LightUtili
 	 * @param wizard the create mission wizard.
 	 */
 	public LightUtilityVehiclePanel(MissionCreate wizard, MissionDataBean state) {
-		super(ID, wizard, new VehicleTableModel(state));
+		super(ID, wizard, new VehicleTableModel(state), 1, getMaxSelection(state));
 	
 	}
 	
 
 	@Override
 	protected void updateState(MissionDataBean state, List<LightUtilityVehicle> selectedItems) {
-		state.setLUV(selectedItems.get(0));
+		if (state.getMissionType() == MissionType.CONSTRUCTION) {
+			state.setConstructionVehicles(selectedItems);
+		}
+		else {
+			state.setLUV(selectedItems.get(0));
+		}
 	}
 
 	/**
@@ -47,6 +53,11 @@ class LightUtilityVehiclePanel extends WizardItemStep<MissionDataBean,LightUtili
 	public void clearState(MissionDataBean state) {
 		super.clearState(state);
 		state.setLUV(null);
+		state.setConstructionVehicles(null);
+	}
+
+	private static int getMaxSelection(MissionDataBean state) {
+		return state.getMissionType() == MissionType.CONSTRUCTION ? Integer.MAX_VALUE : 1;
 	}
 
 	/**

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/MissionDataBean.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/MissionDataBean.java
@@ -243,6 +243,14 @@ class MissionDataBean {
 	public Vehicle getLUV() {
 		return luv;
 	}
+
+	public void setConstructionVehicles(List<LightUtilityVehicle> constructionVehicles) {
+		this.constructionVehicles = constructionVehicles;
+	}
+
+	public List<LightUtilityVehicle> getConstructionVehicles() {
+		return constructionVehicles;
+	}
 	
 	public void setMiningSite(MineralSite miningSite) {
 		this.miningSite = miningSite;

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/MissionDataBean.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/MissionDataBean.java
@@ -41,7 +41,6 @@ import com.mars_sim.core.robot.Robot;
 import com.mars_sim.core.science.ScientificStudy;
 import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.vehicle.Drone;
-import com.mars_sim.core.vehicle.GroundVehicle;
 import com.mars_sim.core.vehicle.LightUtilityVehicle;
 import com.mars_sim.core.vehicle.Rover;
 import com.mars_sim.core.vehicle.Vehicle;
@@ -74,7 +73,7 @@ class MissionDataBean {
     
 	private List<Person> personMembers = new ArrayList<>();
 	private List<Robot> botMembers = new ArrayList<>();
-    private List<GroundVehicle> constructionVehicles;
+    private List<LightUtilityVehicle> constructionVehicles;
 	private Map<Good, Integer> sellGoods;
 	private Map<Good, Integer> buyGoods;
 


### PR DESCRIPTION
## Summary

- Use `LightUtilityVehicle` directly for construction mission vehicle collections.
- Remove unnecessary `GroundVehicle` typing and casts around construction vehicle handling.
- Allow the mission wizard's LUV step to select multiple LUVs for construction missions while keeping mining missions single-select.
- Show selected construction LUVs on the wizard confirmation panel.
- Add a regression test that keeps `ConstructionMission` construction vehicles typed as `LightUtilityVehicle`.

## Why

Construction missions reserve and operate light utility vehicles specifically. Keeping the public mission/objective data as generic `GroundVehicle` makes the API less precise and forces casts in construction task code.

Fixes #2028.

## Validation

- `mvn -pl mars-sim-core -Dtest=ConstructionMissionTest test`
- `mvn -pl mars-sim-ui -am -DskipTests compile`