### PR TITLE
fix(ui): Stop salvaged vehicles being displayed on the map layer

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/CollectionUtils.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/CollectionUtils.java
@@ -291,34 +291,6 @@ public class CollectionUtils {
 	}
 	
 	/**
-	 * Gets a list of vehicles (regardless their association) of a settlement in its vicinity.
-	 * Note: a vehicle can be either inside the settlement or within its vicinity
-	 *
-	 * @param settlement the settlement
-	 * @return list of vehicles to display.
-	 */
-	public static List<Vehicle> getVehiclesInSettlementVicinity(Settlement settlement) {
-		if (unitManager == null)
-			unitManager = Simulation.instance().getUnitManager();
-		
-		List<Vehicle> result = new ArrayList<>();
-
-		if (settlement != null) {
-			Iterator<Vehicle> i = unitManager.getVehicles().iterator();
-			while (i.hasNext()) {
-				Vehicle vehicle = i.next();
-				Settlement settlementLoc = vehicle.getSettlement();
-				// Select a vehicle at the settlement coordinate.
-				if (settlementLoc != null && settlementLoc.equals(settlement)) {
-					result.add(vehicle);
-				}
-			}
-		}
-
-		return result;
-	}
-	
-	/**
 	 * Gets a list of robots associated people of a settlement in its vicinity.
  	 * Note: a robot can be either inside the settlement or within its vicinity
 	 * 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/manufacture/SalvageProcess.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/manufacture/SalvageProcess.java
@@ -85,7 +85,6 @@ public class SalvageProcess extends WorkshopProcess {
 			} break;
 			case Vehicle v: {
 				settlement.removeOwnedVehicle(v);
-				settlement.removeParkedNGaragedVehicle(v);
 			} break;
 			default: throw new IllegalStateException("Salvage process can not remote target");
 		}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -2109,6 +2109,9 @@ public class Settlement extends Unit implements Temporal,
 	 * return true if the vehicle can be removed
 	 */
 	public boolean removeOwnedVehicle(Vehicle vehicle) {
+		if (!ownedVehicles.contains(vehicle))
+			return true;
+		
 		if (ownedVehicles.remove(vehicle)) {
 			removeParkedNGaragedVehicle(vehicle);
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/structure/Settlement.java
@@ -2109,9 +2109,9 @@ public class Settlement extends Unit implements Temporal,
 	 * return true if the vehicle can be removed
 	 */
 	public boolean removeOwnedVehicle(Vehicle vehicle) {
-		if (!ownedVehicles.contains(vehicle))
-			return true;
 		if (ownedVehicles.remove(vehicle)) {
+			removeParkedNGaragedVehicle(vehicle);
+
 			numOwnedVehicles = ownedVehicles.size();
 			return true;
 		}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/VehicleMapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/VehicleMapLayer.java
@@ -11,6 +11,7 @@ import java.awt.Font;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
+import java.util.ArrayList;
 
 import org.apache.batik.gvt.GraphicsNode;
 
@@ -58,8 +59,8 @@ public class VehicleMapLayer extends AbstractMapLayer {
 		AffineTransform saveTransform = viewpoint.prepareGraphics();
 		boolean drawLabel = mapPanel.isOptionDisplayed(DisplayOption.VEHICLE_LABELS);
 
-		// Vehicles parked and on a construction mission
-		var vehicles = settlement.getParkedNGaragedVehicles();
+		// Vehicles parked take a copy to avoid changes during iteration.
+		var vehicles = new ArrayList<>(settlement.getParkedNGaragedVehicles());
 
 		// Draw all parked vehicles at this settlement location
 		for (Vehicle v : vehicles) {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/VehicleMapLayer.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/tool/settlement/VehicleMapLayer.java
@@ -14,7 +14,6 @@ import java.awt.image.BufferedImage;
 
 import org.apache.batik.gvt.GraphicsNode;
 
-import com.mars_sim.core.CollectionUtils;
 import com.mars_sim.core.map.location.LocalBoundedObject;
 import com.mars_sim.core.resource.Part;
 import com.mars_sim.core.structure.Settlement;
@@ -59,8 +58,11 @@ public class VehicleMapLayer extends AbstractMapLayer {
 		AffineTransform saveTransform = viewpoint.prepareGraphics();
 		boolean drawLabel = mapPanel.isOptionDisplayed(DisplayOption.VEHICLE_LABELS);
 
+		// Vehicles parked and on a construction mission
+		var vehicles = settlement.getParkedNGaragedVehicles();
+
 		// Draw all parked vehicles at this settlement location
-		for (Vehicle v : CollectionUtils.getVehiclesInSettlementVicinity(settlement)) {
+		for (Vehicle v : vehicles) {
 			if (v.isReady())
 				drawVehicle(v, drawLabel, viewpoint);
 		}


### PR DESCRIPTION
Changes:
- VehicleMapLayer selects parked vehicles from the settlement insted of scanning UnitManager.
- Settlement takes on responsibility to remove unowned vehicles automatically from the parked list.
- SalvageProcess no longer needs to remove vehicles from the parked list, just the owned list.
- CollectionUtils remove unused vehicle vicinity method.

close #2056