### PR TITLE
fix(core): Fix building area calculation by adding shape attribute in buildings.xml

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/Building.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/Building.java
@@ -123,7 +123,6 @@ public class Building extends FixedUnit implements Malfunctionable,
 	// Regarding the length, how to best handle the variable length of brickway/walkly/hallway/tunnel 
 	private double length;
 	private double floorArea;
-	private String shape;
 	private double areaFactor;
 	private double facing;
 
@@ -214,7 +213,6 @@ public class Building extends FixedUnit implements Malfunctionable,
 		
 		this.floorArea = buildingSpec.getArea();
 		this.areaFactor = Math.sqrt(this.floorArea) / 2;
-		this.shape = buildingSpec.getShape();
 		
 		constructionType = buildingSpec.getConstruction();
 
@@ -1420,10 +1418,6 @@ public class Building extends FixedUnit implements Malfunctionable,
 
 	// TODO this is wrong as names can change. This is just used to identify if there are multiple floors.
 	public boolean isAHabOrHub() {
-		if (shape != null) {
-			return "circular".equalsIgnoreCase(shape);
-		}
-		// Fallback for tests if shape is not loaded
         return buildingType.contains(" Hab") || buildingType.contains(" Hub");
     }
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/Building.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/Building.java
@@ -123,6 +123,7 @@ public class Building extends FixedUnit implements Malfunctionable,
 	// Regarding the length, how to best handle the variable length of brickway/walkly/hallway/tunnel 
 	private double length;
 	private double floorArea;
+	private String shape;
 	private double areaFactor;
 	private double facing;
 
@@ -187,12 +188,7 @@ public class Building extends FixedUnit implements Malfunctionable,
 		this.width = bounds.getWidth();
 		this.length = bounds.getLength();
 
-		com.mars_sim.core.building.config.BuildingSpec spec = BuildingManager.getBuildingConfig().getBuildingSpec(buildingType);
-		if (spec != null) {
-			this.floorArea = spec.getArea();
-		} else {
-			this.floorArea = length * width;
-		}
+		this.floorArea = length * width;
 		
 		areaFactor = Math.sqrt(floorArea) / 2;
 				
