### PR TITLE
task(core): Clean interface implementation of MicroInventory and EquipmentInventory

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/unit/ResourceHolderRefillCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/unit/ResourceHolderRefillCommand.java
@@ -54,8 +54,8 @@ public class ResourceHolderRefillCommand extends AbstractUnitCommand {
 			if (ar != null)  {
 				return adjustResource(source, ar, quantity, context);
 			}
-		} catch (IllegalArgumentException e) {
-			// Name is not a amount resource
+		} catch (IllegalArgumentException _) {
+			// Name is not a amount resource sp try Item
 		}
 
 		try {
@@ -101,7 +101,7 @@ public class ResourceHolderRefillCommand extends AbstractUnitCommand {
 			return false;
 		}
 
-		double existingAmount = rh.getAllAmountResourceStored(resource.getID());
+		double existingAmount = rh.getSpecificAmountResourceStored(resource.getID());
 		if (quantity> 0) {
 			rh.storeAmountResource(resource.getID(), quantity);
 		}
@@ -109,7 +109,7 @@ public class ResourceHolderRefillCommand extends AbstractUnitCommand {
 			rh.retrieveAmountResource(resource.getID(), -quantity);
 		}
 		
-		double newAmount = rh.getAllSpecificAmountResourceStored(resource.getID());
+		double newAmount = rh.getSpecificAmountResourceStored(resource.getID());
 		
 		context.println(Math.round(quantity * 1000.0)/1000.0 + " kg " + resource.getName() + " added.");
 		

--- a/mars-sim-core/src/main/java/com/mars_sim/core/building/Building.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/building/Building.java
@@ -1455,17 +1455,6 @@ public class Building extends FixedUnit implements Malfunctionable,
 	public double getSpecificAmountResourceStored(int resource) {
 		return getAssociatedSettlement().getEquipmentInventory().getSpecificAmountResourceStored(resource);
 	}
-
-	/**
-	 * Gets all the specific amount resources stored, including those inside equipment.
-	 *
-	 * @param resource
-	 * @return amount
-	 */
-	@Override
-	public double getAllSpecificAmountResourceStored(int resource) {
-		return getAssociatedSettlement().getEquipmentInventory().getAllSpecificAmountResourceStored(resource);
-	}
 	
 	/**
 	 * Gets the quantity of all stock and specific amount resource stored.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuit.java
@@ -652,7 +652,7 @@ public class EVASuit extends Equipment
 	 */
 	@Override
 	public Set<Integer> getItemResourceIDs() {
-		return microInventory.getItemStoredIDs();
+		return microInventory.getItemResourceIDs();
 	}
 
 	@Override
@@ -660,17 +660,6 @@ public class EVASuit extends Equipment
 		return microInventory.getSpecificAmountResourceStored(resource);
 	}
 
-	/**
-	 * Gets all the amount resource resource stored, including inside equipment.
-	 *
-	 * @param resource
-	 * @return quantity
-	 */
-	@Override
-	public double getAllSpecificAmountResourceStored(int resource) {
-		return microInventory.getSpecificAmountResourceStored(resource);
-	}
-	
 	/**
 	 * Retrieves the resource.
 	 *

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentInventory.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentInventory.java
@@ -104,16 +104,7 @@ public class EquipmentInventory
 		}
 		return result + microInventory.getStoredMass();
 	}
-	
-	/**
-	 * Prints the micro inventory stored mass.
-	 *
-	 * @return mass [kg]
-	 */
-	public void printMicroInventoryStoredMass() {
-		microInventory.printStoredMass();
-	}
-	
+
 	/**
 	 * Gets the modified mass for a container. Useful when accounting for pushing a wheelbarrow, 
 	 * instead of carrying a wheelbarrow.
@@ -695,15 +686,6 @@ public class EquipmentInventory
 
 	/**
 	 * Sets the resource capacities.
-	 *
-	 * @param capacities
-	 */
-	public void setResourceCapacityMap(Map<Integer, Double> capacities) {
-		setResourceCapacityMap(capacities, false);
-	}
-
-	/**
-	 * Sets the resource capacities.
 	 * 
 	 * @param capacities
 	 * @param add True if it should these be "added" on top of its existing capacity. False if it should be 'set' to a new capacity
@@ -740,18 +722,6 @@ public class EquipmentInventory
  		microInventory.addStockCapacity(cargoCapacity);
 	}
 	
-	
-	
-	/**
-	 * Adds the specific capacity of a particular resource.
-	 *
-	 * @param resource
-	 * @param capacity
-	 */
-	public void addSpecificCapacity(int resource, double capacity) {
-		microInventory.addSpecificCapacity(resource, capacity);
-	}
-
 	/**
 	 * Removes the specific capacity of a particular resource.
 	 *

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentInventory.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentInventory.java
@@ -27,7 +27,7 @@ import com.mars_sim.core.resource.ResourceUtil;
  * basic capacity management.
  */
 public class EquipmentInventory
