### PR TITLE
task(core): Remove inventory interfaces from Equipment

### DIFF
--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/Container.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/Container.java
@@ -13,24 +13,25 @@ import com.mars_sim.core.unit.UnitHolder;
  */
 public interface Container extends ResourceHolder {
 
-	public EquipmentType getEquipmentType();
+	EquipmentType getEquipmentType();
 
 	/**
 	 * Containers only support a single resource.
 	 * 
 	 * @return Resource ID assigned to the container.
 	 */
-	public int getResource();
+	int getResource();
 	
-	public double getBaseMass();
+	double getBaseMass();
 
-	public boolean transfer(UnitHolder newOwner);
+	boolean transfer(UnitHolder newOwner);
 
-	public double getStoredMass();
+	double getStoredMass();
 
 	/**
 	 * Cleans the container if empty. This will reset the assigned Resource.
 	 */
-    public void clean();
+    void clean();
 	
+	boolean isEmpty(boolean brandNew);
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/DataRecorder.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/DataRecorder.java
@@ -172,51 +172,13 @@ public class DataRecorder extends Equipment implements Malfunctionable, Temporal
 		return malfunctionManager;
 	}
 
-
 	@Override
 	public UnitType getUnitType() {
 		return UnitType.DATA_RECORDER;
 	}
 
-
-	@Override
-	public double getStoredMass() {
-		return 0;
-	}
-
-
-	@Override
-	public double storeAmountResource(int resource, double quantity) {
-		// TODO Auto-generated method stub
-		return 0;
-	}
-
-
-	@Override
-	public double retrieveAmountResource(int resource, double quantity) {
-		// TODO Auto-generated method stub
-		return 0;
-	}
-
-
-	@Override
-	public double getSpecificCapacity(int resource) {
-		// TODO Auto-generated method stub
-		return 0;
-	}
-
-
-	@Override
-	public double getSpecificAmountResourceStored(int resource) {
-		// TODO Auto-generated method stub
-		return 0;
-	}
-
-
 	@Override
 	public boolean isEmpty(boolean brandNew) {
-		// TODO Auto-generated method stub
 		return false;
 	}
-
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuit.java
@@ -268,6 +268,13 @@ public class EVASuit extends Equipment
     }
 
 	/**
+	 * Get access to the resource held within the equipment.
+	 */
+	public ResourceHolder getResourcesInventory() {
+		return microInventory;
+	}
+
+	/**
 	 * Is this resource supported ?
 	 *
 	 * @param resource
@@ -288,7 +295,7 @@ public class EVASuit extends Equipment
 	public double storeAmountResource(int resource, double quantity) {
 		// Note: this method is different from
 		// Equipment's storeAmountResource
-		if (isResourceSupported(resource)) {
+		if (microInventory.isResourceSupported(resource)) {
 			return microInventory.storeAmountResource(resource, quantity);
 		}
 		else {
@@ -333,7 +340,7 @@ public class EVASuit extends Equipment
 	public boolean lifeSupportCheck() {
 		try {
 
-			if (getSpecificAmountResourceStored(ResourceUtil.WATER_ID) <= 0D) {
+			if (microInventory.getSpecificAmountResourceStored(ResourceUtil.WATER_ID) <= 0D) {
 				logger.log(this, Level.WARNING, 30_000,
 						"Ran out of water.");
 			}
@@ -393,7 +400,7 @@ public class EVASuit extends Equipment
 		// 17    kPa -> 0.2552 kg (target O2 pressure)
 		// 11.94 kPa -> 0.1792 kg (min O2 pressure)
 
-		double oxygenLeft = getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID);
+		double oxygenLeft = microInventory.getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID);
 		
 		double pp = AirComposition.getOxygenPressure(oxygenLeft, TOTAL_VOLUME);
 		// Assuming that we can maintain a constant oxygen partial pressure unless it falls below massO2NominalLimit
@@ -415,16 +422,6 @@ public class EVASuit extends Equipment
 		return pp;
 	}
 
-	/**
-	 * Gets oxygen partial pressure.
-	 * 
-	 * @return
-	 */
-	private double getCurrentOxygenPartialPressure() {
-		double oxygenLeft = getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID);
-		return AirComposition.getOxygenPressure(oxygenLeft, TOTAL_VOLUME);
-	}
-	
 	/**
 	 * Gets the number of people the life support can provide for.
 	 *
@@ -451,10 +448,10 @@ public class EVASuit extends Equipment
 		// May pressurize the suit to 1/3 of atmospheric pressure, per NASA aboard on
 		// the ISS
 
-		oxygenLacking = retrieveAmountResource(ResourceUtil.OXYGEN_ID, oxygenTaken);
+		oxygenLacking = microInventory.retrieveAmountResource(ResourceUtil.OXYGEN_ID, oxygenTaken);
 
 		double carbonDioxideProvided = gasRatio * (oxygenTaken - oxygenLacking);
-		storeAmountResource(ResourceUtil.CO2_ID, carbonDioxideProvided);
+		microInventory.storeAmountResource(ResourceUtil.CO2_ID, carbonDioxideProvided);
 
 		return oxygenTaken - oxygenLacking;
 	}
@@ -468,7 +465,7 @@ public class EVASuit extends Equipment
 	 */
 	@Override
 	public double provideWater(double waterTaken) {
-		double lacking = retrieveAmountResource(ResourceUtil.WATER_ID, waterTaken);
+		double lacking = microInventory.retrieveAmountResource(ResourceUtil.WATER_ID, waterTaken);
 
 		return waterTaken - lacking;
 	}
