### PR TITLE
fix(core): Missions are now added to MissionControl when created

### DIFF
--- a/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/MissionCreateCommand.java
+++ b/mars-sim-console/src/main/java/com/mars_sim/console/chat/simcommand/settlement/MissionCreateCommand.java
@@ -63,7 +63,6 @@ public class MissionCreateCommand extends AbstractSettlementCommand {
 			}
 			else {
 				context.println("Create Mission " + newMission.getName());
-				settlement.getMissionControl().addMission(newMission);
 
 				if (doReview) {
 					var plan = newMission.getPlan();

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionBuilder.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionBuilder.java
@@ -208,7 +208,10 @@ public class MissionBuilder {
 
 		var crew = new MetaMission.Roster(startingMember, members, vehicle);
 		try {
-			return mission.constructInstance(crew, needsReview);
+			Mission newMission = mission.constructInstance(crew, needsReview);
+			startingMember.getAssociatedSettlement().getMissionControl().addMission(newMission);
+			return newMission;
+
 		} catch (MissionCreationException e) {
 			logError(e.getContext());
 			return null;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionControl.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/MissionControl.java
@@ -160,9 +160,6 @@ public class MissionControl implements ScheduledEventHandler {
 		Person p = mission.getStartingPerson();
 
 		logger.info(p, "Put together a mission plan for " + plan.getMission().getName() + ".");
-
-		// Add this mission only after the mission plan has been submitted for review.
-		addMission(mission);
 	}
 
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/mission/task/ExploreSite.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/mission/task/ExploreSite.java
@@ -246,8 +246,6 @@ public class ExploreSite extends EVAOperation {
 					objective.recordResourceCollected(rockId, mass);
 					double collected = mass - excess;
 					totalCollected += collected;
-					logger.info(person, 10_000, "Collected " + Math.round(collected * 100.0)/100.0 
-							+ " kg " + ResourceUtil.findAmountResourceName(rockId) + " into a specimen box.");
 				}
 				else {
 					double excess = box.storeAmountResource(rockId, remain);


### PR DESCRIPTION
MissionProjects created automatically were not being added to the MissionControl.

Changes:
- MissionBuilder is now responsible for adding Mission to MissionControl when created
- Mission create command does not have to add mission
- ExploreSite, remove excessive debug output

ref #975