@@ -215,6 +211,10 @@ public class Building extends FixedUnit implements Malfunctionable,
 	public Building(Settlement owner, String id, int zone, String name, BoundedObject bounds,
 						BuildingSpec buildingSpec) {
 		this(owner, id, zone, name, buildingSpec.getValidBounds(bounds), buildingSpec.getName(), buildingSpec.getCategory());
+		
+		this.floorArea = buildingSpec.getArea();
+		this.areaFactor = Math.sqrt(this.floorArea) / 2;
+		this.shape = buildingSpec.getShape();
 		
 		constructionType = buildingSpec.getConstruction();
 
@@ -1420,8 +1420,11 @@ public class Building extends FixedUnit implements Malfunctionable,
 
 	// TODO this is wrong as names can change. This is just used to identify if there are multiple floors.
 	public boolean isAHabOrHub() {
-        com.mars_sim.core.building.config.BuildingSpec spec = BuildingManager.getBuildingConfig().getBuildingSpec(buildingType);
-        return spec != null && "circular".equalsIgnoreCase(spec.getShape());
+		if (shape != null) {
+			return "circular".equalsIgnoreCase(shape);
+		}
+		// Fallback for tests if shape is not loaded
+        return buildingType.contains(" Hab") || buildingType.contains(" Hub");
     }
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/Building.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/Building.java
@@ -187,12 +187,12 @@ public class Building extends FixedUnit implements Malfunctionable,
 		this.width = bounds.getWidth();
 		this.length = bounds.getLength();
 
-		if (name.toLowerCase().contains(_HAB) || name.toLowerCase().contains(_HUB)) {
-			// For Habs and Hubs that have a circular footprint
-			this.floorArea = Math.PI * (.5 * length) * (.5 * length);
-		}
-		else
+		com.mars_sim.core.building.config.BuildingSpec spec = BuildingManager.getBuildingConfig().getBuildingSpec(buildingType);
+		if (spec != null) {
+			this.floorArea = spec.getArea();
+		} else {
 			this.floorArea = length * width;
+		}
 		
 		areaFactor = Math.sqrt(floorArea) / 2;
 				
@@ -1420,8 +1420,8 @@ public class Building extends FixedUnit implements Malfunctionable,
 
 	// TODO this is wrong as names can change. This is just used to identify if there are multiple floors.
 	public boolean isAHabOrHub() {
-        return buildingType.contains(" Hab")
-                || buildingType.contains(" Hub");
+        com.mars_sim.core.building.config.BuildingSpec spec = BuildingManager.getBuildingConfig().getBuildingSpec(buildingType);
+        return spec != null && "circular".equalsIgnoreCase(spec.getShape());
     }
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/config/BuildingConfig.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/config/BuildingConfig.java
@@ -149,6 +149,13 @@ public class BuildingConfig {
 
 		double width = Double.parseDouble(buildingElement.getAttributeValue(WIDTH));
 		double length = Double.parseDouble(buildingElement.getAttributeValue(LENGTH));
+		String shape = buildingElement.getAttributeValue("shape");
+		double area;
+		if (shape != null && shape.equalsIgnoreCase("circular")) {
+			area = Math.PI * (length / 2.0) * (length / 2.0);
+		} else {
+			area = width * length;
+		}
 		String alignment = buildingElement.getAttributeValue(N_S_ALIGNMENT);
 		int baseLevel = Integer.parseInt(buildingElement.getAttributeValue(BASE_LEVEL));
 		double presetTemp = Double.parseDouble(buildingElement.getAttributeValue(ROOM_TEMPERATURE));
@@ -204,11 +211,18 @@ public class BuildingConfig {
 			category = deriveCategory(supportedFunctions.keySet());
 		}
 
-		return new BuildingSpec(buildingTypeName, desc, category, 
+		BuildingSpec newSpec = new BuildingSpec(buildingTypeName, desc, category, 
 				width, length, alignment, constructionType, scopeNames, baseLevel,
 			 	presetTemp, maintenanceTime, wearLifeTime,
 			 	powerPriority, baseFullPowerLoad, baseLowPowerLoad,
 			 	supportedFunctions);
+		
+		newSpec.setArea(area);
+		if (shape != null) {
+			newSpec.setShape(shape);
+		}
+		
+		return newSpec;
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/config/BuildingSpec.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/config/BuildingSpec.java
@@ -39,6 +39,8 @@ public class BuildingSpec {
 
 	private double length;
 	private double width;
+	private double area;
+	private String shape;
 	
 	private String alignment;
 	private String buildingType;
@@ -197,6 +199,22 @@ public class BuildingSpec {
 
 	public double getWidth() {
 		return width;
+	}
+
+	public double getArea() {
+		return area;
+	}
+	
+	public void setArea(double area) {
+		this.area = area;
+	}
+
+	public String getShape() {
+		return shape;
+	}
+	
+	public void setShape(String shape) {
+		this.shape = shape;
 	}
 	
     /**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/function/LifeSupport.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/function/LifeSupport.java
@@ -61,7 +61,7 @@ public class LifeSupport extends Function {
 
 		length = building.getLength();
 		width = building.getWidth();
-		floorArea = length * width;
+		floorArea = building.getFloorArea();
 
 		occupants = new UnitSet<>();
 

--- a/mars-sim-core/src/main/resources/xml/buildings.xml
+++ b/mars-sim-core/src/main/resources/xml/buildings.xml
@@ -6,6 +6,7 @@
 	<!ATTLIST building category CDATA #IMPLIED>
 	<!ATTLIST building width CDATA #REQUIRED>
 	<!ATTLIST building length CDATA #REQUIRED>
+	<!ATTLIST building shape CDATA #IMPLIED>
 	<!ATTLIST building north-south-alignment (width|length) #REQUIRED>
 	<!ATTLIST building construction CDATA #IMPLIED>
 	<!ATTLIST building base-level CDATA #REQUIRED>
@@ -186,7 +187,7 @@ http://www.uss-hornet.org/groups/pdf/SEMB_MarsHabitat.pdf
 	<!-- maintenance-time: in millisols (old default : 50 millisols). -->
 	<!-- room-temperature: in deg Celsius (old default : 22.5D). -->
 	<!-- base-mass: in kg (old default : 3000). -->
-	<building type="Lander Hab" width="9.0" length="9.0" north-south-alignment="length" base-level="1"
+	<building type="Lander Hab" shape="circular" width="9.0" length="9.0" north-south-alignment="length" base-level="1"
 		wear-lifetime="3340000" maintenance-time="250" room-temperature="22.5" base-mass="3000">
 		<description> The Lander Hab is a jack-of-all-trades building that houses many basic but critical functions
 		to jump start a settlement. It's commonly used as a main hub.
@@ -3843,7 +3844,7 @@ http://www.uss-hornet.org/groups/pdf/SEMB_MarsHabitat.pdf
 	<!-- end of Astronomy Observatory-->
 
 	<!-- A lander hab refitted for storage. -->
-	<building type="Storage Hab" width="9.0" length="9.0" north-south-alignment="length" base-level="1"
+	<building type="Storage Hab" shape="circular" width="9.0" length="9.0" north-south-alignment="length" base-level="1"
 			wear-lifetime="3340000" maintenance-time="50" room-temperature="22.5" base-mass="2000">
 		<description> The Storage Hab is a Lander Hab refitted storage
 			building with ample storage space. It has built-in PV panels
@@ -3883,7 +3884,7 @@ http://www.uss-hornet.org/groups/pdf/SEMB_MarsHabitat.pdf
 	</building>
 <!-- end of Storage Hab-->
 
-	<building type="Research Hab" width="9.0" length="9.0" north-south-alignment="length" base-level="1"
+	<building type="Research Hab" shape="circular" width="9.0" length="9.0" north-south-alignment="length" base-level="1"
 			wear-lifetime="3340000" maintenance-time="150" room-temperature="22.5" base-mass="3000">
 		<description> The Research Hab is a Lander Hab refitted laboratory
 			building for scientific research. It can be custom-tailored with COMPUTING
@@ -3968,7 +3969,7 @@ http://www.uss-hornet.org/groups/pdf/SEMB_MarsHabitat.pdf
 	</building>
 <!-- end of Research Hab-->
 
-	<building type="Residential Hab" width="9.0" length="9.0" north-south-alignment="length" base-level="1"
+	<building type="Residential Hab" shape="circular" width="9.0" length="9.0" north-south-alignment="length" base-level="1"
 			wear-lifetime="3340000" maintenance-time="150" room-temperature="22.5" base-mass="2000"
 			category="LIVING">
 		<description> The Residential Hab is a Lander Hab refitted residential
@@ -4022,7 +4023,7 @@ http://www.uss-hornet.org/groups/pdf/SEMB_MarsHabitat.pdf
 <!-- end of Residential Hab-->
 
 	<!-- A lander hab refitted as a medical facility. -->
-	<building type="Medical Hab" width="9.0" length="9.0" north-south-alignment="length" base-level="1"
+	<building type="Medical Hab" shape="circular" width="9.0" length="9.0" north-south-alignment="length" base-level="1"
 			wear-lifetime="3340000" maintenance-time="100" room-temperature="22.5" base-mass="2500">
 		<description> The Medical Hab is a Lander Hab refitted medical facility
 		 for providing medical basic care. It also has medical research workbench and
@@ -4100,7 +4101,7 @@ http://www.uss-hornet.org/groups/pdf/SEMB_MarsHabitat.pdf
 	</building>
 <!-- end of Medical Hab-->
 
-	<building type="Machinery Hab" width="9.0" length="9.0" north-south-alignment="length" base-level="1"
+	<building type="Machinery Hab" shape="circular" width="9.0" length="9.0" north-south-alignment="length" base-level="1"
 			wear-lifetime="3340000" maintenance-time="250" room-temperature="22.5" base-mass="3000">
 		<description> The Machinery Hab is a Lander Hab refitted manufacturing workshop
 		 	for making items and synthesizing resource. It provides storage space for
@@ -4275,7 +4276,7 @@ http://www.uss-hornet.org/groups/pdf/SEMB_MarsHabitat.pdf
 <!-- The buildings below are constructed with in-situ materials, primarly 
 	underground and are used primarily for trading and mining settlements -->
 
-	<building type="Outpost Hub" width="10.0" length="10.0" north-south-alignment="length" 
+	<building type="Outpost Hub" shape="circular" width="10.0" length="10.0" north-south-alignment="length" 
 			construction="CONCRETE" base-level="-1"
 			wear-lifetime="3340000" maintenance-time="250" room-temperature="22.5" base-mass="3000">
 		<description> The Outpost Hub is a vaulted brick building that acts


### PR DESCRIPTION
Fixes #2031

Re-opening this PR against the official repository (my previous PR was accidentally opened against a personal fork with an outdated base).

Changes:

Added a shape="circular" attribute to buildings.xml for all circular Habs and Hubs.
Removed the hardcoded string matching (name.contains("Hab")) in Building.java.
BuildingConfig.java now parses the shape and calculates exact circular floor area using pi * r^2.
LifeSupport.java now relies on this exact floor area from the BuildingSpec instead of overestimating with length * width.
This should completely fix the oxygen and heat overestimations for the circular dome buildings.

