### PR TITLE
task: Reduce dependency on casting Settlement to EquipmentOwner

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/EntityEventType.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/EntityEventType.java
@@ -17,7 +17,6 @@ public class EntityEventType {
 	// For Unit
 	public static final String NAME_EVENT = "name";
 	public static final String DESCRIPTION_EVENT = "description";
-	public static final String MASS_EVENT = "mass";
 	public static final String COORDINATE_EVENT = "coordinate";
 	public static final String LOCAL_POSITION_EVENT = "local position";
 	
@@ -27,12 +26,7 @@ public class EntityEventType {
 
 	public static final String ADD_ASSOCIATED_ROBOT_EVENT = "add associated robot";
 	public static final String REMOVE_ASSOCIATED_ROBOT_EVENT = "remove associated robot";
-	
-	public static final String ADD_ASSOCIATED_EQUIPMENT_EVENT = "add associated equipment";
-
-	public static final String ADD_ASSOCIATED_BIN_EVENT = "add associated bin";
-	public static final String REMOVE_ASSOCIATED_BIN_EVENT = "remove associated bin";
-	
+		
 	public static final String EMOTION_EVENT = "emotion event";
 	
 	// Others
@@ -55,9 +49,6 @@ public class EntityEventType {
 	public static final String REMOVE_BUILDING_EVENT = "remove building";
 
 	public static final String START_BUILDING_PLACEMENT_EVENT = "start building placement";
-
-	// For Cooking and PreparingDessert
-	public static final String FOOD_EVENT = "food event";
 
 	// For Mind
 	public static final String JOB_EVENT = "job event";

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuitUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuitUtil.java
@@ -111,20 +111,19 @@ public final class EVASuitUtil {
 	/**
 	 * Finds the instance of an available EVA suit (preferably the one registered by the person) 
 	 * with or without resources from a given inventory. 
-	 * 
 	 * @Note: this method does not transfer the suit
 	 * 
-	 * @param owner 	the EquipmentOwner
+	 * @param inv 	the inventory to search for resources
 	 * @param p 		the person who's looking for an EVA Suit
 	 * @return EVA suit's instance
 	 */
-	public static EVASuit findEVASuitWithResources(EquipmentOwner owner, Person p) {
+	public static EVASuit findEVASuitWithResources(EquipmentOwner inv, Person p) {
 		EVASuit previousSuit = null;
 		List<EVASuit> noResourceSuits = new ArrayList<>(0);
 		List<EVASuit> goodSuits = new ArrayList<>(0);
 		List<EVASuit> suits = new ArrayList<>();
 		
-		for (Equipment e : owner.getSuitSet()) {
+		for (Equipment e : inv.getSuitSet()) {
 			EVASuit suit = (EVASuit)e;
 			boolean lastOwner = p.getIdentifier() == suit.getRegisteredOwnerID();
 			boolean malfunction = suit.getMalfunctionManager().hasMalfunction();
@@ -145,7 +144,13 @@ public final class EVASuitUtil {
 			boolean hasEnoughResources = false;
 			
 			try {
-				hasEnoughResources = hasEnoughResourcesForSuit(owner, suit);
+				var location = p.getContainerUnit();
+				int otherPeopleNum = 0;
+				if (location instanceof Settlement s)
+					otherPeopleNum = s.getIndoorPeopleCount() - 1;
+				else if (location instanceof Crewable c)
+					otherPeopleNum = c.getCrewNum();
+				hasEnoughResources = hasEnoughResourcesForSuit(inv, suit, otherPeopleNum);
 
 			} catch (Exception ex) {
 				logger.severe(p, 50_000,
@@ -204,38 +209,34 @@ public final class EVASuitUtil {
 	/**
 	 * Checks if entity unit has enough resource supplies to fill the EVA suit.
 	 *
-	 * @param owner 	the EquipmentOwner
+	 * @param resourceStore 	the EquipmentOwner
 	 * @param suit      the EVA suit
+	 * @param otherPeopleNum  the number of other people who will be using the EVA suit
 	 * @return true if enough supplies
 	 */
-	private static boolean hasEnoughResourcesForSuit(EquipmentOwner owner, EVASuit suit) {
-		int otherPeopleNum = 0;
-		if (owner instanceof Settlement s)
-			otherPeopleNum = s.getIndoorPeopleCount() - 1;
-		else if (owner instanceof Crewable c)
-			otherPeopleNum = c.getCrewNum();
-		
+	private static boolean hasEnoughResourcesForSuit(EquipmentOwner resourceStore, EVASuit suit, int otherPeopleNum) {
+
 		// Check if enough oxygen.
 		double neededOxygen = suit.getRemainingCombinedCapacity(ResourceUtil.OXYGEN_ID);
-		double availableOxygen = owner.getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID);
+		double availableOxygen = resourceStore.getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID);
 		// Make sure there is enough extra oxygen for everyone else.
 		availableOxygen -= (neededOxygen * otherPeopleNum);
 		boolean hasEnoughOxygen = (availableOxygen >= neededOxygen);
 
 		// Check if enough water.
 		double neededWater = suit.getRemainingCombinedCapacity(ResourceUtil.WATER_ID);
-		double availableWater = owner.getSpecificAmountResourceStored(ResourceUtil.WATER_ID);
+		double availableWater = resourceStore.getSpecificAmountResourceStored(ResourceUtil.WATER_ID);
 		// Make sure there is enough extra water for everyone else.
 		availableWater -= (neededWater * otherPeopleNum);
 		boolean hasEnoughWater = (availableWater >= neededWater);
 
 		// it's okay even if there's not enough water
 		if (!hasEnoughWater) {
-			if (owner instanceof Settlement settlement)
+			if (resourceStore instanceof Settlement settlement)
 				logger.warning(settlement, 20_000, 
 					"No enough water to feed " + suit.getName() 
 					+ " but can still use the EVA Suit.");
-			else if (owner instanceof Rover rover)
+			else if (resourceStore instanceof Rover rover)
 				logger.warning(rover, 20_000, 
 					"No enough water to feed " + suit.getName() 
 					+ " but can still use the EVA Suit.");

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentFactory.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentFactory.java
@@ -9,7 +9,6 @@ package com.mars_sim.core.equipment;
 
 import java.util.EnumMap;
 
-import com.mars_sim.core.EntityEventType;
 import com.mars_sim.core.UnitManager;
 import com.mars_sim.core.structure.Settlement;
 
@@ -74,7 +73,6 @@ public final class EquipmentFactory {
 
 		// Add this equipment as being placed in this settlement
 		settlement.addEquipment(newEqm);
-		settlement.fireUnitUpdate(EntityEventType.ADD_ASSOCIATED_EQUIPMENT_EVENT, newEqm);
 		return newEqm;
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/food/FoodUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/food/FoodUtil.java
@@ -55,12 +55,23 @@ public class FoodUtil {
 	/**
 	 * Converts good object to food object.
 	 * 
-	 * @param food
-	 * @return
+	 * @param good Source Good.
 	 */
 	public static Food convertGoodToFood(Good good) {
 		return getFoodList().stream()
 			    .filter(f -> f.getID() == good.getID())
+			    .findFirst().orElse(null);
+	}
+	
+	/**
+	 * Converts resource Id to food object.
+	 * 
+	 * @param resourceId Source resource Id.
+	 * @return
+	 */
+	public static Food convertResourceToFood(int resourceId) {
+		return getFoodList().stream()
+			    .filter(f -> f.getID() == resourceId)
 			    .findFirst().orElse(null);
 	}
 	

--- a/mars-sim-core/src/main/java/com/mars_sim/core/malfunction/task/RepairInsideMalfunction.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/malfunction/task/RepairInsideMalfunction.java
@@ -102,10 +102,7 @@ public class RepairInsideMalfunction extends Task implements Repair {
 		logger.info(worker, "Starting repair " + malfunction.getName());
 		this.partStore = RepairHelper.getClosestRepairStore(worker);
 
-		if (RepairHelper.hasRepairParts(partStore, malfunction)) {
-			logger.log(worker, Level.INFO, 1_000, "Parts available for repairing malfunction '" + malfunction + "' in " + entity.getName() + ".");
-		} 
-		else {
+		if (!RepairHelper.hasRepairParts(partStore, malfunction)) {
 			logger.log(worker, Level.INFO, 1_000, "Parts not available for repairing malfunction '" + malfunction + "' in " + entity.getName() + ".");
 			endTask();
 		}	
@@ -176,12 +173,7 @@ public class RepairInsideMalfunction extends Task implements Repair {
 		}
 		
 		// Add repair parts if necessary.
-		if (RepairHelper.hasRepairParts(partStore, malfunction)) {
-			if (!worker.isOutside()) {
-				logger.log(worker, Level.INFO, 1_000, "Parts available for repairing malfunction '" + malfunction + "' in " + entity.getName() + ".");
-			}
-		} 
-		else {
+		if (!RepairHelper.hasRepairParts(partStore, malfunction)) {
 			logger.log(worker, Level.INFO, 1_000, "Parts not available for repairing malfunction '" + malfunction + "' in " + entity.getName() + ".");
 		}
 		

--- a/mars-sim-core/src/main/java/com/mars_sim/core/malfunction/task/RepairMalfunctionMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/malfunction/task/RepairMalfunctionMeta.java
@@ -6,6 +6,7 @@
  */
 package com.mars_sim.core.malfunction.task;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -22,6 +23,7 @@ import com.mars_sim.core.malfunction.RepairHelper;
 import com.mars_sim.core.person.Person;
 import com.mars_sim.core.person.ai.fav.FavoriteType;
 import com.mars_sim.core.person.ai.job.util.JobType;
+import com.mars_sim.core.person.ai.task.util.AbstractTaskJob;
 import com.mars_sim.core.person.ai.task.util.FactoryMetaTask;
 import com.mars_sim.core.person.ai.task.util.SettlementMetaTask;
 import com.mars_sim.core.person.ai.task.util.SettlementTask;
@@ -41,69 +43,104 @@ import com.mars_sim.core.tool.Msg;
  */
 public class RepairMalfunctionMeta extends FactoryMetaTask implements SettlementMetaTask {
 	
-	private static class RepairTaskJob extends SettlementTask {
+	record RepairNeeded(Malfunctionable broken, Malfunction malfunction, int demand, boolean eva, RatingScore score)
+				implements Serializable {
+					
+		Task createRobotRepair(Robot robot) {
+			if (eva) {
+				throw new IllegalStateException("Robots cannot perform eva repairs");
+			}
+			return new RepairInsideMalfunction(robot, broken, malfunction);
+		}
+
+		Task createPersonRepair(Person person) {
+			if (eva) {
+				return new RepairEVAMalfunction(person, broken, malfunction);
+			}
+			return new RepairInsideMalfunction(person, broken, malfunction);
+		}
+
+		String getDescription() {
+			return "Repair " + (eva ? "EVA " : "") + malfunction.getMalfunctionMeta().getName();
+		}
+	}
+
+	/**
+	 * This is for use as a Repair that goes onto the Settlement Backlog.
+	 */
+	private static class SettlementRepairTask extends SettlementTask {
 		
 		private static final long serialVersionUID = 1L;
+		private RepairNeeded repair;
 
-		private Malfunction mal;
-
-		public RepairTaskJob(SettlementMetaTask ownerTask, Settlement owner, Malfunctionable entity, Malfunction mal,
-							 int demand, boolean eva, RatingScore score) {
-			super(ownerTask, owner, "Repair " + (eva ? "EVA " : "") + mal.getMalfunctionMeta().getName(), entity,
-						score);
-			setDemand(demand);
-			setEVA(eva);
-			this.mal = mal;
+		public SettlementRepairTask(SettlementMetaTask ownerTask, Settlement owner, RepairNeeded repair) {
+			super(ownerTask, owner, repair.getDescription(), repair.broken,
+					repair.score);
+			setDemand(repair.demand);
+			setEVA(repair.eva);
+			this.repair = repair;
 		}
-		
-		/**
-		 * The Malfunctionable with the fault is the focus of this Task.
-		 */
-		Malfunctionable getProblem() {
-			return (Malfunctionable) getFocus();
-		}
-
 
 		@Override
 		public Task createTask(Person person) {
-			if (isEVA()) {
-				return new RepairEVAMalfunction(person, getProblem(), mal);
-			}
-			return new RepairInsideMalfunction(person, getProblem(), mal);
+			return repair.createPersonRepair(person);
 		}
 
 		@Override
 		public Task createTask(Robot robot) {
-			if (isEVA()) {
-				throw new IllegalStateException("Robots cannot perform eva repairs");
-			}
-			return new RepairInsideMalfunction(robot, getProblem(), mal);
+			return repair.createRobotRepair(robot);
 		}
 
 		@Override
 		public int hashCode() {
-			return super.hashCode();
+			final int prime = 31;
+			int result = super.hashCode();
+			result = prime * result + repair.hashCode();
+			return result;
 		}
 
 		@Override
 		public boolean equals(Object obj) {
-			if (super.equals(obj)) {
-				// Check the actual malfunction to distinguish between 2 repiar task on the same entity
-				RepairTaskJob other = (RepairTaskJob) obj;
-				if (mal == null) {
-					if (other.mal != null)
-						return false;
-				} else if (!mal.equals(other.mal))
-					return false;
+			if (this == obj)
 				return true;
-			}
-			return false;
+			if (obj == null)
+				return false;
+			if (!super.equals(obj))
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			SettlementRepairTask other = (SettlementRepairTask) obj;
+			return repair.equals(other.repair);
+		}
+	}
+
+	/**
+	 * This is a repair task for a specific malfunction on a specific entity. This is for individuals.
+	 */
+	private static class RepairTaskJob extends AbstractTaskJob {
+		
+		private static final long serialVersionUID = 1L;
+
+		private RepairNeeded repair;
+
+		public RepairTaskJob(RepairNeeded repair) {
+			super(repair.getDescription(), repair.score);
+			this.repair = repair;
+		}
+		
+		@Override
+		public Task createTask(Person person) {
+			return repair.createPersonRepair(person);
+		}
+
+		@Override
+		public Task createTask(Robot robot) {
+			return repair.createRobotRepair(robot);
 		}
 	}
 	
     /** Task name */
-    private static final String NAME = Msg.getString(
-            "Task.description.repairMalfunction"); //$NON-NLS-1$
+    private static final String NAME = Msg.getString("Task.description.repairMalfunction"); //$NON-NLS-1$
 
 	private static final double WEIGHT = 5D;
 	
@@ -129,12 +166,10 @@ public class RepairMalfunctionMeta extends FactoryMetaTask implements Settlement
         if (person.isInVehicle()) {
 			EquipmentOwner partStore = person.getVehicle();
 			Collection<Malfunctionable> source = MalfunctionFactory.getMalfunctionables(person.getVehicle());
-			for (SettlementTask t: getRepairTasks(source, partStore)) {
-				RepairTaskJob rtj = (RepairTaskJob) t;
-				RatingScore score = new RatingScore(rtj.getScore());
+			for (RepairNeeded t: getRepairTasks(source, partStore)) {
+				RatingScore score = new RatingScore(t.score);
 				score.addModifier("inside", 3D); //Repairs in Vehicles are important
-				tasks.add(new RepairTaskJob(this, person.getAssociatedSettlement(), rtj.getProblem(), rtj.mal, rtj.getDemand(),
-											rtj.isEVA(), score));
+				tasks.add(new RepairTaskJob(t));
 			}
 		}
 
@@ -170,7 +205,11 @@ public class RepairMalfunctionMeta extends FactoryMetaTask implements Settlement
 	public List<SettlementTask> getSettlementTasks(Settlement settlement) {
 		Collection<Malfunctionable> source = MalfunctionFactory.getAssociatedMalfunctionables(settlement);
 
-		return getRepairTasks(source, settlement);
+		List<SettlementTask> settlementTasks = new ArrayList<>();
+		for(var r : getRepairTasks(source, settlement.getEquipmentInventory())) {
+			settlementTasks.add(new SettlementRepairTask(this, settlement, r));
+		}
+		return settlementTasks;
 	}
 
 	/**
@@ -178,10 +217,11 @@ public class RepairMalfunctionMeta extends FactoryMetaTask implements Settlement
 	 * 
 	 * @param source Source of repair tasks
 	 * @param partStore Where any needed Parts come from
+	 * @param settlement 
 	 */
-    private List<SettlementTask> getRepairTasks(Collection<Malfunctionable> source, EquipmentOwner partStore) {
+    private List<RepairNeeded> getRepairTasks(Collection<Malfunctionable> source, EquipmentOwner partStore) {
 
-		List<SettlementTask> tasks = new ArrayList<>();
+		List<RepairNeeded> tasks = new ArrayList<>();
 		
         // Add probability for all malfunctionable entities in person's local.
         for (Malfunctionable entity : source) {
@@ -195,25 +235,19 @@ public class RepairMalfunctionMeta extends FactoryMetaTask implements Settlement
 			MalfunctionManager manager = entity.getMalfunctionManager();
 			if (manager.hasMalfunction()) {
 				// Create repair tasks for all active malfunctions
-				for(Malfunction mal : manager.getMalfunctions()) {
-					SettlementTask task = createRepairTask(partStore, entity, mal, MalfunctionRepairWork.INSIDE);
-					if (task != null) {
-						tasks.add(task);
-					}
+				var active = manager.getMalfunctions().stream()
+						.map(m -> createRepair(partStore, entity, m, MalfunctionRepairWork.INSIDE))
+						.filter(m -> m != null)
+						.toList();
 
-					// Pick any EVA repair activities
-					task = createRepairTask(partStore, entity, mal, MalfunctionRepairWork.EVA);
-					if (task != null) {
-						tasks.add(task);
-					}
-				}
+				tasks.addAll(active);
 			}
 		}
 		return tasks;
 	}
 
 	/**
-     * Creates a repair task for a Malfunction.
+     * Creates a repair for a Malfunction.
      * 
 	 * @param partsStore Where are spare parts coming from
 	 * @param entity Entity suffering the malfunction
@@ -221,9 +255,8 @@ public class RepairMalfunctionMeta extends FactoryMetaTask implements Settlement
 	 * @param workType Type of work to check for.
      * @return It may return null if the Malfunction need no further repair work
      */
-    private SettlementTask createRepairTask(EquipmentOwner partsStore, Malfunctionable entity,
-											Malfunction malfunction,
-											MalfunctionRepairWork workType) {    
+    private RepairNeeded createRepair(EquipmentOwner partsStore, Malfunctionable entity,
+											Malfunction malfunction, MalfunctionRepairWork workType) {    
 		if (!malfunction.isWorkDone(workType)
 				&& (malfunction.numRepairerSlotsEmpty(workType) > 0)) {
 			RatingScore score = new RatingScore(WEIGHT);
@@ -233,7 +266,7 @@ public class RepairMalfunctionMeta extends FactoryMetaTask implements Settlement
 	    		score.addModifier("parts", 2);
 	    	}
 		
-			return new RepairTaskJob(this, (partsStore instanceof Settlement s ? s : null), entity, malfunction,
+			return new RepairNeeded(entity, malfunction,
 									malfunction.numRepairerSlotsEmpty(workType),
 									(workType == MalfunctionRepairWork.EVA),
 									score);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/malfunction/task/RepairMalfunctionMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/malfunction/task/RepairMalfunctionMeta.java
@@ -217,7 +217,6 @@ public class RepairMalfunctionMeta extends FactoryMetaTask implements Settlement
 	 * 
 	 * @param source Source of repair tasks
 	 * @param partStore Where any needed Parts come from
-	 * @param settlement 
 	 */
     private List<RepairNeeded> getRepairTasks(Collection<Malfunctionable> source, EquipmentOwner partStore) {
 
@@ -233,14 +232,18 @@ public class RepairMalfunctionMeta extends FactoryMetaTask implements Settlement
 
 			// Get the malfunction manager
 			MalfunctionManager manager = entity.getMalfunctionManager();
-			if (manager.hasMalfunction()) {
-				// Create repair tasks for all active malfunctions
-				var active = manager.getMalfunctions().stream()
-						.map(m -> createRepair(partStore, entity, m, MalfunctionRepairWork.INSIDE))
-						.filter(m -> m != null)
-						.toList();
+			
+			// Create repair tasks for all active malfunctions
+			for(var m : manager.getMalfunctions()) {
+				var inside = createRepair(partStore, entity, m, MalfunctionRepairWork.INSIDE);
+				if (inside != null) {
+					tasks.add(inside);
+				}
 
-				tasks.addAll(active);
+				var outside = createRepair(partStore, entity, m, MalfunctionRepairWork.EVA);
+				if (outside != null) {
+					tasks.add(outside);
+				}
 			}
 		}
 		return tasks;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/process/ProcessInfo.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/process/ProcessInfo.java
@@ -9,8 +9,6 @@ package com.mars_sim.core.process;
 import java.io.Serializable;
 import java.util.List;
 
-import com.mars_sim.core.EntityEventType;
-import com.mars_sim.core.goods.GoodsUtil;
 import com.mars_sim.core.resource.ItemType;
 import com.mars_sim.core.structure.Settlement;
 
@@ -231,9 +229,7 @@ public abstract class ProcessInfo implements Serializable , Comparable<ProcessIn
 					break;
 				default:
 					throw new IllegalArgumentException("Process input: " + item.getType() + " not a valid type.");
-			}
-			
-			settlement.fireUnitUpdate(EntityEventType.MASS_EVENT, GoodsUtil.getGood(item.getId()));
+			}			
 		}
 	}
 	

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -61,7 +61,6 @@ import com.mars_sim.core.events.ScheduledEventManager;
 import com.mars_sim.core.goods.CreditManager;
 import com.mars_sim.core.goods.GoodsManager;
 import com.mars_sim.core.goods.GoodsManager.CommerceType;
-import com.mars_sim.core.goods.GoodsUtil;
 import com.mars_sim.core.logging.SimLogger;
 import com.mars_sim.core.manufacture.ManufacturingManager;
 import com.mars_sim.core.map.location.Coordinates;
@@ -2120,9 +2119,7 @@ public class Settlement extends Unit implements Temporal,
 	 */
 	@Override
 	public boolean addEquipment(Equipment e) {
-		boolean success = eqmInventory.addEquipment(e);
-		fireUnitUpdate(EntityEventType.MASS_EVENT, GoodsUtil.getGood(e.getIdentifier()));
-		return success;
+		return eqmInventory.addEquipment(e);
 	}
 
 	/**
@@ -2132,9 +2129,7 @@ public class Settlement extends Unit implements Temporal,
 	 */
 	@Override
 	public boolean removeEquipment(Equipment e) {
-		boolean success = eqmInventory.removeEquipment(e);
-		fireUnitUpdate(EntityEventType.MASS_EVENT, GoodsUtil.getGood(e.getIdentifier()));
-		return success;
+		return eqmInventory.removeEquipment(e);
 	}
 
 	/**
@@ -2145,12 +2140,7 @@ public class Settlement extends Unit implements Temporal,
 	 */
 	@Override
 	public boolean addBin(Bin bin) {
-		if (eqmInventory.addBin(bin)) {
-			fireUnitUpdate(EntityEventType.ADD_ASSOCIATED_BIN_EVENT, this);
-			fireUnitUpdate(EntityEventType.MASS_EVENT, GoodsUtil.getGood(bin.getID()));
-			return true;
-		}
-		return false;
+		return eqmInventory.addBin(bin);
 	}
 
 	/**
@@ -3081,9 +3071,7 @@ public class Settlement extends Unit implements Temporal,
 	 */
 	@Override
 	public int storeItemResource(int resource, int quantity) {
-		int num = eqmInventory.storeItemResource(resource, quantity);
-		fireUnitUpdate(EntityEventType.MASS_EVENT, GoodsUtil.getGood(resource));
-		return num;
+		return eqmInventory.storeItemResource(resource, quantity);
 	}
 
 	/**
@@ -3095,9 +3083,7 @@ public class Settlement extends Unit implements Temporal,
 	 */
 	@Override
 	public int retrieveItemResource(int resource, int quantity) {
-		int num = eqmInventory.retrieveItemResource(resource, quantity);
-		fireUnitUpdate(EntityEventType.MASS_EVENT, GoodsUtil.getGood(resource));
-		return num;
+		return eqmInventory.retrieveItemResource(resource, quantity);
 	}
 
 	/**
@@ -3120,9 +3106,7 @@ public class Settlement extends Unit implements Temporal,
 	 */
 	@Override
 	public double storeAmountResource(int resource, double quantity) {
-		double amt = eqmInventory.storeAmountResource(resource, quantity);
-		fireUnitUpdate(EntityEventType.MASS_EVENT, GoodsUtil.getGood(resource));
-		return amt;
+		return eqmInventory.storeAmountResource(resource, quantity);
 	}
 
 	/**
@@ -3134,9 +3118,7 @@ public class Settlement extends Unit implements Temporal,
 	 */
 	@Override
 	public double retrieveAmountResource(int resource, double quantity) {
-		double amt = eqmInventory.retrieveAmountResource(resource, quantity);
-		fireUnitUpdate(EntityEventType.MASS_EVENT, GoodsUtil.getGood(resource));
-		return amt;
+		return eqmInventory.retrieveAmountResource(resource, quantity);
 	}
 
 	/**

--- a/mars-sim-core/src/test/java/com/mars_sim/core/malfunction/task/RepairMalfunctionMetaTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/malfunction/task/RepairMalfunctionMetaTest.java
@@ -27,7 +27,7 @@ class RepairMalfunctionMetaTest extends MarsSimUnitTest {
         MalfunctionManager.setNoFailures(true);
     }
 
-    private void byuldMalfunction(String fault, Malfunctionable b, EquipmentOwner eqmInv) {
+    private void buldMalfunction(String fault, Malfunctionable b, EquipmentOwner eqmInv) {
         
         var mm = getConfig().getMalfunctionConfiguration().getMalfunctionList().stream()
                 .filter(m -> m.getName().equals(fault))
@@ -52,7 +52,7 @@ class RepairMalfunctionMetaTest extends MarsSimUnitTest {
         var tasks = mt.getSettlementTasks(s);
         assertTrue(tasks.isEmpty(), "No tasks should be available when there are no malfunctions");
 
-        byuldMalfunction(FIRE, b, s.getEquipmentInventory());
+        buldMalfunction(FIRE, b, s.getEquipmentInventory());
 
         tasks = mt.getSettlementTasks(s);
         assertEquals(1, tasks.size(), "Tasks should be available when resources are available");
@@ -69,7 +69,7 @@ class RepairMalfunctionMetaTest extends MarsSimUnitTest {
         var tasks = mt.getTaskJobs(p);
         assertTrue(tasks.isEmpty(), "No tasks should be available when there are no malfunctions");
 
-        byuldMalfunction(FIRE, v, s.getEquipmentInventory());
+        buldMalfunction(FIRE, v, s.getEquipmentInventory());
 
         tasks = mt.getTaskJobs(p);
         assertEquals(1, tasks.size(), "Tasks should be available when resources are available");

--- a/mars-sim-core/src/test/java/com/mars_sim/core/malfunction/task/RepairMalfunctionMetaTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/malfunction/task/RepairMalfunctionMetaTest.java
@@ -1,0 +1,77 @@
+package com.mars_sim.core.malfunction.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.mars_sim.core.equipment.EquipmentOwner;
+import com.mars_sim.core.malfunction.MalfunctionManager;
+import com.mars_sim.core.malfunction.Malfunctionable;
+import com.mars_sim.core.map.location.LocalPosition;
+import com.mars_sim.core.test.MarsSimUnitTest;
+
+class RepairMalfunctionMetaTest extends MarsSimUnitTest {
+    private static final String FIRE = "Class A Combustible Fire";
+
+    // This unit test needs failures
+    @BeforeEach
+    void setup() {
+        MalfunctionManager.setNoFailures(false);
+    }
+
+    @AfterEach
+    void teardown() {
+        MalfunctionManager.setNoFailures(true);
+    }
+
+    private void byuldMalfunction(String fault, Malfunctionable b, EquipmentOwner eqmInv) {
+        
+        var mm = getConfig().getMalfunctionConfiguration().getMalfunctionList().stream()
+                .filter(m -> m.getName().equals(fault))
+                .findFirst();
+        assertTrue(mm.isPresent(), fault + " malfunction should be defined in the configuration");
+        var fire = mm.get();
+
+        var man = b.getMalfunctionManager();
+        var m = man.triggerMalfunction(fire, false, null);
+        assertTrue(man.hasMalfunction(), "Malfunction should be present after triggering");
+
+        m.getRepairParts().entrySet().forEach(e -> eqmInv.storeItemResource(e.getKey().getPart().getID(),
+                                                                    e.getValue()));                                                            
+    }
+
+    @Test
+    void testGetSettlementTasks() {
+        var s = buildSettlement("test");
+        var b = buildResearch(s.getBuildingManager(), LocalPosition.DEFAULT_POSITION, 0D);
+
+        var mt = new RepairMalfunctionMeta();
+        var tasks = mt.getSettlementTasks(s);
+        assertTrue(tasks.isEmpty(), "No tasks should be available when there are no malfunctions");
+
+        byuldMalfunction(FIRE, b, s.getEquipmentInventory());
+
+        tasks = mt.getSettlementTasks(s);
+        assertEquals(1, tasks.size(), "Tasks should be available when resources are available");
+    }
+
+    @Test
+    void testVehicleFault() {
+        var s = buildSettlement("test");
+        var v = buildRover(s, CARGO_ROVER, LocalPosition.DEFAULT_POSITION, TRANSPORT_ROVER);
+        var p = buildPerson("Fixed", s);
+        p.transfer(v);
+
+        var mt = new RepairMalfunctionMeta();
+        var tasks = mt.getTaskJobs(p);
+        assertTrue(tasks.isEmpty(), "No tasks should be available when there are no malfunctions");
+
+        byuldMalfunction(FIRE, v, s.getEquipmentInventory());
+
+        tasks = mt.getTaskJobs(p);
+        assertEquals(1, tasks.size(), "Tasks should be available when resources are available");
+    }
+}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/FoodTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/FoodTableModel.java
@@ -79,31 +79,32 @@ class FoodTableModel extends CategoryTableModel<Food> {
 	 */
 	@Override
 	public void entityUpdate(EntityEvent event) {
-		if (event.getTarget() instanceof Good g
-				&& event.getSource() instanceof Settlement s) {
+		String eventType = event.getType();
+
+		if (event.getSource() instanceof Settlement s) {
+			if (event.getTarget() instanceof Good g) {
+				// Target is a Good
+				Food f = FoodUtil.convertGoodToFood(g);
+				CategoryKey<Food> key = new CategoryKey<>(s, f);
 			
-			String eventType = event.getType();
-			Food f = FoodUtil.convertGoodToFood(g);
-			CategoryKey<Food> key = new CategoryKey<>(s, f);
-		
-			if (EntityEventType.DEMAND_EVENT.equals(eventType)) {
-				entityValueUpdated(key, LOCAL_DEMAND_COL); 
-			} else if (EntityEventType.MARKET_VALUE_EVENT.equals(eventType)) {
-				entityValueUpdated(key, MARKET_DEMAND_COL);
-			} else if (EntityEventType.SUPPLY_EVENT.equals(eventType)) {
-				entityValueUpdated(key, SUPPLY_COL);
-			} else if (EntityEventType.MASS_EVENT.equals(eventType)) {
+				switch(eventType) {
+					case EntityEventType.DEMAND_EVENT -> entityValueUpdated(key, LOCAL_DEMAND_COL);
+					case EntityEventType.MARKET_VALUE_EVENT -> {
+						entityValueUpdated(key, MARKET_DEMAND_COL);
+						entityValueUpdated(key, MARKET_VP_COL);
+					}
+					case EntityEventType.SUPPLY_EVENT -> entityValueUpdated(key, SUPPLY_COL);
+					case EntityEventType.VALUE_EVENT -> entityValueUpdated(key, LOCAL_VP_COL);
+					case EntityEventType.COST_EVENT -> entityValueUpdated(key, COST_COL);
+					case EntityEventType.PRICE_EVENT -> entityValueUpdated(key, PRICE_COL);
+					default -> entityValueUpdated(key, NUM_INITIAL_COLUMNS, COLUMNCOUNT-1);
+				}
+			}
+			else if (EntityEventType.INVENTORY_RESOURCE_EVENT.equals(eventType)
+					&& event.getTarget() instanceof Integer resourceID) {
+				Food f = FoodUtil.convertResourceToFood(resourceID);
+				CategoryKey<Food> key = new CategoryKey<>(s, f);
 				entityValueUpdated(key, MASS_COL);
-			} else if (EntityEventType.VALUE_EVENT.equals(eventType)) {
-				entityValueUpdated(key, LOCAL_VP_COL);
-			} else if (EntityEventType.MARKET_VALUE_EVENT.equals(eventType)) {
-				entityValueUpdated(key, MARKET_VP_COL);
-			} else if (EntityEventType.COST_EVENT.equals(eventType)) {
-				entityValueUpdated(key, COST_COL);
-			} else if (EntityEventType.PRICE_EVENT.equals(eventType)) {
-				entityValueUpdated(key, PRICE_COL);
-			} else {
-				entityValueUpdated(key, NUM_INITIAL_COLUMNS, COLUMNCOUNT-1);
 			}
 		}
 	}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTableModel.java
@@ -115,40 +115,31 @@ class TradeTableModel extends CategoryTableModel<Good> {
 	 */
 	@Override
 	public void entityUpdate(EntityEvent event) {
-		if (event.getTarget() instanceof Good g
-			&& event.getSource() instanceof Settlement s) {
-			
-			String eventType = event.getType();
-			CategoryKey<Good> key = new CategoryKey<>(s, g);
-			
-			if (EntityEventType.VALUE_EVENT.equals(eventType)) {
-				entityValueUpdated(key, VALUE_COL, VALUE_COL);
-			} else if (EntityEventType.DEMAND_EVENT.equals(eventType)) {
-				entityValueUpdated(key, DEMAND_COL, DEMAND_COL);
-			} else if (EntityEventType.MARKET_VALUE_EVENT.equals(eventType)) {
-				entityValueUpdated(key, MARKET_VALUE_COL, MARKET_VALUE_COL);
-			} else if (EntityEventType.MARKET_DEMAND_EVENT.equals(eventType)) {
-				entityValueUpdated(key, MARKET_DEMAND_COL, MARKET_DEMAND_COL);
-			} else if (EntityEventType.PROJECTED_DEMAND_EVENT.equals(eventType)) {
-				entityValueUpdated(key, PROJECTED_COL, PROJECTED_COL);
-			} else if (EntityEventType.TRADE_DEMAND_EVENT.equals(eventType)) {
-				entityValueUpdated(key, TRADE_COL, TRADE_COL);
-			} else if (EntityEventType.REPAIR_DEMAND_EVENT.equals(eventType)) {
-				entityValueUpdated(key, REPAIR_COL, REPAIR_COL);
-			} else if (EntityEventType.MASS_EVENT.equals(eventType)) {
+		String eventType = event.getType();
+		if (event.getSource() instanceof Settlement s) {
+
+			if (event.getTarget() instanceof Good g) {
+				CategoryKey<Good> key = new CategoryKey<>(s, g);
+				
+				switch(eventType) {
+					case EntityEventType.VALUE_EVENT -> entityValueUpdated(key, VALUE_COL, VALUE_COL);
+					case EntityEventType.DEMAND_EVENT -> entityValueUpdated(key, DEMAND_COL, DEMAND_COL);
+					case EntityEventType.MARKET_VALUE_EVENT -> entityValueUpdated(key, MARKET_VALUE_COL, MARKET_VALUE_COL);
+					case EntityEventType.MARKET_DEMAND_EVENT -> entityValueUpdated(key, MARKET_DEMAND_COL, MARKET_DEMAND_COL);
+					case EntityEventType.PROJECTED_DEMAND_EVENT -> entityValueUpdated(key, PROJECTED_COL, PROJECTED_COL);
+					case EntityEventType.TRADE_DEMAND_EVENT -> entityValueUpdated(key, TRADE_COL, TRADE_COL);
+					case EntityEventType.REPAIR_DEMAND_EVENT -> entityValueUpdated(key, REPAIR_COL, REPAIR_COL);
+					case EntityEventType.SUPPLY_EVENT -> entityValueUpdated(key, SUPPLY_COL, SUPPLY_COL);
+					default -> entityValueUpdated(key, NUM_INITIAL_COLUMNS, COLUMNCOUNT-1);
+				}
+			}
+			else if (EntityEventType.INVENTORY_RESOURCE_EVENT.equals(eventType)
+					&& event.getTarget() instanceof Integer resourceID) {
+				Good g = GoodsUtil.getGood(resourceID);
+
+				CategoryKey<Good> key = new CategoryKey<>(s, g);
+
 				entityValueUpdated(key, MASS_COL, MASS_COL);
-			} else if (EntityEventType.SUPPLY_EVENT.equals(eventType)) {
-				entityValueUpdated(key, SUPPLY_COL, SUPPLY_COL);
-//			} else if (EntityEventType.COST_EVENT.equals(eventType)) {
-//				entityValueUpdated(key, COST_COL, COST_COL);
-//			} else if (EntityEventType.PRICE_EVENT.equals(eventType)) {
-//				entityValueUpdated(key, PRICE_COL, PRICE_COL);
-//			} else if (EntityEventType.MARKET_COST_EVENT.equals(eventType)) {
-//				entityValueUpdated(key, MARKET_COST_COL, MARKET_COST_COL);
-//			} else if (EntityEventType.MARKET_PRICE_EVENT.equals(eventType)) {
-//				entityValueUpdated(key, MARKET_PRICE_COL, MARKET_PRICE_COL);
-			} else {
-				entityValueUpdated(key, NUM_INITIAL_COLUMNS, COLUMNCOUNT-1);
 			}
 		}
 	}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/monitor/TradeTableModel.java
@@ -139,7 +139,7 @@ class TradeTableModel extends CategoryTableModel<Good> {
 
 				CategoryKey<Good> key = new CategoryKey<>(s, g);
 
-				entityValueUpdated(key, MASS_COL, MASS_COL);
+				entityValueUpdated(key, QUANTITY_COL, MASS_COL);
 			}
 		}
 	}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/MalfunctionTabPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/MalfunctionTabPanel.java
@@ -39,6 +39,7 @@ import com.mars_sim.ui.swing.components.PercentageTableCellRenderer;
 import com.mars_sim.ui.swing.entitywindow.EntityTabPanel;
 import com.mars_sim.ui.swing.utils.EntityLauncher;
 import com.mars_sim.ui.swing.utils.EntityModel;
+import com.mars_sim.ui.swing.utils.SwingHelper;
 
 
 /**
@@ -89,10 +90,7 @@ public class MalfunctionTabPanel extends EntityTabPanel<Malfunctionable> impleme
 
         @Override
 		public int getColumnCount() {
-            if (showSource)
-			    return 5;
-            else
-                return 4;
+            return (showSource ? 5 : 4);
 		}
 
         @Override
@@ -123,6 +121,10 @@ public class MalfunctionTabPanel extends EntityTabPanel<Malfunctionable> impleme
         @Override
 		public Object getValueAt(int row, int column) {
             Malfunction p = malfunctions.get(row);
+			if (p == null) {
+				// Malfunction has been removed from the building, but not yet from the table.
+				return null;
+			}
             int realColumn = getPropFromColumn(column);
             switch(realColumn) {
                 case NAME: return p.getName();
@@ -168,13 +170,16 @@ public class MalfunctionTabPanel extends EntityTabPanel<Malfunctionable> impleme
 
 		public void update(List<Malfunction> newMalfunctions) {
 
+			boolean changed = false;
 			if (newMalfunctions.isEmpty() && !malfunctions.isEmpty()) {
 				// No new malfunction but old in table
 				malfunctions.clear();
+				changed = true;
 			}
-			else if (malfunctions.isEmpty()) {
+			else if (malfunctions.isEmpty() && !newMalfunctions.isEmpty()) {
 				// New malfunction but none in model
 				malfunctions.addAll(newMalfunctions);
+				changed = true;
 			}
 			else {
 				// Malfunctions on both sides; need to do a Union
@@ -184,12 +189,15 @@ public class MalfunctionTabPanel extends EntityTabPanel<Malfunctionable> impleme
 				List<Malfunction> rowsToAdd = new ArrayList<>(newMalfunctions);
 				rowsToAdd.removeAll(malfunctions);
 
-				malfunctions.removeAll(rowsToDelete);
-				malfunctions.addAll(rowsToAdd);
+				if (!rowsToDelete.isEmpty() || !rowsToAdd.isEmpty()) {
+					changed = true;
+					malfunctions.removeAll(rowsToDelete);
+					malfunctions.addAll(rowsToAdd);
+				}
 			}
 
-			if (!malfunctions.isEmpty()) {
-				fireTableDataChanged();
+			if (changed) {
+				SwingHelper.runInEDT(() -> fireTableDataChanged());
 			}
 		}
 
@@ -326,7 +334,8 @@ public class MalfunctionTabPanel extends EntityTabPanel<Malfunctionable> impleme
 					  .append((int) malfunction.getCompletedWorkTime(workType))
 					  .append(SLASH)
 					  .append((int) malfunction.getWorkTime(workType))
-					  .append(MILLISOLS + BR);
+					  .append(MILLISOLS)
+					  .append(BR);
 			}
 		}
 
@@ -352,23 +361,6 @@ public class MalfunctionTabPanel extends EntityTabPanel<Malfunctionable> impleme
 		
 		if (useHTML)
 			return result.replaceAll(COMMA, BR);
-		
-//		if (!parts.isEmpty()) {
-//			boolean first = true;
-//			for(Entry<MaintenanceScope, Integer> entry : parts.entrySet()) {
-//				if (!first) {
-//					buf.append(useHTML ? BR : COMMA);
-//				}
-//				first = false;
-//				Integer part = entry.getKey();
-//				int number = entry.getValue();
-//				buf.append(number).append(ONE_SPACE)
-//						.append(ItemResourceUtil.findItemResource(part).getName());
-//			}
-//			buf.append(DOT);
-//		} else
-//			buf.append(NONE);
-
 		return result;
 	}
 


### PR DESCRIPTION
As a preparation of #1729 the dependency on a Settlement also being a EquipmentOwner can be reduced. This minimises the risk of breakign logic when the actual change to the Settlement class is made in a later PR.

In summary:
- RepairMalfunctionMeta is reworked to stop casting Settlemet to EquipmentOwner. This means seperating out the Worker and Settlement repair tasks
- Remove the MASS_EVENT use and base model updates on existing Inventory events.
- EVA resource searching uses the Person location to identify how many people need to be supported.