@@ -584,12 +581,12 @@ public class EVASuit extends Equipment
 	 * @return Suit is fully loaded with resource
 	 */
 	private boolean loadResource(ResourceHolder source, int resourceId) {
-		double needed = getRemainingSpecificCapacity(resourceId);
+		double needed = microInventory.getRemainingSpecificCapacity(resourceId);
 		if (needed > 0D) {
 			double shortfall = source.retrieveAmountResource(resourceId, needed);
 			double taken = needed - shortfall;
 			if (taken > 0) {
-				storeAmountResource(resourceId, taken);
+				microInventory.storeAmountResource(resourceId, taken);
 			}
 		}
 		return needed <= 0D;
@@ -601,9 +598,9 @@ public class EVASuit extends Equipment
 	 * @param newSuitOwner
 	 */
 	public void unloadWaste(EquipmentOwner holder) {
-		double co2 = getSpecificAmountResourceStored(ResourceUtil.CO2_ID);
+		double co2 = microInventory.getSpecificAmountResourceStored(ResourceUtil.CO2_ID);
 		if (co2 > 0) {
-			retrieveAmountResource(ResourceUtil.CO2_ID, co2);
+			microInventory.retrieveAmountResource(ResourceUtil.CO2_ID, co2);
 			holder.storeAmountResource(ResourceUtil.CO2_ID, co2);
 		}
 	}
@@ -614,8 +611,8 @@ public class EVASuit extends Equipment
 	 * @return Percentage of lowest resource
 	 */
 	public double getFullness() {
-		double o2Loaded = getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID)/OXYGEN_CAPACITY;
-		double waterLoaded = getSpecificAmountResourceStored(ResourceUtil.WATER_ID)/WATER_CAPACITY;
+		double o2Loaded = microInventory.getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID)/OXYGEN_CAPACITY;
+		double waterLoaded = microInventory.getSpecificAmountResourceStored(ResourceUtil.WATER_ID)/WATER_CAPACITY;
 
 		return Math.min(o2Loaded, waterLoaded);
 	}
