### PR TITLE
feat: Move Exploration selection logic to Meta class

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/ExploredCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/ExploredCommand.java
@@ -117,8 +117,8 @@ public class ExploredCommand extends AbstractSettlementCommand {
 		response.appendText(" A total of " + locations.size() + " mineral sites have been identified.");
 		response.appendText("");
 		
-		response.appendTableHeading("Location", CommandHelper.COORDINATE_WIDTH,
-									"Authority", 18, 
+		response.appendTableHeading("Name", 10, "Location", CommandHelper.COORDINATE_WIDTH,
+									"Authority", 10, 
 									"Status*", "Reviews", "Mineral with highest %");
 		for (MineralSite s : locations) {
 			String mineral = "";
@@ -131,7 +131,7 @@ public class ExploredCommand extends AbstractSettlementCommand {
 			
 			String status = (s.isMinable() ? "M" : "-") +  (s.isExplored() ? "E" : "-") + (s.isClaimed() ? "C" : "-") +(s.isReserved() ? "R" : "-") + "  ";
 			var owner = s.getOwner();
-			response.appendTableRow(s.getLocation().getFormattedString(),
+			response.appendTableRow(s.getName(), s.getLocation().getFormattedString(),
 									(owner != null ? owner.getName() : ""),
 									status,
 									s.getNumEstimationImprovement(),

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/task/ExploreSite.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/task/ExploreSite.java
@@ -172,7 +172,7 @@ public class ExploreSite extends EVAOperation {
 			return time;
 
 		// Add to the cumulative combined site time
-		((Exploration)mission).addSiteTime(time);
+		mission.addSiteTime(time);
 		
 		if (totalCollected > averageRockCollected) {
 			endEVA("Rocks collected exceeded the set average.");

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/EVAMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/EVAMission.java
@@ -88,25 +88,28 @@ abstract class EVAMission extends RoverMission {
 	/**
 	 * Can the EVA phase be started ?
 	 * 
-	 * @param member
-	 * @return 
+	 * @return False means EVA not startable
 	 */
 	private boolean canStartEVA() {
-		boolean result = true;
-		// Note: checking for EVA has caused too many Exploration mission to terminate EVA
-		MarsTime sunrise = surfaceFeatures.getOrbitInfo().getSunrise(getCurrentMissionLocation());
-		if (surfaceFeatures.inDarkPolarRegion(getCurrentMissionLocation())
-				|| (sunrise.getTimeDiff(getMarsTime()) > MAX_WAIT_SUBLIGHT)) {
-			// No point waiting, move to next site
-			logger.info(getVehicle(), "Continue to travel since sunrise is too late " + sunrise.getTruncatedDateTimeStamp());
-			addMissionLog(NOT_ENOUGH_SUNLIGHT, getStartingPerson().getName());
-			startTravellingPhase();
-		}
-		else {
-			// Wait for sunrise
-			logger.info(getVehicle(), "Waiting for sunrise @ " + sunrise.getTruncatedDateTimeStamp());
-			setPhase(WAIT_SUNLIGHT, sunrise.getTruncatedDateTimeStamp());
-			// May call this the first time but how to avoid duplicate entry : addMissionLog(WAIT_SUNLIGHT.getName(), getStartingPerson().getName()) 
+		boolean result = isEnoughSunlightForEVA();
+		if (!result) {
+			// Not enough sunlight so what to do
+			// Note: checking for EVA has caused too many Exploration mission to terminate EVA
+			MarsTime sunrise = surfaceFeatures.getOrbitInfo().getSunrise(getCurrentMissionLocation());
+			if (surfaceFeatures.inDarkPolarRegion(getCurrentMissionLocation())
+					|| (sunrise.getTimeDiff(getMarsTime()) > MAX_WAIT_SUBLIGHT)) {
+				// No point waiting, move to next site
+				logger.info(getVehicle(), "Continue to travel since sunrise is too late " + sunrise.getTruncatedDateTimeStamp());
+				addMissionLog(NOT_ENOUGH_SUNLIGHT, getStartingPerson().getName());
+				startTravellingPhase();
+				result = false;
+			}
+			else {
+				// Wait for sunrise
+				logger.info(getVehicle(), "Waiting for sunrise @ " + sunrise.getTruncatedDateTimeStamp());
+				setPhase(WAIT_SUNLIGHT, sunrise.getTruncatedDateTimeStamp());
+				result = false;
+			}
 		}
 		return result;
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/Exploration.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/Exploration.java
@@ -6,14 +6,13 @@
  */
 package com.mars_sim.core.person.ai.mission;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 import com.mars_sim.core.environment.MineralSite;
 import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.logging.SimLogger;
-import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.mission.MetaMission;
 import com.mars_sim.core.mission.objectives.ExplorationObjective;
 import com.mars_sim.core.mission.task.ExploreSite;
@@ -44,7 +43,7 @@ public class Exploration extends EVAMission
 	private static final double STANDARD_TIME_PER_SITE = 1000.0;
 	
 	/** Exploration Site */
-	private static final String EXPLORATION_SITE = "Exploration Site ";
+	private static final String EXPLORATION_SITE = "Explore ";
 
 	
 	/** Mission Type enum. */
@@ -63,7 +62,7 @@ public class Exploration extends EVAMission
 	private ExplorationObjective objective;
 	
 	/** The set of sites to be claimed by this mission. */
-	private Set<MineralSite> claimedSites = new HashSet<>();
+	private List<MineralSite> claimedSites = new ArrayList<>();
 	
 
 	/**
@@ -90,8 +89,8 @@ public class Exploration extends EVAMission
 		setEVAEquipment(EquipmentType.SPECIMEN_BOX, newContainerNum);
 	
 		// Set exploration navpoints.
-		var coords = explorationSites.stream().map(MineralSite::getCoordinates).toList();
-		addNavpoints(coords, (i -> EXPLORATION_SITE + (i+1)));
+		explorationSites.forEach(es -> addNavpoint(es.getCoordinates(), EXPLORATION_SITE + es.getName()));
+		claimedSites.addAll(explorationSites);
 
 		// Add home navpoint.
 		Settlement s = getStartingSettlement();
@@ -117,13 +116,14 @@ public class Exploration extends EVAMission
 	 */
 	private MineralSite retrieveASiteToClaim() {
 		
-		Coordinates current = getCurrentMissionLocation();
-		for (MineralSite e: claimedSites) {
-			if (e.getLocation().equals(current))
-				return e;
+		int idx = getCurrentNavpointIndex();
+		idx--; // Decrement to allow for starting
+
+		if (idx < 0 || idx >= claimedSites.size()) {
+			logger.severe(this, "Cannot find Mineral site for navpoint index " + idx);
+			return null;
 		}
-		logger.severe(this, "Cannot find Mineral site for " + current.getFormattedString());
-		return null;
+		return claimedSites.get(idx);
 	}
 
 	/**
@@ -138,6 +138,15 @@ public class Exploration extends EVAMission
 		
 		// If person can explore the site, start that task.
 		if (ExploreSite.canExploreSite(person)) {
+			
+			// Add new explored site if just starting exploring.
+			if (currentSite == null) {
+				currentSite = retrieveASiteToClaim();
+				if (currentSite == null) {
+					abortMission(INVALID_EXPLORATION_SITE);
+					return false;
+				}
+			}
 			canAssign = assignTask(person, new ExploreSite(person, currentSite, getRover(), this));
 			
 			if (canAssign) {
@@ -154,22 +163,6 @@ public class Exploration extends EVAMission
 		else if (completion < 0D) {
 			completion = 0D;
 		}		
-
-		// Add new explored site if just starting exploring.
-		if (currentSite == null) {
-	
-			// Question: how to check if EVA is supposed to be ended and gracefully terminate calling performEVA
-			// prior to calling currentSite below ?
-			
-			// For instance, currentSite becomes null due to medical emergency in AbstractVehicleMission's
-			// determineEmergencyDestination()
-			
-			currentSite = retrieveASiteToClaim();
-			if (currentSite == null) {
-				abortMission(INVALID_EXPLORATION_SITE);
-				return false;
-			}
-		}
 		
 		fireMissionUpdate(SITE_EXPLORATION_EVENT, getCurrentNavpointDescription());
 
@@ -208,7 +201,7 @@ public class Exploration extends EVAMission
 	 *
 	 * @return list of explored sites.
 	 */
-	public Set<MineralSite> getExploredSites() {
+	public List<MineralSite> getExploredSites() {
 		return claimedSites;
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/Exploration.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/Exploration.java
@@ -105,7 +105,7 @@ public class Exploration extends EVAMission
 		if (!isDone()) {
 			addMembers(crew.members(), false);
 			// Set initial mission phase.
-			setInitialPhase(false);
+			setInitialPhase(needsReview);
 		}
 	}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/Exploration.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/Exploration.java
@@ -6,8 +6,6 @@
  */
 package com.mars_sim.core.person.ai.mission;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -20,13 +18,8 @@ import com.mars_sim.core.mission.MetaMission;
 import com.mars_sim.core.mission.objectives.ExplorationObjective;
 import com.mars_sim.core.mission.task.ExploreSite;
 import com.mars_sim.core.person.Person;
-import com.mars_sim.core.person.ai.SkillType;
-import com.mars_sim.core.person.ai.task.util.Worker;
-import com.mars_sim.core.structure.ExplorationManager;
 import com.mars_sim.core.structure.ObjectiveType;
 import com.mars_sim.core.structure.Settlement;
-import com.mars_sim.core.time.MarsTime;
-import com.mars_sim.core.tool.RandomUtil;
 import com.mars_sim.core.vehicle.Rover;
 
 /**
@@ -59,7 +52,6 @@ public class Exploration extends EVAMission
 
 	/** Mission phase. */
 	private static final MissionPhase EXPLORE_SITE = new MissionPhase("Mission.phase.exploreSite");
-	private static final MissionStatus NO_EXPLORATION_SITES = new MissionStatus("Mission.status.noExplorationSites");
 	private static final MissionStatus INVALID_EXPLORATION_SITE = new MissionStatus("Mission.status.invalidExplorationSite");
 	
 	private static final Set<ObjectiveType> OBJECTIVES = Set.of(ObjectiveType.TOURISM, ObjectiveType.TRANSPORTATION_HUB);
@@ -69,21 +61,20 @@ public class Exploration extends EVAMission
 	private MineralSite currentSite;
 
 	private ExplorationObjective objective;
-
-	/** Manager of the explorations at the home Settlement */
-	private ExplorationManager explorationMgr;
 	
 	/** The set of sites to be claimed by this mission. */
 	private Set<MineralSite> claimedSites = new HashSet<>();
 	
 
 	/**
-	 * Constructor.
+	 * Constructor with explicit data.
 	 *
-	 * @param startingPerson the person starting the mission.
-	 * @throws MissionException if problem constructing mission.
+	 * @param crew            collection of mission members.
+	 * @param needsReview      whether the mission needs review.
+	 * @param explorationSites   the sites to explore.
 	 */
-	public Exploration(MetaMission.Roster crew, boolean needsReview) {
+	public Exploration(MetaMission.Roster crew, boolean needsReview,
+			List<MineralSite> explorationSites) {
 
 		// Use RoverMission constructor.
 		super(MISSION_TYPE, crew.leader(), (Rover)crew.vehicle(),
@@ -91,85 +82,16 @@ public class Exploration extends EVAMission
 		
 		this.objective = new ExplorationObjective();
 		addObjective(objective);
-		
-		Settlement s = getStartingSettlement();
-
-		if (s != null && !isDone()) {
-			explorationMgr = s.getExplorations();
-
-			int skill = crew.leader().getSkillManager().getEffectiveSkillLevel(SkillType.AREOLOGY);
-
-			int sol = getMarsTime().getMissionSol();
-			var numSites = 2 + (int)(1.0 * sol / 20);
-			
-			List<Coordinates> sitesToClaim = determineExplorationSites(getVehicle().getEstimatedRange(),
-					getRover().getTotalTripTimeLimit(true),
-					numSites, skill);
-
-			if (sitesToClaim.isEmpty()) {
-				endMission(NO_EXPLORATION_SITES);
-				return;
-			}
-			
-			initializeExplorationSites(sitesToClaim);
-
-
-			// Add mission members.
-			if (!isDone()) {
-				addMembers(crew.members(), false);
-
-				// Set initial mission phase.
-				setInitialPhase(needsReview);
-			}
-		}
-	}
-
-	/**
-	 * Constructor with explicit data.
-	 *
-	 * @param members            collection of mission members.
-	 * @param explorationSites   the sites to explore.
-	 * @param rover              the rover to use.
-	 */
-	public Exploration(Collection<Worker> members,
-			List<Coordinates> explorationSites, Rover rover) {
-
-		// Use RoverMission constructor.
-		super(MISSION_TYPE,(Worker) members.toArray()[0], rover,
-				EXPLORE_SITE, ExploreSite.LIGHT_LEVEL);
-		
-		this.objective = new ExplorationObjective();
-		addObjective(objective);
-
-		explorationMgr = getStartingSettlement().getExplorations();
 				
-		initializeExplorationSites(explorationSites);
-
-		// Add mission members.
-		if (!isDone()) {
-			addMembers(members, false);
-			// Set initial mission phase.
-			setInitialPhase(false);
-		}
-	}
-
-	/**
-	 * Sets up the exploration sites.
-	 *  
-	 * @param explorationSites
-	 * @param skill
-	 */
-	private void initializeExplorationSites(List<Coordinates> explorationSites) {
-		
 		// Initialize explored sites.
-		int numMembers = getMembers().size();
-		int buffer = (int)(numMembers * 1.5);
+		int buffer = (int)(getMembers().size() * 1.5);
 		int newContainerNum = Math.max(buffer, REQUIRED_SPECIMEN_CONTAINERS);
 		
 		setEVAEquipment(EquipmentType.SPECIMEN_BOX, newContainerNum);
 	
 		// Set exploration navpoints.
-		addNavpoints(explorationSites, (i -> EXPLORATION_SITE + (i+1)));
+		var coords = explorationSites.stream().map(MineralSite::getCoordinates).toList();
+		addNavpoints(coords, (i -> EXPLORATION_SITE + (i+1)));
 
 		// Add home navpoint.
 		Settlement s = getStartingSettlement();
@@ -179,22 +101,13 @@ public class Exploration extends EVAMission
 		if (!isVehicleLoadable()) {
 			endMission(CANNOT_LOAD_RESOURCES);
 		}
-	}
 
-	/**
-	 * Gets the range of a trip based on its time limit and exploration sites.
-	 *
-	 * @param numSites
-	 * @param currentSiteTime
-	 * @param tripTimeLimit time (millisols) limit of trip.
-	 * @param averageSpeed  the average speed of the vehicle.
-	 * @return range (km) limit.
-	 */
-	private double getTripTimeRange(int numSites, double tripTimeLimit, double averageSpeed) {
-		double tripTimeTravellingLimit = tripTimeLimit - (numSites * STANDARD_TIME_PER_SITE);
-		double millisolsInHour = MarsTime.convertSecondsToMillisols(60D * 60D);
-		double averageSpeedMillisol = averageSpeed / millisolsInHour;
-		return tripTimeTravellingLimit * averageSpeedMillisol;
+		// Add mission members.
+		if (!isDone()) {
+			addMembers(crew.members(), false);
+			// Set initial mission phase.
+			setInitialPhase(false);
+		}
 	}
 
 	/**
@@ -288,104 +201,6 @@ public class Exploration extends EVAMission
 	 */
 	protected double getEstimatedTimeOfAllEVAs() {
 		return STANDARD_TIME_PER_SITE * getNumEVASites();
-	}
-
-	/**
-	 * Determines the locations of the exploration sites.
-	 *
-	 * @param roverRange    the rover's driving range
-	 * @param numSites      the number of exploration sites
-	 * @param areologySkill the skill level in areology for the areologist starting
-	 *                      the mission.
-	 * @throws MissionException if exploration sites can not be determined.
-	 */
-	private List<Coordinates> determineExplorationSites(double roverRange, double tripTimeLimit, int numSites, int areologySkill) {
-
-		List<Coordinates> selectedLocns = new ArrayList<>();
-
-		// Determining the actual traveling range.
-		double range = roverRange;
-		double timeRange = getTripTimeRange(numSites, tripTimeLimit, getAverageVehicleSpeedForOperators());
-		if (timeRange < range) {
-			range = timeRange;
-		}
-
-		// Determine the first exploration site.
-		Coordinates startingLocation = getCurrentMissionLocation();
-		
-		// Find mature sites to explore
-		List<MineralSite> knownSites = findClaimedCandidateSites();
-		Coordinates currentLocation = startingLocation;
-
-		// Determine remaining exploration sites.
-		double remainingRange = range;
-		double returnDist = 0D;
-
-		// Add in some existing ones first
-		int knownId = 0;
-		while ((selectedLocns.size() < numSites)
-				&& (remainingRange > returnDist)
-				&& (knownId < knownSites.size())) {
-			// Take the next one off the front
-			var site = knownSites.get(knownId++);
-			claimedSites.add(site);
-
-			// Calc what distance is left
-			Coordinates nextLocation = site.getCoordinates();
-			selectedLocns.add(nextLocation);
-			remainingRange -= nextLocation.getDistance(currentLocation);
-			currentLocation = nextLocation;
-			returnDist = currentLocation.getDistance(startingLocation);
-		}
-
-		// Pick some new ones if still space but limit the attempts
-		int unplannedAttempts = 10;
-		while ((selectedLocns.size() < numSites)
-				&& (remainingRange > returnDist)
-				&& (unplannedAttempts-- > 0)) {
-			// Find minerals near base
-			var unplannedLimit = (remainingRange - returnDist) / 2D;
-			var newLocn = explorationMgr.getUnexploredLocalSites(false, unplannedLimit);
-
-			// Check not in the current list
-			if ((newLocn == null) || selectedLocns.contains(newLocn)) {
-				continue;
-			}
-
-			// Is it good enough to create MineralSite
-			var el = explorationMgr.createROI(newLocn, areologySkill);
-			if (el != null) {
-				claimedSites.add(el);
-
-				// Add to the list
-				selectedLocns.add(newLocn);
-				remainingRange -= newLocn.getDistance(currentLocation);
-				currentLocation = newLocn;
-				returnDist = currentLocation.getDistance(startingLocation);
-			}
-		}
-
-		return getMinimalPath(startingLocation, selectedLocns);
-	}
-	
-	/**
-	 * Gets a list of candidate MineralSites known to a settlement.
-	 * Filter for those that needs estimation improvement.
-	 * 
-	 * @return
-	 */
-	private List<MineralSite> findClaimedCandidateSites() {
-
-		var home = getStartingSettlement().getReportingAuthority();
-
-		// Get any locations that belong to this home Settlement and need further
-		// exploration before mining
-		return explorationMgr.getDeclaredROIs()
-				.stream()
-				.filter(e -> e.getNumEstimationImprovement() < 
-						RandomUtil.getRandomInt(0, Mining.MATURE_ESTIMATE_NUM * 10))
-				.filter(s -> home.equals(s.getOwner()))
-				.toList();
 	}
 
 	/**

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMeta.java
@@ -190,8 +190,9 @@ public class ExplorationMeta extends AbstractMetaMission {
 				}
 			}
 		}
-		// TODO
-		//return getMinimalPath(startingLocation, selectedLocns);
+		
+		// Original used route optimisation
+		// getMinimalPath(startingLocation, selectedLocns)
 
 		return claimedSites;
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMeta.java
@@ -90,7 +90,7 @@ public class ExplorationMeta extends AbstractMetaMission {
 			throw new MissionCreationException("mission.exploration.nosites");
 		}
 			
-		return constructInstance(crew, sites);
+		return constructInstance(crew, needsReview, sites);
 	}
 
 	/**
@@ -232,11 +232,12 @@ public class ExplorationMeta extends AbstractMetaMission {
 	/**
 	 * Constructs a new instance of the Exploration mission with the given crew and exploration sites.
 	 * @param crew the roster of crew members for the mission.
+	 * @param needsReview whether the mission requires review before execution.
 	 * @param sites the list of mineral sites to be explored during the mission.
 	 * @return a new instance of the Exploration mission.
 	 */
-	public Mission constructInstance(Roster crew, List<MineralSite> sites) {
-		return new Exploration(crew, false, sites);
+	public Mission constructInstance(Roster crew, boolean needsReview, List<MineralSite> sites) {
+		return new Exploration(crew, needsReview, sites);
 	}
 
 	@Override
@@ -295,7 +296,7 @@ public class ExplorationMeta extends AbstractMetaMission {
 	}
 
 	/**
-	 * Hopw many sites should be explroed for this Settlement.
+	 * How many sites should be explored for this Settlement.
 	 * Default returns 2
 	 * @param s Settlement leading exploration
 	 * @return

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMeta.java
@@ -16,19 +16,26 @@ import com.mars_sim.core.data.RatingScore;
 import com.mars_sim.core.environment.MineralSite;
 import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.goods.GoodsManager.CommerceType;
+import com.mars_sim.core.map.location.Coordinates;
 import com.mars_sim.core.mission.AbstractMetaMission;
+import com.mars_sim.core.mission.MetaMission;
+import com.mars_sim.core.mission.MissionCreationException;
 import com.mars_sim.core.person.Person;
+import com.mars_sim.core.person.ai.SkillType;
 import com.mars_sim.core.person.ai.job.util.JobType;
 import com.mars_sim.core.person.ai.mission.Exploration;
+import com.mars_sim.core.person.ai.mission.Mining;
 import com.mars_sim.core.person.ai.mission.Mission;
 import com.mars_sim.core.person.ai.mission.MissionType;
 import com.mars_sim.core.person.ai.role.RoleType;
-import com.mars_sim.core.person.ai.task.util.Worker;
 import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.core.time.MarsTime;
+import com.mars_sim.core.tool.RandomUtil;
 import com.mars_sim.core.vehicle.Rover;
 import com.mars_sim.core.vehicle.Vehicle;
 import com.mars_sim.core.vehicle.VehicleType;
 import com.mars_sim.core.vehicle.comparators.LabRangeComparator;
+import com.mars_sim.core.vehicle.task.OperateVehicle;
 
 /**
  * A meta mission for the Exploration mission.
@@ -42,6 +49,8 @@ public class ExplorationMeta extends AbstractMetaMission {
 
 	/** Starting sol for this mission to commence. */
 	private static final int MIN_STARTING_SOL = 2;
+	private static final double STANDARD_TIME_PER_SITE = 1000.0;
+
 
 	private static final double VALUE = 20D;
 
@@ -71,8 +80,152 @@ public class ExplorationMeta extends AbstractMetaMission {
 	 * @return a new instance of the Exploration mission.
 	 */
 	@Override
-	public Mission constructInstance(Roster crew, boolean needsReview) {
-		return new Exploration(crew, needsReview);
+	public Mission constructInstance(Roster crew, boolean needsReview) throws MissionCreationException{
+
+		var numSites = getExpectedSites(crew.leader().getAssociatedSettlement());
+		List<MineralSite> sites = determineExplorationSites(crew, numSites);
+
+		if (sites.isEmpty()) {
+			throw new MissionCreationException("mission.exploration.nosites");
+		}
+			
+		return constructInstance(crew, sites);
+	}
+
+	/**
+	 * Gets a list of candidate MineralSites known to a settlement.
+	 * Filter for those that needs estimation improvement.
+	 * 
+	 * @return
+	 */
+	private List<MineralSite> findClaimedCandidateSites(Settlement settlement) {
+
+		var home = settlement.getReportingAuthority();
+
+		// Get any locations that belong to this home Settlement and need further
+		// exploration before mining
+		return settlement.getExplorations().getDeclaredROIs()
+				.stream()
+				.filter(e -> e.getNumEstimationImprovement() < 
+						RandomUtil.getRandomInt(0, Mining.MATURE_ESTIMATE_NUM * 10))
+				.filter(s -> home.equals(s.getOwner()))
+				.toList();
+	}
+
+	/**
+	 * Determines the locations of the exploration sites.
+	 *
+	 * @param crew		  the roster of crew members for the mission
+	 * @param numSites      the number of exploration sites
+	 */
+	private List<MineralSite> determineExplorationSites(MetaMission.Roster crew, int numSites) {
+
+		Rover rover = (Rover)crew.vehicle();	
+		double theorticalMaxRange = rover.getEstimatedRange();
+		double theoreticalMaxTripTime = rover.getTotalTripTimeLimit(true);
+
+		// Determining the actual traveling range.
+		double possibleRange = getTripTimeRange(numSites, theoreticalMaxTripTime, getAverageVehicleSpeed(crew));
+		double range = Math.min(theorticalMaxRange, possibleRange);
+
+
+		// Determine the first exploration site.
+		var starting = crew.leader().getAssociatedSettlement();
+		
+		// Find mature sites to explore
+		List<MineralSite> knownSites = findClaimedCandidateSites(starting);
+
+		// Determine remaining exploration sites.
+		Coordinates homeLocation = starting.getCoordinates();
+		Coordinates currentLocation = homeLocation;
+		double remainingRange = range;
+		double returnDist = 0D;
+		List<MineralSite> claimedSites = new ArrayList<>();
+
+		// Add in some existing ones first
+		int knownId = 0;
+		while ((claimedSites.size() < numSites)
+				&& (remainingRange > returnDist)
+				&& (knownId < knownSites.size())) {
+			// Take the next one off the front
+			var site = knownSites.get(knownId++);
+			claimedSites.add(site);
+
+			// Calc what distance is left
+			Coordinates nextLocation = site.getCoordinates();
+			remainingRange -= nextLocation.getDistance(currentLocation);
+			currentLocation = nextLocation;
+			returnDist = currentLocation.getDistance(homeLocation);
+		}
+
+		// Pick some new ones if still space but limit the attempts
+		if (claimedSites.size() < numSites) {
+			var explorationMgr = starting.getExplorations();
+			var claimedLocns = claimedSites.stream().map(MineralSite::getLocation).toList();
+			int unplannedAttempts = 10;
+			int areologySkill = crew.leader().getSkillManager().getEffectiveSkillLevel(SkillType.AREOLOGY);
+
+			while ((claimedSites.size() < numSites)
+					&& (remainingRange > returnDist)
+					&& (unplannedAttempts-- > 0)) {
+				// Find minerals near base
+				var unplannedLimit = (remainingRange - returnDist) / 2D;
+				var newLocn = explorationMgr.getUnexploredLocalSites(false, unplannedLimit);
+
+				// Check not in the current list
+				if ((newLocn == null) || claimedLocns.contains(newLocn)) {
+					continue;
+				}
+
+				// Is it good enough to create MineralSite
+				var el = explorationMgr.createROI(newLocn, areologySkill);
+				if (el != null) {
+					claimedSites.add(el);
+
+					// Add to the list
+					remainingRange -= newLocn.getDistance(currentLocation);
+					currentLocation = newLocn;
+					returnDist = currentLocation.getDistance(homeLocation);
+				}
+			}
+		}
+		// TODO
+		//return getMinimalPath(startingLocation, selectedLocns);
+
+		return claimedSites;
+	}
+
+	/**
+	 * What is the travelling speed for this crew. This may be sharable?
+	 * @param crew Crew travelling
+	 * @return
+	 */
+	private static double getAverageVehicleSpeed(Roster crew) {
+
+		var v = crew.vehicle();
+		double totalSpeed = OperateVehicle.getAverageVehicleSpeed(v, crew.leader());
+
+		totalSpeed += crew.members().stream()
+				.mapToDouble(member -> OperateVehicle.getAverageVehicleSpeed(v, member))
+				.sum();
+	
+		return totalSpeed / (crew.members().size() + 1);
+	}
+
+	/**
+	 * Gets the range of a trip based on its time limit and exploration sites.
+	 *
+	 * @param numSites
+	 * @param currentSiteTime
+	 * @param tripTimeLimit time (millisols) limit of trip.
+	 * @param averageSpeed  the average speed of the vehicle.
+	 * @return range (km) limit.
+	 */
+	private double getTripTimeRange(int numSites, double tripTimeLimit, double averageSpeed) {
+		double tripTimeTravellingLimit = tripTimeLimit - (numSites * STANDARD_TIME_PER_SITE);
+		double millisolsInHour = MarsTime.convertSecondsToMillisols(60D * 60D);
+		double averageSpeedMillisol = averageSpeed / millisolsInHour;
+		return tripTimeTravellingLimit * averageSpeedMillisol;
 	}
 
 	/**
@@ -82,16 +235,7 @@ public class ExplorationMeta extends AbstractMetaMission {
 	 * @return a new instance of the Exploration mission.
 	 */
 	public Mission constructInstance(Roster crew, List<MineralSite> sites) {
-		var locations = sites.stream().map(MineralSite::getLocation).toList();
-
-		return new Exploration(getMembers(crew), locations, (Rover) crew.vehicle());
-	}
-
-	private static List<Worker> getMembers(Roster crew) {
-		List<Worker> members = new ArrayList<>();
-		members.add(crew.leader());
-		members.addAll(crew.members());
-		return members;
+		return new Exploration(crew, false, sites);
 	}
 
 	@Override
@@ -147,5 +291,15 @@ public class ExplorationMeta extends AbstractMetaMission {
 		}
 
 		return missionProbability;
+	}
+
+	/**
+	 * Hopw many sites should be explroed for this Settlement.
+	 * Default returns 2
+	 * @param s Settlement leading exploration
+	 * @return
+	 */
+	public int getExpectedSites(Settlement s) {
+		return 2;
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMeta.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMeta.java
@@ -8,6 +8,7 @@ package com.mars_sim.core.person.ai.mission.meta;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -128,7 +129,6 @@ public class ExplorationMeta extends AbstractMetaMission {
 		double possibleRange = getTripTimeRange(numSites, theoreticalMaxTripTime, getAverageVehicleSpeed(crew));
 		double range = Math.min(theorticalMaxRange, possibleRange);
 
-
 		// Determine the first exploration site.
 		var starting = crew.leader().getAssociatedSettlement();
 		
@@ -161,7 +161,7 @@ public class ExplorationMeta extends AbstractMetaMission {
 		// Pick some new ones if still space but limit the attempts
 		if (claimedSites.size() < numSites) {
 			var explorationMgr = starting.getExplorations();
-			var claimedLocns = claimedSites.stream().map(MineralSite::getLocation).toList();
+			var claimedLocns = new HashSet<>(claimedSites.stream().map(MineralSite::getLocation).toList());
 			int unplannedAttempts = 10;
 			int areologySkill = crew.leader().getSkillManager().getEffectiveSkillLevel(SkillType.AREOLOGY);
 
@@ -183,6 +183,7 @@ public class ExplorationMeta extends AbstractMetaMission {
 					claimedSites.add(el);
 
 					// Add to the list
+					claimedLocns.add(newLocn);
 					remainingRange -= newLocn.getDistance(currentLocation);
 					currentLocation = newLocn;
 					returnDist = currentLocation.getDistance(homeLocation);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/ExplorationManager.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/ExplorationManager.java
@@ -78,7 +78,7 @@ public class ExplorationManager implements Serializable {
     /** The extra search radius [in km] to be added. */
 	private double extraKM = 0D;
 
-    ExplorationManager(Settlement base) {
+    public ExplorationManager(Settlement base) {
         this.base = base;
     }
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -451,6 +451,8 @@ public class Settlement extends Unit implements Temporal,
 		rationing = new Rationing(this);
 
 		missionControl = new MissionControl(this);
+
+		explorations = new ExplorationManager(this);
 	}
 
 	/**

--- a/mars-sim-core/src/main/resources/messages.properties
+++ b/mars-sim-core/src/main/resources/messages.properties
@@ -753,6 +753,7 @@ mission.builder.notEnoughMembers = Not enough members recruited
 mission.builder.noVehicle = No available vehicle
 mission.travelsettlement.dest = No destination settlement found
 mission.landmark.noneinrange = No landmarks within range
+mission.exploration.nosites = No exploration sites found
 
 mission.status.accomplished=Mission Accomplished
 mission.status.notApproved=Mission not approved
@@ -768,7 +769,6 @@ mission.status.lowPopulation=Not enough remaining Settlement members
 mission.status.noEmergencySettlement=No emergency settlement destination found
 mission.status.noTradeSettlement=No trading settlement found
 mission.status.noStudy=No on-going scientific study being conducted in this subject
-mission.status.noExplorationSites=Exploration sites could not be determined
 mission.status.noIceSites=No ice collection sites found
 mission.status.medicalEmergency = Had a medical emergency
 mission.status.noEVASuits=EVA suits cannot be loaded

--- a/mars-sim-core/src/test/java/com/mars_sim/core/MarsSimContext.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/MarsSimContext.java
@@ -10,6 +10,7 @@ import com.mars_sim.core.structure.Settlement;
 import com.mars_sim.core.time.ClockPulse;
 import com.mars_sim.core.time.MarsTime;
 import com.mars_sim.core.unit.UnitHolder;
+import com.mars_sim.core.vehicle.Rover;
 
 /**
  * Context that allows creating simulation entities for unit tests
@@ -32,5 +33,7 @@ public interface MarsSimContext {
             FunctionType medicalCare, LocalPosition defaultPosition, double d, boolean b);
 
     UnitHolder getSurface();
+
+    Rover buildRover(Settlement settlement, String name, LocalPosition defaultPosition, String roverType);
 
 }

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMetaTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMetaTest.java
@@ -1,0 +1,138 @@
+package com.mars_sim.core.person.ai.mission.meta;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.mars_sim.core.MarsSimContext;
+import com.mars_sim.core.environment.MineralSite;
+import com.mars_sim.core.equipment.EquipmentFactory;
+import com.mars_sim.core.equipment.EquipmentType;
+import com.mars_sim.core.map.location.LocalPosition;
+import com.mars_sim.core.mineral.RandomMineralFactory;
+import com.mars_sim.core.mission.MetaMission;
+import com.mars_sim.core.mission.MetaMission.Roster;
+import com.mars_sim.core.mission.MissionCreationException;
+import com.mars_sim.core.person.ai.mission.VehicleMission;
+import com.mars_sim.core.resource.ResourceUtil;
+import com.mars_sim.core.structure.Settlement;
+import com.mars_sim.core.test.MarsSimUnitTest;
+
+class ExplorationMetaTest extends MarsSimUnitTest {
+
+    @Test
+    void testConstructFullySpecified() {
+        var mt = new ExplorationMeta();
+
+        var s = buildSettlement("Test");
+
+        var crew = buildEVACrew(getContext(), s, EquipmentType.SPECIMEN_BOX, 10, EXPLORER_ROVER);
+
+        List<MineralSite> sites = buildSites(s, 2);
+        var m = (VehicleMission) mt.constructInstance(crew, sites);
+
+        assertNotNull(m, "Exploration mission instance should not be null");
+        assertFalse(m.isDone(), "Exploration mission should not be done upon construction");
+        var waypoints = m.getNavpoints();
+        assertEquals(sites.size() + 2, waypoints.size(), "Exploration mission should have waypoints for each site plus the settlement");
+   
+        assertEquals(s.getCoordinates(), waypoints.get(0).getCoordinates(), "First waypoint should be the settlement coordinates");
+        assertEquals(s.getCoordinates(), waypoints.get(waypoints.size() - 1).getCoordinates(), "Last waypoint should be the settlement coordinates");
+
+        for(var st = 0; st < sites.size(); st++) {
+            assertEquals(sites.get(st).getLocation(), waypoints.get(st + 1).getCoordinates(), "Waypoint should match the mineral site coordinates");
+        }
+    }
+
+    
+    @Test
+    void testConstructSearch() throws MissionCreationException {
+        var mt = new ExplorationMeta();
+
+        var s = buildSettlement("Test");
+
+        var crew = buildEVACrew(getContext(), s, EquipmentType.SPECIMEN_BOX, 10, EXPLORER_ROVER);
+
+        List<MineralSite> sites = buildSites(s, 3);
+
+        var m = (VehicleMission) mt.constructInstance(crew, false);
+
+        assertNotNull(m, "Exploration mission instance should not be null");
+        assertFalse(m.isDone(), "Exploration mission should not be done upon construction");
+        var waypoints = m.getNavpoints();
+        assertEquals(mt.getExpectedSites(s) + 2, waypoints.size(), "Exploration mission should have waypoints for each site plus the settlement");
+   
+        assertEquals(s.getCoordinates(), waypoints.get(0).getCoordinates(), "First waypoint should be the settlement coordinates");
+        assertEquals(s.getCoordinates(), waypoints.get(waypoints.size() - 1).getCoordinates(), "Last waypoint should be the settlement coordinates");
+
+        var claimedLocns = sites.stream().map(MineralSite::getCoordinates).toList();
+        for(var st = 1; st < sites.size(); st++) {
+            assertTrue(claimedLocns.contains(waypoints.get(st).getCoordinates()),
+                            "Waypoint #" + st + " out of " + sites.size() + " should match the mineral site coordinates");
+        }
+    }
+
+    private List<MineralSite> buildSites(Settlement s, int i) {
+        var eMgr = s.getExplorations();
+
+        var mineralMap = getSim().getSurfaceFeatures().getMineralMap();
+        RandomMineralFactory.createLocalConcentration(mineralMap, s.getCoordinates());
+
+        List<MineralSite> sites = new ArrayList<>();
+        for(int j = 0; j < i; j++) {
+            var found = mineralMap.findRandomMineralLocation(s.getCoordinates(), 20, List.of());
+            assertNotNull(found, "Expected to find a nearby mineral location");
+
+            MineralSite site = eMgr.createROI(found.getKey(), 100);
+            assertNotNull(site, "Exploration manager should create a mineral site ROI");
+            sites.add(site);
+        }
+        
+        return sites;
+    }
+
+
+    /**
+     * This build a Roster crew for an EVA mission needing an optional set of Containers.
+     * @param context The test context to build the crew.
+     * @param s The settlement to build the crew in.
+     * @param containterType The type of container to build for the mission; optional if containerCount is 0.
+     * @param containerCount The number of containers to build for the mission.
+     * @param roverType The type of rover to build for the mission.
+     * @return A Roster of crew members for the EVA mission.
+     */
+    public static MetaMission.Roster buildEVACrew(MarsSimContext context, Settlement s, EquipmentType containterType,
+        int containerCount, String roverType) {
+  
+        var l = context.buildPerson("Leader", s);
+        var rover = context.buildRover(s, "Test", LocalPosition.DEFAULT_POSITION, roverType);
+
+        var w = context.buildPerson("Worker1", s);
+        var members = List.of(w);
+        Roster crew = new Roster(l, members, rover);
+
+        // Build EVA suite to support mission
+        for(int i = 0; i < members.size() + 1; i++) {
+            EquipmentFactory.createEquipment(EquipmentType.EVA_SUIT, s);
+        }
+
+        var resources = Map.of(ResourceUtil.OXYGEN_ID, 200D,
+                ResourceUtil.WATER_ID, 200D,
+                ResourceUtil.FOOD_ID, 200D,
+                ResourceUtil.METHANOL_ID, 200D);
+        loadSettlementAmounts(s, resources);
+
+        for(int c = 0; c < containerCount; c++) {
+            EquipmentFactory.createEquipment(containterType, s);
+        }
+
+        return crew;
+    }
+}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMetaTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/mission/meta/ExplorationMetaTest.java
@@ -36,7 +36,7 @@ class ExplorationMetaTest extends MarsSimUnitTest {
         var crew = buildEVACrew(getContext(), s, EquipmentType.SPECIMEN_BOX, 10, EXPLORER_ROVER);
 
         List<MineralSite> sites = buildSites(s, 2);
-        var m = (VehicleMission) mt.constructInstance(crew, sites);
+        var m = (VehicleMission) mt.constructInstance(crew, false, sites);
 
         assertNotNull(m, "Exploration mission instance should not be null");
         assertFalse(m.isDone(), "Exploration mission should not be done upon construction");
@@ -60,7 +60,7 @@ class ExplorationMetaTest extends MarsSimUnitTest {
 
         var crew = buildEVACrew(getContext(), s, EquipmentType.SPECIMEN_BOX, 10, EXPLORER_ROVER);
 
-        List<MineralSite> sites = buildSites(s, 3);
+        var sites = buildSites(s, mt.getExpectedSites(s) + 1);
 
         var m = (VehicleMission) mt.constructInstance(crew, false);
 
@@ -100,7 +100,7 @@ class ExplorationMetaTest extends MarsSimUnitTest {
 
 
     /**
-     * This build a Roster crew for an EVA mission needing an optional set of Containers.
+     * This builds a Roster crew for an EVA mission needing an optional set of Containers.
      * @param context The test context to build the crew.
      * @param s The settlement to build the crew in.
      * @param containterType The type of container to build for the mission; optional if containerCount is 0.

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/MissionDataBean.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/missionwizard/MissionDataBean.java
@@ -87,7 +87,7 @@ class MissionDataBean {
 
 		// Create the mission roster;this is for the new single constructor per Mission pattern
 		var roster = new MetaMission.Roster(getLeader(), getWorkerMembers(), rover);
-
+		boolean needsReview = false;  // This could be user selected in the future
 		Mission mission = switch (meta) {
 			case AreologyFieldStudyMeta m -> m
 					.constructInstance(roster, study, routePoints.get(0));
@@ -103,14 +103,14 @@ class MissionDataBean {
 					.constructInstance(mixedMembers, destination, (Drone) rover, sellGoods, buyGoods);
 			case EmergencySupplyMeta m -> m
 					.constructInstance(roster, destination, sellGoods);
-			case ExplorationMeta m -> m.constructInstance(roster, exploration);
+			case ExplorationMeta m -> m.constructInstance(roster, needsReview, exploration);
 			case MiningMeta m -> m.constructInstance(roster, miningSite, luv);
 			case RescueSalvageVehicleMeta m -> m.constructInstance(roster, rescueVehicle);
 			case TradeMeta m -> m
 					.constructInstance(roster, destination, sellGoods, buyGoods);
-			case TravelToSettlementMeta m -> m.constructInstance(roster, destination, false);
-			case TestDriveMetaMission m -> m.constructInstance(roster, false);
-			case LandmarkMetaMission m -> m.constructInstance(roster, landmark, false);
+			case TravelToSettlementMeta m -> m.constructInstance(roster, destination, needsReview);
+			case TestDriveMetaMission m -> m.constructInstance(roster, needsReview);
+			case LandmarkMetaMission m -> m.constructInstance(roster, landmark, needsReview);
 			default -> throw new IllegalStateException("Mission type: " + type + " unknown");
 		};
 


### PR DESCRIPTION
This PR is part of #975 and involves moving the creation logic for Exploration missions from the `Exploration` to the `ExplorationMeta`. This facilitates the later replace of the custom Exploration Mission class with the generic `Missionproject`
 
Changes:
- Exploration mission has a single constructor that takes a list of MineralSites to explore and execute only that
- ExplorationMeta constrcutIsntance with minimal parameters (leader, settlement) is now responsible for searching for sites
- ConstructInstance method with fully qualified parameters creates a Exploration Mission directly
- Fix problem with waiting for sunlight on Exploratino missions
- Use the MineralSit name more