### PR TITLE
feat: Correct misreporting of mining output

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/environment/MineralSite.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/environment/MineralSite.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.mars_sim.core.authority.Authority;
@@ -174,10 +174,23 @@ public class MineralSite implements Serializable, SurfacePOI {
 	 * @return Map from resource id to estimated amount in kg
 	 */
 	public Map<Integer,Double> getEstimatedMineralAmounts() {
-		return minerals.entrySet().stream()
-				.collect(Collectors.toMap(Entry::getKey,
-									v -> (remainingMass * v.getValue().concentration())/100D));
+		return minerals.keySet().stream()
+				.collect(Collectors.toMap(Function.identity(),
+									this::getEstimatedMineralAmount));
 	}
+
+	/**
+	 * Get the estimated amount of each mineral at the site based on the Mass and mineral concentration
+	 * @return Map from resource id to estimated amount in kg
+	 */
+	public double getEstimatedMineralAmount(int resourceId) {
+		var mineral = minerals.get(resourceId);
+		if (mineral != null) {
+			return (remainingMass * mineral.concentration()) / 100D;
+		}
+		return 0.0;
+	}
+
 	/**
 	 * Gets the number of times the mineral concentration estimation has been
 	 * improved.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/objectives/MiningObjective.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/objectives/MiningObjective.java
@@ -114,7 +114,5 @@ public class MiningObjective implements MissionObjective {
     public void extractedMineral(int mineralId, double amount) {
         var found = minerals.get(mineralId);
         found.extracted += amount;
-
-        site.excavateMass(amount);
     }
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/task/CollectMinedMinerals.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/task/CollectMinedMinerals.java
@@ -11,9 +11,11 @@ import com.mars_sim.core.equipment.Container;
 import com.mars_sim.core.equipment.ContainerUtil;
 import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.logging.SimLogger;
+import com.mars_sim.core.mission.MissionObjective;
 import com.mars_sim.core.mission.objectives.MiningObjective;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.SkillType;
+import com.mars_sim.core.person.ai.mission.Mission;
 import com.mars_sim.core.person.ai.task.EVAOperation;
 import com.mars_sim.core.person.ai.task.util.TaskPhase;
 import com.mars_sim.core.tool.Msg;
@@ -55,6 +57,7 @@ public class CollectMinedMinerals extends EVAOperation {
 	
 	private MiningObjective objective;
 	private Rover rover;
+	private Mission eventSource;
 	
 	/**
 	 * Constructor.
@@ -63,8 +66,10 @@ public class CollectMinedMinerals extends EVAOperation {
 	 * @param objective The objective
 	 * @param rover Base for the collection
 	 * @param mineralType the type of mineral to collect.
+	 * @param eventSource The source of the mission event.
 	 */
-	public CollectMinedMinerals(Person person, MiningObjective objective, Rover rover, int mineralType) {
+	public CollectMinedMinerals(Person person, MiningObjective objective, Rover rover, int mineralType,
+						Mission eventSource) {
 
 		// Use EVAOperation parent constructor.
 		super(NAME, person, LABOR_TIME + RandomUtil.getRandomDouble(-5, 5), COLLECT_MINERALS);
@@ -76,6 +81,7 @@ public class CollectMinedMinerals extends EVAOperation {
 		this.mineralType = mineralType;
 		this.maxAmount = objective.getMineralStats().get(mineralType).getAvailable();
 		this.rover = rover;
+		this.eventSource = eventSource;
 
 		// Determine location for collection site.
 		setRandomOutsideLocation(rover);
@@ -203,6 +209,7 @@ public class CollectMinedMinerals extends EVAOperation {
 	@Override
 	protected void clearDown() {
 		objective.recordResourceCollected(mineralType, totalCollected);
+		eventSource.fireMissionUpdate(MissionObjective.CHANGE_EVENT, "collected");
 
 		// Task may end early before a Rover is selected
 		returnEquipmentToVehicle(rover);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/task/MineSite.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/task/MineSite.java
@@ -6,20 +6,19 @@
  */
 package com.mars_sim.core.mission.task;
 
-import com.mars_sim.core.LocalAreaUtil;
 import com.mars_sim.core.logging.SimLogger;
-import com.mars_sim.core.map.location.LocalPosition;
+import com.mars_sim.core.mission.MissionObjective;
 import com.mars_sim.core.mission.objectives.MiningObjective;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.NaturalAttributeType;
 import com.mars_sim.core.person.ai.SkillType;
+import com.mars_sim.core.person.ai.mission.Mission;
 import com.mars_sim.core.person.ai.task.EVAOperation;
 import com.mars_sim.core.person.ai.task.ExitAirlock;
 import com.mars_sim.core.person.ai.task.util.TaskPhase;
 import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.tool.Msg;
 import com.mars_sim.core.tool.RandomUtil;
-import com.mars_sim.core.vehicle.LightUtilityVehicle;
 import com.mars_sim.core.vehicle.Rover;
 
 /**
@@ -45,9 +44,9 @@ public class MineSite extends EVAOperation {
 
 
 	/** Excavation rates (kg/millisol). */
-	private static final double HAND_EXCAVATION_RATE = .1D;
+	private static final double HAND_EXCAVATION_RATE = 5D;
 	/** Excavation rates (kg/millisol). */
-	private static final double LUV_EXCAVATION_RATE = 1D;
+	private static final double LUV_EXCAVATION_RATE = 25D;
 
 	/** The base chance of an accident while operating LUV per millisol. */
 	public static final double BASE_LUV_ACCIDENT_CHANCE = .001;
@@ -57,8 +56,9 @@ public class MineSite extends EVAOperation {
 
 	// Data members
 	private MiningObjective objectives;
-	private LightUtilityVehicle luv;
 	private boolean operatingLUV;
+
+	private Mission eventSource;
 
 	/**
 	 * Constructor.
@@ -66,16 +66,17 @@ public class MineSite extends EVAOperation {
 	 * @param person the person performing the task.
 	 * @param objective   the objectives of the mining
 	 * @param rover  the rover used for the EVA operation.
+	 * @param eventSource The source of the mission event.
 	 */
-	public MineSite(Person person, MiningObjective objective, Rover rover) {
+	public MineSite(Person person, MiningObjective objective, Rover rover, Mission eventSource) {
 
 		// Use EVAOperation parent constructor.
-		super(NAME, person, RandomUtil.getRandomDouble(50D) + 10D, MINING);
+		super(NAME, person, RandomUtil.getRandomDouble(50D) + 50D, MINING);
 		setMinimumSunlight(LIGHT_LEVEL);
 
 		// Initialize data members.
 		this.objectives = objective;
-		this.luv = objective.getLUV();
+		this.eventSource = eventSource;		
 		operatingLUV = false;
 
 		if (EVAOperation.isSuperUnfit(person)){
@@ -124,6 +125,20 @@ public class MineSite extends EVAOperation {
 		return time;
 	}
 
+	@Override
+	public void endEVA(String reason) {
+		// End operating light utility vehicle.
+		if (operatingLUV) {
+			var luv = objectives.getLUV();
+			logger.info(person, "Release " + luv.getName());
+			luv.setOperator(null);
+			luv.removePerson(person);
+			operatingLUV = false;
+		}
+
+		super.endEVA(reason);
+	}
+
 	/**
 	 * Perform the mining phase of the task.
 	 *
@@ -134,41 +149,23 @@ public class MineSite extends EVAOperation {
 	private double miningPhase(double time) {
 		double remainingTime = 0;
 
-		// Check if there is reason to cut the mining phase short and return
-		// to the rover.
-		if (addTimeOnSite(time)) {
-			// End operating light utility vehicle.
-			if (person != null && luv.isCrewmember(person)) {
-				luv.removePerson(person);
-				luv.setOperator(null);
-				operatingLUV = false;
-
-			}
-			endEVA("Time on site expired.");
-			return 0;
-		}
-	
 		// Note: need to call addTimeOnSite() ahead of checkReadiness() since
 		// checkReadiness's addTimeOnSite() lacks the details of handling LUV
-		if (checkReadiness(time) > 0)
+		if (checkReadiness(time) > 0) {
 			return time;
+		}
 		
 		// Operate light utility vehicle if no one else is operating it.
-		if (person != null && !luv.getMalfunctionManager().hasMalfunction()
-				&& (luv.getCrewNum() == 0) && (luv.getRobotCrewNum() == 0)) {
+		var luv = objectives.getLUV();
+		if (!luv.getMalfunctionManager().hasMalfunction()
+				&& (luv.getOperator() == null)) {
 
-			if (luv.addPerson(person)) {
+			luv.addPerson(person);
+			luv.setOperator(person);
+			logger.info(person, "Operating " + luv.getName());
 
-				LocalPosition settlementLoc = LocalAreaUtil.getRandomLocalPos(luv);
-
-				person.setPosition(settlementLoc);
-				luv.setOperator(person);
-
-				operatingLUV = true;
-				setDescription(Msg.getString("Task.description.mineSite.detail", luv.getName())); // -NLS-1$
-			} else {
-				logger.info(person, " could not operate " + luv.getName());
-			}
+			operatingLUV = true;
+			setDescription(Msg.getString("Task.description.mineSite.detail", luv.getName())); // -NLS-1$
 		}
 
 		// Excavate minerals.
@@ -187,32 +184,38 @@ public class MineSite extends EVAOperation {
 	 * Excavating minerals from the mining site.
 	 *
 	 * @param time the time to excavate minerals.
-	 * @throws Exception if error excavating minerals.
 	 */
 	private void excavateMinerals(double time) {
-		int skill = getEffectiveSkillLevel();
-		double extractionRate = (operatingLUV ? LUV_EXCAVATION_RATE 
+		double totalToBeExtracted = (operatingLUV ? LUV_EXCAVATION_RATE 
 									: HAND_EXCAVATION_RATE) * time;
-		if (skill == 0)
-			extractionRate /= 2D;
-		else if (skill > 1)
-			extractionRate += (.2D * skill);
+		int skill = getEffectiveSkillLevel();
+		if (skill > 1)
+			totalToBeExtracted += (.2D * skill);
 
+		var totalExtracted = 0D;
 		var site = objectives.getSite();
-		var minerals = surfaceFeatures.getMineralMap()
-				.getAllMineralConcentrations(site.getLocation());
 		var siteMinerals = site.getMinerals();
-		for(var e : minerals.entrySet()) {
+		for(var e : siteMinerals.entrySet()) {
 
 			int mineralId = e.getKey();
-			double mineralConcentration = e.getValue();
-			double reserve = site.getRemainingMass();
-			double certainty = siteMinerals.get(mineralId).certainty();
-			double variance = .5 + RandomUtil.getRandomDouble(.5 * certainty) / 100;
-
-			double amountExcavated = variance * reserve * extractionRate * mineralConcentration;
-			objectives.extractedMineral(mineralId, amountExcavated);
+			double concentration = e.getValue().concentration()/100D;
+			double certainty = e.getValue().certainty()/100D;
+			double mineralExcavated = totalToBeExtracted * certainty * concentration;
+			mineralExcavated = Math.min(mineralExcavated, site.getEstimatedMineralAmount(mineralId));
+			objectives.extractedMineral(mineralId, mineralExcavated);
+			
+        	totalExtracted += mineralExcavated;
 		}
+
+		site.excavateMass(totalExtracted);
+	}
+
+	@Override
+	protected void clearDown() {
+		// Just fire one event at the end of the task
+		eventSource.fireMissionUpdate(MissionObjective.CHANGE_EVENT, "extracted");
+
+		super.clearDown();
 	}
 
 	@Override
@@ -241,6 +244,8 @@ public class MineSite extends EVAOperation {
 
 			// Driving skill modification.
 			int skill = worker.getSkillManager().getEffectiveSkillLevel(SkillType.PILOTING);
+
+			var luv = objectives.getLUV();
 			checkForAccident(luv, time, BASE_LUV_ACCIDENT_CHANCE, skill, luv.getName());
 		}
 	}
@@ -250,7 +255,7 @@ public class MineSite extends EVAOperation {
 		boolean result = super.shouldEndEVAOperation();
 
 		// If operating LUV, check if LUV has malfunction.
-		if (operatingLUV && luv.getMalfunctionManager().hasMalfunction()) {
+		if (operatingLUV && objectives.getLUV().getMalfunctionManager().hasMalfunction()) {
 			result = true;
 		}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/Mining.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/Mining.java
@@ -52,10 +52,6 @@ public class Mining extends EVAMission
 	/** default logger. */
 	private static final SimLogger logger = SimLogger.getLogger(Mining.class.getName());
 	
-	// Mining mission event types
-	public static final String EXCAVATE_MINERALS_EVENT = "excavate minerals";
-	public static final String COLLECT_MINERALS_EVENT = "collect minerals";
-	
 	/** Mission phases */
 	private static final MissionPhase MINING_SITE = new MissionPhase("Mission.phase.miningSite");
 	private static final MissionStatus MINING_SITE_NOT_BE_DETERMINED = new MissionStatus("Mission.status.miningSite");
@@ -87,6 +83,8 @@ public class Mining extends EVAMission
 	public static final int MATURE_ESTIMATE_NUM = 75;
 
 	private static final Set<ObjectiveType> OBJECTIVES = Set.of(ObjectiveType.BUILDERS_HAVEN, ObjectiveType.MANUFACTURING_DEPOT);
+
+	private static final double MIN_COLLECTION = 20;
 
 	private MiningObjective objective;
 
@@ -319,15 +317,19 @@ public class Mining extends EVAMission
 		if (person.isEVAFit()) {
 			attachLUV(false);
 
+			boolean doMining = true;
 			// Is there extractable minerals ?
 			if (getExtractMineralsStream(person).findAny().isPresent()) {
 				int mineralToCollect = getMineralToCollect(person);
-				if (mineralToCollect > 0) {
-					assignTask(person, new CollectMinedMinerals(person, objective, getRover(), mineralToCollect));
+				if (mineralToCollect > MIN_COLLECTION) {
+					assignTask(person, new CollectMinedMinerals(person, objective, getRover(), mineralToCollect, this));
+					doMining = false;
 				}
 			}
-			else {
-				assignTask(person, new MineSite(person, objective, getRover()));
+			
+			// Nothing to collect so mine
+			if (doMining) {
+				assignTask(person, new MineSite(person, objective, getRover(), this));
 			}	
 		}
 		return true;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/LightUtilityVehicle.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/LightUtilityVehicle.java
@@ -11,7 +11,6 @@ import java.util.Set;
 
 import com.mars_sim.core.EntityEventType;
 import com.mars_sim.core.data.UnitSet;
-import com.mars_sim.core.location.LocationStateType;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.resource.Part;
 import com.mars_sim.core.robot.Robot;
@@ -67,6 +66,7 @@ public class LightUtilityVehicle extends GroundVehicle implements Crewable {
 	 * 
 	 * @return capacity
 	 */
+	@Override
 	public int getCrewCapacity() {
 		return crewCapacity;
 	}
@@ -76,6 +76,7 @@ public class LightUtilityVehicle extends GroundVehicle implements Crewable {
 	 * 
 	 * @return capacity
 	 */
+	@Override
 	public int getRobotCrewCapacity() {
 		return robotCrewCapacity;
 	}
@@ -85,6 +86,7 @@ public class LightUtilityVehicle extends GroundVehicle implements Crewable {
 	 * 
 	 * @return number of crewmembers
 	 */
+	@Override
 	public int getCrewNum() {
 		if (!getCrew().isEmpty())
 			return occupants.size();
@@ -96,6 +98,7 @@ public class LightUtilityVehicle extends GroundVehicle implements Crewable {
 	 * 
 	 * @return number of crewmembers
 	 */
+	@Override
 	public int getRobotCrewNum() {
 		if (!getRobotCrew().isEmpty())
 			return robotOccupants.size();
@@ -107,6 +110,7 @@ public class LightUtilityVehicle extends GroundVehicle implements Crewable {
 	 * 
 	 * @return robot crewmembers as Collection
 	 */
+	@Override
 	public Set<Person> getCrew() {
 		if (occupants == null || occupants.isEmpty())
 			return new UnitSet<>();
@@ -118,6 +122,7 @@ public class LightUtilityVehicle extends GroundVehicle implements Crewable {
 	 * 
 	 * @return robot crewmembers as Collection
 	 */
+	@Override
 	public Set<Robot> getRobotCrew() {
 		if (robotOccupants == null || robotOccupants.isEmpty())
 			return new UnitSet<>();
@@ -130,6 +135,7 @@ public class LightUtilityVehicle extends GroundVehicle implements Crewable {
 	 * @param person the person to check
 	 * @return true if person is a crewmember
 	 */
+	@Override
 	public boolean isCrewmember(Person person) {
 		return occupants.contains(person);
 	}
@@ -140,6 +146,7 @@ public class LightUtilityVehicle extends GroundVehicle implements Crewable {
 	 * @param robot the robot to check
 	 * @return true if robot is a crewmember
 	 */
+	@Override
 	public boolean isRobotCrewmember(Robot robot) {
 		return robotOccupants.contains(robot);
 	}
@@ -158,11 +165,10 @@ public class LightUtilityVehicle extends GroundVehicle implements Crewable {
 	 * @param true if the person can be added
 	 */
 	public boolean addPerson(Person person) {
-		if (occupants.size() == 0 && robotOccupants.size() == 0) {
-			person.setLocationStateType(LocationStateType.INSIDE_VEHICLE);
+		if (occupants.size() < crewCapacity) {
 			// Fire the unit event type
 			fireUnitUpdate(EntityEventType.INVENTORY_STORING_UNIT_EVENT, person);
-			return true;
+			return occupants.add(person);
 		}
 		return false;
 	}
@@ -188,7 +194,7 @@ public class LightUtilityVehicle extends GroundVehicle implements Crewable {
 	 * @param true if the robot can be added
 	 */
 	public boolean addRobot(Robot robot) {
-		if (occupants.size() == 0 && robotOccupants.size() == 0) {
+		if (robotOccupants.size() < robotCrewCapacity) {
 			fireUnitUpdate(EntityEventType.INVENTORY_STORING_UNIT_EVENT, robot);
 			return robotOccupants.add(robot);
 		}
@@ -202,6 +208,7 @@ public class LightUtilityVehicle extends GroundVehicle implements Crewable {
 	 * @param robot
 	 * @param true if the robot can be removed
 	 */
+	@Override
 	public boolean removeRobot(Robot robot) {
 		if (isRobotCrewmember(robot)) {
 			fireUnitUpdate(EntityEventType.INVENTORY_RETRIEVING_UNIT_EVENT, robot);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/mission/objectives/MiningObjectiveTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/mission/objectives/MiningObjectiveTest.java
@@ -40,7 +40,7 @@ class MiningObjectiveTest extends MarsSimUnitTest {
         // Extract some mineral
         var amount = initialMineral/2;
         obj.extractedMineral(targetId, amount);
-
+        site.excavateMass(amount);
         assertLessThan("Site reduced mass", initialMass, site.getRemainingMass());
 
         var minDetails = obj.getMineralStats().get(targetId);

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/mission/objectives/MiningPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/mission/objectives/MiningPanel.java
@@ -16,11 +16,10 @@ import javax.swing.JTable;
 import javax.swing.table.AbstractTableModel;
 
 import com.mars_sim.core.EntityEvent;
-import com.mars_sim.core.EntityEventType;
 import com.mars_sim.core.EntityListener;
+import com.mars_sim.core.mission.MissionObjective;
 import com.mars_sim.core.mission.objectives.MiningObjective;
 import com.mars_sim.core.mission.objectives.MiningObjective.MineralStats;
-import com.mars_sim.core.person.ai.mission.Mining;
 import com.mars_sim.core.resource.AmountResource;
 import com.mars_sim.core.resource.ResourceUtil;
 import com.mars_sim.ui.swing.StyleManager;
@@ -73,9 +72,7 @@ public class MiningPanel extends JPanel
 
 	@Override
 	public void entityUpdate(EntityEvent event) {
-		if (event.getType().equals(Mining.EXCAVATE_MINERALS_EVENT)
-				|| event.getType().equals(Mining.COLLECT_MINERALS_EVENT)
-				|| EntityEventType.INVENTORY_RESOURCE_EVENT.equals(event.getType())) {
+		if (event.getType().equals(MissionObjective.CHANGE_EVENT)) {
 			excavationTableModel.updateTable();
 		}
 	}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/vehicle/NavigationTabPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/vehicle/NavigationTabPanel.java
@@ -345,7 +345,7 @@ public class NavigationTabPanel extends EntityTabPanel<Vehicle>
                 destinationLabelPanel.add(destinationButton);
             }
         }
-        catch (ArrayIndexOutOfBoundsException e) {
+        catch (ArrayIndexOutOfBoundsException _) {
             destinationLabelPanel.add(destinationButton);
         }
     }
@@ -361,7 +361,7 @@ public class NavigationTabPanel extends EntityTabPanel<Vehicle>
                 destinationLabelPanel.add(destinationTextLabel);
             }
         }
-        catch (ArrayIndexOutOfBoundsException e) {
+        catch (ArrayIndexOutOfBoundsException _) {
             destinationLabelPanel.add(destinationTextLabel);
         }
     }
@@ -400,7 +400,8 @@ public class NavigationTabPanel extends EntityTabPanel<Vehicle>
     @Override
     public void entityUpdate(EntityEvent event) {
         if (EntityEventType.COORDINATE_EVENT.equals(event.getType())
-                || EntityEventType.STATUS_EVENT.equals(event.getType())) {
+                || EntityEventType.STATUS_EVENT.equals(event.getType())
+                || EntityEventType.OPERATOR_EVENT.equals(event.getType())) {
             updateDisplay();
         }
     }


### PR DESCRIPTION
Changes:
- MineSite calculates the minerals extracted to make sure more can not be over extracted.
- Extraction calculation takes account of remianign mineral of each type
- Mining rates increased as well as time on site for Mining
- Correct problem in LightUtilityVehicle where Persons added to LUV incorrectly changes LocationState
- MineralSite returns the remianing mass for inidividual minerals
- Navigation panel in Vehicle is updated when the Operator changes
- MiningPanel (objectives) reacts to a MissionObjectives.CHANGE_EVENT
- MineSite & CollectMinedMinerals fire a CHANGE_EVENT when the Task completes.

Close #2021
Relates to #2022