-		implements EquipmentOwner, ItemHolder, BinHolder, Serializable {
+		implements EquipmentOwner, BinHolder, Serializable {
 
 	private static final long serialVersionUID = 1L;
 
@@ -187,67 +187,6 @@ public class EquipmentInventory
 
 		return containerSet.add(equipment); 
 	}
-	
-//	/**
-//	 * Adds the equipment (suit or container) to a particular equipment set.
-//	 * 
-//	 * @param set
-//	 * @param equipment
-//	 * @return true if this unit can carry it
-//	 */
-//	private boolean addToSet(Set<Equipment> set, Equipment equipment) {
-//		boolean contained = set.contains(equipment);
-//		
-//		if (contained) {
-//			return false;
-//		}
-//		
-//		if (!contained) {
-//			double suitMass = 0;
-//			for (Equipment e: suitSet) {
-//				suitMass += e.getMass();
-//			}
-//			
-//			double containerMass = 0;
-//			String containerName = "";
-//			
-//			for (Equipment e: containerSet) {
-//				Container c = (Container)e;
-//				Set<Integer> ids = c.getSpecificResourceStoredIDs();
-//				String arNames = "";
-//				for (int i: ids) {
-//					arNames += ResourceUtil.findAmountResourceName(i) 
-//							+ " (" + Math.round(c.getSpecificAmountResourceStored(i) * 100.0)/100.0 + ")";
-//				}
-//				containerName += e.getName() + " [" + arNames + "]";
-//				containerMass += e.getMass();
-//			}
-//
-//			double microInvMass = microInventory.getStoredMass();
-//			
-//			double totalStored = suitMass + containerMass + microInvMass;
-//			
-//			double newCapacity = cargoCapacity - totalStored - equipment.getMass();
-//			if (newCapacity >= 0D) {
-//				owner.fireUnitUpdate(EntityEventType.INVENTORY_STORING_UNIT_EVENT, equipment);
-//				return set.add(equipment);
-//			}
-//			else {
-//				logger.warning(owner, 60_000L, "No capacity to hold " + equipment.getName()
-//								+ " - cargoCapacity: " + cargoCapacity 
-//								+ ", container name: " + containerName
-//								+ ", totalStored: " + totalStored 
-//								+ ", microInvMass: " + microInvMass
-//								+ ", containerMass: " + containerMass 
-//								+ ", suitMass: " + suitMass
-//								+ ", equipmentMass: " + equipment.getMass() 
-//								+ ".");
-//				return false;
-//			}
-//		}
-//		
-//		return !contained;
-//	}
 
 	/**
 	 * Removes an equipment.
@@ -393,6 +332,7 @@ public class EquipmentInventory
 	 * @param resource
 	 * @return
 	 */
+	@Override
 	public boolean hasAmountResourceRemainingCapacity(int resource) {
 		
 		double cap = microInventory.getSpecificCapacity(resource);
@@ -409,7 +349,7 @@ public class EquipmentInventory
 	 *
 	 * @return
 	 */
-	public double getStockCapacity() {
+	double getStockCapacity() {
 		return microInventory.getStockCapacity();
 	}
 	
@@ -420,7 +360,7 @@ public class EquipmentInventory
 	 */
 	@Override
 	public double getRemainingCargoCapacity() {
-		return cargoCapacity - getStoredMass();
+		return getCargoCapacity() - getStoredMass();
 	}
 
 	/**
@@ -430,9 +370,7 @@ public class EquipmentInventory
      */
 	@Override
 	public double getCargoCapacity() {
-		// Question: Should the total capacity varies ?
-		// based on one's instant carrying capacity ?
-		return cargoCapacity;
+		return microInventory.getCargoCapacity();
 	}
 
 	/**
@@ -447,31 +385,12 @@ public class EquipmentInventory
 	}
 
 	/**
-	 * Gets all the specific amount resources stored, including those inside equipment.
-	 *
-	 * @param resource
-	 * @return amount
-	 */
-	@Override
-	public double getAllSpecificAmountResourceStored(int resource) {
-		double result = 0;
-		// Do not consume resources from container Equipment. THis is an expensive
-		// and can generate concurrency issues
-		for (Equipment e: suitSet) {
-		 	result += e.getSpecificAmountResourceStored(resource);
-		 }
-		for (Equipment e: containerSet) {
-		 	result += e.getSpecificAmountResourceStored(resource);
-		 }
-		return result + getSpecificAmountResourceStored(resource);
-	}
-
-	/**
 	 * Gets the quantity of all stock and specific amount resource stored.
 	 *
 	 * @param resource
 	 * @return quantity
 	 */
+	@Override
 	public double getAllAmountResourceStored(int resource) {
 		return microInventory.getAllAmountResourceStored(resource);
 	}
@@ -487,19 +406,6 @@ public class EquipmentInventory
 	 */
 	@Override
 	public int findNumEmptyContainersOfType(EquipmentType containerType, boolean brandNew) {
-		return (int) containerSet.stream()
-					.filter(e -> e.isEmpty(brandNew) && (e.getEquipmentType() == containerType))
-					.count();
-	}
-
-	/**
-	 * Finds the number of empty containers of a particular equipment type.
-	 * 
-	 * @param containerType
-	 * @param brandNew
-	 * @return
-	 */
-	public int findNumEmptyCopyContainersOfType(EquipmentType containerType, boolean brandNew) {
 		return (int) containerSet.stream()
 					.filter(e -> e.isEmpty(brandNew) && (e.getEquipmentType() == containerType))
 					.count();
@@ -524,6 +430,7 @@ public class EquipmentInventory
 	 *
 	 * @return collection of containers or empty collection if none.
 	 */
+	@Override
 	public Collection<Container> findContainersOfType(EquipmentType type) {
 		Collection<Container> result = new HashSet<>();
 		for (Equipment e : containerSet) {
@@ -624,7 +531,7 @@ public class EquipmentInventory
 	 */
 	@Override
 	public Set<Integer> getItemResourceIDs() {
-		return microInventory.getItemStoredIDs();
+		return microInventory.getItemResourceIDs();
 	}
 
 	/**
@@ -644,8 +551,9 @@ public class EquipmentInventory
 	 * 
 	 * @return all stored amount resources.
 	 */
+	@Override
 	public Set<Integer> getAllAmountResourceStoredIDs() {
-		Set<Integer> set = new HashSet<>(getSpecificResourceStoredIDs());
+		Set<Integer> set = new HashSet<>(microInventory.getAllAmountResourceStoredIDs());
 		for (Equipment e: containerSet) {
 			if (e instanceof ResourceHolder rh) {
 				set.addAll(rh.getSpecificResourceStoredIDs());

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentOwner.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EquipmentOwner.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 import com.mars_sim.core.structure.Settlement;
 
-public interface EquipmentOwner extends ResourceHolder {
+public interface EquipmentOwner extends ItemHolder, ResourceHolder {
 	  
 	/**
 	 * Gets the total mass held in this entity.

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/GenericContainer.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/GenericContainer.java
@@ -164,17 +164,6 @@ class GenericContainer extends Equipment implements Container {
 	}
 
 	/**
-	 * Gets all the amount resource resource stored, including inside equipment.
-	 *
-	 * @param resource
-	 * @return quantity
-	 */
-	@Override
-	public double getAllSpecificAmountResourceStored(int resource) {
-		return getSpecificAmountResourceStored(resource);
-	}
-	
-	/**
 	 * Gets the quantity of all stock and specific amount resource stored.
 	 *
 	 * @param resource

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/MicroInventory.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/MicroInventory.java
@@ -22,7 +22,7 @@ import com.mars_sim.core.resource.ResourceUtil;
 /**
  * The MicroInventory class represents a simple resource storage solution.
  */
-public class MicroInventory implements Serializable {
+public class MicroInventory implements ItemHolder, ResourceHolder, Serializable {
 
 	private static final class AmountStored implements Serializable {
 
@@ -47,7 +47,7 @@ public class MicroInventory implements Serializable {
 		}
 	}
 
-	static final class ItemStored implements Serializable {
+	private static final class ItemStored implements Serializable {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
@@ -101,6 +101,11 @@ public class MicroInventory implements Serializable {
 	public MicroInventory(Unit owner, double stockCapacity) {
 		this.owner = owner;
 		this.stockCapacity = stockCapacity;
+	}
+
+	@Override
+	public double getCargoCapacity() {
+		return stockCapacity;
 	}
 
 	/**
@@ -560,7 +565,8 @@ public class MicroInventory implements Serializable {
 	 *
 	 * @return
 	 */
-	public Set<Integer> getAllSpecificResourceStoredIDs() {
+	@Override
+	public Set<Integer> getAllAmountResourceStoredIDs() {
 		Set<Integer> set = specificAmountStorage.keySet()
 				.stream()
 				.filter(i -> (specificAmountStorage.get(i).storedAmount > 0))
@@ -590,7 +596,7 @@ public class MicroInventory implements Serializable {
 	 * 
 	 * @return
 	 */
-	public Set<Integer> getItemStoredIDs() {
+	public Set<Integer> getItemResourceIDs() {
 		return itemStorage.keySet()
 				.stream()
 				.filter(i -> (itemStorage.get(i).quantity > 0))

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/MicroInventory.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/MicroInventory.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.EntityEventType;
@@ -25,7 +24,7 @@ import com.mars_sim.core.resource.ResourceUtil;
  */
 public class MicroInventory implements Serializable {
 
-	static final class AmountStored implements Serializable {
+	private static final class AmountStored implements Serializable {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
@@ -104,64 +103,6 @@ public class MicroInventory implements Serializable {
 		this.stockCapacity = stockCapacity;
 	}
 
-	
-	/** 
-	 * Gets a map of stock amount resources.
-	 * 
-	 * @return
-	 */
-	public Map<Integer, Double> getStockAmountStorage() {
-		return stockAmountStorage;
-	}
-	
-	/** 
-	 * Gets a map of specific amount resources. 
-	 * 
-	 * @return
-	 */
-	public Map<Integer, Double> getSpecificAmountStorage() {
-		Map<Integer, Double> map = new HashMap<>();
-		for (Map.Entry<Integer, AmountStored> entry : specificAmountStorage.entrySet()) {
-			int k = entry.getKey();
-			AmountStored s = entry.getValue();
-			double amount = s.storedAmount;
-			map.put(k, amount);
-        }
-		return map;
-	}
-	
-	/** 
-	 * Gets a map of item resources. 
-	 * 
-	 * @return
-	 */
-	public Map<Integer, Double> getItemStorage() {
-		Map<Integer, Double> map = new HashMap<>();
-		for (Map.Entry<Integer, ItemStored> entry : itemStorage.entrySet()) {
-			int k = entry.getKey();
-			ItemStored s = entry.getValue();
-			double q = s.quantity;
-			map.put(k, q);
-        }
-		return map;
-	}
-	
-	/** 
-	 * Gets a map of all stock and specific amount resources. 
-	 * 
-	 * @return
-	 */
-	public Map<Integer, Double> getAllAmountResourceMap() {
-		return Stream.concat(getStockAmountStorage().entrySet().stream(), 
-				getSpecificAmountStorage().entrySet().stream())
-				.collect(Collectors.toMap(
-                Map.Entry::getKey,
-                Map.Entry::getValue,
-                // Handling duplicate keys by adding their values together
-                (v1, v2) -> v1 + v2  
-        ));
-	}
-	
 	/**
 	 * Gets the stock capacity.
 	 *
@@ -266,19 +207,6 @@ public class MicroInventory implements Serializable {
 	}
 
 	/**
-	 * Prints the stored mass.
-	 *
-	 * @return mass [kg]
-	 */
-	public void printStoredMass() {
-		String s = "stockAmountTotalMass: " + stockAmountTotalMass 
-				+ " specificAmountTotalMass: " + specificAmountTotalMass 
-				+ " itemTotalMass: " + itemTotalMass;
-		System.out.println(s);
-	}
-
-	
-	/**
 	 * Is this inventory empty ?
 	 *
 	 * @return
@@ -322,15 +250,13 @@ public class MicroInventory implements Serializable {
 			// Update the quantity
 			quantity = remaining;
 			
-			String name = ResourceUtil.findAmountResourceName(resource);
-			for (int i: ResourceUtil.getEssentialResources()) {
-				if (i == resource)
-					logger.warning(owner, 60_000L, "Specific Storage is full. Excess " + Math.round(excess * 1_000.0)/1_000.0 + " kg " + name + ".");
+			if (ResourceUtil.getEssentialResources().contains(resource)) {
+				String name = ResourceUtil.findAmountResourceName(resource);
+				logger.warning(owner, 60_000L, "Specific Storage is full. Excess " + Math.round(excess * 1_000.0)/1_000.0 + " kg " + name + ".");
 			}
 			
 			// Store excess as stock amount resource
 			excess = storeStockAmountResource(resource, excess);
-
 		}
 
 		s.storedAmount += quantity;
@@ -339,7 +265,7 @@ public class MicroInventory implements Serializable {
 		specificAmountTotalMass += quantity;
 		
 		// Fire the unit event type
-		owner.fireUnitUpdate(EntityEventType.INVENTORY_RESOURCE_EVENT, resource); //ResourceUtil.findAmountResource(resource));
+		owner.fireUnitUpdate(EntityEventType.INVENTORY_RESOURCE_EVENT, resource);
 		return excess;
 	}
 
@@ -350,7 +276,7 @@ public class MicroInventory implements Serializable {
 	 * @param quantity
 	 * @return excess quantity that cannot be stored
 	 */
-	public double storeStockAmountResource(int resource, double quantity) {
+	private double storeStockAmountResource(int resource, double quantity) {
 		double stockAmount = 0;
 		
 		if (stockAmountStorage.containsKey(resource)) {
@@ -548,7 +474,7 @@ public class MicroInventory implements Serializable {
 	 * @param quantity
 	 * @return shortfall quantity that cannot be retrieved
 	 */
-	public double retrieveStockAmountResource(int resource, double quantity) {
+	private double retrieveStockAmountResource(int resource, double quantity) {
 		double stockAmount = 0;
 		
 		if (stockAmountStorage.containsKey(resource)) {
@@ -760,7 +686,7 @@ public class MicroInventory implements Serializable {
 	 * @param resource
 	 * @return quantity
 	 */
-	public double getStockAmountResourceStored(int resource) {
+	private double getStockAmountResourceStored(int resource) {
 		return stockAmountStorage.getOrDefault(resource, 0.0);
 	}
 	
@@ -772,30 +698,6 @@ public class MicroInventory implements Serializable {
 	 */
 	public double getAllAmountResourceStored(int resource) {
 		return getStockAmountResourceStored(resource) + getSpecificAmountResourceStored(resource);
-	}
-	
-	/**
-	 * Gets the total amount of specific amount resource stored.
-	 *
-	 * @return total amount
-	 */
-	public double getTotalSpecificAmountResourceStored() {
-		double total = 0;
-		for (Map.Entry<Integer, AmountStored> entry : specificAmountStorage.entrySet()) {
-			AmountStored s = entry.getValue();
-			total += s.storedAmount;
-        }
-		return total;
-	}
-	
-	/**
-	 * Gets the total amount of stock amount resource stored.
-	 *
-	 * @return total amount
-	 */
-	public double getTotalStockAmountResourceStored() {
-		updateStockAmountResourceTotalMass();
-		return this.stockAmountTotalMass;
 	}
 
 	/**
@@ -820,14 +722,5 @@ public class MicroInventory implements Serializable {
 	 */
 	public boolean isResourceSupported(int resource) {
 		return specificAmountStorage.containsKey(resource);
-	}
-
-
-	/**
-	 * Cleans this container for future use.
-	 */
-	public void clean() {
-		specificAmountStorage.clear();
-		itemStorage.clear();
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/ResourceHolder.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/ResourceHolder.java
@@ -23,15 +23,6 @@ public interface ResourceHolder {
 	 * @return amount
 	 */
 	double getSpecificAmountResourceStored(int resource);
-
-	
-	/**
-	 * Gets all the specific amount resources stored, including inside equipment
-	 *
-	 * @param resource
-	 * @return quantity
-	 */
-	double getAllSpecificAmountResourceStored(int resource);
 	
 	/**
 	 * Stores the amount resource

--- a/mars-sim-core/src/main/java/com/mars_sim/core/goods/CommerceUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/goods/CommerceUtil.java
@@ -399,7 +399,7 @@ public final class CommerceUtil {
 		EquipmentType containerType = ContainerUtil.getEquipmentTypeNeeded(resource.getPhase());
 
 		var eo = settlement.getEquipmentInventory();
-		int containersStored = eo.findNumEmptyCopyContainersOfType(containerType, false);
+		int containersStored = eo.findNumEmptyContainersOfType(containerType, false);
 
 		Good containerGood = GoodsUtil.getEquipmentGood(containerType);
 		int containersTraded = 0;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/Person.java
@@ -1473,6 +1473,11 @@ public class Person extends AbstractMobileUnit implements Worker, Temporal, Unit
 		return eqmInventory.retrieveItemResource(resource, quantity);
 	}
 
+	@Override
+	public int getItemResourceRemainingQuantity(int resource) {
+		return eqmInventory.getItemResourceRemainingQuantity(resource);
+	}
+
 	/**
 	 * Gets the item resource stored.
 	 *
@@ -1573,17 +1578,6 @@ public class Person extends AbstractMobileUnit implements Worker, Temporal, Unit
 		return eqmInventory.getSpecificAmountResourceStored(resource);
 	}
 
-	/**
-	 * Gets all the amount resource resource stored, including inside equipment.
-	 *
-	 * @param resource
-	 * @return quantity
-	 */
-	@Override
-	public double getAllSpecificAmountResourceStored(int resource) {
-		return eqmInventory.getAllSpecificAmountResourceStored(resource);
-	}
-	
 	/**
 	 * Gets the quantity of all stock and specific amount resource stored.
 	 *

--- a/mars-sim-core/src/main/java/com/mars_sim/core/robot/Robot.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/robot/Robot.java
@@ -377,14 +377,6 @@ public class Robot extends AbstractMobileUnit implements Salvagable, Temporal, M
     }
 
 	/**
-	 * Sets the robot to be salvaged.
-	 */
-	private void toBeSalvaged() {
-		((Settlement)getContainerUnit()).removeOwnedRobot(this);
-		isInoperable = true;
-	}
-
-	/**
 	 * Is the robot operable ?
 	 * 
 	 * @return
@@ -792,6 +784,11 @@ public class Robot extends AbstractMobileUnit implements Salvagable, Temporal, M
 		return eqmInventory.getItemResourceStored(resource);
 	}
 
+	@Override
+	public int getItemResourceRemainingQuantity(int resource) {
+		return eqmInventory.getItemResourceRemainingQuantity(resource);
+	}
+
 	/**
 	 * Stores the amount resource
 	 *
@@ -881,17 +878,6 @@ public class Robot extends AbstractMobileUnit implements Salvagable, Temporal, M
 		return eqmInventory.getSpecificAmountResourceStored(resource);
 	}
 
-	/**
-	 * Gets all the amount resource resource stored, including inside equipment.
-	 *
-	 * @param resource
-	 * @return quantity
-	 */
-	@Override
-	public double getAllSpecificAmountResourceStored(int resource) {
-		return eqmInventory.getAllSpecificAmountResourceStored(resource);
-	}
-	
 	/**
 	 * Gets the quantity of all stock and specific amount resource stored.
 	 *

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
@@ -261,7 +261,7 @@ public abstract class Vehicle extends AbstractMobileUnit
 		// Set the capacities for each supported resource
 		Map<Integer, Double> capacities = spec.getCargoCapacityMap();
 		if (capacities != null) {
-			eqmInventory.setResourceCapacityMap(capacities);
+			eqmInventory.setResourceCapacityMap(capacities, false);
 		}
 
 		// Set total distance traveled by vehicle (km)

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/Vehicle.java
@@ -240,8 +240,6 @@ public abstract class Vehicle extends AbstractMobileUnit
 	Vehicle(String name, VehicleSpec spec, Settlement settlement, double maintenanceWorkTime) {
 		// Use Unit constructor
 		super(name, settlement);
-		// Call Person's setContainerUnit to set up coordinates and related states
-//		setContainerUnit(getContainerUnit());
 		
 		this.spec = spec;
 		this.specName = spec.getName();
@@ -2246,17 +2244,6 @@ public abstract class Vehicle extends AbstractMobileUnit
 	public double getSpecificAmountResourceStored(int resource) {
 		return eqmInventory.getSpecificAmountResourceStored(resource);
 	}
-	
-	/**
-	 * Gets all the specific amount resources stored, including those inside equipment.
-	 *
-	 * @param resource
-	 * @return quantity
-	 */
-	@Override
-	public double getAllSpecificAmountResourceStored(int resource) {
-		return eqmInventory.getAllSpecificAmountResourceStored(resource);
-	}
 
 	/**
 	 * Gets the quantity of all stock and specific amount resource stored.
@@ -2432,25 +2419,6 @@ public abstract class Vehicle extends AbstractMobileUnit
 			else {
 				// Set the container unit for this vehicle
 				setContainerUnit(destination);
-				
-//				// Transfer each occupant 
-//				if (this instanceof Crewable crewable) {
-//		            for (Person crewmember : crewable.getCrew()) {
-//		                crewmember.transfer(this);
-//		            }
-//				}
-//				else if (this instanceof LightUtilityVehicle luv 
-//						&& !luv.hasNoCrew()) {
-//					Worker occupant = luv.getOccupant();
-//					if (occupant != null && luv.getOperator().equals(occupant)) {
-//						occupant.transfer(this);
-//					}
-//				}
-//				
-//				// Transfer each piece of equipment 
-//				for (Equipment equipment : getEquipmentSet()) {
-//					equipment.transfer(this);
-//	            }	
 			}
 		}
 		return canTransferOut;

--- a/mars-sim-core/src/test/java/com/mars_sim/core/MicroInventoryTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/MicroInventoryTest.java
@@ -131,7 +131,6 @@ class MicroInventoryTest {
 		double cap = inv.getRemainingSpecificCapacity(resource);		
 		assertEquals(CAPACITY_AMOUNT, cap, "Remaining after 2nd retrieve");
 		
-		inv.printStoredMass();
 		mass = inv.getStoredMass();
 		
 		assertEquals(0D, mass, "Total mass after 2nd retrieve");

--- a/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/UnloadHelperTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/UnloadHelperTest.java
@@ -19,7 +19,7 @@ import com.mars_sim.core.resource.ResourceUtil;
 
 class UnloadHelperTest extends MarsSimUnitTest{
     @Test
-    public void testReleaseTowedVehicle() {
+    void testReleaseTowedVehicle() {
         var s = buildSettlement("towing");
 
         var towing = buildRover(s, "towing", LocalPosition.DEFAULT_POSITION, EXPLORER_ROVER);
@@ -33,7 +33,7 @@ class UnloadHelperTest extends MarsSimUnitTest{
     }
 
     @Test
-    public void testUnloadDeceased() {
+    void testUnloadDeceased() {
         var s = buildSettlement("towing");
 
         var v = buildRover(s, "towing", LocalPosition.DEFAULT_POSITION, EXPLORER_ROVER);
@@ -50,7 +50,7 @@ class UnloadHelperTest extends MarsSimUnitTest{
     }
 
     @Test
-    public void testUnloadEVASuits() {
+    void testUnloadEVASuits() {
         var s = buildSettlement("towing");
 
         var v = buildRover(s, "rover", LocalPosition.DEFAULT_POSITION, EXPLORER_ROVER);
@@ -72,7 +72,7 @@ class UnloadHelperTest extends MarsSimUnitTest{
     }
 
     @Test
-    public void testUnloadInventory() {
+    void testUnloadInventory() {
         var s = buildSettlement("towing");
         var v = buildRover(s, "rover", LocalPosition.DEFAULT_POSITION, EXPLORER_ROVER);
         s.getEquipmentInventory().setCargoCapacity(50);
@@ -94,7 +94,6 @@ class UnloadHelperTest extends MarsSimUnitTest{
         assertEquals(0D, amountNotUsed, "All efforts being used up");
         
         mass = v.getStoredMass();
-        v.getEquipmentInventory().printMicroInventoryStoredMass();
         
         assertEquals(0D, mass, "Final stored mass");
         

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/components/AbstractEnhancedTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/components/AbstractEnhancedTableModel.java
@@ -1,0 +1,68 @@
+/*
+ * Mars Simulation Project
+ * AbstractEnhancedTableModel.java
+ * @date 2026-08-23
+ * @author Barry Evans
+ */
+package com.mars_sim.ui.swing.components;
+
+import javax.swing.table.AbstractTableModel;
+
+/**
+ * Default implementation of the EnhancedTableModel interface. This class provides a base implementation for table models that need to support enhanced features such as column specifications and tooltips.
+ * Subclasses can extend this class to provide specific data and behavior for their table models.
+ */
+public abstract class AbstractEnhancedTableModel extends AbstractTableModel
+    implements EnhancedTableModel {
+    private ColumnSpec[] columns;
+    
+    protected AbstractEnhancedTableModel(ColumnSpec... columns) {
+        this.columns = columns;
+    }
+
+	/**
+	 * Returns the number of columns in the model.
+	 * @return the number of columns in the model.
+	 */
+	@Override
+	public int getColumnCount() {
+		return columns.length;
+	}
+
+    /**
+     * Get the column name from teh assoaicted ColumnSpec.
+     */
+	@Override
+	public String getColumnName(int columnIndex) {
+		return getColumnSpec(columnIndex).name();
+	}
+
+    /**
+	 * Returns the most specific superclass for all the cell values in the column.
+	 * @param columnIndex the index of the column.
+	 * @return the common ancestor class of the object values in the model.
+	 */
+	@Override
+	public Class<?> getColumnClass(int columnIndex) {
+		return getColumnSpec(columnIndex).type();
+	}
+
+    /**
+     * Get the column specification for the given model index.
+     */
+    @Override
+    public ColumnSpec getColumnSpec(int modelIndex) {
+        return columns[modelIndex];
+    }
+    
+    /**
+     * Default tooltip is nothing.
+     * @param row Row of cell
+     * @param col Column of cell
+     * @return Always returns null.
+     */
+    @Override
+    public String getToolTipAt(int row, int col) {
+        return null;
+    }
+}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/building/BuildingPanelStorage.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/entitywindow/building/BuildingPanelStorage.java
@@ -70,7 +70,7 @@ class BuildingPanelStorage extends EntityTableTabPanel<Building> implements Temp
 				
 				buildingStorage.put(name, resource.getValue());
 
-				available.put(name, holder.getAllSpecificAmountResourceStored(id));
+				available.put(name, holder.getSpecificAmountResourceStored(id));
 				
 				settlementStorage.put(name, holder.getSpecificCapacity(id));
 			}

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/InventoryTabPanel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/unit_window/InventoryTabPanel.java
@@ -9,7 +9,6 @@ package com.mars_sim.ui.swing.unit_window;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.GridLayout;
-import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -17,13 +16,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.SwingConstants;
-import javax.swing.border.EmptyBorder;
-import javax.swing.table.AbstractTableModel;
-import javax.swing.table.DefaultTableCellRenderer;
-import javax.swing.table.TableColumnModel;
 
 import com.mars_sim.core.Entity;
 import com.mars_sim.core.Unit;
@@ -43,11 +35,11 @@ import com.mars_sim.core.tool.Msg;
 import com.mars_sim.ui.swing.ImageLoader;
 import com.mars_sim.ui.swing.TemporalComponent;
 import com.mars_sim.ui.swing.UIContext;
-import com.mars_sim.ui.swing.components.NumberCellRenderer;
-import com.mars_sim.ui.swing.components.ToolTipTableModel;
+import com.mars_sim.ui.swing.components.AbstractEnhancedTableModel;
+import com.mars_sim.ui.swing.components.ColumnSpec;
 import com.mars_sim.ui.swing.entitywindow.EntityTabPanel;
-import com.mars_sim.ui.swing.utils.EntityLauncher;
 import com.mars_sim.ui.swing.utils.EntityModel;
+import com.mars_sim.ui.swing.utils.SwingHelper;
 
 
 /**
@@ -82,134 +74,37 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
         // Create inventory content panel
         JPanel inventoryContentPanel = new JPanel(new GridLayout(3, 1, 0, 0));
         content.add(inventoryContentPanel, BorderLayout.CENTER);
-
-		NumberCellRenderer digit2Renderer = new NumberCellRenderer(2);
-		DefaultTableCellRenderer rightRenderer = new DefaultTableCellRenderer();
-		// Align the preference score to the right of the cell
-		rightRenderer.setHorizontalAlignment(SwingConstants.RIGHT);
 		
         // Create resources panel
 		var rh = ResourceHolder.getAttached(getEntity());
 		if (rh != null) {
-			JScrollPane resourcesPanel = new JScrollPane();
-			resourcesPanel.setBorder(new EmptyBorder(2, 2, 2, 2));
-			inventoryContentPanel.add(resourcesPanel);
-
 			// Create resources table model
 			resourceTableModel = new ResourceTableModel(rh);
 
-			// Create resources table
-			JTable resourceTable = new JTable(resourceTableModel) {
-	            // Implement table cell tool tips.   
-				@Override        
-	            public String getToolTipText(MouseEvent e) {
-	                return ToolTipTableModel.extractToolTip(e, this);
-	            }
-	        };			
-			
-			resourceTable.setPreferredScrollableViewportSize(new Dimension(200, 75));
-
-			resourceTable.setRowSelectionAllowed(true);
-			resourcesPanel.setViewportView(resourceTable);
-
-			// Add sorting
-			resourceTable.setAutoCreateRowSorter(true);
-			
-			TableColumnModel resourceColumns = resourceTable.getColumnModel();
-			resourceColumns.getColumn(0).setPreferredWidth(140);
-			resourceColumns.getColumn(1).setPreferredWidth(30);
-			resourceColumns.getColumn(2).setPreferredWidth(30);
-			
-			resourceColumns.getColumn(0).setCellRenderer(rightRenderer);
-			resourceColumns.getColumn(1).setCellRenderer(digit2Renderer);
-			resourceColumns.getColumn(2).setCellRenderer(digit2Renderer);
+			var resourcesPanel = SwingHelper.createScrolledTable(resourceTableModel, getContext(), null,
+												new Dimension(200, 75));
+			inventoryContentPanel.add(resourcesPanel);
 		}
 
         // Create item panel
 		var ih = ItemHolder.getAttached(getEntity());
 		if (ih != null) {
-			JScrollPane itemPanel = new JScrollPane();
-			itemPanel.setBorder(new EmptyBorder(2, 2, 2, 2));
-			inventoryContentPanel.add(itemPanel);
-
 			// Create item table model
 			itemTableModel = new ItemTableModel(ih);
 
-			// Create item table
-			JTable itemTable = new JTable(itemTableModel) {
-	            // Implement table cell tool tips.    
-				@Override              
-	            public String getToolTipText(MouseEvent e) {
-	                return ToolTipTableModel.extractToolTip(e, this);
-	            }
-	        };			
-			itemTable.setPreferredScrollableViewportSize(new Dimension(200, 75));
-
-			itemTable.setRowSelectionAllowed(true);
-			itemPanel.setViewportView(itemTable);
-
-			// Add sorting
-			itemTable.setAutoCreateRowSorter(true);
-
-			TableColumnModel itemColumns = itemTable.getColumnModel();
-			itemColumns.getColumn(0).setPreferredWidth(110);
-			itemColumns.getColumn(1).setPreferredWidth(20);
-			itemColumns.getColumn(2).setPreferredWidth(30);
-			itemColumns.getColumn(3).setPreferredWidth(30);
-			itemColumns.getColumn(4).setPreferredWidth(30);
-			
-			itemColumns.getColumn(0).setCellRenderer(rightRenderer);
-			itemColumns.getColumn(1).setCellRenderer(new NumberCellRenderer(0));
-			itemColumns.getColumn(2).setCellRenderer(digit2Renderer);
-			itemColumns.getColumn(3).setCellRenderer(digit2Renderer);
-			itemColumns.getColumn(4).setCellRenderer(digit2Renderer);
+			var itemPanel = SwingHelper.createScrolledTable(itemTableModel, getContext(), null,
+												new Dimension(200, 75));
+			inventoryContentPanel.add(itemPanel);
 		}
 		
         // Create equipment panel
 		var eo = EquipmentOwner.getAttached(getEntity());
-        if (eo != null) {
-            JScrollPane equipmentPanel = new JScrollPane();
-            equipmentPanel.setBorder(new EmptyBorder(2, 2, 2, 2));
-            inventoryContentPanel.add(equipmentPanel);
-            
+        if (eo != null) {     
 	        // Create equipment table model
 	        equipmentTableModel = new EquipmentTableModel(eo);
-	
-	        // Create equipment table
-	        JTable equipmentTable = new JTable(equipmentTableModel) {
-	            // Implement table cell tool tips.  
-				@Override         
-	            public String getToolTipText(MouseEvent e) {
-	                return ToolTipTableModel.extractToolTip(e, this);
-	            }
-	        };
-	        equipmentTable.setPreferredScrollableViewportSize(new Dimension(200, 75));
-	        
-	        equipmentTable.setRowSelectionAllowed(true);
-	        equipmentPanel.setViewportView(equipmentTable);
-	
-			// Add sorting
-	        equipmentTable.setAutoCreateRowSorter(true);
-			
-	        equipmentTable.setDefaultRenderer(Double.class, new NumberCellRenderer(2));
-	
-			// Align the preference score to the center of the cell
-			DefaultTableCellRenderer renderer2 = new DefaultTableCellRenderer();
-			renderer2.setHorizontalAlignment(SwingConstants.RIGHT);
-	        
-			TableColumnModel equipmentColumns = equipmentTable.getColumnModel();
-	        equipmentColumns.getColumn(0).setPreferredWidth(80);
-	        equipmentColumns.getColumn(1).setPreferredWidth(30);
-	        equipmentColumns.getColumn(2).setPreferredWidth(50);
-	        equipmentColumns.getColumn(3).setPreferredWidth(70);
-	
-			equipmentColumns.getColumn(0).setCellRenderer(renderer2);
-			equipmentColumns.getColumn(1).setCellRenderer(digit2Renderer);
-			equipmentColumns.getColumn(2).setCellRenderer(renderer2);
-			equipmentColumns.getColumn(3).setCellRenderer(renderer2);
-	
-			// Add a mouse listener to hear for double-clicking a person (rather than single click using valueChanged()
-	        EntityLauncher.attach(equipmentTable, getContext());
+
+			var equipmentPanel = SwingHelper.createScrolledTable(equipmentTableModel, getContext(), null, new Dimension(200, 75));
+			inventoryContentPanel.add(equipmentPanel);
         }
     }
 	
@@ -221,11 +116,15 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
      * @return
      */
     private static String generateToolTip(Resource resource) {
+		var desc = resource.getDescription();
+		if (desc == null || desc.isEmpty()) {
+			return null;
+		}
 
         // NOTE: internationalize the resource processes' dynamic tooltip.
         StringBuilder result = new StringBuilder("<html>");
         // Future: Use another tool tip manager to align text to improve tooltip readability			
-        result.append(wrapText(resource.getDescription(), 80));
+        result.append(wrapText(desc, 80));
      
         result.append("</html>");   
         
@@ -243,7 +142,7 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
         int lastBreak = 0;
         int nextBreak = wrapCharAt;
         if (text.length() > wrapCharAt) {
-            String setString = "";
+            StringBuffer setString = new StringBuffer();
             do {
                 while (text.charAt(nextBreak) != ' ' && nextBreak > lastBreak) {
                     nextBreak--;
@@ -251,13 +150,13 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
                 if (nextBreak == lastBreak) {
                     nextBreak = lastBreak + wrapCharAt;
                 }
-                setString += text.substring(lastBreak, nextBreak).trim() + BR;
+                setString.append(text.substring(lastBreak, nextBreak).trim()).append(BR);
                 lastBreak = nextBreak;
                 nextBreak += wrapCharAt;
 
             } while (nextBreak < text.length());
-            setString += text.substring(lastBreak).trim();
-            return setString;
+            setString.append(text.substring(lastBreak).trim());
+            return setString.toString();
         }
         else {
         
@@ -278,35 +177,17 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
         	equipmentTableModel.update();
     }
 
-    
-	/**
-	 * Prepares object for garbage collection.
-	 */
-	@Override
-	public void destroy() {	
-		if (itemTableModel != null) {
-			itemTableModel.destroy();
-			itemTableModel = null;
-		}
-		if (resourceTableModel != null) {
-			resourceTableModel.destroy();
-			resourceTableModel = null;
-		}
-		if (equipmentTableModel != null) {
-			equipmentTableModel.destroy();
-		    equipmentTableModel = null;
-		}
-
-		super.destroy();
-	}
-	
 	/**
 	 * Internal class used as model for the resource table.
 	 */
-	private static class ResourceTableModel extends AbstractTableModel implements ToolTipTableModel {
+	private static class ResourceTableModel extends AbstractEnhancedTableModel {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
+
+		private static final ColumnSpec RESOURCE_NAME = new ColumnSpec(Msg.getString("InventoryTabPanel.Resource.header.name"), String.class);
+		private static final ColumnSpec RESOURCE_STORED = new ColumnSpec(Msg.getString("InventoryTabPanel.Resource.header.quantity"), Double.class, ColumnSpec.STYLE_DIGIT2);
+		private static final ColumnSpec RESOURCE_CAPACITY = new ColumnSpec(Msg.getString("InventoryTabPanel.Resource.header.capacity"), Double.class, ColumnSpec.STYLE_DIGIT2);
 
 		private Map<Resource, Double> stored = new HashMap<>();
 		private Map<Resource, Double> capacity = new HashMap<>();
@@ -315,6 +196,7 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
 		private ResourceHolder holder;
 
         private ResourceTableModel(ResourceHolder unit) {
+			super(RESOURCE_NAME, RESOURCE_STORED, RESOURCE_CAPACITY);
         	this.holder = unit;
         	loadResources(keys, stored, capacity);
         }
@@ -333,38 +215,15 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
 			}
         }
 
-        public Resource getResource(int row) {
+        private Resource getResource(int row) {
         	return keys.get(row);
         }
         
+		@Override
         public int getRowCount() {
             return keys.size();
         }
-
-        public int getColumnCount() {
-            return 3;
-        }
-
-		@Override
-        public Class<?> getColumnClass(int columnIndex) {
-            Class<?> dataType = null;
-            if (columnIndex == 0) dataType = String.class;
-            else if (columnIndex == 1) dataType = Double.class;
-            else if (columnIndex == 2) dataType = Double.class;
-            return dataType;
-        }
-
-		@Override
-        public String getColumnName(int columnIndex) {
-			// Internationalized and capitalized column headers
-            return switch (columnIndex) {
-              case 0 -> Msg.getString("InventoryTabPanel.Resource.header.name");
-              case 1 -> Msg.getString("InventoryTabPanel.Resource.header.quantity");
-              case 2 -> Msg.getString("InventoryTabPanel.Resource.header.capacity");
-              default -> null;
-            };
-        }
-
+		
 		@Override
         public Object getValueAt(int row, int column) {
             if (column == 0) {
@@ -410,18 +269,6 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
 				updateData();
 			}
     	}
-        
-    	/**
-    	 * Prepares object for garbage collection.
-    	 */
-    	public void destroy() {
-    		stored = null;
-    		capacity.clear();
-    		keys.clear();
-    		capacity = null;
-    		keys = null;
-    		holder = null;
-    	}
 
 		@Override
 		public String getToolTipAt(int row, int col) {
@@ -436,16 +283,23 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
 	/**
 	 * Internal class used as model for the item resource table.
 	 */
-	private static class ItemTableModel extends AbstractTableModel implements ToolTipTableModel {
+	private static class ItemTableModel extends AbstractEnhancedTableModel {
 
 		/** default serial id. */
 		private static final long serialVersionUID = 1L;
+		
+		private static final ColumnSpec ITEM_NAME = new ColumnSpec(Msg.getString("InventoryTabPanel.item.header.name"), String.class);
+		private static final ColumnSpec ITEM_QUANTITY = new ColumnSpec(Msg.getString("InventoryTabPanel.item.header.quantity"), Integer.class);
+		private static final ColumnSpec ITEM_MASS = new ColumnSpec(Msg.getString("InventoryTabPanel.item.header.mass"), Double.class, ColumnSpec.STYLE_DIGIT2);
+		private static final ColumnSpec ITEM_RELIABILITY = new ColumnSpec(Msg.getString("InventoryTabPanel.item.header.reliability"), Double.class, ColumnSpec.STYLE_DIGIT2);
+		private static final ColumnSpec ITEM_MTBF = new ColumnSpec(Msg.getString("InventoryTabPanel.item.header.mtbf"), Double.class, ColumnSpec.STYLE_DIGIT2);
 
 		private ItemHolder holder;
 
 		private List<Part> items;
 
         private ItemTableModel(ItemHolder unit) {
+			super(ITEM_NAME, ITEM_QUANTITY, ITEM_MASS, ITEM_RELIABILITY, ITEM_MTBF);
         	this.holder = unit;
         	this.items = getItems();
         }
@@ -457,39 +311,13 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
 							.toList();
 		}
 
-        public Part getPart(int row) {
+        private Part getPart(int row) {
         	return items.get(row);
         }
         
+        @Override
         public int getRowCount() {
             return items.size();
-        }
-
-        public int getColumnCount() {
-            return 5;
-        }
-
-		@Override
-        public Class<?> getColumnClass(int columnIndex) {
-            Class<?> dataType = super.getColumnClass(columnIndex);
-            if (columnIndex == 0) dataType = String.class;
-            else if (columnIndex == 1) dataType = Integer.class;
-            else if (columnIndex == 2) dataType = Double.class;
-            else if (columnIndex == 3) dataType = Double.class;
-            else if (columnIndex == 4) dataType = Double.class;
-            return dataType;
-        }
-
-		@Override
-        public String getColumnName(int columnIndex) {
-			// Internationalized and capitalized column headers
-            return switch (columnIndex) {
-              case 0 -> Msg.getString("InventoryTabPanel.item.header.name");
-              case 1 -> Msg.getString("InventoryTabPanel.item.header.quantity");
-              case 2 -> Msg.getString("InventoryTabPanel.item.header.mass");
-              case 3 -> Msg.getString("InventoryTabPanel.item.header.reliability");
-              default -> Msg.getString("InventoryTabPanel.item.header.mtbf");
-            };
         }
 
         public Object getValueAt(int row, int column) {
@@ -527,16 +355,6 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
 				updateData();
 			}
     	}
-        
-    	/**
-    	 * Prepares object for garbage collection.
-    	 */
-    	public void destroy() {
-    		// Note: calling clear() below will trigger UnsupportedOperationException on ImmutableCollections
-    		// on InventoryTabPanel's itemTableModel.destroy()
-    		items = null;
-    		holder = null;
-    	}
 
 		@Override
 		public String getToolTipAt(int row, int col) {
@@ -551,10 +369,15 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
 	/**
 	 * Internal class used as model for the equipment table.
 	 */
-	public class EquipmentTableModel extends AbstractTableModel
-				implements EntityModel, ToolTipTableModel {
+	public class EquipmentTableModel extends AbstractEnhancedTableModel
+				implements EntityModel {
 
 		private List<Equipment> equipmentList = new ArrayList<>();
+
+		private static final ColumnSpec EQUIPMENT_NAME = new ColumnSpec(Msg.getString("equipment.singular"), String.class);
+		private static final ColumnSpec EQUIPMENT_MASS = new ColumnSpec(Msg.getString("InventoryTabPanel.Equipment.header.mass"), Double.class, ColumnSpec.STYLE_DIGIT2);
+		private static final ColumnSpec EQUIPMENT_OWNER = new ColumnSpec(Msg.getString("InventoryTabPanel.Equipment.header.owner"), String.class);
+		private static final ColumnSpec EQUIPMENT_CONTENT = new ColumnSpec(Msg.getString("InventoryTabPanel.Equipment.header.content"), String.class);
 
 		private EquipmentOwner owner;
 
@@ -564,6 +387,7 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
 		 * @param inventory {@link Inventory}
 		 */
 		public EquipmentTableModel(EquipmentOwner owner) {
+			super(EQUIPMENT_NAME, EQUIPMENT_MASS, EQUIPMENT_OWNER, EQUIPMENT_CONTENT);
 			this.owner = owner;
 			equipmentList = new ArrayList<>(owner.getEquipmentSet());
 		}
@@ -590,32 +414,6 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
 			if (equipmentList != null && !equipmentList.isEmpty())
 				return equipmentList.size();
 			return 0;
-		}
-
-		public int getColumnCount() {
-			return 4;
-		}
-
-		@Override
-		public Class<?> getColumnClass(int columnIndex) {
-			return switch(columnIndex) {
-				case 0 -> String.class;
-				case 1 -> Double.class;
-				case 2 -> String.class;
-				case 3 -> String.class;
-				default -> Object.class;
-			};
-		}
-
-		@Override
-		public String getColumnName(int columnIndex) {
-			return switch (columnIndex) {
-				case 0 -> Msg.getString("equipment.singular");
-				case 1 -> Msg.getString("InventoryTabPanel.Equipment.header.mass");
-				case 2 -> Msg.getString("InventoryTabPanel.Equipment.header.owner");
-				case 3 -> Msg.getString("InventoryTabPanel.Equipment.header.content");
-				default -> "unknown";
-};
 		}
 
 		@Override
@@ -664,15 +462,6 @@ public class InventoryTabPanel extends EntityTabPanel<Unit> implements TemporalC
 		public Entity getAssociatedEntity(int row) {
 			return getEquipment(row);
 		}
-		
-    	/**
-    	 * Prepares object for garbage collection.
-    	 */
-    	public void destroy() {
-    		equipmentList.clear();
-    		equipmentList = null;
-    		owner = null;
-    	}
 
 		@Override
 		public String getToolTipAt(int row, int col) {

--- a/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/AchievementTableModel.java
+++ b/mars-sim-ui/src/main/java/com/mars_sim/ui/swing/utils/AchievementTableModel.java
@@ -8,17 +8,15 @@ package com.mars_sim.ui.swing.utils;
 
 import java.util.function.Function;
 
-import javax.swing.table.AbstractTableModel;
-
 import com.mars_sim.core.science.ScienceType;
 import com.mars_sim.core.tool.Msg;
+import com.mars_sim.ui.swing.components.AbstractEnhancedTableModel;
 import com.mars_sim.ui.swing.components.ColumnSpec;
-import com.mars_sim.ui.swing.components.EnhancedTableModel;
 
 /**
  * Table model for Science achievement table.
  */
-public class AchievementTableModel extends AbstractTableModel implements EnhancedTableModel {
+public class AchievementTableModel extends AbstractEnhancedTableModel {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
@@ -30,32 +28,9 @@ public class AchievementTableModel extends AbstractTableModel implements Enhance
 
 	/** hidden constructor. */
 	public AchievementTableModel(Function<ScienceType, Double> resolver) {
+		super(SCIENCE, ACHIEVEMENT_CREDIT);
         this.resolver = resolver;
 		sciences = ScienceType.values();
-	}
-
-	/**
-	 * Returns the number of columns in the model.
-	 * @return the number of columns in the model.
-	 */
-	@Override
-	public int getColumnCount() {
-		return 2;
-	}
-
-	@Override
-	public String getColumnName(int columnIndex) {
-		return getColumnSpec(columnIndex).name();
-	}
-
-	/**
-	 * Returns the most specific superclass for all the cell values in the column.
-	 * @param columnIndex the index of the column.
-	 * @return the common ancestor class of the object values in the model.
-	 */
-	@Override
-	public Class<?> getColumnClass(int columnIndex) {
-		return getColumnSpec(columnIndex).type();
 	}
 
 	/**
@@ -94,18 +69,4 @@ public class AchievementTableModel extends AbstractTableModel implements Enhance
             fireTableCellUpdated(i, 1);
         }
 	}
-
-    @Override
-    public String getToolTipAt(int row, int col) {
-        return null;
-    }
-
-    @Override
-    public ColumnSpec getColumnSpec(int modelIndex) {
-        return switch (modelIndex) {
-            case 0 -> SCIENCE;
-            case 1 -> ACHIEVEMENT_CREDIT;
-            default -> null;
-        };
-    }
 }


### PR DESCRIPTION
This PR is a clean-up of the interface/implementations in the Inventory area. Reducing the coupling and following good separation of concerns principle will make the  isolating inventory easier. The principles are:

- `MicroInventory` should implement `ItemHolder` and `ResourceHolder`. Use case is use by an EVASuit
- `EquipmentOwner` interface should extends the `ItemHolder` and `ResourceHolder`. Use case is a Person or Robot
- `EquipmentInventory` class as an implementation should implement `EquipmentOwner`.

Following these principle will allow the Person, Robot & Vehicle to be detected from implementing the large Inventory interfaces and can use delegation following the recent introduction of the `getAttached` pattern in the interfaces.

ref #1729