@@ -668,7 +665,7 @@ public class EVASuit extends Equipment
 	 */
 	@Override
 	public double retrieveAmountResource(int resource, double quantity) {
-		if (isResourceSupported(resource)) {
+		if (microInventory.isResourceSupported(resource)) {
 			return microInventory.retrieveAmountResource(resource, quantity);
 		}
 

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuit.java
@@ -6,6 +6,7 @@
  */
 package com.mars_sim.core.equipment;
 
+import java.text.DecimalFormat;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
@@ -72,14 +73,14 @@ import com.mars_sim.core.unit.UnitHolder;
  * `Extravehicular Activity Suit Systems Design How to Walk, Talk, and Breathe on Mars` 
  */
 public class EVASuit extends Equipment
-	implements LifeSupportInterface, Malfunctionable, ResourceHolder, ItemHolder,
-				Temporal {
+	implements LifeSupportInterface, Malfunctionable, Temporal {
 
 	/** default serial id. */
 	private static final long serialVersionUID = 1L;
 
 	/* default logger. */
 	private static final SimLogger logger = SimLogger.getLogger(EVASuit.class.getName());
+    private static final DecimalFormat DECIMAL_KPA = new DecimalFormat("#,##0.00 kPa");
 
 	// Static members
 	public static final String EVA = "EVA";
@@ -275,51 +276,6 @@ public class EVASuit extends Equipment
 	}
 
 	/**
-	 * Is this resource supported ?
-	 *
-	 * @param resource
-	 * @return true if this resource is supported
-	 */
-	public boolean isResourceSupported(int resource) {
-		return microInventory.isResourceSupported(resource);
-	}
-
-	/**
-	 * Stores the resource.
-	 *
-	 * @param resource
-	 * @param quantity
-	 * @return excess quantity that cannot be stored
-	 */
-	@Override
-	public double storeAmountResource(int resource, double quantity) {
-		// Note: this method is different from
-		// Equipment's storeAmountResource
-		if (microInventory.isResourceSupported(resource)) {
-			return microInventory.storeAmountResource(resource, quantity);
-		}
-		else {
-			String name = ResourceUtil.findAmountResourceName(resource);
-			logger.warning(this, name + "Not allowed to be stored in "
-					+ this + ".");
-			return quantity;
-		}
-	}
-
-
-	/**
-	 * Gets the specific capacity of a particular amount resource.
-	 *
-	 * @param resource
-	 * @return capacity
-	 */
-	@Override
-	public double getSpecificCapacity(int resource) {
-		// Note: this method is different from Equipment's getAmountResourceCapacity
-		return microInventory.getSpecificCapacity(resource);
-	}
-
-	/**
 	 * Gets the unit's malfunction manager.
 	 *
 	 * @return malfunction manager
@@ -353,19 +309,19 @@ public class EVASuit extends Equipment
 			double p = getAirPressure();
 			if (p > PhysicalCondition.MAXIMUM_AIR_PRESSURE) {
 				logger.log(this, Level.WARNING, 30_000,
-						"Detected improper oxygen partial pressure at " + Math.round(p * 100.0D) / 100.0D + " kPa.");
+						"Detected improper oxygen partial pressure at " + DECIMAL_KPA.format(p) + ".");
 				return false;
 			}
 			else if (p <= minO2Pressure) {
 				logger.log(this, Level.WARNING, 30_000,
-						"Dwindling amount of oxygen at " + Math.round(p * 100.0D) / 100.0D
-						+ " kPa, already below the minimum safety partial pressure of " + minO2Pressure + " kPa.");
+						"Dwindling amount of oxygen at " + DECIMAL_KPA.format(p)
+						+ ", already below the minimum safety partial pressure of " + DECIMAL_KPA.format(minO2Pressure) + ".");
 			return false;
 			}
 			else if (p <= (minO2Pressure + TARGET_O2_PRESSURE) / 2) {
 				logger.log(this, Level.WARNING, 30_000,
-						"Dwindling amount of oxygen at " + Math.round(p * 100.0D) / 100.0D 
-						+ " kPa, already below the target partial pressure of " + TARGET_O2_PRESSURE + " kPa.");
+						"Dwindling amount of oxygen at " + DECIMAL_KPA.format(p)
+						+ ", already below the target partial pressure of " + DECIMAL_KPA.format(TARGET_O2_PRESSURE) + ".");
 				return false;
 			}
 			
@@ -616,119 +572,6 @@ public class EVASuit extends Equipment
 
 		return Math.min(o2Loaded, waterLoaded);
 	}
-
-
-	@Override
-	public int getItemResourceStored(int resource) {
-		return microInventory.getItemResourceStored(resource);
-	}
-
-	/**
-	 * NOTE: EVASuit doesn't have any items/parts yet.
-	 */
-	@Override
-	public int getItemResourceRemainingQuantity(int resource) {
-		return microInventory.getItemResourceRemainingQuantity(resource);
-	}
-
-	@Override
-	public int storeItemResource(int resource, int quantity) {
-		return microInventory.storeItemResource(resource, quantity);
-	}
-
-	@Override
-	public int retrieveItemResource(int resource, int quantity) {
-		return microInventory.retrieveItemResource(resource, quantity);
-	}
-
-	/**
-	 * Gets a list of all stored item resources.
-	 *
-	 * @return a list of resource ids
-	 */
-	@Override
-	public Set<Integer> getItemResourceIDs() {
-		return microInventory.getItemResourceIDs();
-	}
-
-	@Override
-	public double getSpecificAmountResourceStored(int resource) {
-		return microInventory.getSpecificAmountResourceStored(resource);
-	}
-
-	/**
-	 * Retrieves the resource.
-	 *
-	 * @param resource
-	 * @param quantity
-	 * @return quantity that cannot be retrieved
-	 */
-	@Override
-	public double retrieveAmountResource(int resource, double quantity) {
-		if (microInventory.isResourceSupported(resource)) {
-			return microInventory.retrieveAmountResource(resource, quantity);
-		}
-
-		else {
-			String name = ResourceUtil.findAmountResourceName(resource);
-			logger.warning(this, "No such resource. Cannot retrieve "
-					+ Math.round(quantity* 1_000.0)/1_000.0 + " kg "+ name + ".");
-			return quantity;
-		}
-	}
-
-	/**
-	 * Obtains the remaining combined capacity of storage space of a particular amount resource.
-	 *
-	 * @param resource
-	 * @return quantity
-	 */
-	@Override
-	public double getRemainingCombinedCapacity(int resource) {
-		return microInventory.getRemainingCombinedCapacity(resource);
-	}
-
-	/**
-	 * Obtains the remaining specific capacity of storage space of a particular amount resource.
-	 *
-	 * @param resource
-	 * @return quantity
-	 */
-	@Override
-	public double getRemainingSpecificCapacity(int resource) {
-		return microInventory.getRemainingSpecificCapacity(resource);
-	}
-	
-	/**
-	 * Gets the quantity of all stock and specific amount resource stored.
-	 *
-	 * @param resource
-	 * @return quantity
-	 */
-	@Override
-	public double getAllAmountResourceStored(int resource) {
-		return microInventory.getAllAmountResourceStored(resource);
-	}
-	
-	/**
-	 * Gets a list of all stored specific amount resources.
-	 *
-	 * @return a list of resource ids
-	 */
-	@Override
-	public Set<Integer> getSpecificResourceStoredIDs() {
-		return microInventory.getSpecificResourceStoredIDs();
-	}
-	
-	/**
-	 * Gets all stored amount resources in eqmInventory, including inside equipment.
-	 *
-	 * @return all stored amount resources.
-	 */
-	@Override
-	public Set<Integer> getAllAmountResourceStoredIDs() {
-		return getSpecificResourceStoredIDs();
-	}
 	
 	/**
 	 * Is this equipment empty ?
@@ -736,6 +579,7 @@ public class EVASuit extends Equipment
 	 * @param brandNew true if it needs to be brand new
 	 * @return
 	 */
+	@Override 
 	public boolean isEmpty(boolean brandNew) {
 		if (brandNew) {
 			return (getRegisteredOwnerID() == -1);
@@ -749,22 +593,12 @@ public class EVASuit extends Equipment
 	 *
 	 * @return
 	 */
-	public double getStoredMass() {
+	@Override
+	protected double getStoredMass() {
 		if (microInventory == null)
 			// Note: needed when starting up
 			return 0;
 		return microInventory.getStoredMass();
-	}
-
-	/**
-	 * Does it have unused space or capacity for a particular resource ?
-	 * 
-	 * @param resource
-	 * @return
-	 */
-	@Override
-	public boolean hasAmountResourceRemainingCapacity(int resource) {
-		return microInventory.hasAmountResourceRemainingCapacity(resource);
 	}
 	
 	@Override

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuitUtil.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/EVASuitUtil.java
@@ -206,15 +206,17 @@ public final class EVASuitUtil {
 	 */
 	private static boolean hasEnoughResourcesForSuit(EquipmentOwner resourceStore, EVASuit suit, int otherPeopleNum) {
 
+		var inv = suit.getResourcesInventory();
+		
 		// Check if enough oxygen.
-		double neededOxygen = suit.getRemainingCombinedCapacity(ResourceUtil.OXYGEN_ID);
+		double neededOxygen = inv.getRemainingCombinedCapacity(ResourceUtil.OXYGEN_ID);
 		double availableOxygen = resourceStore.getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID);
 		// Make sure there is enough extra oxygen for everyone else.
 		availableOxygen -= (neededOxygen * otherPeopleNum);
 		boolean hasEnoughOxygen = (availableOxygen >= neededOxygen);
 
 		// Check if enough water.
-		double neededWater = suit.getRemainingCombinedCapacity(ResourceUtil.WATER_ID);
+		double neededWater = inv.getRemainingCombinedCapacity(ResourceUtil.WATER_ID);
 		double availableWater = resourceStore.getSpecificAmountResourceStored(ResourceUtil.WATER_ID);
 		// Make sure there is enough extra water for everyone else.
 		availableWater -= (neededWater * otherPeopleNum);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/Equipment.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/Equipment.java
@@ -6,8 +6,8 @@
  */
 package com.mars_sim.core.equipment;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 
 import com.mars_sim.core.Unit;
 import com.mars_sim.core.building.Building;
@@ -77,9 +77,6 @@ public abstract class Equipment extends AbstractMobileUnit implements Salvagable
 	 */
 	protected Equipment(String name, EquipmentType eType, String type, Settlement settlement) {
 		super(name, settlement);
-
-		// Call Equipment's setContainerUnit to set up coordinates and related states
-//		setContainerUnit(getContainerUnit());
 		
 		// Initialize data members.
 		this.equipmentType = eType;
@@ -103,7 +100,9 @@ public abstract class Equipment extends AbstractMobileUnit implements Salvagable
 	 *
 	 * @return
 	 */
-	public abstract double getStoredMass();
+	protected double getStoredMass() {
+		return 0;
+	}
 
 	/**
      * Gets the total capacity of resource that this container can hold.
@@ -113,42 +112,6 @@ public abstract class Equipment extends AbstractMobileUnit implements Salvagable
 	public double getCargoCapacity() {
 		return ContainerUtil.getContainerCapacity(equipmentType);
 	}
-
-	/**
-	 * Stores the resource.
-	 *
-	 * @param resource
-	 * @param quantity
-	 * @return excess quantity that cannot be stored
-	 */
-	public abstract double storeAmountResource(int resource, double quantity);
-		// Question: if a bag was filled with regolith and later was emptied out
-		// should it be tagged for only regolith and NOT for another resource ?
-
-	/**
-	 * Retrieves the resource.
-	 *
-	 * @param resource
-	 * @param quantity
-	 * @return quantity that cannot be retrieved
-	 */
-	public abstract double retrieveAmountResource(int resource, double quantity);
-
-	/**
-	 * Gets the capacity of a particular amount resource.
-	 *
-	 * @param resource
-	 * @return capacity
-	 */
-	public abstract double getSpecificCapacity(int resource);
-
-	/**
-	 * Gets all the specific amount resource stored.
-	 *
-	 * @param resource
-	 * @return quantity
-	 */
-	public abstract double getSpecificAmountResourceStored(int resource);
 
 	/**
 	 * Is this equipment empty ?
@@ -164,31 +127,26 @@ public abstract class Equipment extends AbstractMobileUnit implements Salvagable
 	 * @return person collection
 	 */
 	public Collection<Person> getAffectedPeople() {
-		Collection<Person> people = new ArrayList<>();
+		Collection<Person> people = new HashSet<>();
 
 		if (registeredOwner != -1) {
 			people.add(unitManager.getPersonByID(registeredOwner));
 		}
 
 		// Check all people.
-		for (Person person : unitManager.getPeople()) {
-			Task task = person.getMind().getTaskManager().getTask();
+		for (Person person : getAssociatedSettlement().getCitizens()) {
+			Task task = person.getTaskManager().getTask();
 
 			// Add all people maintaining this equipment.
-			if (task instanceof MaintainBuilding maintain) {
-				if (maintain.getEntity() == this) {
-					if (!people.contains(person))
-						people.add(person);
-				}
+			if (task instanceof MaintainBuilding maintain && maintain.getEntity().equals(this)) {
+				people.add(person);
 			}
+			
 
 			// Add all people repairing this equipment.
-			if (task instanceof Repair repair) {
-				if (repair.getEntity() == this) {
-					if (!people.contains(person))
-						people.add(person);
-				}
-			}
+			if (task instanceof Repair repair && repair.getEntity().equals(this)) {
+				people.add(person);
+			}			
 		}
 
 		return people;

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/GenericContainer.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/GenericContainer.java
@@ -41,7 +41,7 @@ class GenericContainer extends Equipment implements Container {
 	 * @param reusable Is the container reusable by a different resource when empty
 	 * @throws Exception if error creating bag.
 	 */
-	GenericContainer(String name, EquipmentType type, boolean reusable, Settlement base) {
+	protected GenericContainer(String name, EquipmentType type, boolean reusable, Settlement base) {
 		// Use Equipment constructor
 		super(name, type, type.name(), base);
 		setDescription(createDescription(type));
@@ -122,7 +122,6 @@ class GenericContainer extends Equipment implements Container {
 		return amountStored;
 	}
 
-	
 	/**
 	 * Retrieves the resource.
 	 *
@@ -130,6 +129,7 @@ class GenericContainer extends Equipment implements Container {
 	 * @param quantity
 	 * @return quantity that cannot be retrieved
 	 */
+	@Override
 	public double retrieveAmountResource(int resource, double quantity) {
 		if (resourceHeld == resource) {
 			if (quantity < amountStored) {
@@ -295,6 +295,7 @@ class GenericContainer extends Equipment implements Container {
 	 * @param brandNew true if it needs to be brand new
 	 * @return
 	 */
+	@Override
 	public boolean isEmpty(boolean brandNew) {
 		if (brandNew) {
 			return (getRegisteredOwnerID() == -1);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/Kit.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/Kit.java
@@ -8,7 +8,6 @@
 package com.mars_sim.core.equipment;
 
 import com.mars_sim.core.UnitType;
-import com.mars_sim.core.building.Building;
 import com.mars_sim.core.malfunction.MalfunctionManager;
 import com.mars_sim.core.malfunction.Malfunctionable;
 import com.mars_sim.core.structure.Settlement;
@@ -76,38 +75,8 @@ public class Kit extends Equipment
 	}
 
 	@Override
-	public Building getBuildingLocation() {
-		return null;
-	}
-
-	@Override
-	public double storeAmountResource(int resource, double quantity) {
-		return 0;
-	}
-
-	@Override
-	public double retrieveAmountResource(int resource, double quantity) {
-		return 0;
-	}
-
-	@Override
-	public double getSpecificCapacity(int resource) {
-		return 0;
-	}
-
-	@Override
-	public double getSpecificAmountResourceStored(int resource) {
-		return 0;
-	}
-
-	@Override
 	public boolean isEmpty(boolean brandNew) {
 		return false;
-	}
-
-	@Override
-	public double getStoredMass() {
-		return 0;
 	}
 
 	@Override

--- a/mars-sim-core/src/main/java/com/mars_sim/core/equipment/ResourceHolder.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/equipment/ResourceHolder.java
@@ -108,10 +108,10 @@ public interface ResourceHolder {
 	 * @return May be null
 	 */
 	static ResourceHolder getAttached(Object obj) {
-		if (obj instanceof ResourceHolder rh) {
-			return rh;
-		}
-
-		return EquipmentOwner.getAttached(obj);
+		return switch(obj) {
+			case EVASuit eva -> eva.getResourcesInventory();
+			case ResourceHolder rh -> rh;
+			default -> EquipmentOwner.getAttached(obj);
+		};
 	}
 }

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/AbstractVehicleMission.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/AbstractVehicleMission.java
@@ -24,6 +24,7 @@ import com.mars_sim.core.EntityEventType;
 import com.mars_sim.core.EntityListener;
 import com.mars_sim.core.UnitType;
 import com.mars_sim.core.data.collection.DataCollectionSite;
+import com.mars_sim.core.equipment.Container;
 import com.mars_sim.core.equipment.ContainerUtil;
 import com.mars_sim.core.equipment.Equipment;
 import com.mars_sim.core.equipment.EquipmentOwner;
@@ -1120,7 +1121,7 @@ public abstract class AbstractVehicleMission extends AbstractMission implements 
 						}
 						// Check vehicle's equipment
 						for (Equipment equipment: vehAH.getContainerSet()) {
-							amountStored += equipment.getSpecificAmountResourceStored(id);
+							amountStored += ((Container)equipment).getSpecificAmountResourceStored(id);
 						}
 					}
 					

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/Mining.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/mission/Mining.java
@@ -391,9 +391,10 @@ public class Mining extends EVAMission
 
 		EVASuit suit = EVASuitUtil.findRegisteredOrGoodEVASuit(member);
 		if (suit != null) {
+			var inv = suit.getResourcesInventory();
 			carryMass += suit.getMass();
-			carryMass += suit.getRemainingCombinedCapacity(ResourceUtil.OXYGEN_ID);
-			carryMass += suit.getRemainingCombinedCapacity(ResourceUtil.WATER_ID);
+			carryMass += inv.getRemainingCombinedCapacity(ResourceUtil.OXYGEN_ID);
+			carryMass += inv.getRemainingCombinedCapacity(ResourceUtil.WATER_ID);
 		}
 		double carryCapacity = member.getCarryingCapacity();
 		boolean canCarryEquipment = (carryCapacity >= carryMass);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/ConsolidateContainers.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/ConsolidateContainers.java
@@ -180,7 +180,7 @@ extends Task {
         	int resourceID = c.getResource();
             if (resourceID != -1) {
             	// resourceID = -1 means the container has not been initialized
-                double sourceAmount = source.getSpecificAmountResourceStored(resourceID);
+                double sourceAmount = c.getSpecificAmountResourceStored(resourceID);
                 if (sourceAmount > 0D) {
 	                // Move resource in container to top inventory if possible.
 	                double topRemainingCapacity = parent.getRemainingCombinedCapacity(resourceID);

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/EVAOperation.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/EVAOperation.java
@@ -452,8 +452,6 @@ public abstract class EVAOperation extends Task {
 		}
 
 		else { // if a person is already inside, end the task gracefully here
-//			logger.log(person, Level.WARNING, 10_000, 
-//					"Case 6: Just went inside successfully. Current location: " + person.getContainerUnit());
 			endTask();
 		}
 
@@ -482,12 +480,6 @@ public abstract class EVAOperation extends Task {
 			logger.info(person, "Too hungry at meal time.");
 			return true;
 		}
-
-//        // Checks if the person is physically drained
-//		if (isExhausted(person)) {
-//			logger.info(person, "Exhausted.");
-//			return true;
-//		}
 		
 		if (isInEmergency(person)) {
 			logger.info(person, "Medical Emergency.");
@@ -631,8 +623,9 @@ public abstract class EVAOperation extends Task {
 
 		try {
 			// Check if EVA suit is at 15% of its oxygen capacity.
-			double oxygenCap = suit.getSpecificCapacity(ResourceUtil.OXYGEN_ID);
-			double oxygen = suit.getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID);
+			var suitInv = suit.getResourcesInventory();
+			double oxygenCap = suitInv.getSpecificCapacity(ResourceUtil.OXYGEN_ID);
+			double oxygen = suitInv.getSpecificAmountResourceStored(ResourceUtil.OXYGEN_ID);
 			if (oxygen <= (oxygenCap * .1D)) {
 				logger.log(person, Level.WARNING, 30_000,
 						suit.getName() + " reported less than 10% O2 left when "
@@ -641,8 +634,8 @@ public abstract class EVAOperation extends Task {
 			}
 
 			// Check if EVA suit is at 15% of its water capacity.
-			double waterCap = suit.getSpecificCapacity(ResourceUtil.WATER_ID);
-			double water = suit.getSpecificAmountResourceStored(ResourceUtil.WATER_ID);
+			double waterCap = suitInv.getSpecificCapacity(ResourceUtil.WATER_ID);
+			double water = suitInv.getSpecificAmountResourceStored(ResourceUtil.WATER_ID);
 			if (water <= (waterCap * .1D)) {
 				logger.log(person, Level.WARNING, 30_000,
 						suit.getName() + " reported less than 10% water left when "
@@ -818,7 +811,6 @@ public abstract class EVAOperation extends Task {
 		}
 		else {
             endEVA("No good random outside location found.");
-			logger.warning(worker, "No good random outside location found.");
 		}
 		return goodLocation;
 	}

--- a/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/EatDrink.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/person/ai/task/EatDrink.java
@@ -794,18 +794,18 @@ public class EatDrink extends Task {
 		if (localStores == null) {
 			// No local stores so get water from one's EVA suit
 			EVASuit suit = person.getSuit();
-
-			double available = suit.getSpecificAmountResourceStored(ResourceUtil.WATER_ID);
+			var suitInv = suit.getResourcesInventory();
+			double available = suitInv.getSpecificAmountResourceStored(ResourceUtil.WATER_ID);
 			
 			// Test to see if there's enough water
 			if (available >= amount) {
 				logger.fine(person, 4_000L, "Drinking " + Math.round(amount * 100.0)/100.0 + " kg of water from " + suit.getName() + ".");
-				consumeWater(suit, amount, waterOnly);
+				consumeWater(suitInv, amount, waterOnly);
 			}
 			else if (available > 0) {
 				amount = available;
 				logger.info(person, 10_000L, "Drinking " + Math.round(amount * 100.0)/100.0 + " kg of water from " + suit.getName() + ".");
-				consumeWater(suit, amount, waterOnly);
+				consumeWater(suitInv, amount, waterOnly);
 			}
 		}
 		else {

--- a/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/UnloadHelper.java
+++ b/mars-sim-core/src/main/java/com/mars_sim/core/vehicle/task/UnloadHelper.java
@@ -202,7 +202,7 @@ public final class UnloadHelper {
     	// Unload the surplus
     	for(var extra : surplus) {
     		// Unload inventories of equipment (if possible)
-    		unloadResourcesHolder(extra, dest);
+    		unloadResourcesHolder(extra.getResourcesInventory(), dest);
     		extra.transfer(dest);		
     		amountUnloading -= extra.getMass();
     	}

--- a/mars-sim-core/src/test/java/com/mars_sim/core/equipment/EquipmentInventoryTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/equipment/EquipmentInventoryTest.java
@@ -31,6 +31,7 @@ class EquipmentInventoryTest extends MarsSimUnitTest {
 
 	private Settlement settlement = null;
 
+	@Override 
     @BeforeEach
     public void init() {
 		super.init();
@@ -53,9 +54,8 @@ class EquipmentInventoryTest extends MarsSimUnitTest {
 		// Store some CO2 directly and then a Bag containing rocks
 		inv.storeAmountResource(co2, co2Mass);
 		
-		Equipment bag = EquipmentFactory.createEquipment(EquipmentType.BAG, settlement);
-		
-		double excess = ((Container)bag).storeAmountResource(rock, rockMass);
+		GenericContainer bag = new GenericContainer("Bag", EquipmentType.BAG, false, settlement);
+		double excess = bag.storeAmountResource(rock, rockMass);
 		
 		assertEquals(0D, excess, "Bag cannot store the rock.");
 				
@@ -86,17 +86,14 @@ class EquipmentInventoryTest extends MarsSimUnitTest {
 		int resource = ResourceUtil.CO2_ID;
 
 		double excess = inv.storeAmountResource(resource, CAPACITY_AMOUNT/2);
-//		System.out.println("excess: " + excess);
 		
 		assertEquals(0D, excess, "No excess on 1st load");
 		
 		double stored = inv.getSpecificAmountResourceStored(resource);
-//		System.out.println("stored: " + stored);
 		
 		assertEquals(CAPACITY_AMOUNT/2, stored, "Stored capacity after 1st load");
 		
 		double cap = inv.getRemainingSpecificCapacity(resource);
-//		System.out.println("cap: " + cap);
 				
 		assertEquals(CAPACITY_AMOUNT/2, cap, "Remaining after 1st load capacity");
 		assertEquals(CAPACITY_AMOUNT/2, inv.getStoredMass(), "Total mass after 1st load");

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/EVAOperationTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/EVAOperationTest.java
@@ -10,7 +10,6 @@ import com.mars_sim.core.building.BuildingManager;
 import com.mars_sim.core.building.function.EVA;
 import com.mars_sim.core.building.function.FunctionType;
 import com.mars_sim.core.equipment.EVASuit;
-import com.mars_sim.core.equipment.Equipment;
 import com.mars_sim.core.equipment.EquipmentFactory;
 import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.map.location.Coordinates;
@@ -65,7 +64,8 @@ public class EVAOperationTest extends MarsSimUnitTest{
         var s = p.getAssociatedSettlement();
         var b = context.buildEVA(s.getBuildingManager(), LocalPosition.DEFAULT_POSITION, 0D);
         BuildingManager.addToActivitySpot(p, b, FunctionType.EVA);
-        Equipment e = EquipmentFactory.createEquipment(EquipmentType.EVA_SUIT, s);
+        var suit = (EVASuit) EquipmentFactory.createEquipment(EquipmentType.EVA_SUIT, s);
+        var e = suit.getResourcesInventory();
         e.storeAmountResource(ResourceUtil.OXYGEN_ID, EVASuit.OXYGEN_CAPACITY);
         e.storeAmountResource(ResourceUtil.WATER_ID, EVASuit.WATER_CAPACITY);
 
@@ -83,7 +83,7 @@ public class EVAOperationTest extends MarsSimUnitTest{
      * @throws CoordinatesException 
      */
     @Test
-    public void testIsSunlightAroundGlobal() throws CoordinatesException {
+    void testIsSunlightAroundGlobal() throws CoordinatesException {
         var locn = CoordinatesFormat.fromString("0.0 0.0");
         
         assertLightLevel("zero time, center locn", locn, false, false);

--- a/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/EatDrinkTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/person/ai/task/EatDrinkTest.java
@@ -10,6 +10,7 @@ import com.mars_sim.core.building.Building;
 import com.mars_sim.core.building.BuildingCategory;
 import com.mars_sim.core.building.BuildingManager;
 import com.mars_sim.core.building.function.FunctionType;
+import com.mars_sim.core.equipment.Container;
 import com.mars_sim.core.equipment.EquipmentFactory;
 import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.equipment.ResourceHolder;
@@ -48,7 +49,7 @@ class EatDrinkTest extends MarsSimUnitTest {
         var p = buildPerson("eater", s, JobType.ENGINEER, d, FunctionType.DINING);
 
         // Create bottle and assign to person
-        var b = EquipmentFactory.createEquipment(EquipmentType.THERMAL_BOTTLE, s);
+        var b = (Container)EquipmentFactory.createEquipment(EquipmentType.THERMAL_BOTTLE, s);
         b.storeAmountResource(ResourceUtil.WATER_ID, INITIAL_RESOURCE);
         p.dressForInside(s.getEquipmentInventory());
 

--- a/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/UnloadHelperTest.java
+++ b/mars-sim-core/src/test/java/com/mars_sim/core/vehicle/task/UnloadHelperTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 
 import com.mars_sim.core.test.MarsSimUnitTest;
+import com.mars_sim.core.equipment.EVASuit;
 import com.mars_sim.core.equipment.EquipmentFactory;
 import com.mars_sim.core.equipment.EquipmentType;
 import com.mars_sim.core.map.location.LocalPosition;
@@ -56,8 +57,8 @@ class UnloadHelperTest extends MarsSimUnitTest{
         var v = buildRover(s, "rover", LocalPosition.DEFAULT_POSITION, EXPLORER_ROVER);
         int suits = 3;
         for(int i = 0; i < suits; i++) {
-            var e = EquipmentFactory.createEquipment(EquipmentType.EVA_SUIT, s);
-            e.storeAmountResource(ResourceUtil.OXYGEN_ID, 10);
+            var e = (EVASuit)EquipmentFactory.createEquipment(EquipmentType.EVA_SUIT, s);
+            e.getResourcesInventory().storeAmountResource(ResourceUtil.OXYGEN_ID, 10);
             e.transfer(v);
         }
 


### PR DESCRIPTION
This PR completes the clean up of removing excessive inventory interfaces from Units.

Changes:
- Equipment drops abstract inventory orientated methods
- Remove empty methods from Kit & DataCollection
- EVASuit provides a ResouceHolder to ResourceHolder.getAttached


close #1729